### PR TITLE
Update INSTALL.md and simplify graphics_file_rules.mk

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,6 +8,6 @@ TBD
 
 Install [**devkitARM**](http://devkitpro.org/wiki/Getting_Started/devkitARM).
 
-Then get the compiled tools from https://github.com/YamaArashi/pokeruby-tools. Copy the "tools" folder over the "tools" folder in your pokeemerald directory.
+Then download [**pokeruby-tools**](https://github.com/pret/pokeruby-tools). Copy the `tools/` folder with the compiled `exe`s to the `tools/` folder in your `pokeemerald/` directory.
 
-You can then build pokeemerald using "make" in the MSYS environment provided with devkitARM.
+You can then build pokeemerald using `make` in the MSYS environment provided with devkitARM.

--- a/graphics_file_rules.mk
+++ b/graphics_file_rules.mk
@@ -2,113 +2,109 @@ monstillfrontdir := graphics/pokemon/front_pics
 monbackdir := graphics/pokemon/back_pics
 monfrontdir := graphics/pokemon/anim_front_pics
 monpaldir := graphics/pokemon/palettes
-INTROGFXDIR := graphics/intro
-interfacedir := graphics/interface
-PKNAVGFXDIR := graphics/pokenav
-MISCGFXDIR := graphics/misc
+tilesetdir := data/tilesets
+fontdir := data/graphics/fonts
 
 $(monstillfrontdir)/castform_still_front_pic.4bpp: $(monstillfrontdir)/castform_normal_form_still_front_pic.4bpp \
                                                    $(monstillfrontdir)/castform_sunny_form_still_front_pic.4bpp \
                                                    $(monstillfrontdir)/castform_rainy_form_still_front_pic.4bpp \
                                                    $(monstillfrontdir)/castform_snowy_form_still_front_pic.4bpp
-	@cat $(monstillfrontdir)/castform_normal_form_still_front_pic.4bpp $(monstillfrontdir)/castform_sunny_form_still_front_pic.4bpp $(monstillfrontdir)/castform_rainy_form_still_front_pic.4bpp $(monstillfrontdir)/castform_snowy_form_still_front_pic.4bpp >$@
+	@cat $^ >$@
 
 $(monbackdir)/castform_back_pic.4bpp: $(monbackdir)/castform_normal_form_back_pic.4bpp \
                                       $(monbackdir)/castform_sunny_form_back_pic.4bpp \
                                       $(monbackdir)/castform_rainy_form_back_pic.4bpp \
                                       $(monbackdir)/castform_snowy_form_back_pic.4bpp
-	@cat $(monbackdir)/castform_normal_form_back_pic.4bpp $(monbackdir)/castform_sunny_form_back_pic.4bpp $(monbackdir)/castform_rainy_form_back_pic.4bpp $(monbackdir)/castform_snowy_form_back_pic.4bpp >$@
+	@cat $^ >$@
 
 $(monfrontdir)/castform_front_pic.4bpp: $(monfrontdir)/castform_normal_form_front_pic.4bpp \
                                         $(monfrontdir)/castform_sunny_form_front_pic.4bpp \
                                         $(monfrontdir)/castform_rainy_form_front_pic.4bpp \
                                         $(monfrontdir)/castform_snowy_form_front_pic.4bpp
-	@cat $(monfrontdir)/castform_normal_form_front_pic.4bpp $(monfrontdir)/castform_sunny_form_front_pic.4bpp $(monfrontdir)/castform_rainy_form_front_pic.4bpp $(monfrontdir)/castform_snowy_form_front_pic.4bpp >$@
+	@cat $^ >$@
 
 $(monpaldir)/castform_palette.gbapal: $(monpaldir)/castform_normal_form_palette.gbapal \
                                       $(monpaldir)/castform_sunny_form_palette.gbapal \
                                       $(monpaldir)/castform_rainy_form_palette.gbapal \
                                       $(monpaldir)/castform_snowy_form_palette.gbapal
-	@cat $(monpaldir)/castform_normal_form_palette.gbapal $(monpaldir)/castform_sunny_form_palette.gbapal $(monpaldir)/castform_rainy_form_palette.gbapal $(monpaldir)/castform_snowy_form_palette.gbapal >$@
+	@cat $^ >$@
 
 $(monpaldir)/castform_shiny_palette.gbapal: $(monpaldir)/castform_normal_form_shiny_palette.gbapal \
                                             $(monpaldir)/castform_sunny_form_shiny_palette.gbapal \
                                             $(monpaldir)/castform_rainy_form_shiny_palette.gbapal \
                                             $(monpaldir)/castform_snowy_form_shiny_palette.gbapal
-	@cat $(monpaldir)/castform_normal_form_shiny_palette.gbapal $(monpaldir)/castform_sunny_form_shiny_palette.gbapal $(monpaldir)/castform_rainy_form_shiny_palette.gbapal $(monpaldir)/castform_snowy_form_shiny_palette.gbapal >$@
+	@cat $^ >$@
 
-tilesetdir := data/tilesets
-
-$(tilesetdir)/secondary/petalburg/tiles.4bpp: $(tilesetdir)/secondary/petalburg/tiles.png
+$(tilesetdir)/secondary/petalburg/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 159
 
-$(tilesetdir)/secondary/rustboro/tiles.4bpp: $(tilesetdir)/secondary/rustboro/tiles.png
+$(tilesetdir)/secondary/rustboro/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 498
 
-$(tilesetdir)/secondary/dewford/tiles.4bpp: $(tilesetdir)/secondary/dewford/tiles.png
+$(tilesetdir)/secondary/dewford/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 503
 
-$(tilesetdir)/secondary/slateport/tiles.4bpp: $(tilesetdir)/secondary/slateport/tiles.png
+$(tilesetdir)/secondary/slateport/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 504
 
-$(tilesetdir)/secondary/mauville/tiles.4bpp: $(tilesetdir)/secondary/mauville/tiles.png
+$(tilesetdir)/secondary/mauville/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 503
 
-$(tilesetdir)/secondary/lavaridge/tiles.4bpp: $(tilesetdir)/secondary/lavaridge/tiles.png
+$(tilesetdir)/secondary/lavaridge/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 450
 
-$(tilesetdir)/secondary/fortree/tiles.4bpp: $(tilesetdir)/secondary/fortree/tiles.png
+$(tilesetdir)/secondary/fortree/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 493
 
-$(tilesetdir)/secondary/pacifidlog/tiles.4bpp: $(tilesetdir)/secondary/pacifidlog/tiles.png
+$(tilesetdir)/secondary/pacifidlog/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 504
 
-$(tilesetdir)/secondary/sootopolis/tiles.4bpp: $(tilesetdir)/secondary/sootopolis/tiles.png
+$(tilesetdir)/secondary/sootopolis/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 328
 
-$(tilesetdir)/secondary/battle_frontier_outside_west/tiles.4bpp: $(tilesetdir)/secondary/battle_frontier_outside_west/tiles.png
+$(tilesetdir)/secondary/battle_frontier_outside_west/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 508
 
-$(tilesetdir)/secondary/battle_frontier_outside_east/tiles.4bpp: $(tilesetdir)/secondary/battle_frontier_outside_east/tiles.png
+$(tilesetdir)/secondary/battle_frontier_outside_east/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 508
 
-$(tilesetdir)/primary/building/tiles.4bpp: $(tilesetdir)/primary/building/tiles.png
+$(tilesetdir)/primary/building/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 502
 
-$(tilesetdir)/secondary/shop/tiles.4bpp: $(tilesetdir)/secondary/shop/tiles.png
+$(tilesetdir)/secondary/shop/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 502
 
-$(tilesetdir)/secondary/pokemon_center/tiles.4bpp: $(tilesetdir)/secondary/pokemon_center/tiles.png
+$(tilesetdir)/secondary/pokemon_center/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 478
 
-$(tilesetdir)/secondary/cave/tiles.4bpp: $(tilesetdir)/secondary/cave/tiles.png
+$(tilesetdir)/secondary/cave/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 425
 
-$(tilesetdir)/secondary/pokemon_school/tiles.4bpp: $(tilesetdir)/secondary/pokemon_school/tiles.png
+$(tilesetdir)/secondary/pokemon_school/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 278
 
-$(tilesetdir)/secondary/pokemon_fan_club/tiles.4bpp: $(tilesetdir)/secondary/pokemon_fan_club/tiles.png
+$(tilesetdir)/secondary/pokemon_fan_club/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 319
 
-$(tilesetdir)/secondary/unused_1/tiles.4bpp: $(tilesetdir)/secondary/unused_1/tiles.png
+$(tilesetdir)/secondary/unused_1/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 17
 
-$(tilesetdir)/secondary/meteor_falls/tiles.4bpp: $(tilesetdir)/secondary/meteor_falls/tiles.png
+$(tilesetdir)/secondary/meteor_falls/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 460
 
-$(tilesetdir)/secondary/oceanic_museum/tiles.4bpp: $(tilesetdir)/secondary/oceanic_museum/tiles.png
+$(tilesetdir)/secondary/oceanic_museum/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 319
 
-$(tilesetdir)/secondary/cable_club/unknown_tiles.4bpp: $(tilesetdir)/secondary/cable_club/unknown_tiles.png
+$(tilesetdir)/secondary/cable_club/unknown_tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 120
 
-$(tilesetdir)/secondary/seashore_house/tiles.4bpp: $(tilesetdir)/secondary/seashore_house/tiles.png
+$(tilesetdir)/secondary/seashore_house/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 312
 
-$(tilesetdir)/secondary/pretty_petal_flower_shop/tiles.4bpp: $(tilesetdir)/secondary/pretty_petal_flower_shop/tiles.png
+$(tilesetdir)/secondary/pretty_petal_flower_shop/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 345
 
-$(tilesetdir)/secondary/pokemon_day_care/tiles.4bpp: $(tilesetdir)/secondary/pokemon_day_care/tiles.png
+$(tilesetdir)/secondary/pokemon_day_care/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 355
 
 $(tilesetdir)/secondary/secret_base/brown_cave/unused_tiles.4bpp: $(tilesetdir)/secondary/secret_base/brown_cave/tiles.png
@@ -129,109 +125,107 @@ $(tilesetdir)/secondary/secret_base/yellow_cave/unused_tiles.4bpp: $(tilesetdir)
 $(tilesetdir)/secondary/secret_base/red_cave/unused_tiles.4bpp: $(tilesetdir)/secondary/secret_base/red_cave/tiles.png
 	$(GFX) $< $@ -num_tiles 82
 
-$(tilesetdir)/secondary/secret_base/brown_cave/tiles.4bpp: $(tilesetdir)/secondary/secret_base/brown_cave/tiles.png
+$(tilesetdir)/secondary/secret_base/brown_cave/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 83
 
-$(tilesetdir)/secondary/secret_base/tree/tiles.4bpp: $(tilesetdir)/secondary/secret_base/tree/tiles.png
+$(tilesetdir)/secondary/secret_base/tree/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 83
 
-$(tilesetdir)/secondary/secret_base/shrub/tiles.4bpp: $(tilesetdir)/secondary/secret_base/shrub/tiles.png
+$(tilesetdir)/secondary/secret_base/shrub/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 83
 
-$(tilesetdir)/secondary/secret_base/blue_cave/tiles.4bpp: $(tilesetdir)/secondary/secret_base/blue_cave/tiles.png
+$(tilesetdir)/secondary/secret_base/blue_cave/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 83
 
-$(tilesetdir)/secondary/secret_base/yellow_cave/tiles.4bpp: $(tilesetdir)/secondary/secret_base/yellow_cave/tiles.png
+$(tilesetdir)/secondary/secret_base/yellow_cave/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 83
 
-$(tilesetdir)/secondary/secret_base/red_cave/tiles.4bpp: $(tilesetdir)/secondary/secret_base/red_cave/tiles.png
+$(tilesetdir)/secondary/secret_base/red_cave/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 83
 
-$(tilesetdir)/secondary/inside_of_truck/tiles.4bpp: $(tilesetdir)/secondary/inside_of_truck/tiles.png
+$(tilesetdir)/secondary/inside_of_truck/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 62
 
-$(tilesetdir)/secondary/contest/tiles.4bpp: $(tilesetdir)/secondary/contest/tiles.png
+$(tilesetdir)/secondary/contest/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 430
 
-$(tilesetdir)/secondary/lilycove_museum/tiles.4bpp: $(tilesetdir)/secondary/lilycove_museum/tiles.png
+$(tilesetdir)/secondary/lilycove_museum/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 431
 
-$(tilesetdir)/secondary/lab/tiles.4bpp: $(tilesetdir)/secondary/lab/tiles.png
+$(tilesetdir)/secondary/lab/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 500
 
-$(tilesetdir)/secondary/underwater/tiles.4bpp: $(tilesetdir)/secondary/underwater/tiles.png
+$(tilesetdir)/secondary/underwater/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 500
 
-$(tilesetdir)/secondary/generic_building/tiles.4bpp: $(tilesetdir)/secondary/generic_building/tiles.png
+$(tilesetdir)/secondary/generic_building/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 509
 
-$(tilesetdir)/secondary/mauville_game_corner/tiles.4bpp: $(tilesetdir)/secondary/mauville_game_corner/tiles.png
+$(tilesetdir)/secondary/mauville_game_corner/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 469
 
-$(tilesetdir)/secondary/unused_2/tiles.4bpp: $(tilesetdir)/secondary/unused_2/tiles.png
+$(tilesetdir)/secondary/unused_2/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 150
 
-$(tilesetdir)/secondary/rustboro_gym/tiles.4bpp: $(tilesetdir)/secondary/rustboro_gym/tiles.png
+$(tilesetdir)/secondary/rustboro_gym/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 60
 
-$(tilesetdir)/secondary/dewford_gym/tiles.4bpp: $(tilesetdir)/secondary/dewford_gym/tiles.png
+$(tilesetdir)/secondary/dewford_gym/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 61
 
-$(tilesetdir)/secondary/lavaridge_gym/tiles.4bpp: $(tilesetdir)/secondary/lavaridge_gym/tiles.png
+$(tilesetdir)/secondary/lavaridge_gym/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 54
 
-$(tilesetdir)/secondary/petalburg_gym/tiles.4bpp: $(tilesetdir)/secondary/petalburg_gym/tiles.png
+$(tilesetdir)/secondary/petalburg_gym/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 148
 
-$(tilesetdir)/secondary/fortree_gym/tiles.4bpp: $(tilesetdir)/secondary/fortree_gym/tiles.png
+$(tilesetdir)/secondary/fortree_gym/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 61
 
-$(tilesetdir)/secondary/mossdeep_gym/tiles.4bpp: $(tilesetdir)/secondary/mossdeep_gym/tiles.png
+$(tilesetdir)/secondary/mossdeep_gym/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 82
 
-$(tilesetdir)/secondary/sootopolis_gym/tiles.4bpp: $(tilesetdir)/secondary/sootopolis_gym/tiles.png
+$(tilesetdir)/secondary/sootopolis_gym/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 484
 
-$(tilesetdir)/secondary/trick_house_puzzle/tiles.4bpp: $(tilesetdir)/secondary/trick_house_puzzle/tiles.png
+$(tilesetdir)/secondary/trick_house_puzzle/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 294
 
-$(tilesetdir)/secondary/inside_ship/tiles.4bpp: $(tilesetdir)/secondary/inside_ship/tiles.png
+$(tilesetdir)/secondary/inside_ship/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 342
 
-$(tilesetdir)/secondary/elite_four/tiles.4bpp: $(tilesetdir)/secondary/elite_four/tiles.png
+$(tilesetdir)/secondary/elite_four/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 505
 
-$(tilesetdir)/secondary/battle_frontier/tiles.4bpp: $(tilesetdir)/secondary/battle_frontier/tiles.png
+$(tilesetdir)/secondary/battle_frontier/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 310
 
-$(tilesetdir)/secondary/battle_factory/tiles.4bpp: $(tilesetdir)/secondary/battle_factory/tiles.png
+$(tilesetdir)/secondary/battle_factory/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 424
 
-$(tilesetdir)/secondary/battle_pike/tiles.4bpp: $(tilesetdir)/secondary/battle_pike/tiles.png
+$(tilesetdir)/secondary/battle_pike/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 382
 
-$(tilesetdir)/secondary/mirage_tower/tiles.4bpp: $(tilesetdir)/secondary/mirage_tower/tiles.png
+$(tilesetdir)/secondary/mirage_tower/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 420
 
-$(tilesetdir)/secondary/mossdeep_game_corner/tiles.4bpp: $(tilesetdir)/secondary/mossdeep_game_corner/tiles.png
+$(tilesetdir)/secondary/mossdeep_game_corner/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 95
 
-$(tilesetdir)/secondary/island_harbor/tiles.4bpp: $(tilesetdir)/secondary/island_harbor/tiles.png
+$(tilesetdir)/secondary/island_harbor/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 503
 
-$(tilesetdir)/secondary/trainer_hill/tiles.4bpp: $(tilesetdir)/secondary/trainer_hill/tiles.png
+$(tilesetdir)/secondary/trainer_hill/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 374
 
-$(tilesetdir)/secondary/navel_rock/tiles.4bpp: $(tilesetdir)/secondary/navel_rock/tiles.png
+$(tilesetdir)/secondary/navel_rock/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 420
 
-$(tilesetdir)/secondary/battle_frontier_ranking_hall/tiles.4bpp: $(tilesetdir)/secondary/battle_frontier_ranking_hall/tiles.png
+$(tilesetdir)/secondary/battle_frontier_ranking_hall/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 136
 
-$(tilesetdir)/secondary/mystery_events_house/tiles.4bpp: $(tilesetdir)/secondary/mystery_events_house/tiles.png
+$(tilesetdir)/secondary/mystery_events_house/tiles.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 509
-
-fontdir := data/graphics/fonts
 
 $(fontdir)/font0.latfont: $(fontdir)/font0_latin.png
 	$(GFX) $< $@
@@ -269,31 +263,32 @@ $(fontdir)/unused_frlg_male.fwjpnfont: $(fontdir)/unused_japanese_frlg_male_font
 $(fontdir)/unused_frlg_female.fwjpnfont: $(fontdir)/unused_japanese_frlg_female_font.png
 	$(GFX) $< $@
 
-$(fontdir)/down_arrow.4bpp: $(fontdir)/down_arrow.png
+$(fontdir)/down_arrow.4bpp: %.4bpp: %.png
 	$(GFX) $< $@
 
-$(fontdir)/down_arrow_rs.4bpp: $(fontdir)/down_arrow_rs.png
+$(fontdir)/down_arrow_rs.4bpp: %.4bpp: %.png
 	$(GFX) $< $@
 
-$(fontdir)/unused_frlg_blanked_down_arrow.4bpp: $(fontdir)/unused_frlg_blanked_down_arrow.png
+$(fontdir)/unused_frlg_blanked_down_arrow.4bpp: %.4bpp: %.png
 	$(GFX) $< $@
 
-$(fontdir)/unused_frlg_down_arrow.4bpp: $(fontdir)/unused_frlg_down_arrow.png
+$(fontdir)/unused_frlg_down_arrow.4bpp: %.4bpp: %.png
 	$(GFX) $< $@
 
-$(fontdir)/keypad_icons.4bpp: $(fontdir)/keypad_icons.png
+$(fontdir)/keypad_icons.4bpp: %.4bpp: %.png
 	$(GFX) $< $@
 
-graphics/title_screen/pokemon_logo.gbapal: graphics/title_screen/pokemon_logo.pal
+graphics/title_screen/pokemon_logo.gbapal: %.gbapal: %.pal
 	$(GFX) $< $@ -num_colors 224
 
-$(INTROGFXDIR)/copyright.4bpp: $(INTROGFXDIR)/copyright.png
+graphics/intro/copyright.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 39
     
-$(interfacedir)/pkmnjump_bg.4bpp: $(interfacedir)/pkmnjump_bg.png
+graphics/interface/pkmnjump_bg.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 63
 
-$(PKNAVGFXDIR)/region_map.8bpp: $(PKNAVGFXDIR)/region_map.png
+graphics/pokenav/region_map.8bpp: %.8bpp: %.png
 	$(GFX) $< $@ -num_tiles 233
-$(MISCGFXDIR)/japanese_hof.4bpp: $(MISCGFXDIR)/japanese_hof.png
+
+graphics/misc/japanese_hof.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 29


### PR DESCRIPTION
INSTALL.md:

* Link to pret/pokeruby-tools, since YamaArashi/pokeruby-tools and ProjectRevoTPP/pokeruby-tools are 404

graphics_file_rules.mk:

* Use the `$^` automatic variable for Castform files to avoid repetition
* Use static pattern rules for `png`→`otherextension` to avoid repetition
* Multi-use directories are declared at the top; single-use directories do not use variables