### PR TITLE
Add ability to specify metatile dimensions to gbagfx

### DIFF
--- a/tools/gbagfx/Makefile
+++ b/tools/gbagfx/Makefile
@@ -1,12 +1,15 @@
 CC = gcc
 
-CFLAGS = -Wall -Wextra -Werror -std=c11 -O2 -DPNG_SKIP_SETJMP_CHECK
+CFLAGS = -Wall -Wextra -Werror -std=c11 -O2 -s -DPNG_SKIP_SETJMP_CHECK
 
 LIBS = -lpng -lz
 
 SRCS = main.c convert_png.c gfx.c jasc_pal.c lz.c rl.c util.c font.c
 
-.PHONY: clean
+.PHONY: all clean
+
+all: gbagfx
+	@:
 
 gbagfx: $(SRCS) convert_png.h gfx.h global.h jasc_pal.h lz.h rl.h util.h font.h
 	$(CC) $(CFLAGS) $(SRCS) -o $@ $(LDFLAGS) $(LIBS)

--- a/tools/gbagfx/gfx.h
+++ b/tools/gbagfx/gfx.h
@@ -27,8 +27,8 @@ struct Image {
 	bool hasTransparency;
 };
 
-void ReadImage(char *path, int tilesWidth, int bitDepth, struct Image *image, bool invertColors);
-void WriteImage(char *path, int numTiles, int bitDepth, struct Image *image, bool invertColors);
+void ReadImage(char *path, int tilesWidth, int bitDepth, int metatileWidth, int metatileHeight, struct Image *image, bool invertColors);
+void WriteImage(char *path, int numTiles, int bitDepth, int metatileWidth, int metatileHeight, struct Image *image, bool invertColors);
 void FreeImage(struct Image *image);
 void ReadGbaPalette(char *path, struct Palette *palette);
 void WriteGbaPalette(char *path, struct Palette *palette);

--- a/tools/gbagfx/main.c
+++ b/tools/gbagfx/main.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include "global.h"
 #include "util.h"
+#include "options.h"
 #include "gfx.h"
 #include "convert_png.h"
 #include "jasc_pal.h"
@@ -19,13 +20,13 @@ struct CommandHandler
     void(*function)(char *inputPath, char *outputPath, int argc, char **argv);
 };
 
-void ConvertGbaToPng(char *inputPath, char *outputPath, int width, int bitDepth, char *paletteFilePath, bool hasTransparency)
+void ConvertGbaToPng(char *inputPath, char *outputPath, struct GbaToPngOptions *options)
 {
     struct Image image;
 
-    if (paletteFilePath != NULL)
+    if (options->paletteFilePath != NULL)
     {
-        ReadGbaPalette(paletteFilePath, &image.palette);
+        ReadGbaPalette(options->paletteFilePath, &image.palette);
         image.hasPalette = true;
     }
     else
@@ -33,24 +34,24 @@ void ConvertGbaToPng(char *inputPath, char *outputPath, int width, int bitDepth,
         image.hasPalette = false;
     }
 
-    ReadImage(inputPath, width, bitDepth, &image, !image.hasPalette);
+    ReadImage(inputPath, options->width, options->bitDepth, options->metatileWidth, options->metatileHeight, &image, !image.hasPalette);
 
-    image.hasTransparency = hasTransparency;
+    image.hasTransparency = options->hasTransparency;
 
     WritePng(outputPath, &image);
 
     FreeImage(&image);
 }
 
-void ConvertPngToGba(char *inputPath, char *outputPath, int numTiles, int bitDepth)
+void ConvertPngToGba(char *inputPath, char *outputPath, struct PngToGbaOptions *options)
 {
     struct Image image;
 
-    image.bitDepth = bitDepth;
+    image.bitDepth = options->bitDepth;
 
     ReadPng(inputPath, &image);
 
-    WriteImage(outputPath, numTiles, bitDepth, &image, !image.hasPalette);
+    WriteImage(outputPath, options->numTiles, options->bitDepth, options->metatileWidth, options->metatileHeight, &image, !image.hasPalette);
 
     FreeImage(&image);
 }
@@ -58,10 +59,13 @@ void ConvertPngToGba(char *inputPath, char *outputPath, int numTiles, int bitDep
 void HandleGbaToPngCommand(char *inputPath, char *outputPath, int argc, char **argv)
 {
     char *inputFileExtension = GetFileExtension(inputPath);
-    int bitDepth = inputFileExtension[0] - '0';
-    char *paletteFilePath = NULL;
-    bool hasTransparency = false;
-    int width = 1;
+    struct GbaToPngOptions options;
+    options.paletteFilePath = NULL;
+    options.bitDepth = inputFileExtension[0] - '0';
+    options.hasTransparency = false;
+    options.width = 1;
+    options.metatileWidth = 1;
+    options.metatileHeight = 1;
 
     for (int i = 3; i < argc; i++)
     {
@@ -74,11 +78,11 @@ void HandleGbaToPngCommand(char *inputPath, char *outputPath, int argc, char **a
 
             i++;
 
-            paletteFilePath = argv[i];
+            options.paletteFilePath = argv[i];
         }
         else if (strcmp(option, "-object") == 0)
         {
-            hasTransparency = true;
+            options.hasTransparency = true;
         }
         else if (strcmp(option, "-width") == 0)
         {
@@ -87,11 +91,37 @@ void HandleGbaToPngCommand(char *inputPath, char *outputPath, int argc, char **a
 
             i++;
 
-            if (!ParseNumber(argv[i], NULL, 10, &width))
+            if (!ParseNumber(argv[i], NULL, 10, &options.width))
                 FATAL_ERROR("Failed to parse width.\n");
 
-            if (width < 1)
+            if (options.width < 1)
                 FATAL_ERROR("Width must be positive.\n");
+        }
+        else if (strcmp(option, "-mwidth") == 0)
+        {
+            if (i + 1 >= argc)
+                FATAL_ERROR("No metatile width value following \"-mwidth\".\n");
+
+            i++;
+
+            if (!ParseNumber(argv[i], NULL, 10, &options.metatileWidth))
+                FATAL_ERROR("Failed to parse metatile width.\n");
+
+            if (options.metatileWidth < 1)
+                FATAL_ERROR("metatile width must be positive.\n");
+        }
+        else if (strcmp(option, "-mheight") == 0)
+        {
+            if (i + 1 >= argc)
+                FATAL_ERROR("No metatile height value following \"-mheight\".\n");
+
+            i++;
+
+            if (!ParseNumber(argv[i], NULL, 10, &options.metatileHeight))
+                FATAL_ERROR("Failed to parse metatile height.\n");
+
+            if (options.metatileHeight < 1)
+                FATAL_ERROR("metatile height must be positive.\n");
         }
         else
         {
@@ -99,14 +129,21 @@ void HandleGbaToPngCommand(char *inputPath, char *outputPath, int argc, char **a
         }
     }
 
-    ConvertGbaToPng(inputPath, outputPath, width, bitDepth, paletteFilePath, hasTransparency);
+    if (options.metatileWidth > options.width)
+        options.width = options.metatileWidth;
+
+    ConvertGbaToPng(inputPath, outputPath, &options);
 }
 
 void HandlePngToGbaCommand(char *inputPath, char *outputPath, int argc, char **argv)
 {
     char *outputFileExtension = GetFileExtension(outputPath);
     int bitDepth = outputFileExtension[0] - '0';
-    int numTiles = 0;
+    struct PngToGbaOptions options;
+    options.numTiles = 0;
+    options.bitDepth = bitDepth;
+    options.metatileWidth = 1;
+    options.metatileHeight = 1;
 
     for (int i = 3; i < argc; i++)
     {
@@ -119,11 +156,37 @@ void HandlePngToGbaCommand(char *inputPath, char *outputPath, int argc, char **a
 
             i++;
 
-            if (!ParseNumber(argv[i], NULL, 10, &numTiles))
+            if (!ParseNumber(argv[i], NULL, 10, &options.numTiles))
                 FATAL_ERROR("Failed to parse number of tiles.\n");
 
-            if (numTiles < 1)
+            if (options.numTiles < 1)
                 FATAL_ERROR("Number of tiles must be positive.\n");
+        }
+        else if (strcmp(option, "-mwidth") == 0)
+        {
+            if (i + 1 >= argc)
+                FATAL_ERROR("No metatile width value following \"-mwidth\".\n");
+
+            i++;
+
+            if (!ParseNumber(argv[i], NULL, 10, &options.metatileWidth))
+                FATAL_ERROR("Failed to parse metatile width.\n");
+
+            if (options.metatileWidth < 1)
+                FATAL_ERROR("metatile width must be positive.\n");
+        }
+        else if (strcmp(option, "-mheight") == 0)
+        {
+            if (i + 1 >= argc)
+                FATAL_ERROR("No metatile height value following \"-mheight\".\n");
+
+            i++;
+
+            if (!ParseNumber(argv[i], NULL, 10, &options.metatileHeight))
+                FATAL_ERROR("Failed to parse metatile height.\n");
+
+            if (options.metatileHeight < 1)
+                FATAL_ERROR("metatile height must be positive.\n");
         }
         else
         {
@@ -131,7 +194,7 @@ void HandlePngToGbaCommand(char *inputPath, char *outputPath, int argc, char **a
         }
     }
 
-    ConvertPngToGba(inputPath, outputPath, numTiles, bitDepth);
+    ConvertPngToGba(inputPath, outputPath, &options);
 }
 
 void HandlePngToGbaPaletteCommand(char *inputPath, char *outputPath, int argc UNUSED, char **argv UNUSED)

--- a/tools/gbagfx/options.h
+++ b/tools/gbagfx/options.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2018 huderlem
+
+#ifndef OPTIONS_H
+#define OPTIONS_H
+
+#include <stdbool.h>
+
+struct GbaToPngOptions {
+    char *paletteFilePath;
+    int bitDepth;
+    bool hasTransparency;
+    int width;
+    int metatileWidth;
+    int metatileHeight;
+};
+
+struct PngToGbaOptions {
+    int numTiles;
+    int bitDepth;
+    int metatileWidth;
+    int metatileHeight;
+};
+
+#endif // OPTIONS_H


### PR DESCRIPTION
This is supported for `.1bpp`, `.4bpp`, and `.8bpp`.

When converting from or to `.png`, you can now specify the `-mwidth` and `-mheight` options to control the metatile dimensions in the image.  This feature allows spritesheets to be created since images won't be processed linearly.  Metatile dimensions are specified in number of tiles, not pixels.

For example, to properly convert brendan's spritesheet from this image, you would use the following arguments:
![00](https://user-images.githubusercontent.com/2229288/45172852-26f78300-b1cc-11e8-95e9-e93b1933ee18.png)
```
gbagfx.exe brendan_normal.png brendan_normal.4bpp -mwidth 2 -mheight 4
```