### PR TITLE
adds constants, cleans up callstd and msgbox code

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -50,6 +50,12 @@
 	.byte \function
 	.endm
 
+	@ callstd function names
+	STD_OBTAIN_ITEM = 0
+	STD_FIND_ITEM = 1
+	STD_OBTAIN_DECORATION = 7
+	STD_REGISTER_MATCH_CALL = 8
+
 	@ Calls the standard function at index function.
 	.macro callstd function
 	.byte 0x09
@@ -262,7 +268,7 @@
 	.2byte \output
 	.2byte SPECIAL_\function
 	.endm
-	
+
 	@ temporary solution
 	.macro specialvar_ output, functionId
 	.byte 0x26
@@ -1523,16 +1529,20 @@
 	goto_eq \dest
 	.endm
 
-	.macro msgbox text, type=4
-	loadword 0, \text
-	callstd \type
-	.endm
-
 	@ Message box types
+	MSGBOX_NPC = 2
+	MSGBOX_SIGN = 3
+	MSGBOX_DEFAULT = 4
 	MSGBOX_YESNO = 5
+	MSGBOX_AUTOCLOSE = 6
 
 	YES = 1
 	NO  = 0
+
+	.macro msgbox text, type=MSGBOX_DEFAULT
+	loadword 0, \text
+	callstd \type
+	.endm
 
 	.macro giveitem_std item, amount=1, function=0
 	setorcopyvar 0x8000, \item
@@ -1542,5 +1552,5 @@
 
 	.macro givedecoration_std decoration
 	setorcopyvar 0x8000, \decoration
-	callstd 7
+	callstd STD_OBTAIN_DECORATION
 	.endm

--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1554,3 +1554,10 @@
 	setorcopyvar 0x8000, \decoration
 	callstd STD_OBTAIN_DECORATION
 	.endm
+
+	.macro register_matchcall trainer
+	setvar VAR_0x8004, \trainer
+	special SetMatchCallRegisteredFlag
+	setorcopyvar VAR_0x8000, \trainer
+	callstd STD_REGISTER_MATCH_CALL
+	.endm

--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -47,11 +47,11 @@ gSpecialVars:: @ 81DBA0C
 gStdScripts:: @ 81DC2A0
 	.4byte Std_ObtainItem
 	.4byte Std_FindItem
-	.4byte Std_2
-	.4byte Std_3
-	.4byte Std_4
-	.4byte Std_5
-	.4byte Std_6
+	.4byte Std_MsgboxNPC
+	.4byte Std_MsgboxSign
+	.4byte Std_MsgboxDefault
+	.4byte Std_MsgboxYesNo
+	.4byte Std_MsgboxAutoclose
 	.4byte Std_ObtainDecoration
 	.4byte Std_RegisteredInMatchCall
 	.4byte Std_9
@@ -478,7 +478,7 @@ EventScript_23B531:: @ 823B531
 	end
 
 EventScript_23B568:: @ 823B568
-	msgbox Text_2766AA, 5
+	msgbox Text_2766AA, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq EventScript_23B4D3
 	closemessage
@@ -530,34 +530,34 @@ EventScript_23B5F0:: @ 823B5F0
 	compare VAR_RESULT, 2
 	goto_eq EventScript_23B652
 	special sub_80E980C
-	msgbox Text_276707, 5
+	msgbox Text_276707, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq EventScript_23B5A1
-	msgbox Text_2767D1, 3
+	msgbox Text_2767D1, MSGBOX_SIGN
 	special sub_80E9C2C
 	special sub_80FA57C
 	releaseall
 	end
 
 EventScript_23B62F:: @ 823B62F
-	msgbox Text_276731, 5
+	msgbox Text_276731, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq EventScript_23B5A1
-	msgbox Text_2767E9, 3
+	msgbox Text_2767E9, MSGBOX_SIGN
 	special sub_80E9C2C
 	special sub_80FA57C
 	releaseall
 	end
 
 EventScript_23B652:: @ 823B652
-	msgbox Text_27676F, 3
+	msgbox Text_27676F, MSGBOX_SIGN
 	special sub_80FA57C
 	closemessage
 	releaseall
 	end
 
 EventScript_23B660:: @ 823B660
-	msgbox Text_276835, 4
+	msgbox Text_276835, MSGBOX_DEFAULT
 	goto EventScript_23B5A1
 	end
 
@@ -602,19 +602,19 @@ EventScript_SecretBaseShieldOrToyTV:: @ 823B68C
 	end
 
 EventScript_23B6BC:: @ 823B6BC
-	msgbox Text_27692B, 3
+	msgbox Text_27692B, MSGBOX_SIGN
 	end
 
 EventScript_23B6C5:: @ 823B6C5
-	msgbox Text_276974, 3
+	msgbox Text_276974, MSGBOX_SIGN
 	end
 
 EventScript_23B6CE:: @ 823B6CE
-	msgbox Text_2769B8, 3
+	msgbox Text_2769B8, MSGBOX_SIGN
 	end
 
 EventScript_23B6D7:: @ 823B6D7
-	msgbox Text_2769FF, 3
+	msgbox Text_2769FF, MSGBOX_SIGN
 	end
 
 gText_23B6E0:: @ 823B6E0
@@ -779,7 +779,7 @@ SecretBase_RedCave1_Text_23B759: @ 823B759
 	.include "data/maps/Route119_House/scripts.inc"
 	.include "data/maps/Route124_DivingTreasureHuntersHouse/scripts.inc"
 
-Std_2: @ 8271315
+Std_MsgboxNPC: @ 8271315
 	lock
 	faceplayer
 	message 0x0
@@ -788,7 +788,7 @@ Std_2: @ 8271315
 	release
 	return
 
-Std_3: @ 8271320
+Std_MsgboxSign: @ 8271320
 	lockall
 	message 0x0
 	waitmessage
@@ -796,13 +796,13 @@ Std_3: @ 8271320
 	releaseall
 	return
 
-Std_4: @ 827132A
+Std_MsgboxDefault: @ 827132A
 	message 0x0
 	waitmessage
 	waitbuttonpress
 	return
 
-Std_5: @ 8271332
+Std_MsgboxYesNo: @ 8271332
 	message 0x0
 	waitmessage
 	yesnobox 20, 8
@@ -981,7 +981,7 @@ EventScript_271491:: @ 8271491
 	releaseall
 	end
 
-Std_6:: @ 8271494
+Std_MsgboxAutoclose:: @ 8271494
 	message 0x0
 	waitmessage
 	waitbuttonpress
@@ -1401,7 +1401,7 @@ VerdanturfTown_PokemonCenter_1F_EventScript_27191E:: @ 827191E
 	specialvar VAR_RESULT, sub_80C2E40
 	compare VAR_RESULT, 4
 	goto_eq OldaleTown_PokemonCenter_1F_EventScript_271A68
-	msgbox gUnknown_082726EB, 5
+	msgbox gUnknown_082726EB, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq OldaleTown_PokemonCenter_1F_EventScript_27195A
 	compare VAR_RESULT, 0
@@ -1476,7 +1476,7 @@ OldaleTown_PokemonCenter_1F_EventScript_271A03:: @ 8271A03
 OldaleTown_PokemonCenter_1F_EventScript_271A19:: @ 8271A19
 	checkflag FLAG_0x880
 	goto_eq OldaleTown_PokemonCenter_1F_EventScript_2719E2
-	msgbox gUnknown_08272798, 4
+	msgbox gUnknown_08272798, MSGBOX_DEFAULT
 	setflag FLAG_0x880
 	message OldaleTown_PokemonCenter_1F_Text_278A48
 	waitmessage
@@ -1502,20 +1502,20 @@ OldaleTown_PokemonCenter_1F_EventScript_271A68:: @ 8271A68
 	checkflag FLAG_0x159
 	goto_eq OldaleTown_PokemonCenter_1F_EventScript_271AAC
 	setflag FLAG_0x159
-	msgbox gUnknown_082727F5, 4
+	msgbox gUnknown_082727F5, MSGBOX_DEFAULT
 	playse SE_PIN
 	applymovement VAR_0x800B, OldaleTown_PokemonCenter_1F_Movement_272598
 	waitmovement 0
 	applymovement VAR_0x800B, OldaleTown_PokemonCenter_1F_Movement_27259A
 	waitmovement 0
-	msgbox gUnknown_08272860, 5
+	msgbox gUnknown_08272860, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq OldaleTown_PokemonCenter_1F_EventScript_271AC5
 	message gUnknown_08272A07
 	return
 
 OldaleTown_PokemonCenter_1F_EventScript_271AAC:: @ 8271AAC
-	msgbox gUnknown_08272982, 5
+	msgbox gUnknown_08272982, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq OldaleTown_PokemonCenter_1F_EventScript_271AC5
 	message gUnknown_08272A07
@@ -1589,7 +1589,7 @@ EventScript_271B85:: @ 8271B85
 EventScript_271B95:: @ 8271B95
 	message gUnknown_08272A78
 	waitfanfare
-	msgbox gUnknown_08272A9A, 4
+	msgbox gUnknown_08272A9A, MSGBOX_DEFAULT
 	setvar VAR_RESULT, 1
 	return
 
@@ -1623,7 +1623,7 @@ EventScript_271BE0:: @ 8271BE0
 	playfanfare MUS_FANFA4
 	message gUnknown_08272B09
 	waitfanfare
-	msgbox gUnknown_08272B48, 4
+	msgbox gUnknown_08272B48, MSGBOX_DEFAULT
 	setvar VAR_RESULT, 1
 	return
 
@@ -1665,11 +1665,11 @@ EventScript_271C3A:: @ 8271C3A
 	special CallBattlePyramidFunction
 	compare VAR_RESULT, 1
 	goto_eq EventScript_271C86
-	msgbox gUnknown_08272A9A, 4
+	msgbox gUnknown_08272A9A, MSGBOX_DEFAULT
 	return
 
 EventScript_271C86:: @ 8271C86
-	msgbox gUnknown_08272AEA, 4
+	msgbox gUnknown_08272AEA, MSGBOX_DEFAULT
 	return
 
 EventScript_271C8F:: @ 8271C8F
@@ -1682,8 +1682,8 @@ EventScript_271C9B:: @ 8271C9B
 	return
 
 EventScript_271CA1:: @ 8271CA1
-	msgbox gUnknown_08272A78, 4
-	msgbox gUnknown_08272AD0, 4
+	msgbox gUnknown_08272A78, MSGBOX_DEFAULT
+	msgbox gUnknown_08272AD0, MSGBOX_DEFAULT
 	setvar VAR_RESULT, 0
 	return
 
@@ -1727,15 +1727,15 @@ EventScript_271D2A:: @ 8271D2A
 	waitfanfare
 	bufferitemnameplural 1, VAR_0x8004, 1
 	copyvar VAR_0x8004, VAR_0x8008
-	msgbox gUnknown_08272A9A, 4
+	msgbox gUnknown_08272A9A, MSGBOX_DEFAULT
 	special sub_80EDCE8
 	special SetFlagInVar
 	releaseall
 	end
 
 EventScript_271D47:: @ 8271D47
-	msgbox gUnknown_08272ABF, 4
-	msgbox gUnknown_08272AD0, 4
+	msgbox gUnknown_08272ABF, MSGBOX_DEFAULT
+	msgbox gUnknown_08272AD0, MSGBOX_DEFAULT
 	setvar VAR_RESULT, 0
 	releaseall
 	end
@@ -1743,7 +1743,7 @@ EventScript_271D47:: @ 8271D47
 EventScript_271D5E:: @ 8271D5E
 	lock
 	faceplayer
-	msgbox Text_27260D, 5
+	msgbox Text_27260D, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq EventScript_271D83
 	compare VAR_RESULT, 0
@@ -1768,7 +1768,7 @@ EventScript_PC:: @ 8271D92
 	setvar VAR_0x8004, 0
 	special DoPCTurnOnEffect
 	playse SE_PC_ON
-	msgbox Text_27265A, 4
+	msgbox Text_27265A, MSGBOX_DEFAULT
 	goto EventScript_271DAC
 	end
 
@@ -1791,7 +1791,7 @@ EventScript_271DBC:: @ 8271DBC
 
 EventScript_271DF9:: @ 8271DF9
 	playse SE_PC_LOGIN
-	msgbox gUnknown_082726C2, 4
+	msgbox gUnknown_082726C2, MSGBOX_DEFAULT
 	special PlayerPC
 	waitstate
 	goto EventScript_271DAC
@@ -1803,18 +1803,18 @@ EventScript_271E0E:: @ 8271E0E
 	call_if 0, EventScript_271E35
 	checkflag FLAG_SYS_PC_LANETTE
 	call_if 1, EventScript_271E3E
-	msgbox gUnknown_082726A3, 4
+	msgbox gUnknown_082726A3, MSGBOX_DEFAULT
 	special ShowPokemonStorageSystem
 	waitstate
 	goto EventScript_271DAC
 	end
 
 EventScript_271E35:: @ 8271E35
-	msgbox gUnknown_0827268C, 4
+	msgbox gUnknown_0827268C, MSGBOX_DEFAULT
 	return
 
 EventScript_271E3E:: @ 8271E3E
-	msgbox gUnknown_082726D4, 4
+	msgbox gUnknown_082726D4, MSGBOX_DEFAULT
 	return
 
 EventScript_271E47:: @ 8271E47
@@ -1845,7 +1845,7 @@ RustboroCity_EventScript_271E6A:: @ 8271E6A
 SlateportCity_EventScript_271E6A:: @ 8271E6A
 SootopolisCity_EventScript_271E6A:: @ 8271E6A
 VerdanturfTown_EventScript_271E6A:: @ 8271E6A
-	msgbox gUnknown_08272B6A, 3
+	msgbox gUnknown_08272B6A, MSGBOX_SIGN
 	end
 
 BattleFrontier_OutsideEast_EventScript_271E73:: @ 8271E73
@@ -1864,7 +1864,7 @@ RustboroCity_EventScript_271E73:: @ 8271E73
 SlateportCity_EventScript_271E73:: @ 8271E73
 SootopolisCity_EventScript_271E73:: @ 8271E73
 VerdanturfTown_EventScript_271E73:: @ 8271E73
-	msgbox gUnknown_08272B9E, 3
+	msgbox gUnknown_08272B9E, MSGBOX_SIGN
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_271E7C:: @ 8271E7C
@@ -1911,10 +1911,10 @@ EventScript_UseSurf:: @ 8271EA0
 	bufferpartymonnick 0, VAR_RESULT
 	setfieldeffectargument 0, VAR_RESULT
 	lockall
-	msgbox gUnknown_08272FD6, 5
+	msgbox gUnknown_08272FD6, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq EventScript_271ED5
-	msgbox gUnknown_0827300D, 4
+	msgbox gUnknown_0827300D, MSGBOX_DEFAULT
 	dofieldeffect FLDEFF_USE_SURF
 
 EventScript_271ED5:: @ 8271ED5
@@ -2129,7 +2129,7 @@ SootopolisCity_EventScript_272054:: @ 8272054
 SootopolisCity_Gym_1F_EventScript_272054:: @ 8272054
 SootopolisCity_House1_EventScript_272054:: @ 8272054
 VerdanturfTown_BattleTentLobby_EventScript_272054:: @ 8272054
-	msgbox gUnknown_08272AD0, 4
+	msgbox gUnknown_08272AD0, MSGBOX_DEFAULT
 	release
 	end
 
@@ -2146,11 +2146,11 @@ Route110_TrickHouseEnd_EventScript_27205E:: @ 827205E
 Route110_TrickHouseEntrance_EventScript_27205E:: @ 827205E
 Route113_GlassWorkshop_EventScript_27205E:: @ 827205E
 SootopolisCity_Gym_1F_EventScript_27205E:: @ 827205E
-	msgbox gUnknown_08272AD0, 4
+	msgbox gUnknown_08272AD0, MSGBOX_DEFAULT
 	return
 
 Route114_LanettesHouse_EventScript_272067:: @ 8272067
-	msgbox gUnknown_08272B1A, 4
+	msgbox gUnknown_08272B1A, MSGBOX_DEFAULT
 	release
 	end
 
@@ -2159,7 +2159,7 @@ MauvilleCity_GameCorner_EventScript_272071:: @ 8272071
 Route110_TrickHouseEnd_EventScript_272071:: @ 8272071
 Route110_TrickHouseEntrance_EventScript_272071:: @ 8272071
 Route113_GlassWorkshop_EventScript_272071:: @ 8272071
-	msgbox gUnknown_08272B1A, 4
+	msgbox gUnknown_08272B1A, MSGBOX_DEFAULT
 	return
 
 EverGrandeCity_EventScript_27207A:: @ 827207A
@@ -2205,7 +2205,7 @@ SSTidalRooms_EventScript_272083:: @ 8272083
 
 EventScript_RegionMap:: @ 827208F
 	lockall
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F8820, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F8820, MSGBOX_DEFAULT
 	fadescreen 1
 	special FieldShowRegionMap
 	waitstate
@@ -2283,7 +2283,7 @@ Route103_EventScript_272141:: @ 8272141
 	goto_if 0, Route101_EventScript_1FA2D2
 
 Route101_EventScript_272155:: @ 8272155
-	msgbox gUnknown_082A5C9C, 5
+	msgbox gUnknown_082A5C9C, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route101_EventScript_27216F
 	call Route101_EventScript_272184
@@ -2291,7 +2291,7 @@ Route101_EventScript_272155:: @ 8272155
 	end
 
 Route101_EventScript_27216F:: @ 827216F
-	msgbox Route101_Text_2A5CEB, 4
+	msgbox Route101_Text_2A5CEB, MSGBOX_DEFAULT
 	release
 	end
 
@@ -2311,7 +2311,7 @@ Route101_EventScript_272184:: @ 8272184
 	copyvar VAR_0x800A, VAR_RESULT
 	buffernumberstring 0, VAR_0x8008
 	buffernumberstring 1, VAR_0x8009
-	msgbox gUnknown_082A5D2C, 4
+	msgbox gUnknown_082A5D2C, MSGBOX_DEFAULT
 	call Route101_EventScript_272179
 	compare VAR_0x800A, 0
 	goto_eq Route101_EventScript_27374E
@@ -2321,7 +2321,7 @@ Route101_EventScript_272184:: @ 8272184
 	copyvar VAR_0x8009, VAR_0x8006
 	buffernumberstring 0, VAR_0x8008
 	buffernumberstring 1, VAR_0x8009
-	msgbox gUnknown_082A633D, 4
+	msgbox gUnknown_082A633D, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_OutsideWest_EventScript_2721E2:: @ 82721E2
@@ -2494,19 +2494,19 @@ Route120_EventScript_272336:: @ 8272336
 	checkitem ITEM_DEVON_SCOPE, 1
 	compare VAR_RESULT, 1
 	goto_eq Route119_EventScript_272350
-	msgbox Route119_Text_1F5D00, 4
+	msgbox Route119_Text_1F5D00, MSGBOX_DEFAULT
 	release
 	end
 
 Route119_EventScript_272350:: @ 8272350
-	msgbox Route119_Text_1F5D23, 5
+	msgbox Route119_Text_1F5D23, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route119_EventScript_272365
 	release
 	end
 
 Route119_EventScript_272365:: @ 8272365
-	msgbox Route119_Text_1F5D63, 4
+	msgbox Route119_Text_1F5D63, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, Route119_Movement_27259E
 	waitmovement 0
@@ -3077,31 +3077,31 @@ Movement_2725CB:: @ 82725CB
 	step_end
 
 EventScript_PictureBookShelf:: @ 82725CE
-	msgbox Text_2A81E5, 3
+	msgbox Text_2A81E5, MSGBOX_SIGN
 	end
 
 EventScript_BookShelf:: @ 82725D7
-	msgbox Text_2A820D, 3
+	msgbox Text_2A820D, MSGBOX_SIGN
 	end
 
 EventScript_PokemonCenterBookshelf:: @ 82725E0
-	msgbox Text_2A8232, 3
+	msgbox Text_2A8232, MSGBOX_SIGN
 	end
 
 EventScript_Vase:: @ 82725E9
-	msgbox Text_2A8276, 3
+	msgbox Text_2A8276, MSGBOX_SIGN
 	end
 
 EventScript_TrashCan:: @ 82725F2
-	msgbox Text_2A82B3, 3
+	msgbox Text_2A82B3, MSGBOX_SIGN
 	end
 
 EventScript_ShopShelf:: @ 82725FB
-	msgbox Text_2A82BF, 3
+	msgbox Text_2A82BF, MSGBOX_SIGN
 	end
 
 EventScript_Blueprint:: @ 8272604
-	msgbox Text_2A82F7, 3
+	msgbox Text_2A82F7, MSGBOX_SIGN
 	end
 
 Text_27260D: @ 827260D
@@ -3321,7 +3321,7 @@ gUnknown_08273684:: @ 8273684
 	.string "The intense sunshine appears to\nhave subsided…$"
 
 EventScript_2736B3:: @ 82736B3
-	msgbox gUnknown_08272C98, 3
+	msgbox gUnknown_08272C98, MSGBOX_SIGN
 	end
 
 EventScript_Poison:: @ 82736BC
@@ -3497,7 +3497,7 @@ TerraCave_End_EventScript_273776:: @ 8273776
 	removeobject VAR_LAST_TALKED
 	fadescreenswapbuffers 0
 	bufferspeciesname 0, VAR_0x8004
-	msgbox gUnknown_08273204, 4
+	msgbox gUnknown_08273204, MSGBOX_DEFAULT
 	release
 	end
 
@@ -3537,39 +3537,39 @@ LittlerootTown_ProfessorBirchsLab_EventScript_2737BB:: @ 82737BB
 	specialvar VAR_RESULT, sub_813B21C
 	compare VAR_RESULT, 1
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_2737D4
-	msgbox gText_PkmnTransferredSomeonesPC, 4
+	msgbox gText_PkmnTransferredSomeonesPC, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_2737D4:: @ 82737D4
 	specialvar VAR_RESULT, get_unknown_box_id
 	bufferboxname 2, 32781
-	msgbox gText_PkmnBoxSomeonesPCFull, 4
+	msgbox gText_PkmnBoxSomeonesPCFull, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_2737E6:: @ 82737E6
 	specialvar VAR_RESULT, sub_813B21C
 	compare VAR_RESULT, 1
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_2737FF
-	msgbox gText_PkmnTransferredLanettesPC, 4
+	msgbox gText_PkmnTransferredLanettesPC, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_2737FF:: @ 82737FF
 	specialvar VAR_RESULT, get_unknown_box_id
 	bufferboxname 2, 32781
-	msgbox gText_PkmnBoxLanettesPCFull, 4
+	msgbox gText_PkmnBoxLanettesPCFull, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_273811:: @ 8273811
 MossdeepCity_StevensHouse_EventScript_273811:: @ 8273811
 Route119_WeatherInstitute_2F_EventScript_273811:: @ 8273811
 RustboroCity_DevonCorp_2F_EventScript_273811:: @ 8273811
-	msgbox gUnknown_0827331C, 4
+	msgbox gUnknown_0827331C, MSGBOX_DEFAULT
 	release
 	end
 
 EventScript_Questionnaire:: @ 827381B
 	lockall
-	msgbox gUnknown_0827339F, 5
+	msgbox gUnknown_0827339F, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq EventScript_2738FD
 	setvar VAR_0x8004, 20
@@ -3599,9 +3599,9 @@ EventScript_27386D:: @ 827386D
 	waitmovement 0
 	applymovement VAR_0x8008, BattleFrontier_ReceptionGate_Movement_27259A
 	waitmovement 0
-	msgbox gUnknown_08273506, 4
+	msgbox gUnknown_08273506, MSGBOX_DEFAULT
 	setflag FLAG_SYS_MYSTERY_EVENT_ENABLE
-	msgbox gUnknown_08273559, 4
+	msgbox gUnknown_08273559, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -3617,9 +3617,9 @@ EventScript_2738B5:: @ 82738B5
 	waitmovement 0
 	applymovement VAR_0x8008, BattleFrontier_ReceptionGate_Movement_27259A
 	waitmovement 0
-	msgbox gUnknown_08273446, 4
+	msgbox gUnknown_08273446, MSGBOX_DEFAULT
 	setflag FLAG_SYS_MYSTERY_GIFT_ENABLE
-	msgbox gUnknown_082734CC, 4
+	msgbox gUnknown_082734CC, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -3630,7 +3630,7 @@ EventScript_2738FD:: @ 82738FD
 EventScript_2738FF:: @ 82738FF
 	applymovement VAR_0x8008, BattleFrontier_Mart_Movement_2725B0
 	waitmovement 0
-	msgbox gUnknown_082733D8, 4
+	msgbox gUnknown_082733D8, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -3843,12 +3843,12 @@ Route105_EventScript_273D31:: @ 8273D31
 	end
 
 Route105_EventScript_273D51:: @ 8273D51
-	msgbox gUnknown_08273656, 4
+	msgbox gUnknown_08273656, MSGBOX_DEFAULT
 	goto Route105_EventScript_273D31
 	end
 
 Route105_EventScript_273D5F:: @ 8273D5F
-	msgbox gUnknown_08273684, 4
+	msgbox gUnknown_08273684, MSGBOX_DEFAULT
 	goto Route105_EventScript_273D31
 	end
 
@@ -4085,7 +4085,7 @@ Std_RegisteredInMatchCall:: @ 82742C9
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox gUnknown_08272E0F, 4
+	msgbox gUnknown_08272E0F, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
@@ -4443,10 +4443,10 @@ EventScript_275A50:: @ 8275A50
 	compare VAR_RESULT, 6
 	goto_eq EventScript_275A91
 	bufferpartymonnick 0, VAR_RESULT
-	msgbox gText_23B704, 5
+	msgbox gText_23B704, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq EventScript_275CDE
-	msgbox Route103_Text_290771, 4
+	msgbox Route103_Text_290771, MSGBOX_DEFAULT
 	closemessage
 	dofieldeffect FLDEFF_USE_SECRET_POWER_CAVE
 	waitstate
@@ -4461,12 +4461,12 @@ EventScript_275A86:: @ 8275A86
 	end
 
 EventScript_275A91:: @ 8275A91
-	msgbox gText_23B6E0, 4
+	msgbox gText_23B6E0, MSGBOX_DEFAULT
 	releaseall
 	end
 
 EventScript_275A9B:: @ 8275A9B
-	msgbox gText_23B73E, 4
+	msgbox gText_23B73E, MSGBOX_DEFAULT
 	goto EventScript_275B5B
 	end
 
@@ -4475,10 +4475,10 @@ EventScript_275AA9:: @ 8275AA9
 	compare VAR_RESULT, 6
 	goto_eq EventScript_275AEA
 	bufferpartymonnick 0, VAR_RESULT
-	msgbox Text_274779, 5
+	msgbox Text_274779, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq EventScript_275CDE
-	msgbox Route103_Text_290771, 4
+	msgbox Route103_Text_290771, MSGBOX_DEFAULT
 	closemessage
 	dofieldeffect FLDEFF_USE_SECRET_POWER_TREE
 	waitstate
@@ -4493,12 +4493,12 @@ EventScript_275ADF:: @ 8275ADF
 	end
 
 EventScript_275AEA:: @ 8275AEA
-	msgbox Text_274746, 4
+	msgbox Text_274746, MSGBOX_DEFAULT
 	releaseall
 	end
 
 EventScript_275AF4:: @ 8275AF4
-	msgbox Text_2747C2, 4
+	msgbox Text_2747C2, MSGBOX_DEFAULT
 	goto EventScript_275B5B
 	end
 
@@ -4507,10 +4507,10 @@ EventScript_275B02:: @ 8275B02
 	compare VAR_RESULT, 6
 	goto_eq EventScript_275B43
 	bufferpartymonnick 0, VAR_RESULT
-	msgbox Text_274825, 5
+	msgbox Text_274825, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq EventScript_275CDE
-	msgbox Route103_Text_290771, 4
+	msgbox Route103_Text_290771, MSGBOX_DEFAULT
 	closemessage
 	dofieldeffect FLDEFF_USE_SECRET_POWER_SHRUB
 	waitstate
@@ -4525,12 +4525,12 @@ EventScript_275B38:: @ 8275B38
 	end
 
 EventScript_275B43:: @ 8275B43
-	msgbox Text_2747DD, 4
+	msgbox Text_2747DD, MSGBOX_DEFAULT
 	releaseall
 	end
 
 EventScript_275B4D:: @ 8275B4D
-	msgbox Text_274883, 4
+	msgbox Text_274883, MSGBOX_DEFAULT
 	goto EventScript_275B5B
 	end
 
@@ -4552,7 +4552,7 @@ SecretBase_RedCave1_EventScript_275B81:: @ 8275B81
 	applymovement 255, SecretBase_RedCave1_Movement_275BB4
 	waitmovement 0
 	setvar VAR_0x4097, 1
-	msgbox SecretBase_RedCave1_Text_23B759, 5
+	msgbox SecretBase_RedCave1_Text_23B759, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq SecretBase_RedCave1_EventScript_275BAB
 	closemessage
@@ -4600,22 +4600,22 @@ EventScript_275BE8:: @ 8275BE8
 	setorcopyvar VAR_0x8004, VAR_RESULT
 	lockall
 	special GetSecretBaseNearbyMapName
-	msgbox Text_276A3D, 5
+	msgbox Text_276A3D, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq EventScript_275CDE
-	msgbox Text_2766AA, 5
+	msgbox Text_2766AA, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq EventScript_275CDE
 	fadescreenswapbuffers 1
 	special sub_80E9B70
 	closemessage
 	fadescreenswapbuffers 0
-	msgbox Text_276A95, 5
+	msgbox Text_276A95, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq EventScript_275CDE
 	bufferpartymonnick 0, VAR_0x8004
 	buffermovename 1, MOVE_SECRET_POWER
-	msgbox Route103_Text_290771, 4
+	msgbox Route103_Text_290771, MSGBOX_DEFAULT
 	closemessage
 	closemessage
 	compare VAR_0x8007, 1
@@ -4763,7 +4763,7 @@ SecretBase_RedCave1_EventScript_275DD6:: @ 8275DD6
 	goto_if 0, SecretBase_RedCave1_EventScript_275E25
 	compare VAR_RESULT, 1
 	goto_eq SecretBase_RedCave1_EventScript_275E44
-	msgbox SecretBase_RedCave1_Text_2748A0, 5
+	msgbox SecretBase_RedCave1_Text_2748A0, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_275E2F
 	setvar VAR_RESULT, 1
@@ -4771,12 +4771,12 @@ SecretBase_RedCave1_EventScript_275DD6:: @ 8275DD6
 	call SecretBase_RedCave1_EventScript_27134F
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_275E2F
-	msgbox SecretBase_RedCave1_Text_274939, 4
+	msgbox SecretBase_RedCave1_Text_274939, MSGBOX_DEFAULT
 	goto SecretBase_RedCave1_EventScript_276286
 	end
 
 SecretBase_RedCave1_EventScript_275E25:: @ 8275E25
-	msgbox SecretBase_RedCave1_Text_2749ED, 4
+	msgbox SecretBase_RedCave1_Text_2749ED, MSGBOX_DEFAULT
 	release
 	end
 
@@ -4784,12 +4784,12 @@ SecretBase_RedCave1_EventScript_275E2F:: @ 8275E2F
 	special sub_80EB300
 	setvar VAR_RESULT, 0
 	special sub_80EA30C
-	msgbox SecretBase_RedCave1_Text_27494D, 4
+	msgbox SecretBase_RedCave1_Text_27494D, MSGBOX_DEFAULT
 	release
 	end
 
 SecretBase_RedCave1_EventScript_275E44:: @ 8275E44
-	msgbox SecretBase_RedCave1_Text_2749AA, 4
+	msgbox SecretBase_RedCave1_Text_2749AA, MSGBOX_DEFAULT
 	release
 	end
 
@@ -4800,7 +4800,7 @@ SecretBase_RedCave1_EventScript_275E4E:: @ 8275E4E
 	goto_if 0, SecretBase_RedCave1_EventScript_275E9D
 	compare VAR_RESULT, 1
 	goto_eq SecretBase_RedCave1_EventScript_275EBC
-	msgbox SecretBase_RedCave1_Text_274C13, 5
+	msgbox SecretBase_RedCave1_Text_274C13, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_275EA7
 	setvar VAR_RESULT, 1
@@ -4808,12 +4808,12 @@ SecretBase_RedCave1_EventScript_275E4E:: @ 8275E4E
 	call SecretBase_RedCave1_EventScript_27134F
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_275EA7
-	msgbox SecretBase_RedCave1_Text_274CB0, 4
+	msgbox SecretBase_RedCave1_Text_274CB0, MSGBOX_DEFAULT
 	goto SecretBase_RedCave1_EventScript_276286
 	end
 
 SecretBase_RedCave1_EventScript_275E9D:: @ 8275E9D
-	msgbox SecretBase_RedCave1_Text_274D69, 4
+	msgbox SecretBase_RedCave1_Text_274D69, MSGBOX_DEFAULT
 	release
 	end
 
@@ -4821,12 +4821,12 @@ SecretBase_RedCave1_EventScript_275EA7:: @ 8275EA7
 	special sub_80EB300
 	setvar VAR_RESULT, 0
 	special sub_80EA30C
-	msgbox SecretBase_RedCave1_Text_274CDA, 4
+	msgbox SecretBase_RedCave1_Text_274CDA, MSGBOX_DEFAULT
 	release
 	end
 
 SecretBase_RedCave1_EventScript_275EBC:: @ 8275EBC
-	msgbox SecretBase_RedCave1_Text_274D34, 4
+	msgbox SecretBase_RedCave1_Text_274D34, MSGBOX_DEFAULT
 	release
 	end
 
@@ -4837,7 +4837,7 @@ SecretBase_RedCave1_EventScript_275EC6:: @ 8275EC6
 	goto_if 0, SecretBase_RedCave1_EventScript_275F15
 	compare VAR_RESULT, 1
 	goto_eq SecretBase_RedCave1_EventScript_275F34
-	msgbox SecretBase_RedCave1_Text_274F39, 5
+	msgbox SecretBase_RedCave1_Text_274F39, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_275F1F
 	setvar VAR_RESULT, 1
@@ -4845,12 +4845,12 @@ SecretBase_RedCave1_EventScript_275EC6:: @ 8275EC6
 	call SecretBase_RedCave1_EventScript_27134F
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_275F1F
-	msgbox SecretBase_RedCave1_Text_274FCA, 4
+	msgbox SecretBase_RedCave1_Text_274FCA, MSGBOX_DEFAULT
 	goto SecretBase_RedCave1_EventScript_276286
 	end
 
 SecretBase_RedCave1_EventScript_275F15:: @ 8275F15
-	msgbox SecretBase_RedCave1_Text_2750A4, 4
+	msgbox SecretBase_RedCave1_Text_2750A4, MSGBOX_DEFAULT
 	release
 	end
 
@@ -4858,12 +4858,12 @@ SecretBase_RedCave1_EventScript_275F1F:: @ 8275F1F
 	special sub_80EB300
 	setvar VAR_RESULT, 0
 	special sub_80EA30C
-	msgbox SecretBase_RedCave1_Text_274FDA, 4
+	msgbox SecretBase_RedCave1_Text_274FDA, MSGBOX_DEFAULT
 	release
 	end
 
 SecretBase_RedCave1_EventScript_275F34:: @ 8275F34
-	msgbox SecretBase_RedCave1_Text_27502A, 4
+	msgbox SecretBase_RedCave1_Text_27502A, MSGBOX_DEFAULT
 	release
 	end
 
@@ -4874,7 +4874,7 @@ SecretBase_RedCave1_EventScript_275F3E:: @ 8275F3E
 	goto_if 0, SecretBase_RedCave1_EventScript_275F8D
 	compare VAR_RESULT, 1
 	goto_eq SecretBase_RedCave1_EventScript_275FAC
-	msgbox SecretBase_RedCave1_Text_275287, 5
+	msgbox SecretBase_RedCave1_Text_275287, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_275F97
 	setvar VAR_RESULT, 1
@@ -4882,12 +4882,12 @@ SecretBase_RedCave1_EventScript_275F3E:: @ 8275F3E
 	call SecretBase_RedCave1_EventScript_27134F
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_275F97
-	msgbox SecretBase_RedCave1_Text_275315, 4
+	msgbox SecretBase_RedCave1_Text_275315, MSGBOX_DEFAULT
 	goto SecretBase_RedCave1_EventScript_276286
 	end
 
 SecretBase_RedCave1_EventScript_275F8D:: @ 8275F8D
-	msgbox SecretBase_RedCave1_Text_2753AB, 4
+	msgbox SecretBase_RedCave1_Text_2753AB, MSGBOX_DEFAULT
 	release
 	end
 
@@ -4895,12 +4895,12 @@ SecretBase_RedCave1_EventScript_275F97:: @ 8275F97
 	special sub_80EB300
 	setvar VAR_RESULT, 0
 	special sub_80EA30C
-	msgbox SecretBase_RedCave1_Text_275330, 4
+	msgbox SecretBase_RedCave1_Text_275330, MSGBOX_DEFAULT
 	release
 	end
 
 SecretBase_RedCave1_EventScript_275FAC:: @ 8275FAC
-	msgbox SecretBase_RedCave1_Text_275374, 4
+	msgbox SecretBase_RedCave1_Text_275374, MSGBOX_DEFAULT
 	release
 	end
 
@@ -4911,7 +4911,7 @@ SecretBase_RedCave1_EventScript_275FB6:: @ 8275FB6
 	goto_if 0, SecretBase_RedCave1_EventScript_276005
 	compare VAR_RESULT, 1
 	goto_eq SecretBase_RedCave1_EventScript_276024
-	msgbox SecretBase_RedCave1_Text_2755D2, 5
+	msgbox SecretBase_RedCave1_Text_2755D2, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_27600F
 	setvar VAR_RESULT, 1
@@ -4919,12 +4919,12 @@ SecretBase_RedCave1_EventScript_275FB6:: @ 8275FB6
 	call SecretBase_RedCave1_EventScript_27134F
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_27600F
-	msgbox SecretBase_RedCave1_Text_275679, 4
+	msgbox SecretBase_RedCave1_Text_275679, MSGBOX_DEFAULT
 	goto SecretBase_RedCave1_EventScript_276286
 	end
 
 SecretBase_RedCave1_EventScript_276005:: @ 8276005
-	msgbox SecretBase_RedCave1_Text_27571E, 4
+	msgbox SecretBase_RedCave1_Text_27571E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -4932,12 +4932,12 @@ SecretBase_RedCave1_EventScript_27600F:: @ 827600F
 	special sub_80EB300
 	setvar VAR_RESULT, 0
 	special sub_80EA30C
-	msgbox SecretBase_RedCave1_Text_275696, 4
+	msgbox SecretBase_RedCave1_Text_275696, MSGBOX_DEFAULT
 	release
 	end
 
 SecretBase_RedCave1_EventScript_276024:: @ 8276024
-	msgbox SecretBase_RedCave1_Text_2756EF, 4
+	msgbox SecretBase_RedCave1_Text_2756EF, MSGBOX_DEFAULT
 	release
 	end
 
@@ -4948,7 +4948,7 @@ SecretBase_RedCave1_EventScript_27602E:: @ 827602E
 	goto_if 0, SecretBase_RedCave1_EventScript_27607D
 	compare VAR_RESULT, 1
 	goto_eq SecretBase_RedCave1_EventScript_27609C
-	msgbox SecretBase_RedCave1_Text_274A64, 5
+	msgbox SecretBase_RedCave1_Text_274A64, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_276087
 	setvar VAR_RESULT, 1
@@ -4956,12 +4956,12 @@ SecretBase_RedCave1_EventScript_27602E:: @ 827602E
 	call SecretBase_RedCave1_EventScript_27134F
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_276087
-	msgbox SecretBase_RedCave1_Text_274AFA, 4
+	msgbox SecretBase_RedCave1_Text_274AFA, MSGBOX_DEFAULT
 	goto SecretBase_RedCave1_EventScript_276286
 	end
 
 SecretBase_RedCave1_EventScript_27607D:: @ 827607D
-	msgbox SecretBase_RedCave1_Text_274BA2, 4
+	msgbox SecretBase_RedCave1_Text_274BA2, MSGBOX_DEFAULT
 	release
 	end
 
@@ -4969,12 +4969,12 @@ SecretBase_RedCave1_EventScript_276087:: @ 8276087
 	special sub_80EB300
 	setvar VAR_RESULT, 0
 	special sub_80EA30C
-	msgbox SecretBase_RedCave1_Text_274B0B, 4
+	msgbox SecretBase_RedCave1_Text_274B0B, MSGBOX_DEFAULT
 	release
 	end
 
 SecretBase_RedCave1_EventScript_27609C:: @ 827609C
-	msgbox SecretBase_RedCave1_Text_274B6C, 4
+	msgbox SecretBase_RedCave1_Text_274B6C, MSGBOX_DEFAULT
 	release
 	end
 
@@ -4985,7 +4985,7 @@ SecretBase_RedCave1_EventScript_2760A6:: @ 82760A6
 	goto_if 0, SecretBase_RedCave1_EventScript_2760F5
 	compare VAR_RESULT, 1
 	goto_eq SecretBase_RedCave1_EventScript_276114
-	msgbox SecretBase_RedCave1_Text_274DD2, 5
+	msgbox SecretBase_RedCave1_Text_274DD2, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_2760FF
 	setvar VAR_RESULT, 1
@@ -4993,12 +4993,12 @@ SecretBase_RedCave1_EventScript_2760A6:: @ 82760A6
 	call SecretBase_RedCave1_EventScript_27134F
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_2760FF
-	msgbox SecretBase_RedCave1_Text_274E41, 4
+	msgbox SecretBase_RedCave1_Text_274E41, MSGBOX_DEFAULT
 	goto SecretBase_RedCave1_EventScript_276286
 	end
 
 SecretBase_RedCave1_EventScript_2760F5:: @ 82760F5
-	msgbox SecretBase_RedCave1_Text_274EF1, 4
+	msgbox SecretBase_RedCave1_Text_274EF1, MSGBOX_DEFAULT
 	release
 	end
 
@@ -5006,12 +5006,12 @@ SecretBase_RedCave1_EventScript_2760FF:: @ 82760FF
 	special sub_80EB300
 	setvar VAR_RESULT, 0
 	special sub_80EA30C
-	msgbox SecretBase_RedCave1_Text_274E5A, 4
+	msgbox SecretBase_RedCave1_Text_274E5A, MSGBOX_DEFAULT
 	release
 	end
 
 SecretBase_RedCave1_EventScript_276114:: @ 8276114
-	msgbox SecretBase_RedCave1_Text_274EB3, 4
+	msgbox SecretBase_RedCave1_Text_274EB3, MSGBOX_DEFAULT
 	release
 	end
 
@@ -5022,7 +5022,7 @@ SecretBase_RedCave1_EventScript_27611E:: @ 827611E
 	goto_if 0, SecretBase_RedCave1_EventScript_27616D
 	compare VAR_RESULT, 1
 	goto_eq SecretBase_RedCave1_EventScript_27618C
-	msgbox SecretBase_RedCave1_Text_275114, 5
+	msgbox SecretBase_RedCave1_Text_275114, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_276177
 	setvar VAR_RESULT, 1
@@ -5030,12 +5030,12 @@ SecretBase_RedCave1_EventScript_27611E:: @ 827611E
 	call SecretBase_RedCave1_EventScript_27134F
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_276177
-	msgbox SecretBase_RedCave1_Text_2751AF, 4
+	msgbox SecretBase_RedCave1_Text_2751AF, MSGBOX_DEFAULT
 	goto SecretBase_RedCave1_EventScript_276286
 	end
 
 SecretBase_RedCave1_EventScript_27616D:: @ 827616D
-	msgbox SecretBase_RedCave1_Text_275226, 4
+	msgbox SecretBase_RedCave1_Text_275226, MSGBOX_DEFAULT
 	release
 	end
 
@@ -5043,12 +5043,12 @@ SecretBase_RedCave1_EventScript_276177:: @ 8276177
 	special sub_80EB300
 	setvar VAR_RESULT, 0
 	special sub_80EA30C
-	msgbox SecretBase_RedCave1_Text_2751CA, 4
+	msgbox SecretBase_RedCave1_Text_2751CA, MSGBOX_DEFAULT
 	release
 	end
 
 SecretBase_RedCave1_EventScript_27618C:: @ 827618C
-	msgbox SecretBase_RedCave1_Text_2751EC, 4
+	msgbox SecretBase_RedCave1_Text_2751EC, MSGBOX_DEFAULT
 	release
 	end
 
@@ -5059,7 +5059,7 @@ SecretBase_RedCave1_EventScript_276196:: @ 8276196
 	goto_if 0, SecretBase_RedCave1_EventScript_2761E5
 	compare VAR_RESULT, 1
 	goto_eq SecretBase_RedCave1_EventScript_276204
-	msgbox SecretBase_RedCave1_Text_275405, 5
+	msgbox SecretBase_RedCave1_Text_275405, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_2761EF
 	setvar VAR_RESULT, 1
@@ -5067,12 +5067,12 @@ SecretBase_RedCave1_EventScript_276196:: @ 8276196
 	call SecretBase_RedCave1_EventScript_27134F
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_2761EF
-	msgbox SecretBase_RedCave1_Text_2754B2, 4
+	msgbox SecretBase_RedCave1_Text_2754B2, MSGBOX_DEFAULT
 	goto SecretBase_RedCave1_EventScript_276286
 	end
 
 SecretBase_RedCave1_EventScript_2761E5:: @ 82761E5
-	msgbox SecretBase_RedCave1_Text_275546, 4
+	msgbox SecretBase_RedCave1_Text_275546, MSGBOX_DEFAULT
 	release
 	end
 
@@ -5080,12 +5080,12 @@ SecretBase_RedCave1_EventScript_2761EF:: @ 82761EF
 	special sub_80EB300
 	setvar VAR_RESULT, 0
 	special sub_80EA30C
-	msgbox SecretBase_RedCave1_Text_2754D8, 4
+	msgbox SecretBase_RedCave1_Text_2754D8, MSGBOX_DEFAULT
 	release
 	end
 
 SecretBase_RedCave1_EventScript_276204:: @ 8276204
-	msgbox SecretBase_RedCave1_Text_27550C, 4
+	msgbox SecretBase_RedCave1_Text_27550C, MSGBOX_DEFAULT
 	release
 	end
 
@@ -5096,7 +5096,7 @@ SecretBase_RedCave1_EventScript_27620E:: @ 827620E
 	goto_if 0, SecretBase_RedCave1_EventScript_27625D
 	compare VAR_RESULT, 1
 	goto_eq SecretBase_RedCave1_EventScript_27627C
-	msgbox SecretBase_RedCave1_Text_2757B5, 5
+	msgbox SecretBase_RedCave1_Text_2757B5, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_276267
 	setvar VAR_RESULT, 1
@@ -5104,12 +5104,12 @@ SecretBase_RedCave1_EventScript_27620E:: @ 827620E
 	call SecretBase_RedCave1_EventScript_27134F
 	compare VAR_RESULT, 0
 	goto_eq SecretBase_RedCave1_EventScript_276267
-	msgbox SecretBase_RedCave1_Text_275884, 4
+	msgbox SecretBase_RedCave1_Text_275884, MSGBOX_DEFAULT
 	goto SecretBase_RedCave1_EventScript_276286
 	end
 
 SecretBase_RedCave1_EventScript_27625D:: @ 827625D
-	msgbox SecretBase_RedCave1_Text_275944, 4
+	msgbox SecretBase_RedCave1_Text_275944, MSGBOX_DEFAULT
 	release
 	end
 
@@ -5117,12 +5117,12 @@ SecretBase_RedCave1_EventScript_276267:: @ 8276267
 	special sub_80EB300
 	setvar VAR_RESULT, 0
 	special sub_80EA30C
-	msgbox SecretBase_RedCave1_Text_27589D, 4
+	msgbox SecretBase_RedCave1_Text_27589D, MSGBOX_DEFAULT
 	release
 	end
 
 SecretBase_RedCave1_EventScript_27627C:: @ 827627C
-	msgbox SecretBase_RedCave1_Text_275909, 4
+	msgbox SecretBase_RedCave1_Text_275909, MSGBOX_DEFAULT
 	release
 	end
 
@@ -5511,7 +5511,7 @@ SlateportCity_PokemonFanClub_EventScript_28C7F0:: @ 828C7F0
 	compare VAR_RESULT, 1
 	goto_eq SlateportCity_PokemonFanClub_EventScript_28C879
 	copyvar VAR_0x8009, VAR_0x8006
-	msgbox SlateportCity_PokemonFanClub_Text_280674, 5
+	msgbox SlateportCity_PokemonFanClub_Text_280674, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq SlateportCity_PokemonFanClub_EventScript_28C827
 	compare VAR_RESULT, 0
@@ -5519,7 +5519,7 @@ SlateportCity_PokemonFanClub_EventScript_28C7F0:: @ 828C7F0
 	end
 
 SlateportCity_PokemonFanClub_EventScript_28C827:: @ 828C827
-	msgbox SlateportCity_PokemonFanClub_Text_28073B, 4
+	msgbox SlateportCity_PokemonFanClub_Text_28073B, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 5
 	copyvar VAR_0x8005, VAR_0x8009
 	setvar VAR_0x8006, 1
@@ -5533,18 +5533,18 @@ SlateportCity_PokemonFanClub_EventScript_28C827:: @ 828C827
 	end
 
 SlateportCity_PokemonFanClub_EventScript_28C85C:: @ 828C85C
-	msgbox SlateportCity_PokemonFanClub_Text_2805E2, 4
+	msgbox SlateportCity_PokemonFanClub_Text_2805E2, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_PokemonFanClub_EventScript_28C866:: @ 828C866
-	msgbox SlateportCity_PokemonFanClub_Text_280789, 4
+	msgbox SlateportCity_PokemonFanClub_Text_280789, MSGBOX_DEFAULT
 	setvar VAR_0x8005, 1
 	goto SlateportCity_PokemonFanClub_EventScript_28C7E9
 	end
 
 SlateportCity_PokemonFanClub_EventScript_28C879:: @ 828C879
-	msgbox SlateportCity_PokemonFanClub_Text_28062E, 4
+	msgbox SlateportCity_PokemonFanClub_Text_28062E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -5559,7 +5559,7 @@ SlateportCity_OceanicMuseum_1F_EventScript_28C883:: @ 828C883
 	checkflag FLAG_0x069
 	goto_eq SlateportCity_OceanicMuseum_1F_EventScript_28C8C8
 	setflag FLAG_0x069
-	msgbox SlateportCity_OceanicMuseum_1F_Text_2811A0, 5
+	msgbox SlateportCity_OceanicMuseum_1F_Text_2811A0, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq SlateportCity_OceanicMuseum_1F_EventScript_28C8E7
 	compare VAR_RESULT, 0
@@ -5567,7 +5567,7 @@ SlateportCity_OceanicMuseum_1F_EventScript_28C883:: @ 828C883
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_28C8C8:: @ 828C8C8
-	msgbox SlateportCity_OceanicMuseum_1F_Text_28126D, 5
+	msgbox SlateportCity_OceanicMuseum_1F_Text_28126D, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq SlateportCity_OceanicMuseum_1F_EventScript_28C8E7
 	compare VAR_RESULT, 0
@@ -5575,7 +5575,7 @@ SlateportCity_OceanicMuseum_1F_EventScript_28C8C8:: @ 828C8C8
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_28C8E7:: @ 828C8E7
-	msgbox SlateportCity_OceanicMuseum_1F_Text_2812F2, 4
+	msgbox SlateportCity_OceanicMuseum_1F_Text_2812F2, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 5
 	copyvar VAR_0x8005, VAR_0x8009
 	setvar VAR_0x8006, 0
@@ -5589,18 +5589,18 @@ SlateportCity_OceanicMuseum_1F_EventScript_28C8E7:: @ 828C8E7
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_28C91C:: @ 828C91C
-	msgbox SlateportCity_OceanicMuseum_1F_Text_281367, 4
+	msgbox SlateportCity_OceanicMuseum_1F_Text_281367, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_28C926:: @ 828C926
-	msgbox SlateportCity_OceanicMuseum_1F_Text_2813B9, 4
+	msgbox SlateportCity_OceanicMuseum_1F_Text_2813B9, MSGBOX_DEFAULT
 	setvar VAR_0x8005, 2
 	goto SlateportCity_OceanicMuseum_1F_EventScript_28C7E9
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_28C939:: @ 828C939
-	msgbox SlateportCity_OceanicMuseum_1F_Text_28144D, 4
+	msgbox SlateportCity_OceanicMuseum_1F_Text_28144D, MSGBOX_DEFAULT
 	release
 	end
 
@@ -5615,7 +5615,7 @@ SlateportCity_PokemonFanClub_EventScript_28C943:: @ 828C943
 	compare VAR_RESULT, 1
 	goto_eq SlateportCity_PokemonFanClub_EventScript_28CA4F
 	copyvar VAR_0x8009, VAR_0x8006
-	msgbox SlateportCity_PokemonFanClub_Text_280270, 5
+	msgbox SlateportCity_PokemonFanClub_Text_280270, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq SlateportCity_PokemonFanClub_EventScript_28C98C
 	compare VAR_RESULT, 0
@@ -5623,7 +5623,7 @@ SlateportCity_PokemonFanClub_EventScript_28C943:: @ 828C943
 	end
 
 SlateportCity_PokemonFanClub_EventScript_28C98C:: @ 828C98C
-	msgbox SlateportCity_PokemonFanClub_Text_28034F, 4
+	msgbox SlateportCity_PokemonFanClub_Text_28034F, MSGBOX_DEFAULT
 	random 3
 	copyvar VAR_0x800A, VAR_RESULT
 	switch VAR_RESULT
@@ -5633,17 +5633,17 @@ SlateportCity_PokemonFanClub_EventScript_28C98C:: @ 828C98C
 	end
 
 SlateportCity_PokemonFanClub_EventScript_28C9C3:: @ 828C9C3
-	msgbox SlateportCity_PokemonFanClub_Text_280393, 4
+	msgbox SlateportCity_PokemonFanClub_Text_280393, MSGBOX_DEFAULT
 	goto SlateportCity_PokemonFanClub_EventScript_28C9ED
 	end
 
 SlateportCity_PokemonFanClub_EventScript_28C9D1:: @ 828C9D1
-	msgbox SlateportCity_PokemonFanClub_Text_2803EF, 4
+	msgbox SlateportCity_PokemonFanClub_Text_2803EF, MSGBOX_DEFAULT
 	goto SlateportCity_PokemonFanClub_EventScript_28C9ED
 	end
 
 SlateportCity_PokemonFanClub_EventScript_28C9DF:: @ 828C9DF
-	msgbox SlateportCity_PokemonFanClub_Text_280454, 4
+	msgbox SlateportCity_PokemonFanClub_Text_280454, MSGBOX_DEFAULT
 	goto SlateportCity_PokemonFanClub_EventScript_28C9ED
 	end
 
@@ -5656,26 +5656,26 @@ SlateportCity_PokemonFanClub_EventScript_28C9ED:: @ 828C9ED
 	faceplayer
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_PokemonFanClub_EventScript_28CA45
-	msgbox SlateportCity_PokemonFanClub_Text_2804AC, 4
+	msgbox SlateportCity_PokemonFanClub_Text_2804AC, MSGBOX_DEFAULT
 	setvar VAR_0x8006, 1
 	call SlateportCity_PokemonFanClub_EventScript_271E7C
 	lock
 	faceplayer
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_PokemonFanClub_EventScript_28CA45
-	msgbox SlateportCity_PokemonFanClub_Text_280523, 4
+	msgbox SlateportCity_PokemonFanClub_Text_280523, MSGBOX_DEFAULT
 	copyvar VAR_0x8007, VAR_0x800A
 	setvar VAR_0x8005, 3
 	goto SlateportCity_PokemonFanClub_EventScript_28C7E9
 	end
 
 SlateportCity_PokemonFanClub_EventScript_28CA45:: @ 828CA45
-	msgbox SlateportCity_PokemonFanClub_Text_2805E2, 4
+	msgbox SlateportCity_PokemonFanClub_Text_2805E2, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_PokemonFanClub_EventScript_28CA4F:: @ 828CA4F
-	msgbox SlateportCity_PokemonFanClub_Text_28062E, 4
+	msgbox SlateportCity_PokemonFanClub_Text_28062E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -5689,7 +5689,7 @@ LilycoveCity_ContestLobby_EventScript_28CA59:: @ 828CA59
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_ContestLobby_EventScript_28CB21
 	copyvar VAR_0x8009, VAR_0x8006
-	msgbox LilycoveCity_ContestLobby_Text_27EF15, 5
+	msgbox LilycoveCity_ContestLobby_Text_27EF15, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_ContestLobby_EventScript_28CA9B
 	compare VAR_RESULT, 0
@@ -5697,7 +5697,7 @@ LilycoveCity_ContestLobby_EventScript_28CA59:: @ 828CA59
 	end
 
 LilycoveCity_ContestLobby_EventScript_28CA9B:: @ 828CA9B
-	msgbox LilycoveCity_ContestLobby_Text_27EFE7, 4
+	msgbox LilycoveCity_ContestLobby_Text_27EFE7, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 11
 	copyvar VAR_0x8005, VAR_0x8009
 	setvar VAR_0x8006, 0
@@ -5711,14 +5711,14 @@ LilycoveCity_ContestLobby_EventScript_28CA9B:: @ 828CA9B
 	end
 
 LilycoveCity_ContestLobby_EventScript_28CAD0:: @ 828CAD0
-	msgbox LilycoveCity_ContestLobby_Text_27F1EF, 4
+	msgbox LilycoveCity_ContestLobby_Text_27F1EF, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_28CADA:: @ 828CADA
 	setvar VAR_0x8004, 24
 	special SetContestCategoryStringVarForInterview
-	msgbox LilycoveCity_ContestLobby_Text_27F03E, 4
+	msgbox LilycoveCity_ContestLobby_Text_27F03E, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 11
 	copyvar VAR_0x8005, VAR_0x8009
 	setvar VAR_0x8006, 1
@@ -5727,14 +5727,14 @@ LilycoveCity_ContestLobby_EventScript_28CADA:: @ 828CADA
 	faceplayer
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_ContestLobby_EventScript_28CAD0
-	msgbox LilycoveCity_ContestLobby_Text_27F0EC, 4
+	msgbox LilycoveCity_ContestLobby_Text_27F0EC, MSGBOX_DEFAULT
 	setflag FLAG_TEMP_2
 	setvar VAR_0x8005, 6
 	goto LilycoveCity_ContestLobby_EventScript_28C7E9
 	end
 
 LilycoveCity_ContestLobby_EventScript_28CB21:: @ 828CB21
-	msgbox LilycoveCity_ContestLobby_Text_27F23F, 4
+	msgbox LilycoveCity_ContestLobby_Text_27F23F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -5771,7 +5771,7 @@ BattleFrontier_BattleTowerLobby_EventScript_28CB96:: @ 828CB96
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattleTowerLobby_EventScript_28CC7A
 	copyvar VAR_0x8009, VAR_0x8006
-	msgbox BattleFrontier_BattleTowerLobby_Text_27F704, 5
+	msgbox BattleFrontier_BattleTowerLobby_Text_27F704, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattleTowerLobby_EventScript_28CBD8
 	compare VAR_RESULT, 0
@@ -5787,7 +5787,7 @@ BattleFrontier_BattleTowerLobby_EventScript_28CBD8:: @ 828CBD8
 	call_if 1, BattleFrontier_BattleTowerLobby_EventScript_28CC38
 	compare VAR_RESULT, 1
 	call_if 1, BattleFrontier_BattleTowerLobby_EventScript_28CC41
-	msgbox BattleFrontier_BattleTowerLobby_Text_27F97A, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_27F97A, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 12
 	copyvar VAR_0x8005, VAR_0x8009
 	call BattleFrontier_BattleTowerLobby_EventScript_271E7C
@@ -5800,22 +5800,22 @@ BattleFrontier_BattleTowerLobby_EventScript_28CBD8:: @ 828CBD8
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_28CC2E:: @ 828CC2E
-	msgbox BattleFrontier_BattleTowerLobby_Text_27F84C, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_27F84C, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_28CC38:: @ 828CC38
-	msgbox BattleFrontier_BattleTowerLobby_Text_27F8AE, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_27F8AE, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleTowerLobby_EventScript_28CC41:: @ 828CC41
-	msgbox BattleFrontier_BattleTowerLobby_Text_27F921, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_27F921, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleTowerLobby_EventScript_28CC4A:: @ 828CC4A
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattleTowerLobby_EventScript_28CC70
-	msgbox BattleFrontier_BattleTowerLobby_Text_27F9FD, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_27F9FD, MSGBOX_DEFAULT
 	setflag FLAG_TEMP_2
 	copyvar VAR_0x8004, VAR_0x8008
 	setvar VAR_0x8005, 7
@@ -5823,12 +5823,12 @@ BattleFrontier_BattleTowerLobby_EventScript_28CC4A:: @ 828CC4A
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_28CC70:: @ 828CC70
-	msgbox BattleFrontier_BattleTowerLobby_Text_27FA6F, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_27FA6F, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_28CC7A:: @ 828CC7A
-	msgbox BattleFrontier_BattleTowerLobby_Text_27FAF3, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_27FAF3, MSGBOX_DEFAULT
 	release
 	end
 
@@ -5862,7 +5862,7 @@ EventScript_2926F8:: @ 82926F8
 	.include "data/scripts/players_house.inc"
 
 EventScript_RunningShoesManual:: @ 8292DE5
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7F66, 3
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7F66, MSGBOX_SIGN
 	end
 
 	.include "data/scripts/pokeblocks.inc"
@@ -5933,7 +5933,7 @@ gUnknown_082944D5:: @ 82944D5
 	.include "data/text/trainers.inc"
 
 EventScript_RepelWoreOff:: @ 82A4B2A
-	msgbox Text_RepelWoreOff, 3
+	msgbox Text_RepelWoreOff, MSGBOX_SIGN
 	end
 
 Text_RepelWoreOff: @ 82A4B33
@@ -6059,7 +6059,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A836B:: @ 82A836B
 LilycoveCity_PokemonCenter_1F_EventScript_2A8395:: @ 82A8395
 	lock
 	faceplayer
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8A69, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8A69, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, sub_818DBE8
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A83D0
@@ -6070,13 +6070,13 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8395:: @ 82A8395
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A83C6:: @ 82A83C6
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8AB1, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8AB1, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A83D0:: @ 82A83D0
 	special sub_818DC2C
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8A7D, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8A7D, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, sub_818DC60
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A8435
@@ -6095,17 +6095,17 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A83F7:: @ 82A83F7
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8419:: @ 82A8419
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8ACE, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8ACE, MSGBOX_DEFAULT
 	goto LilycoveCity_PokemonCenter_1F_EventScript_2A8435
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8427:: @ 82A8427
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8B36, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8B36, MSGBOX_DEFAULT
 	goto LilycoveCity_PokemonCenter_1F_EventScript_2A8435
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8435:: @ 82A8435
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8B69, 5
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8B69, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A8454
 	compare VAR_RESULT, 1
@@ -6113,12 +6113,12 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8435:: @ 82A8435
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8454:: @ 82A8454
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8BCD, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8BCD, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A845E:: @ 82A845E
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8BAD, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8BAD, MSGBOX_DEFAULT
 	goto LilycoveCity_PokemonCenter_1F_EventScript_2A846C
 	end
 
@@ -6134,7 +6134,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A846C:: @ 82A846C
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A848E:: @ 82A848E
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8BEE, 5
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8BEE, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A8454
 	compare VAR_RESULT, 0
@@ -6151,7 +6151,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A84AD:: @ 82A84AD
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A84C9:: @ 82A84C9
 	special sub_818DC2C
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8C0F, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8C0F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -6165,20 +6165,20 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A84D6:: @ 82A84D6
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A84F2:: @ 82A84F2
 	special sub_818DC2C
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8C6F, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8C6F, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A84FF:: @ 82A84FF
 	special sub_818DC2C
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8CC8, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8CC8, MSGBOX_DEFAULT
 	goto LilycoveCity_PokemonCenter_1F_EventScript_2A8510
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8510:: @ 82A8510
 	setvar VAR_0x8004, 0
 	specialvar VAR_0x8004, sub_818DEA0
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8D5D, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8D5D, MSGBOX_DEFAULT
 	giveitem_std VAR_0x8004
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A8545
@@ -6187,7 +6187,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8510:: @ 82A8510
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8545:: @ 82A8545
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8DBD, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8DBD, MSGBOX_DEFAULT
 	release
 	end
 
@@ -6199,7 +6199,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A854F:: @ 82A854F
 LilycoveCity_PokemonCenter_1F_EventScript_2A8554:: @ 82A8554
 	lock
 	faceplayer
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8E2B, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8E2B, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, sub_818E038
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A8585
@@ -6228,23 +6228,23 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A85AC:: @ 82A85AC
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A85C8:: @ 82A85C8
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8E4E, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8E4E, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A85D2:: @ 82A85D2
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8EAC, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8EAC, MSGBOX_DEFAULT
 	goto LilycoveCity_PokemonCenter_1F_EventScript_2A85EE
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A85E0:: @ 82A85E0
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8EAC, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8EAC, MSGBOX_DEFAULT
 	goto LilycoveCity_PokemonCenter_1F_EventScript_2A85EE
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A85EE:: @ 82A85EE
 	setvar VAR_0x8004, 0
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8EEC, 5
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8EEC, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A861C
 	compare VAR_RESULT, 0
@@ -6252,7 +6252,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A85EE:: @ 82A85EE
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8612:: @ 82A8612
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8F65, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8F65, MSGBOX_DEFAULT
 	release
 	end
 
@@ -6283,7 +6283,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8656:: @ 82A8656
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8660:: @ 82A8660
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8F7E, 5
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8F7E, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A867F
 	compare VAR_RESULT, 0
@@ -6291,13 +6291,13 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8660:: @ 82A8660
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A867F:: @ 82A867F
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8F9A, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8F9A, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8689:: @ 82A8689
 	special sub_818E37C
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8F4D, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8F4D, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, sub_818E308
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A86C7
@@ -6309,7 +6309,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A86B0:: @ 82A86B0
 	playse SE_SEIKAI
 	delay 10
 	playse SE_SEIKAI
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8FC7, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A8FC7, MSGBOX_DEFAULT
 	goto LilycoveCity_PokemonCenter_1F_EventScript_2A86EC
 	end
 
@@ -6319,8 +6319,8 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A86C7:: @ 82A86C7
 	playse SE_HAZURE
 	delay 10
 	playse SE_HAZURE
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A90A5, 4
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A90CD, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A90A5, MSGBOX_DEFAULT
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A90CD, MSGBOX_DEFAULT
 	goto LilycoveCity_PokemonCenter_1F_EventScript_2A8759
 	end
 
@@ -6333,12 +6333,12 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A86EC:: @ 82A86EC
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8708:: @ 82A8708
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9007, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9007, MSGBOX_DEFAULT
 	goto LilycoveCity_PokemonCenter_1F_EventScript_2A8724
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8716:: @ 82A8716
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9007, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9007, MSGBOX_DEFAULT
 	goto LilycoveCity_PokemonCenter_1F_EventScript_2A8724
 	end
 
@@ -6353,13 +6353,13 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8724:: @ 82A8724
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A874C:: @ 82A874C
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A906A, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A906A, MSGBOX_DEFAULT
 	special sub_818E39C
 	release
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8759:: @ 82A8759
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A90FB, 5
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A90FB, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A8785
 	compare VAR_RESULT, 0
@@ -6368,12 +6368,12 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8759:: @ 82A8759
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8778:: @ 82A8778
 	special sub_818E3EC
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9131, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9131, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8785:: @ 82A8785
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9153, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9153, MSGBOX_DEFAULT
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A878D:: @ 82A878D
 	fadescreen 1
@@ -6387,7 +6387,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A878D:: @ 82A878D
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A87AF:: @ 82A87AF
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9212, 5
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9212, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A8778
 	compare VAR_RESULT, 0
@@ -6395,7 +6395,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A87AF:: @ 82A87AF
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A87CE:: @ 82A87CE
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9270, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9270, MSGBOX_DEFAULT
 	special sub_818E430
 	special sub_818E3BC
 	setvar VAR_0x8004, 16
@@ -6410,7 +6410,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A87E1:: @ 82A87E1
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A87F8:: @ 82A87F8
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A92D3, 5
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A92D3, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A8778
 	compare VAR_RESULT, 0
@@ -6421,14 +6421,14 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8817:: @ 82A8817
 	special sub_818E490
 	special sub_818E4A4
 	special sub_818E510
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9336, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9336, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A882A:: @ 82A882A
 	lock
 	faceplayer
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A93A7, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A93A7, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, sub_818E8B4
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A8850
@@ -6445,17 +6445,17 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8850:: @ 82A8850
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A886C:: @ 82A886C
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A93D6, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A93D6, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8876:: @ 82A8876
 	special sub_818E914
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A93F4, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A93F4, MSGBOX_DEFAULT
 	checkitem ITEM_POKEBLOCK_CASE, 1
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A89AE
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A94E8, 5
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A94E8, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A88B0
 	compare VAR_RESULT, 1
@@ -6463,7 +6463,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8876:: @ 82A8876
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A88B0:: @ 82A88B0
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9556, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9556, MSGBOX_DEFAULT
 	release
 	end
 
@@ -6478,7 +6478,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A88BA:: @ 82A88BA
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A88D7:: @ 82A88D7
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9537, 5
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9537, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_2A88B0
 	compare VAR_RESULT, 0
@@ -6486,7 +6486,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A88D7:: @ 82A88D7
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A88F6:: @ 82A88F6
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9571, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9571, MSGBOX_DEFAULT
 	special sub_818E940
 	special sub_818E960
 	goto LilycoveCity_PokemonCenter_1F_EventScript_2A890A
@@ -6524,13 +6524,13 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A894C:: @ 82A894C
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A8970:: @ 82A8970
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A95AD, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A95AD, MSGBOX_DEFAULT
 	goto LilycoveCity_PokemonCenter_1F_EventScript_2A898F
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A897E:: @ 82A897E
 	special sub_818E914
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9605, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9605, MSGBOX_DEFAULT
 	goto LilycoveCity_PokemonCenter_1F_EventScript_2A898F
 	end
 
@@ -6542,13 +6542,13 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A898F:: @ 82A898F
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A89A1:: @ 82A89A1
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9669, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9669, MSGBOX_DEFAULT
 	special PutLilycoveContestLadyShowOnTheAir
 	release
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_2A89AE:: @ 82A89AE
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9451, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9451, MSGBOX_DEFAULT
 	release
 	end
 
@@ -6598,7 +6598,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8A0A:: @ 82A8A0A
 	faceplayer
 	waitse
 	playmoncry VAR_0x8005, 0
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A96DA, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A96DA, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
@@ -6608,7 +6608,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8A1D:: @ 82A8A1D
 	faceplayer
 	waitse
 	playmoncry VAR_0x8005, 0
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A970E, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A970E, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
@@ -6618,7 +6618,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8A30:: @ 82A8A30
 	faceplayer
 	waitse
 	playmoncry VAR_0x8005, 0
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A96F6, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A96F6, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
@@ -6628,7 +6628,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8A43:: @ 82A8A43
 	faceplayer
 	waitse
 	playmoncry VAR_0x8005, 0
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A96E6, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A96E6, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
@@ -6638,7 +6638,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_2A8A56:: @ 82A8A56
 	faceplayer
 	waitse
 	playmoncry VAR_0x8005, 0
-	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9703, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_2A9703, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
@@ -9856,7 +9856,7 @@ gText_MrStone_Pokenav_2B67ED:: @ 82B67ED
 	.string "sometime!$"
 
 	.include "data/scripts/apprentice.inc"
-	
+
 gBattleDomeOpponentPotential1::
 	.string "The best candidate to be a champ!$"
 
@@ -9865,7 +9865,7 @@ gBattleDomeOpponentPotential2::
 
 gBattleDomeOpponentPotential3::
 	.string "A likely top-three finisher.$"
-	
+
 gBattleDomeOpponentPotential4::
 	.string "A candidate to finish first.$"
 
@@ -9908,7 +9908,7 @@ gBattleDomeOpponentPotential16::
 gBattleDomeOpponentPotential17::
 	.string "The perfect, invincible superstar!$"
 
-gBattleDomeOpponentStyle1::	
+gBattleDomeOpponentStyle1::
 	.string "Willing to risk total disaster at times.$"
 
 gBattleDomeOpponentStyle2::
@@ -10350,7 +10350,7 @@ BattleFrontier_BattlePikeThreePathRoom_EventScript_2C406D:: @ 82C406D
 	setvar VAR_TEMP_3, 0
 	setvar VAR_TEMP_2, 0
 	lockall
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CE36, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CE36, MSGBOX_DEFAULT
 	closemessage
 	end
 
@@ -10363,7 +10363,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_2C408D:: @ 82C408D
 	setvar VAR_TEMP_3, 0
 	setvar VAR_TEMP_2, 0
 	lockall
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25CE36, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25CE36, MSGBOX_DEFAULT
 	closemessage
 	end
 
@@ -10472,7 +10472,7 @@ BattleFrontier_BattlePikeRandomRoom3_EventScript_2C420D:: @ 82C420D
 	setvar VAR_TEMP_3, 0
 	setvar VAR_TEMP_2, 0
 	lockall
-	msgbox BattleFrontier_BattlePikeRandomRoom3_Text_25CE36, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom3_Text_25CE36, MSGBOX_DEFAULT
 	closemessage
 	end
 
@@ -11332,13 +11332,13 @@ SlateportCity_PokemonFanClub_EventScript_2C7F16:: @ 82C7F16
 	faceplayer
 	checkflag FLAG_0x1B1
 	goto_eq SlateportCity_PokemonFanClub_EventScript_2C7F74
-	msgbox SlateportCity_PokemonFanClub_Text_2C6E37, 5
+	msgbox SlateportCity_PokemonFanClub_Text_2C6E37, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_PokemonFanClub_EventScript_2C7F6A
 	call SlateportCity_PokemonFanClub_EventScript_2C832D
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_PokemonFanClub_EventScript_2C7F6A
-	msgbox SlateportCity_PokemonFanClub_Text_2C6F66, 4
+	msgbox SlateportCity_PokemonFanClub_Text_2C6F66, MSGBOX_DEFAULT
 	setvar VAR_0x8005, 23
 	call SlateportCity_PokemonFanClub_EventScript_2C8326
 	compare VAR_RESULT, 0
@@ -11348,12 +11348,12 @@ SlateportCity_PokemonFanClub_EventScript_2C7F16:: @ 82C7F16
 	end
 
 SlateportCity_PokemonFanClub_EventScript_2C7F6A:: @ 82C7F6A
-	msgbox SlateportCity_PokemonFanClub_Text_2C6F33, 4
+	msgbox SlateportCity_PokemonFanClub_Text_2C6F33, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_PokemonFanClub_EventScript_2C7F74:: @ 82C7F74
-	msgbox SlateportCity_PokemonFanClub_Text_2C6F9E, 4
+	msgbox SlateportCity_PokemonFanClub_Text_2C6F9E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -11362,13 +11362,13 @@ MauvilleCity_EventScript_2C7F7E:: @ 82C7F7E
 	faceplayer
 	checkflag FLAG_0x1B2
 	goto_eq MauvilleCity_EventScript_2C7FDC
-	msgbox MauvilleCity_Text_2C6FDB, 5
+	msgbox MauvilleCity_Text_2C6FDB, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_EventScript_2C7FD2
 	call MauvilleCity_EventScript_2C832D
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_EventScript_2C7FD2
-	msgbox MauvilleCity_Text_2C70F3, 4
+	msgbox MauvilleCity_Text_2C70F3, MSGBOX_DEFAULT
 	setvar VAR_0x8005, 16
 	call MauvilleCity_EventScript_2C8326
 	compare VAR_RESULT, 0
@@ -11378,12 +11378,12 @@ MauvilleCity_EventScript_2C7F7E:: @ 82C7F7E
 	end
 
 MauvilleCity_EventScript_2C7FD2:: @ 82C7FD2
-	msgbox MauvilleCity_Text_2C70C4, 4
+	msgbox MauvilleCity_Text_2C70C4, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_EventScript_2C7FDC:: @ 82C7FDC
-	msgbox MauvilleCity_Text_2C7133, 4
+	msgbox MauvilleCity_Text_2C7133, MSGBOX_DEFAULT
 	release
 	end
 
@@ -11392,13 +11392,13 @@ VerdanturfTown_PokemonCenter_1F_EventScript_2C7FE6:: @ 82C7FE6
 	faceplayer
 	checkflag FLAG_0x1B3
 	goto_eq VerdanturfTown_PokemonCenter_1F_EventScript_2C8044
-	msgbox VerdanturfTown_PokemonCenter_1F_Text_2C7174, 5
+	msgbox VerdanturfTown_PokemonCenter_1F_Text_2C7174, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq VerdanturfTown_PokemonCenter_1F_EventScript_2C803A
 	call VerdanturfTown_PokemonCenter_1F_EventScript_2C832D
 	compare VAR_RESULT, 0
 	goto_eq VerdanturfTown_PokemonCenter_1F_EventScript_2C803A
-	msgbox VerdanturfTown_PokemonCenter_1F_Text_2C7243, 4
+	msgbox VerdanturfTown_PokemonCenter_1F_Text_2C7243, MSGBOX_DEFAULT
 	setvar VAR_0x8005, 29
 	call VerdanturfTown_PokemonCenter_1F_EventScript_2C8326
 	compare VAR_RESULT, 0
@@ -11408,12 +11408,12 @@ VerdanturfTown_PokemonCenter_1F_EventScript_2C7FE6:: @ 82C7FE6
 	end
 
 VerdanturfTown_PokemonCenter_1F_EventScript_2C803A:: @ 82C803A
-	msgbox VerdanturfTown_PokemonCenter_1F_Text_2C7221, 4
+	msgbox VerdanturfTown_PokemonCenter_1F_Text_2C7221, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_PokemonCenter_1F_EventScript_2C8044:: @ 82C8044
-	msgbox VerdanturfTown_PokemonCenter_1F_Text_2C726E, 4
+	msgbox VerdanturfTown_PokemonCenter_1F_Text_2C726E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -11422,13 +11422,13 @@ LavaridgeTown_House_EventScript_2C804E:: @ 82C804E
 	faceplayer
 	checkflag FLAG_0x1B4
 	goto_eq LavaridgeTown_House_EventScript_2C80AC
-	msgbox LavaridgeTown_House_Text_2C72B6, 5
+	msgbox LavaridgeTown_House_Text_2C72B6, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LavaridgeTown_House_EventScript_2C80A2
 	call LavaridgeTown_House_EventScript_2C832D
 	compare VAR_RESULT, 0
 	goto_eq LavaridgeTown_House_EventScript_2C80A2
-	msgbox LavaridgeTown_House_Text_2C73B1, 4
+	msgbox LavaridgeTown_House_Text_2C73B1, MSGBOX_DEFAULT
 	setvar VAR_0x8005, 7
 	call LavaridgeTown_House_EventScript_2C8326
 	compare VAR_RESULT, 0
@@ -11438,12 +11438,12 @@ LavaridgeTown_House_EventScript_2C804E:: @ 82C804E
 	end
 
 LavaridgeTown_House_EventScript_2C80A2:: @ 82C80A2
-	msgbox LavaridgeTown_House_Text_2C737F, 4
+	msgbox LavaridgeTown_House_Text_2C737F, MSGBOX_DEFAULT
 	release
 	end
 
 LavaridgeTown_House_EventScript_2C80AC:: @ 82C80AC
-	msgbox LavaridgeTown_House_Text_2C73F6, 4
+	msgbox LavaridgeTown_House_Text_2C73F6, MSGBOX_DEFAULT
 	release
 	end
 
@@ -11452,13 +11452,13 @@ FallarborTown_Mart_EventScript_2C80B6:: @ 82C80B6
 	faceplayer
 	checkflag FLAG_0x1B5
 	goto_eq FallarborTown_Mart_EventScript_2C8114
-	msgbox FallarborTown_Mart_Text_2C7449, 5
+	msgbox FallarborTown_Mart_Text_2C7449, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq FallarborTown_Mart_EventScript_2C810A
 	call FallarborTown_Mart_EventScript_2C832D
 	compare VAR_RESULT, 0
 	goto_eq FallarborTown_Mart_EventScript_2C810A
-	msgbox FallarborTown_Mart_Text_2C7582, 4
+	msgbox FallarborTown_Mart_Text_2C7582, MSGBOX_DEFAULT
 	setvar VAR_0x8005, 8
 	call FallarborTown_Mart_EventScript_2C8326
 	compare VAR_RESULT, 0
@@ -11468,12 +11468,12 @@ FallarborTown_Mart_EventScript_2C80B6:: @ 82C80B6
 	end
 
 FallarborTown_Mart_EventScript_2C810A:: @ 82C810A
-	msgbox FallarborTown_Mart_Text_2C7556, 4
+	msgbox FallarborTown_Mart_Text_2C7556, MSGBOX_DEFAULT
 	release
 	end
 
 FallarborTown_Mart_EventScript_2C8114:: @ 82C8114
-	msgbox FallarborTown_Mart_Text_2C75B5, 4
+	msgbox FallarborTown_Mart_Text_2C75B5, MSGBOX_DEFAULT
 	release
 	end
 
@@ -11482,13 +11482,13 @@ FortreeCity_House2_EventScript_2C811E:: @ 82C811E
 	faceplayer
 	checkflag FLAG_0x1B6
 	goto_eq FortreeCity_House2_EventScript_2C817C
-	msgbox FortreeCity_House2_Text_2C7637, 5
+	msgbox FortreeCity_House2_Text_2C7637, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq FortreeCity_House2_EventScript_2C8172
 	call FortreeCity_House2_EventScript_2C832D
 	compare VAR_RESULT, 0
 	goto_eq FortreeCity_House2_EventScript_2C8172
-	msgbox FortreeCity_House2_Text_2C7721, 4
+	msgbox FortreeCity_House2_Text_2C7721, MSGBOX_DEFAULT
 	setvar VAR_0x8005, 24
 	call FortreeCity_House2_EventScript_2C8326
 	compare VAR_RESULT, 0
@@ -11498,12 +11498,12 @@ FortreeCity_House2_EventScript_2C811E:: @ 82C811E
 	end
 
 FortreeCity_House2_EventScript_2C8172:: @ 82C8172
-	msgbox FortreeCity_House2_Text_2C76E2, 4
+	msgbox FortreeCity_House2_Text_2C76E2, MSGBOX_DEFAULT
 	release
 	end
 
 FortreeCity_House2_EventScript_2C817C:: @ 82C817C
-	msgbox FortreeCity_House2_Text_2C775A, 4
+	msgbox FortreeCity_House2_Text_2C775A, MSGBOX_DEFAULT
 	release
 	end
 
@@ -11512,13 +11512,13 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_2C8186:: @ 82C8186
 	faceplayer
 	checkflag FLAG_0x1B7
 	goto_eq LilycoveCity_DepartmentStoreRooftop_EventScript_2C81E4
-	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2C77C6, 5
+	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2C77C6, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_DepartmentStoreRooftop_EventScript_2C81DA
 	call LilycoveCity_DepartmentStoreRooftop_EventScript_2C832D
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_DepartmentStoreRooftop_EventScript_2C81DA
-	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2C7911, 4
+	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2C7911, MSGBOX_DEFAULT
 	setvar VAR_0x8005, 14
 	call LilycoveCity_DepartmentStoreRooftop_EventScript_2C8326
 	compare VAR_RESULT, 0
@@ -11528,12 +11528,12 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_2C8186:: @ 82C8186
 	end
 
 LilycoveCity_DepartmentStoreRooftop_EventScript_2C81DA:: @ 82C81DA
-	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2C78D1, 4
+	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2C78D1, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_DepartmentStoreRooftop_EventScript_2C81E4:: @ 82C81E4
-	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2C794B, 4
+	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2C794B, MSGBOX_DEFAULT
 	release
 	end
 
@@ -11542,13 +11542,13 @@ MossdeepCity_EventScript_2C81EE:: @ 82C81EE
 	faceplayer
 	checkflag FLAG_0x1B8
 	goto_eq MossdeepCity_EventScript_2C824C
-	msgbox MossdeepCity_Text_2C79A6, 5
+	msgbox MossdeepCity_Text_2C79A6, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_EventScript_2C8242
 	call MossdeepCity_EventScript_2C832D
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_EventScript_2C8242
-	msgbox MossdeepCity_Text_2C7B0D, 4
+	msgbox MossdeepCity_Text_2C7B0D, MSGBOX_DEFAULT
 	setvar VAR_0x8005, 15
 	call MossdeepCity_EventScript_2C8326
 	compare VAR_RESULT, 0
@@ -11558,12 +11558,12 @@ MossdeepCity_EventScript_2C81EE:: @ 82C81EE
 	end
 
 MossdeepCity_EventScript_2C8242:: @ 82C8242
-	msgbox MossdeepCity_Text_2C7AD4, 4
+	msgbox MossdeepCity_Text_2C7AD4, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_EventScript_2C824C:: @ 82C824C
-	msgbox MossdeepCity_Text_2C7B4F, 4
+	msgbox MossdeepCity_Text_2C7B4F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -11572,13 +11572,13 @@ SootopolisCity_PokemonCenter_1F_EventScript_2C8256:: @ 82C8256
 	faceplayer
 	checkflag FLAG_0x1B9
 	goto_eq SootopolisCity_PokemonCenter_1F_EventScript_2C82B4
-	msgbox SootopolisCity_PokemonCenter_1F_Text_2C7B8E, 5
+	msgbox SootopolisCity_PokemonCenter_1F_Text_2C7B8E, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_PokemonCenter_1F_EventScript_2C82AA
 	call SootopolisCity_PokemonCenter_1F_EventScript_2C832D
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_PokemonCenter_1F_EventScript_2C82AA
-	msgbox SootopolisCity_PokemonCenter_1F_Text_2C7C98, 4
+	msgbox SootopolisCity_PokemonCenter_1F_Text_2C7C98, MSGBOX_DEFAULT
 	setvar VAR_0x8005, 4
 	call SootopolisCity_PokemonCenter_1F_EventScript_2C8326
 	compare VAR_RESULT, 0
@@ -11588,12 +11588,12 @@ SootopolisCity_PokemonCenter_1F_EventScript_2C8256:: @ 82C8256
 	end
 
 SootopolisCity_PokemonCenter_1F_EventScript_2C82AA:: @ 82C82AA
-	msgbox SootopolisCity_PokemonCenter_1F_Text_2C7C7E, 4
+	msgbox SootopolisCity_PokemonCenter_1F_Text_2C7C7E, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_PokemonCenter_1F_EventScript_2C82B4:: @ 82C82B4
-	msgbox SootopolisCity_PokemonCenter_1F_Text_2C7CC8, 4
+	msgbox SootopolisCity_PokemonCenter_1F_Text_2C7CC8, MSGBOX_DEFAULT
 	release
 	end
 
@@ -11602,13 +11602,13 @@ PacifidlogTown_PokemonCenter_1F_EventScript_2C82BE:: @ 82C82BE
 	faceplayer
 	checkflag FLAG_0x1BA
 	goto_eq PacifidlogTown_PokemonCenter_1F_EventScript_2C831C
-	msgbox PacifidlogTown_PokemonCenter_1F_Text_2C7CFA, 5
+	msgbox PacifidlogTown_PokemonCenter_1F_Text_2C7CFA, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq PacifidlogTown_PokemonCenter_1F_EventScript_2C8312
 	call PacifidlogTown_PokemonCenter_1F_EventScript_2C832D
 	compare VAR_RESULT, 0
 	goto_eq PacifidlogTown_PokemonCenter_1F_EventScript_2C8312
-	msgbox PacifidlogTown_PokemonCenter_1F_Text_2C7E40, 4
+	msgbox PacifidlogTown_PokemonCenter_1F_Text_2C7E40, MSGBOX_DEFAULT
 	setvar VAR_0x8005, 12
 	call PacifidlogTown_PokemonCenter_1F_EventScript_2C8326
 	compare VAR_RESULT, 0
@@ -11618,12 +11618,12 @@ PacifidlogTown_PokemonCenter_1F_EventScript_2C82BE:: @ 82C82BE
 	end
 
 PacifidlogTown_PokemonCenter_1F_EventScript_2C8312:: @ 82C8312
-	msgbox PacifidlogTown_PokemonCenter_1F_Text_2C7E04, 4
+	msgbox PacifidlogTown_PokemonCenter_1F_Text_2C7E04, MSGBOX_DEFAULT
 	release
 	end
 
 PacifidlogTown_PokemonCenter_1F_EventScript_2C831C:: @ 82C831C
-	msgbox PacifidlogTown_PokemonCenter_1F_Text_2C7E7A, 4
+	msgbox PacifidlogTown_PokemonCenter_1F_Text_2C7E7A, MSGBOX_DEFAULT
 	release
 	end
 
@@ -11653,7 +11653,7 @@ PacifidlogTown_PokemonCenter_1F_EventScript_2C832D:: @ 82C832D
 SlateportCity_PokemonFanClub_EventScript_2C832D:: @ 82C832D
 SootopolisCity_PokemonCenter_1F_EventScript_2C832D:: @ 82C832D
 VerdanturfTown_PokemonCenter_1F_EventScript_2C832D:: @ 82C832D
-	msgbox MauvilleCity_Text_2C6E05, 5
+	msgbox MauvilleCity_Text_2C6E05, MSGBOX_YESNO
 	return
 
 TrainerHill_1F_MapScript1_2C8336: @ 82C8336
@@ -11697,7 +11697,7 @@ EventScript_TrainerHillTimer:: @ 82C8393
 	lockall
 	setvar VAR_0x8004, 7
 	special sp194_trainer_tower
-	msgbox TrainerHill_Entrance_Text_268D47, 4
+	msgbox TrainerHill_Entrance_Text_268D47, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -11747,7 +11747,7 @@ Text_ThisIsATestSignpostMsg:: @ 82C840A
 	.string "This is a signpost.$"
 
 EventScript_TestSignpostMsg:: @ 82C8436
-	msgbox Text_ThisIsATestSignpostMsg, 3
+	msgbox Text_ThisIsATestSignpostMsg, MSGBOX_SIGN
 	end
 
 gText_082C843F:: @ 82C843F

--- a/data/maps/AbandonedShip_CaptainsOffice/scripts.inc
+++ b/data/maps/AbandonedShip_CaptainsOffice/scripts.inc
@@ -11,17 +11,17 @@ AbandonedShip_CaptainsOffice_EventScript_2387E2:: @ 82387E2
 	goto_eq AbandonedShip_CaptainsOffice_EventScript_238810
 	checkflag FLAG_ITEM_ABANDONED_SHIP_HIDDEN_FLOOR_ROOM_4_SCANNER
 	goto_eq AbandonedShip_CaptainsOffice_EventScript_23881A
-	msgbox AbandonedShip_CaptainsOffice_Text_238824, 4
+	msgbox AbandonedShip_CaptainsOffice_Text_238824, MSGBOX_DEFAULT
 	release
 	end
 
 AbandonedShip_CaptainsOffice_EventScript_238810:: @ 8238810
-	msgbox AbandonedShip_CaptainsOffice_Text_23889D, 4
+	msgbox AbandonedShip_CaptainsOffice_Text_23889D, MSGBOX_DEFAULT
 	release
 	end
 
 AbandonedShip_CaptainsOffice_EventScript_23881A:: @ 823881A
-	msgbox AbandonedShip_CaptainsOffice_Text_238918, 4
+	msgbox AbandonedShip_CaptainsOffice_Text_238918, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/AbandonedShip_Corridors_1F/scripts.inc
+++ b/data/maps/AbandonedShip_Corridors_1F/scripts.inc
@@ -2,12 +2,12 @@ AbandonedShip_Corridors_1F_MapScripts:: @ 82379A4
 	.byte 0
 
 AbandonedShip_Corridors_1F_EventScript_2379A5:: @ 82379A5
-	msgbox AbandonedShip_Corridors_1F_Text_237A60, 2
+	msgbox AbandonedShip_Corridors_1F_Text_237A60, MSGBOX_NPC
 	end
 
 AbandonedShip_Corridors_1F_EventScript_2379AE:: @ 82379AE
 	trainerbattle 0, TRAINER_CHARLIE, 0, AbandonedShip_Corridors_1F_Text_2379C5, AbandonedShip_Corridors_1F_Text_237A01
-	msgbox AbandonedShip_Corridors_1F_Text_237A1B, 6
+	msgbox AbandonedShip_Corridors_1F_Text_237A1B, MSGBOX_AUTOCLOSE
 	end
 
 AbandonedShip_Corridors_1F_Text_2379C5: @ 82379C5

--- a/data/maps/AbandonedShip_Corridors_B1F/scripts.inc
+++ b/data/maps/AbandonedShip_Corridors_B1F/scripts.inc
@@ -23,7 +23,7 @@ AbandonedShip_Corridors_B1F_EventScript_237DB5:: @ 8237DB5
 	return
 
 AbandonedShip_Corridors_B1F_EventScript_237DBF:: @ 8237DBF
-	msgbox AbandonedShip_Corridors_B1F_Text_237F03, 2
+	msgbox AbandonedShip_Corridors_B1F_Text_237F03, MSGBOX_NPC
 	end
 
 AbandonedShip_Corridors_B1F_EventScript_237DC8:: @ 8237DC8
@@ -33,7 +33,7 @@ AbandonedShip_Corridors_B1F_EventScript_237DC8:: @ 8237DC8
 	checkitem ITEM_STORAGE_KEY, 1
 	compare VAR_RESULT, 0
 	goto_eq AbandonedShip_Corridors_B1F_EventScript_237DFF
-	msgbox AbandonedShip_Corridors_B1F_Text_237F4B, 4
+	msgbox AbandonedShip_Corridors_B1F_Text_237F4B, MSGBOX_DEFAULT
 	playse SE_PIN
 	takeitem ITEM_STORAGE_KEY, 1
 	setflag FLAG_0x0EF
@@ -43,18 +43,18 @@ AbandonedShip_Corridors_B1F_EventScript_237DC8:: @ 8237DC8
 	end
 
 AbandonedShip_Corridors_B1F_EventScript_237DFF:: @ 8237DFF
-	msgbox AbandonedShip_Corridors_B1F_Text_237F15, 4
+	msgbox AbandonedShip_Corridors_B1F_Text_237F15, MSGBOX_DEFAULT
 	releaseall
 	end
 
 AbandonedShip_Corridors_B1F_EventScript_237E09:: @ 8237E09
-	msgbox AbandonedShip_Corridors_B1F_Text_237FA5, 4
+	msgbox AbandonedShip_Corridors_B1F_Text_237FA5, MSGBOX_DEFAULT
 	releaseall
 	end
 
 AbandonedShip_Corridors_B1F_EventScript_237E13:: @ 8237E13
 	trainerbattle 0, TRAINER_DUNCAN, 0, AbandonedShip_Corridors_B1F_Text_237E2A, AbandonedShip_Corridors_B1F_Text_237E80
-	msgbox AbandonedShip_Corridors_B1F_Text_237E92, 6
+	msgbox AbandonedShip_Corridors_B1F_Text_237E92, MSGBOX_AUTOCLOSE
 	end
 
 AbandonedShip_Corridors_B1F_Text_237E2A: @ 8237E2A

--- a/data/maps/AbandonedShip_HiddenFloorCorridors/scripts.inc
+++ b/data/maps/AbandonedShip_HiddenFloorCorridors/scripts.inc
@@ -65,7 +65,7 @@ AbandonedShip_HiddenFloorCorridors_EventScript_238A19:: @ 8238A19
 	checkitem ITEM_ROOM_1_KEY, 1
 	compare VAR_RESULT, 0
 	goto_eq AbandonedShip_HiddenFloorCorridors_EventScript_238AF5
-	msgbox AbandonedShip_HiddenFloorCorridors_Text_238BF7, 4
+	msgbox AbandonedShip_HiddenFloorCorridors_Text_238BF7, MSGBOX_DEFAULT
 	playse SE_PIN
 	takeitem ITEM_ROOM_1_KEY, 1
 	setflag FLAG_0x0F0
@@ -81,7 +81,7 @@ AbandonedShip_HiddenFloorCorridors_EventScript_238A50:: @ 8238A50
 	checkitem ITEM_ROOM_2_KEY, 1
 	compare VAR_RESULT, 0
 	goto_eq AbandonedShip_HiddenFloorCorridors_EventScript_238AFF
-	msgbox AbandonedShip_HiddenFloorCorridors_Text_238BF7, 4
+	msgbox AbandonedShip_HiddenFloorCorridors_Text_238BF7, MSGBOX_DEFAULT
 	playse SE_PIN
 	takeitem ITEM_ROOM_2_KEY, 1
 	setflag FLAG_0x0F1
@@ -97,7 +97,7 @@ AbandonedShip_HiddenFloorCorridors_EventScript_238A87:: @ 8238A87
 	checkitem ITEM_ROOM_4_KEY, 1
 	compare VAR_RESULT, 0
 	goto_eq AbandonedShip_HiddenFloorCorridors_EventScript_238B09
-	msgbox AbandonedShip_HiddenFloorCorridors_Text_238BF7, 4
+	msgbox AbandonedShip_HiddenFloorCorridors_Text_238BF7, MSGBOX_DEFAULT
 	playse SE_PIN
 	takeitem ITEM_ROOM_4_KEY, 1
 	setflag FLAG_0x0F2
@@ -113,7 +113,7 @@ AbandonedShip_HiddenFloorCorridors_EventScript_238ABE:: @ 8238ABE
 	checkitem ITEM_ROOM_6_KEY, 1
 	compare VAR_RESULT, 0
 	goto_eq AbandonedShip_HiddenFloorCorridors_EventScript_238B13
-	msgbox AbandonedShip_HiddenFloorCorridors_Text_238BF7, 4
+	msgbox AbandonedShip_HiddenFloorCorridors_Text_238BF7, MSGBOX_DEFAULT
 	playse SE_PIN
 	takeitem ITEM_ROOM_6_KEY, 1
 	setflag FLAG_0x0F3
@@ -123,27 +123,27 @@ AbandonedShip_HiddenFloorCorridors_EventScript_238ABE:: @ 8238ABE
 	end
 
 AbandonedShip_HiddenFloorCorridors_EventScript_238AF5:: @ 8238AF5
-	msgbox AbandonedShip_HiddenFloorCorridors_Text_238B27, 4
+	msgbox AbandonedShip_HiddenFloorCorridors_Text_238B27, MSGBOX_DEFAULT
 	releaseall
 	end
 
 AbandonedShip_HiddenFloorCorridors_EventScript_238AFF:: @ 8238AFF
-	msgbox AbandonedShip_HiddenFloorCorridors_Text_238B5B, 4
+	msgbox AbandonedShip_HiddenFloorCorridors_Text_238B5B, MSGBOX_DEFAULT
 	releaseall
 	end
 
 AbandonedShip_HiddenFloorCorridors_EventScript_238B09:: @ 8238B09
-	msgbox AbandonedShip_HiddenFloorCorridors_Text_238B8F, 4
+	msgbox AbandonedShip_HiddenFloorCorridors_Text_238B8F, MSGBOX_DEFAULT
 	releaseall
 	end
 
 AbandonedShip_HiddenFloorCorridors_EventScript_238B13:: @ 8238B13
-	msgbox AbandonedShip_HiddenFloorCorridors_Text_238BC3, 4
+	msgbox AbandonedShip_HiddenFloorCorridors_Text_238BC3, MSGBOX_DEFAULT
 	releaseall
 	end
 
 AbandonedShip_HiddenFloorCorridors_EventScript_238B1D:: @ 8238B1D
-	msgbox AbandonedShip_HiddenFloorCorridors_Text_237FA5, 4
+	msgbox AbandonedShip_HiddenFloorCorridors_Text_237FA5, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/AbandonedShip_HiddenFloorRooms/scripts.inc
+++ b/data/maps/AbandonedShip_HiddenFloorRooms/scripts.inc
@@ -138,7 +138,7 @@ AbandonedShip_HiddenFloorRooms_EventScript_238DE3:: @ 8238DE3
 
 AbandonedShip_HiddenFloorRooms_EventScript_238DF3:: @ 8238DF3
 	lockall
-	msgbox AbandonedShip_HiddenFloorRooms_Text_238DFE, 4
+	msgbox AbandonedShip_HiddenFloorRooms_Text_238DFE, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/AbandonedShip_Rooms2_1F/scripts.inc
+++ b/data/maps/AbandonedShip_Rooms2_1F/scripts.inc
@@ -6,22 +6,22 @@ AbandonedShip_Rooms2_1F_EventScript_2380A7:: @ 82380A7
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq AbandonedShip_Rooms2_1F_EventScript_2380F0
-	msgbox AbandonedShip_Rooms2_1F_Text_23820F, 4
+	msgbox AbandonedShip_Rooms2_1F_Text_23820F, MSGBOX_DEFAULT
 	release
 	end
 
 AbandonedShip_Rooms2_1F_EventScript_2380D7:: @ 82380D7
-	msgbox AbandonedShip_Rooms2_1F_Text_2383BB, 4
+	msgbox AbandonedShip_Rooms2_1F_Text_2383BB, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 642
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 642
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 AbandonedShip_Rooms2_1F_EventScript_2380F0:: @ 82380F0
 	trainerbattle 7, TRAINER_KIRA_AND_DAN_1, 0, AbandonedShip_Rooms2_1F_Text_2383FF, AbandonedShip_Rooms2_1F_Text_238473, AbandonedShip_Rooms2_1F_Text_238509
-	msgbox AbandonedShip_Rooms2_1F_Text_238491, 6
+	msgbox AbandonedShip_Rooms2_1F_Text_238491, MSGBOX_AUTOCLOSE
 	end
 
 AbandonedShip_Rooms2_1F_EventScript_23810B:: @ 823810B
@@ -29,32 +29,32 @@ AbandonedShip_Rooms2_1F_EventScript_23810B:: @ 823810B
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq AbandonedShip_Rooms2_1F_EventScript_238154
-	msgbox AbandonedShip_Rooms2_1F_Text_23830A, 4
+	msgbox AbandonedShip_Rooms2_1F_Text_23830A, MSGBOX_DEFAULT
 	release
 	end
 
 AbandonedShip_Rooms2_1F_EventScript_23813B:: @ 823813B
-	msgbox AbandonedShip_Rooms2_1F_Text_2383BB, 4
+	msgbox AbandonedShip_Rooms2_1F_Text_2383BB, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 642
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 642
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 AbandonedShip_Rooms2_1F_EventScript_238154:: @ 8238154
 	trainerbattle 7, TRAINER_KIRA_AND_DAN_1, 0, AbandonedShip_Rooms2_1F_Text_238556, AbandonedShip_Rooms2_1F_Text_2385F2, AbandonedShip_Rooms2_1F_Text_238668
-	msgbox AbandonedShip_Rooms2_1F_Text_23860B, 6
+	msgbox AbandonedShip_Rooms2_1F_Text_23860B, MSGBOX_AUTOCLOSE
 	end
 
 AbandonedShip_Rooms2_1F_EventScript_23816F:: @ 823816F
 	trainerbattle 0, TRAINER_JANI, 0, AbandonedShip_Rooms2_1F_Text_2386B4, AbandonedShip_Rooms2_1F_Text_2386E8
-	msgbox AbandonedShip_Rooms2_1F_Text_238708, 6
+	msgbox AbandonedShip_Rooms2_1F_Text_238708, MSGBOX_AUTOCLOSE
 	end
 
 AbandonedShip_Rooms2_1F_EventScript_238186:: @ 8238186
 	trainerbattle 0, TRAINER_GARRISON, 0, AbandonedShip_Rooms2_1F_Text_23873F, AbandonedShip_Rooms2_1F_Text_238779
-	msgbox AbandonedShip_Rooms2_1F_Text_2387A9, 6
+	msgbox AbandonedShip_Rooms2_1F_Text_2387A9, MSGBOX_AUTOCLOSE
 	end
 
 AbandonedShip_Rooms2_1F_Text_23819D: @ 823819D

--- a/data/maps/AbandonedShip_Rooms2_1F/scripts.inc
+++ b/data/maps/AbandonedShip_Rooms2_1F/scripts.inc
@@ -12,10 +12,7 @@ AbandonedShip_Rooms2_1F_EventScript_2380A7:: @ 82380A7
 
 AbandonedShip_Rooms2_1F_EventScript_2380D7:: @ 82380D7
 	msgbox AbandonedShip_Rooms2_1F_Text_2383BB, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 642
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 642
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_KIRA_AND_DAN_1
 	release
 	end
 
@@ -35,10 +32,7 @@ AbandonedShip_Rooms2_1F_EventScript_23810B:: @ 823810B
 
 AbandonedShip_Rooms2_1F_EventScript_23813B:: @ 823813B
 	msgbox AbandonedShip_Rooms2_1F_Text_2383BB, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 642
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 642
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_KIRA_AND_DAN_1
 	release
 	end
 

--- a/data/maps/AbandonedShip_Rooms2_B1F/scripts.inc
+++ b/data/maps/AbandonedShip_Rooms2_B1F/scripts.inc
@@ -2,7 +2,7 @@ AbandonedShip_Rooms2_B1F_MapScripts:: @ 8238024
 	.byte 0
 
 AbandonedShip_Rooms2_B1F_EventScript_238025:: @ 8238025
-	msgbox AbandonedShip_Rooms2_B1F_Text_23802E, 2
+	msgbox AbandonedShip_Rooms2_B1F_Text_23802E, MSGBOX_NPC
 	end
 
 AbandonedShip_Rooms2_B1F_Text_23802E: @ 823802E

--- a/data/maps/AbandonedShip_Rooms_1F/scripts.inc
+++ b/data/maps/AbandonedShip_Rooms_1F/scripts.inc
@@ -2,12 +2,12 @@ AbandonedShip_Rooms_1F_MapScripts:: @ 8237A92
 	.byte 0
 
 AbandonedShip_Rooms_1F_EventScript_237A93:: @ 8237A93
-	msgbox AbandonedShip_Rooms_1F_Text_237B15, 2
+	msgbox AbandonedShip_Rooms_1F_Text_237B15, MSGBOX_NPC
 	end
 
 AbandonedShip_Rooms_1F_EventScript_237A9C:: @ 8237A9C
 	trainerbattle 0, TRAINER_DEMETRIUS, 0, AbandonedShip_Rooms_1F_Text_237D0C, AbandonedShip_Rooms_1F_Text_237D2A
-	msgbox AbandonedShip_Rooms_1F_Text_237D41, 6
+	msgbox AbandonedShip_Rooms_1F_Text_237D41, MSGBOX_AUTOCLOSE
 	end
 
 AbandonedShip_Rooms_1F_EventScript_237AB3:: @ 8237AB3
@@ -15,24 +15,24 @@ AbandonedShip_Rooms_1F_EventScript_237AB3:: @ 8237AB3
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq AbandonedShip_Rooms_1F_EventScript_237AFE
-	msgbox AbandonedShip_Rooms_1F_Text_237BDB, 4
+	msgbox AbandonedShip_Rooms_1F_Text_237BDB, MSGBOX_DEFAULT
 	release
 	end
 
 AbandonedShip_Rooms_1F_EventScript_237ADF:: @ 8237ADF
 	special sub_80B4808
 	waitmovement 0
-	msgbox AbandonedShip_Rooms_1F_Text_237C2A, 4
+	msgbox AbandonedShip_Rooms_1F_Text_237C2A, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 144
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 144
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 AbandonedShip_Rooms_1F_EventScript_237AFE:: @ 8237AFE
 	trainerbattle 5, TRAINER_THALIA_1, 0, AbandonedShip_Rooms_1F_Text_237C69, AbandonedShip_Rooms_1F_Text_237CB2
-	msgbox AbandonedShip_Rooms_1F_Text_237CC9, 6
+	msgbox AbandonedShip_Rooms_1F_Text_237CC9, MSGBOX_AUTOCLOSE
 	end
 
 AbandonedShip_Rooms_1F_Text_237B15: @ 8237B15

--- a/data/maps/AbandonedShip_Rooms_1F/scripts.inc
+++ b/data/maps/AbandonedShip_Rooms_1F/scripts.inc
@@ -23,10 +23,7 @@ AbandonedShip_Rooms_1F_EventScript_237ADF:: @ 8237ADF
 	special sub_80B4808
 	waitmovement 0
 	msgbox AbandonedShip_Rooms_1F_Text_237C2A, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 144
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 144
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_THALIA_1
 	release
 	end
 

--- a/data/maps/AbandonedShip_Rooms_B1F/scripts.inc
+++ b/data/maps/AbandonedShip_Rooms_B1F/scripts.inc
@@ -7,7 +7,7 @@ AbandonedShip_Rooms_B1F_MapScript1_237FBD: @ 8237FBD
 	end
 
 AbandonedShip_Rooms_B1F_EventScript_237FC6:: @ 8237FC6
-	msgbox AbandonedShip_Rooms_B1F_Text_237FCF, 2
+	msgbox AbandonedShip_Rooms_B1F_Text_237FCF, MSGBOX_NPC
 	end
 
 AbandonedShip_Rooms_B1F_Text_237FCF: @ 8237FCF

--- a/data/maps/AncientTomb/scripts.inc
+++ b/data/maps/AncientTomb/scripts.inc
@@ -51,7 +51,7 @@ AncientTomb_EventScript_239033:: @ 8239033
 	end
 
 AncientTomb_EventScript_239046:: @ 8239046
-	msgbox gUnknown_0827304E, 4
+	msgbox gUnknown_0827304E, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/AquaHideout_1F/scripts.inc
+++ b/data/maps/AquaHideout_1F/scripts.inc
@@ -8,17 +8,17 @@ AquaHideout_1F_EventScript_233494:: @ 8233494
 	goto_eq AquaHideout_1F_EventScript_2334BC
 	checkflag FLAG_0x0D4
 	goto_eq AquaHideout_1F_EventScript_2334B2
-	msgbox AquaHideout_1F_Text_23351D, 4
+	msgbox AquaHideout_1F_Text_23351D, MSGBOX_DEFAULT
 	release
 	end
 
 AquaHideout_1F_EventScript_2334B2:: @ 82334B2
-	msgbox AquaHideout_1F_Text_2335E3, 4
+	msgbox AquaHideout_1F_Text_2335E3, MSGBOX_DEFAULT
 	release
 	end
 
 AquaHideout_1F_EventScript_2334BC:: @ 82334BC
-	msgbox AquaHideout_1F_Text_23367D, 4
+	msgbox AquaHideout_1F_Text_23367D, MSGBOX_DEFAULT
 	release
 	end
 
@@ -29,27 +29,27 @@ AquaHideout_1F_EventScript_2334C6:: @ 82334C6
 	goto_eq AquaHideout_1F_EventScript_2334EE
 	checkflag FLAG_0x0D4
 	goto_eq AquaHideout_1F_EventScript_2334E4
-	msgbox AquaHideout_1F_Text_233739, 4
+	msgbox AquaHideout_1F_Text_233739, MSGBOX_DEFAULT
 	release
 	end
 
 AquaHideout_1F_EventScript_2334E4:: @ 82334E4
-	msgbox AquaHideout_1F_Text_2337FA, 4
+	msgbox AquaHideout_1F_Text_2337FA, MSGBOX_DEFAULT
 	release
 	end
 
 AquaHideout_1F_EventScript_2334EE:: @ 82334EE
-	msgbox AquaHideout_1F_Text_233884, 4
+	msgbox AquaHideout_1F_Text_233884, MSGBOX_DEFAULT
 	release
 	end
 
 AquaHideout_1F_EventScript_2334F8:: @ 82334F8
 	trainerbattle 2, TRAINER_GRUNT_1, 0, AquaHideout_1F_Text_23393D, AquaHideout_1F_Text_233964, AquaHideout_1F_EventScript_233513
-	msgbox AquaHideout_1F_Text_233977, 6
+	msgbox AquaHideout_1F_Text_233977, MSGBOX_AUTOCLOSE
 	end
 
 AquaHideout_1F_EventScript_233513:: @ 8233513
-	msgbox AquaHideout_1F_Text_233977, 4
+	msgbox AquaHideout_1F_Text_233977, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/AquaHideout_B1F/scripts.inc
+++ b/data/maps/AquaHideout_B1F/scripts.inc
@@ -86,34 +86,34 @@ AquaHideout_B1F_EventScript_233A7C:: @ 8233A7C
 
 AquaHideout_B1F_EventScript_233A85:: @ 8233A85
 	trainerbattle 2, TRAINER_GRUNT_2, 0, AquaHideout_B1F_Text_233B03, AquaHideout_B1F_Text_233B4A, AquaHideout_B1F_EventScript_233AA0
-	msgbox AquaHideout_B1F_Text_233B5E, 6
+	msgbox AquaHideout_B1F_Text_233B5E, MSGBOX_AUTOCLOSE
 	end
 
 AquaHideout_B1F_EventScript_233AA0:: @ 8233AA0
 	special sub_80B4808
 	waitmovement 0
-	msgbox AquaHideout_B1F_Text_233B5E, 4
+	msgbox AquaHideout_B1F_Text_233B5E, MSGBOX_DEFAULT
 	release
 	end
 
 AquaHideout_B1F_EventScript_233AB0:: @ 8233AB0
 	trainerbattle 2, TRAINER_GRUNT_3, 0, AquaHideout_B1F_Text_233BC5, AquaHideout_B1F_Text_233C27, AquaHideout_B1F_EventScript_233ACB
-	msgbox AquaHideout_B1F_Text_233C41, 6
+	msgbox AquaHideout_B1F_Text_233C41, MSGBOX_AUTOCLOSE
 	end
 
 AquaHideout_B1F_EventScript_233ACB:: @ 8233ACB
-	msgbox AquaHideout_B1F_Text_233C41, 4
+	msgbox AquaHideout_B1F_Text_233C41, MSGBOX_DEFAULT
 	release
 	end
 
 AquaHideout_B1F_EventScript_233AD5:: @ 8233AD5
 	trainerbattle 0, TRAINER_GRUNT_21, 0, AquaHideout_B1F_Text_233C89, AquaHideout_B1F_Text_233CCA
-	msgbox AquaHideout_B1F_Text_233CDC, 6
+	msgbox AquaHideout_B1F_Text_233CDC, MSGBOX_AUTOCLOSE
 	end
 
 AquaHideout_B1F_EventScript_233AEC:: @ 8233AEC
 	trainerbattle 0, TRAINER_GRUNT_25, 0, AquaHideout_B1F_Text_233D1B, AquaHideout_B1F_Text_233D6E
-	msgbox AquaHideout_B1F_Text_233D84, 6
+	msgbox AquaHideout_B1F_Text_233D84, MSGBOX_AUTOCLOSE
 	end
 
 AquaHideout_B1F_Text_233B03: @ 8233B03

--- a/data/maps/AquaHideout_B2F/scripts.inc
+++ b/data/maps/AquaHideout_B2F/scripts.inc
@@ -25,7 +25,7 @@ AquaHideout_B2F_EventScript_233DE5:: @ 8233DE5
 
 AquaHideout_B2F_EventScript_233E09:: @ 8233E09
 	trainerbattle 2, TRAINER_MATT, 0, AquaHideout_B2F_Text_233EDD, AquaHideout_B2F_Text_233F8D, AquaHideout_B2F_EventScript_233E25
-	msgbox AquaHideout_B2F_Text_233FF2, 4
+	msgbox AquaHideout_B2F_Text_233FF2, MSGBOX_DEFAULT
 	release
 	end
 
@@ -37,7 +37,7 @@ AquaHideout_B2F_EventScript_233E25:: @ 8233E25
 	delay 20
 	applymovement VAR_0x8008, AquaHideout_B2F_Movement_27259E
 	waitmovement 0
-	msgbox AquaHideout_B2F_Text_233FA6, 4
+	msgbox AquaHideout_B2F_Text_233FA6, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_0x8008, AquaHideout_B2F_Movement_2725A4
 	applymovement VAR_0x8009, AquaHideout_B2F_Movement_233E80
@@ -46,7 +46,7 @@ AquaHideout_B2F_EventScript_233E25:: @ 8233E25
 	delay 20
 	applymovement VAR_0x8008, AquaHideout_B2F_Movement_27259E
 	waitmovement 0
-	msgbox AquaHideout_B2F_Text_233FF2, 4
+	msgbox AquaHideout_B2F_Text_233FF2, MSGBOX_DEFAULT
 	setflag FLAG_0x070
 	setflag FLAG_HIDE_LILYCOVE_CITY_AQUA_GRUNTS
 	release
@@ -68,22 +68,22 @@ AquaHideout_B2F_Movement_233E85: @ 8233E85
 
 AquaHideout_B2F_EventScript_233E8A:: @ 8233E8A
 	trainerbattle 2, TRAINER_GRUNT_4, 0, AquaHideout_B2F_Text_2340B4, AquaHideout_B2F_Text_2340F0, AquaHideout_B2F_EventScript_233EA5
-	msgbox AquaHideout_B2F_Text_234112, 6
+	msgbox AquaHideout_B2F_Text_234112, MSGBOX_AUTOCLOSE
 	end
 
 AquaHideout_B2F_EventScript_233EA5:: @ 8233EA5
-	msgbox AquaHideout_B2F_Text_234112, 4
+	msgbox AquaHideout_B2F_Text_234112, MSGBOX_DEFAULT
 	release
 	end
 
 AquaHideout_B2F_EventScript_233EAF:: @ 8233EAF
 	trainerbattle 0, TRAINER_GRUNT_22, 0, AquaHideout_B2F_Text_23412D, AquaHideout_B2F_Text_2341CE
-	msgbox AquaHideout_B2F_Text_2341FE, 6
+	msgbox AquaHideout_B2F_Text_2341FE, MSGBOX_AUTOCLOSE
 	end
 
 AquaHideout_B2F_EventScript_233EC6:: @ 8233EC6
 	trainerbattle 0, TRAINER_GRUNT_26, 0, AquaHideout_B2F_Text_23426F, AquaHideout_B2F_Text_2342CC
-	msgbox AquaHideout_B2F_Text_2342FF, 6
+	msgbox AquaHideout_B2F_Text_2342FF, MSGBOX_AUTOCLOSE
 	end
 
 AquaHideout_B2F_Text_233EDD: @ 8233EDD

--- a/data/maps/BattleFrontier_BattleArenaBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleArenaBattleRoom/scripts.inc
@@ -64,7 +64,7 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_25752E:: @ 825752E
 	playse SE_W187
 	waitse
 	waitmovement 0
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257C3D, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257C3D, MSGBOX_DEFAULT
 	closemessage
 	applymovement 8, BattleFrontier_BattleArenaBattleRoom_Movement_257BE5
 	waitmovement 0
@@ -74,7 +74,7 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_25752E:: @ 825752E
 	waitmovement 0
 	setvar VAR_0x8004, 6
 	special CallBattleArenaFunction
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257C68, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257C68, MSGBOX_DEFAULT
 	closemessage
 	applymovement 7, BattleFrontier_BattleArenaBattleRoom_Movement_257BF2
 	waitmovement 0
@@ -82,14 +82,14 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_25752E:: @ 825752E
 	playse SE_W187
 	waitse
 	waitmovement 0
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257C93, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257C93, MSGBOX_DEFAULT
 	closemessage
 	applymovement 8, BattleFrontier_BattleArenaBattleRoom_Movement_257BE5
 	applymovement 7, BattleFrontier_BattleArenaBattleRoom_Movement_257BF2
 	waitmovement 0
 	setvar VAR_0x8004, 5
 	special CallBattlePalaceFunction
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	waitmessage
 	call BattleFrontier_BattleArenaBattleRoom_EventScript_257B6C
 	switch VAR_RESULT
@@ -106,7 +106,7 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_2575DB:: @ 82575DB
 	waitmovement 0
 	setvar VAR_0x8004, 6
 	special CallBattleArenaFunction
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257CCE, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257CCE, MSGBOX_DEFAULT
 
 BattleFrontier_BattleArenaBattleRoom_EventScript_257615:: @ 8257615
 	setvar VAR_0x8004, 2
@@ -135,7 +135,7 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_257630:: @ 8257630
 	applymovement 5, BattleFrontier_BattleArenaBattleRoom_Movement_257C08
 	applymovement 8, BattleFrontier_BattleArenaBattleRoom_Movement_257BEB
 	waitmovement 0
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257CE9, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257CE9, MSGBOX_DEFAULT
 	special LoadPlayerParty
 	special SavePlayerParty
 	setvar VAR_0x8004, 3
@@ -199,7 +199,7 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_2577D0:: @ 82577D0
 	goto BattleFrontier_BattleArenaBattleRoom_EventScript_2576B0
 
 BattleFrontier_BattleArenaBattleRoom_EventScript_2577DA:: @ 82577DA
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257E6B, 5
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257E6B, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattleArenaBattleRoom_EventScript_2576B0
 	case 1, BattleFrontier_BattleArenaBattleRoom_EventScript_25789A
@@ -277,7 +277,7 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_25789A:: @ 825789A
 BattleFrontier_BattleArenaBattleRoom_EventScript_2578BC:: @ 82578BC
 	compare VAR_TEMP_2, 1
 	goto_eq BattleFrontier_BattleArenaBattleRoom_EventScript_2578D4
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257F45, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257F45, MSGBOX_DEFAULT
 	setvar VAR_TEMP_2, 1
 
 BattleFrontier_BattleArenaBattleRoom_EventScript_2578D4:: @ 82578D4
@@ -311,7 +311,7 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_257961:: @ 8257961
 	playse SE_W187
 	waitse
 	waitmovement 0
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257C3D, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257C3D, MSGBOX_DEFAULT
 	closemessage
 	applymovement 8, BattleFrontier_BattleArenaBattleRoom_Movement_257BE4
 	waitmovement 0
@@ -319,7 +319,7 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_257961:: @ 8257961
 	playse SE_W187
 	waitse
 	waitmovement 0
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257FED, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257FED, MSGBOX_DEFAULT
 	closemessage
 	addobject 7
 	applymovement 7, BattleFrontier_BattleArenaBattleRoom_Movement_257BF4
@@ -335,21 +335,21 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_257961:: @ 8257961
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattleArenaBattleRoom_EventScript_257A3F
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_25801C, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_25801C, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 7
 	special CallFrontierUtilFunc
 	applymovement 7, BattleFrontier_BattleArenaBattleRoom_Movement_257C30
 	waitmovement 0
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_25804E, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_25804E, MSGBOX_DEFAULT
 	closemessage
 	applymovement 7, BattleFrontier_BattleArenaBattleRoom_Movement_257C3A
 	waitmovement 0
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_258068, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_258068, MSGBOX_DEFAULT
 
 BattleFrontier_BattleArenaBattleRoom_EventScript_257A3F:: @ 8257A3F
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_25810D, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_25810D, MSGBOX_DEFAULT
 	call BattleFrontier_BattleArenaBattleRoom_EventScript_257B5E
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattleArenaBattleRoom_EventScript_257A5C
@@ -363,14 +363,14 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_257A5C:: @ 8257A5C
 	goto_if 5, BattleFrontier_BattleArenaBattleRoom_EventScript_257852
 	applymovement 7, BattleFrontier_BattleArenaBattleRoom_Movement_257BF1
 	waitmovement 0
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_25813F, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_25813F, MSGBOX_DEFAULT
 	playfanfare MUS_ME_SYMBOLGET
 	message BattleFrontier_BattleArenaBattleRoom_Text_25819C
 	waitmessage
 	waitfanfare
 	setvar VAR_0x8004, 13
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_2581CF, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_2581CF, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleArenaBattleRoom_EventScript_257852
 
 BattleFrontier_BattleArenaBattleRoom_EventScript_257AA5:: @ 8257AA5
@@ -379,21 +379,21 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_257AA5:: @ 8257AA5
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattleArenaBattleRoom_EventScript_257AF8
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_258213, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_258213, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 7
 	special CallFrontierUtilFunc
 	applymovement 7, BattleFrontier_BattleArenaBattleRoom_Movement_257C30
 	waitmovement 0
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_2582A2, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_2582A2, MSGBOX_DEFAULT
 	closemessage
 	applymovement 7, BattleFrontier_BattleArenaBattleRoom_Movement_257C3A
 	waitmovement 0
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_2582BB, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_2582BB, MSGBOX_DEFAULT
 
 BattleFrontier_BattleArenaBattleRoom_EventScript_257AF8:: @ 8257AF8
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_2582F9, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_2582F9, MSGBOX_DEFAULT
 	call BattleFrontier_BattleArenaBattleRoom_EventScript_257B5E
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattleArenaBattleRoom_EventScript_257B15
@@ -407,18 +407,18 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_257B15:: @ 8257B15
 	goto_eq BattleFrontier_BattleArenaBattleRoom_EventScript_257852
 	applymovement 7, BattleFrontier_BattleArenaBattleRoom_Movement_257BF1
 	waitmovement 0
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_258323, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_258323, MSGBOX_DEFAULT
 	playfanfare MUS_ME_SYMBOLGET
 	message BattleFrontier_BattleArenaBattleRoom_Text_25835B
 	waitmessage
 	waitfanfare
 	setvar VAR_0x8004, 13
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_258383, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_258383, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleArenaBattleRoom_EventScript_257852
 
 BattleFrontier_BattleArenaBattleRoom_EventScript_257B5E:: @ 8257B5E
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257C93, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257C93, MSGBOX_DEFAULT
 	call BattleFrontier_BattleArenaBattleRoom_EventScript_257B6C
 	return
 
@@ -451,7 +451,7 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_257BA9:: @ 8257BA9
 	playse SE_BAN
 	waitse
 	waitmovement 0
-	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257CB3, 4
+	msgbox BattleFrontier_BattleArenaBattleRoom_Text_257CB3, MSGBOX_DEFAULT
 	closemessage
 	call BattleFrontier_BattleArenaBattleRoom_EventScript_241EBA
 	return

--- a/data/maps/BattleFrontier_BattleArenaCorridor/scripts.inc
+++ b/data/maps/BattleFrontier_BattleArenaCorridor/scripts.inc
@@ -14,7 +14,7 @@ BattleFrontier_BattleArenaCorridor_EventScript_2573C9:: @ 82573C9
 	waitmovement 0
 	applymovement 1, BattleFrontier_BattleArenaCorridor_Movement_257444
 	waitmovement 0
-	msgbox BattleFrontier_BattleArenaCorridor_Text_257449, 3
+	msgbox BattleFrontier_BattleArenaCorridor_Text_257449, MSGBOX_SIGN
 	applymovement 1, BattleFrontier_BattleArenaCorridor_Movement_257446
 	waitmovement 0
 	applymovement 255, BattleFrontier_BattleArenaCorridor_Movement_25742C

--- a/data/maps/BattleFrontier_BattleArenaLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattleArenaLobby/scripts.inc
@@ -27,7 +27,7 @@ BattleFrontier_BattleArenaLobby_EventScript_255C7F:: @ 8255C7F
 
 BattleFrontier_BattleArenaLobby_EventScript_255C88:: @ 8255C88
 	lockall
-	msgbox BattleFrontier_BattleArenaLobby_Text_256811, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_256811, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 1
@@ -51,21 +51,21 @@ BattleFrontier_BattleArenaLobby_EventScript_255CCF:: @ 8255CCF
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattleArenaLobby_EventScript_255CF0
-	msgbox BattleFrontier_BattleArenaLobby_Text_2568E7, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_2568E7, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleArenaLobby_EventScript_255CF8
 
 BattleFrontier_BattleArenaLobby_EventScript_255CF0:: @ 8255CF0
-	msgbox BattleFrontier_BattleArenaLobby_Text_2572D9, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_2572D9, MSGBOX_DEFAULT
 
 BattleFrontier_BattleArenaLobby_EventScript_255CF8:: @ 8255CF8
-	msgbox BattleFrontier_BattleArenaLobby_Text_257353, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_257353, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 11
 	special CallFrontierUtilFunc
 	msgbox BattleFrontier_BattleArenaLobby_Text_241520, 9
 	message BattleFrontier_BattleArenaLobby_Text_256931
 	waitmessage
 	call BattleFrontier_BattleArenaLobby_EventScript_255D59
-	msgbox BattleFrontier_BattleArenaLobby_Text_256A74, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_256A74, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
@@ -80,7 +80,7 @@ BattleFrontier_BattleArenaLobby_EventScript_255D2B:: @ 8255D2B
 	setvar VAR_0x8006, 0
 	special CallBattleArenaFunction
 	call BattleFrontier_BattleArenaLobby_EventScript_255D59
-	msgbox BattleFrontier_BattleArenaLobby_Text_256A74, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_256A74, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
@@ -135,7 +135,7 @@ BattleFrontier_BattleArenaLobby_EventScript_255DF4:: @ 8255DF4
 	setvar VAR_FRONTIER_FACILITY, 3
 	setvar VAR_FRONTIER_BATTLE_MODE, 0
 	special SavePlayerParty
-	msgbox BattleFrontier_BattleArenaLobby_Text_256166, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_256166, MSGBOX_DEFAULT
 
 BattleFrontier_BattleArenaLobby_EventScript_255E0B:: @ 8255E0B
 	message BattleFrontier_BattleArenaLobby_Text_2561EA
@@ -162,7 +162,7 @@ BattleFrontier_BattleArenaLobby_EventScript_255E47:: @ 8255E47
 	setvar VAR_0x8005, 1
 	copyvar VAR_0x8006, VAR_RESULT
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleArenaLobby_Text_256573, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_256573, MSGBOX_DEFAULT
 	fadescreen 1
 	call BattleFrontier_BattleArenaLobby_EventScript_23F2B7
 	copyvar VAR_0x8004, VAR_RESULT
@@ -171,7 +171,7 @@ BattleFrontier_BattleArenaLobby_EventScript_255E47:: @ 8255E47
 	waitstate
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattleArenaLobby_EventScript_255FF8
-	msgbox BattleFrontier_BattleArenaLobby_Text_2564CE, 5
+	msgbox BattleFrontier_BattleArenaLobby_Text_2564CE, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattleArenaLobby_EventScript_255FF8
 	case 1, BattleFrontier_BattleArenaLobby_EventScript_255EE8
@@ -209,7 +209,7 @@ BattleFrontier_BattleArenaLobby_EventScript_255F54:: @ 8255F54
 	setvar VAR_0x8004, 3
 	setvar VAR_0x8005, 3
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleArenaLobby_Text_2567E6, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_2567E6, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 1
 	setvar VAR_0x8005, 1
@@ -224,7 +224,7 @@ BattleFrontier_BattleArenaLobby_EventScript_255F54:: @ 8255F54
 	end
 
 BattleFrontier_BattleArenaLobby_EventScript_255F9F:: @ 8255F9F
-	msgbox BattleFrontier_BattleArenaLobby_Text_25624C, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_25624C, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleArenaLobby_EventScript_255E0B
 
 BattleFrontier_BattleArenaLobby_EventScript_255FAC:: @ 8255FAC
@@ -233,11 +233,11 @@ BattleFrontier_BattleArenaLobby_EventScript_255FAC:: @ 8255FAC
 	case 1, BattleFrontier_BattleArenaLobby_EventScript_255FD4
 
 BattleFrontier_BattleArenaLobby_EventScript_255FC7:: @ 8255FC7
-	msgbox BattleFrontier_BattleArenaLobby_Text_2566A8, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_2566A8, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleArenaLobby_EventScript_256003
 
 BattleFrontier_BattleArenaLobby_EventScript_255FD4:: @ 8255FD4
-	msgbox BattleFrontier_BattleArenaLobby_Text_2565A5, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_2565A5, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleArenaLobby_EventScript_256003
 
 BattleFrontier_BattleArenaLobby_EventScript_255FE1:: @ 8255FE1
@@ -251,7 +251,7 @@ BattleFrontier_BattleArenaLobby_EventScript_255FF8:: @ 8255FF8
 	special LoadPlayerParty
 
 BattleFrontier_BattleArenaLobby_EventScript_255FFB:: @ 8255FFB
-	msgbox BattleFrontier_BattleArenaLobby_Text_25621F, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_25621F, MSGBOX_DEFAULT
 
 BattleFrontier_BattleArenaLobby_EventScript_256003:: @ 8256003
 	release
@@ -353,24 +353,24 @@ BattleFrontier_BattleArenaLobby_EventScript_256092:: @ 8256092
 	end
 
 BattleFrontier_BattleArenaLobby_EventScript_2560A6:: @ 82560A6
-	msgbox BattleFrontier_BattleArenaLobby_Text_256B5C, 2
+	msgbox BattleFrontier_BattleArenaLobby_Text_256B5C, MSGBOX_NPC
 	end
 
 BattleFrontier_BattleArenaLobby_EventScript_2560AF:: @ 82560AF
-	msgbox BattleFrontier_BattleArenaLobby_Text_256BCB, 2
+	msgbox BattleFrontier_BattleArenaLobby_Text_256BCB, MSGBOX_NPC
 	end
 
 BattleFrontier_BattleArenaLobby_EventScript_2560B8:: @ 82560B8
-	msgbox BattleFrontier_BattleArenaLobby_Text_256C19, 2
+	msgbox BattleFrontier_BattleArenaLobby_Text_256C19, MSGBOX_NPC
 	end
 
 BattleFrontier_BattleArenaLobby_EventScript_2560C1:: @ 82560C1
-	msgbox BattleFrontier_BattleArenaLobby_Text_256C9A, 2
+	msgbox BattleFrontier_BattleArenaLobby_Text_256C9A, MSGBOX_NPC
 	end
 
 BattleFrontier_BattleArenaLobby_EventScript_2560CA:: @ 82560CA
 	lockall
-	msgbox BattleFrontier_BattleArenaLobby_Text_256DB8, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_256DB8, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleArenaLobby_EventScript_2560D9
 	end
 
@@ -388,22 +388,22 @@ BattleFrontier_BattleArenaLobby_EventScript_2560D9:: @ 82560D9
 	end
 
 BattleFrontier_BattleArenaLobby_EventScript_25612C:: @ 825612C
-	msgbox BattleFrontier_BattleArenaLobby_Text_256E02, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_256E02, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleArenaLobby_EventScript_2560D9
 	end
 
 BattleFrontier_BattleArenaLobby_EventScript_25613A:: @ 825613A
-	msgbox BattleFrontier_BattleArenaLobby_Text_256F43, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_256F43, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleArenaLobby_EventScript_2560D9
 	end
 
 BattleFrontier_BattleArenaLobby_EventScript_256148:: @ 8256148
-	msgbox BattleFrontier_BattleArenaLobby_Text_256FF2, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_256FF2, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleArenaLobby_EventScript_2560D9
 	end
 
 BattleFrontier_BattleArenaLobby_EventScript_256156:: @ 8256156
-	msgbox BattleFrontier_BattleArenaLobby_Text_257202, 4
+	msgbox BattleFrontier_BattleArenaLobby_Text_257202, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleArenaLobby_EventScript_2560D9
 	end
 

--- a/data/maps/BattleFrontier_BattleDomeBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleDomeBattleRoom/scripts.inc
@@ -46,7 +46,7 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_24BD0A:: @ 824BD0A
 	applymovement 1, BattleFrontier_BattleDomeBattleRoom_Movement_2725B4
 	waitmovement 0
 	call BattleFrontier_BattleDomeBattleRoom_EventScript_24BFD5
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24C970, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24C970, MSGBOX_DEFAULT
 	closemessage
 	showobjectat 13, MAP_BATTLE_FRONTIER_BATTLE_DOME_BATTLE_ROOM
 	compare VAR_TEMP_F, 3
@@ -73,7 +73,7 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_24BD61:: @ 824BD61
 BattleFrontier_BattleDomeBattleRoom_EventScript_24BD82:: @ 824BD82
 	setvar VAR_0x8004, 4
 	special CallBattleDomeFunction
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24C990, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24C990, MSGBOX_DEFAULT
 	closemessage
 	applymovement 13, BattleFrontier_BattleDomeBattleRoom_Movement_24C77B
 	applymovement 15, BattleFrontier_BattleDomeBattleRoom_Movement_24C789
@@ -81,7 +81,7 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_24BD82:: @ 824BD82
 	setvar VAR_0x8004, 7
 	setvar VAR_0x8005, 0
 	special sub_8161F74
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 5
 	special CallBattleDomeFunction
@@ -94,7 +94,7 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_24BD82:: @ 824BD82
 	setvar VAR_TEMP_2, 1
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24BDF7:: @ 824BDF7
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24CA86, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24CA86, MSGBOX_DEFAULT
 	closemessage
 	playse SE_W227B
 	call BattleFrontier_BattleDomeBattleRoom_EventScript_24C82E
@@ -199,11 +199,11 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_24BF62:: @ 824BF62
 	special CallFrontierUtilFunc
 	switch VAR_RESULT
 	case 1, BattleFrontier_BattleDomeBattleRoom_EventScript_24BF96
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24CA04, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24CA04, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleDomeBattleRoom_EventScript_24BF9E
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24BF96:: @ 824BF96
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24CA44, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24CA44, MSGBOX_DEFAULT
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24BF9E:: @ 824BF9E
 	special sub_8175280
@@ -217,11 +217,11 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_24BF9E:: @ 824BF9E
 	goto BattleFrontier_BattleDomeBattleRoom_EventScript_24C8F5
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24BFC3:: @ 824BFC3
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24C9BE, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24C9BE, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24BFCC:: @ 824BFCC
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24CB9D, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24CB9D, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24BFD5:: @ 824BFD5
@@ -340,11 +340,11 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_24C151:: @ 824C151
 	return
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24C158:: @ 824C158
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24CEBE, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24CEBE, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24C161:: @ 824C161
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D232, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D232, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24C16A:: @ 824C16A
@@ -390,11 +390,11 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_24C1CB:: @ 824C1CB
 	case 4, BattleFrontier_BattleDomeBattleRoom_EventScript_24C209
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24C1FC:: @ 824C1FC
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24CEDE, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24CEDE, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleDomeBattleRoom_EventScript_24C211
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24C209:: @ 824C209
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D26C, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D26C, MSGBOX_DEFAULT
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24C211:: @ 824C211
 	closemessage
@@ -431,19 +431,19 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_24C211:: @ 824C211
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattleDomeBattleRoom_EventScript_24C2B9
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24CFAE, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24CFAE, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 7
 	special CallFrontierUtilFunc
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24C2B9:: @ 824C2B9
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D0D9, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D0D9, MSGBOX_DEFAULT
 	call BattleFrontier_BattleDomeBattleRoom_EventScript_24C400
 	switch VAR_RESULT
 	case 2, BattleFrontier_BattleDomeBattleRoom_EventScript_24C420
 	case 9, BattleFrontier_BattleDomeBattleRoom_EventScript_24C420
 	case 3, BattleFrontier_BattleDomeBattleRoom_EventScript_24C436
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D0F6, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D0F6, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 12
 	setvar VAR_0x8005, 1
 	special CallBattleDomeFunction
@@ -454,14 +454,14 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_24C2B9:: @ 824C2B9
 	closemessage
 	applymovement 15, BattleFrontier_BattleDomeBattleRoom_Movement_24C82B
 	waitmovement 0
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D172, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D172, MSGBOX_DEFAULT
 	playfanfare MUS_ME_SYMBOLGET
 	message BattleFrontier_BattleDomeBattleRoom_Text_24D1AA
 	waitmessage
 	waitfanfare
 	setvar VAR_0x8004, 13
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D1E0, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D1E0, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleDomeBattleRoom_EventScript_24BF62
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24C346:: @ 824C346
@@ -470,19 +470,19 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_24C346:: @ 824C346
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattleDomeBattleRoom_EventScript_24C373
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D319, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D319, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 7
 	special CallFrontierUtilFunc
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24C373:: @ 824C373
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D43E, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D43E, MSGBOX_DEFAULT
 	call BattleFrontier_BattleDomeBattleRoom_EventScript_24C400
 	switch VAR_RESULT
 	case 2, BattleFrontier_BattleDomeBattleRoom_EventScript_24C420
 	case 9, BattleFrontier_BattleDomeBattleRoom_EventScript_24C420
 	case 3, BattleFrontier_BattleDomeBattleRoom_EventScript_24C436
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D0F6, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D0F6, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 12
 	setvar VAR_0x8005, 1
 	special CallBattleDomeFunction
@@ -493,18 +493,18 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_24C373:: @ 824C373
 	closemessage
 	applymovement 15, BattleFrontier_BattleDomeBattleRoom_Movement_24C82B
 	waitmovement 0
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D47F, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D47F, MSGBOX_DEFAULT
 	playfanfare MUS_ME_SYMBOLGET
 	message BattleFrontier_BattleDomeBattleRoom_Text_24D522
 	waitmessage
 	waitfanfare
 	setvar VAR_0x8004, 13
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D54D, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D54D, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleDomeBattleRoom_EventScript_24BF62
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24C400:: @ 824C400
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D677, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D677, MSGBOX_DEFAULT
 	closemessage
 	applymovement 13, BattleFrontier_BattleDomeBattleRoom_Movement_24C787
 	applymovement 15, BattleFrontier_BattleDomeBattleRoom_Movement_24C829
@@ -513,7 +513,7 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_24C400:: @ 824C400
 	return
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_24C420:: @ 824C420
-	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D127, 4
+	msgbox BattleFrontier_BattleDomeBattleRoom_Text_24D127, MSGBOX_DEFAULT
 	playse SE_W227B
 	call BattleFrontier_BattleDomeBattleRoom_EventScript_24C82E
 	waitse

--- a/data/maps/BattleFrontier_BattleDomeLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattleDomeLobby/scripts.inc
@@ -34,7 +34,7 @@ BattleFrontier_BattleDomeLobby_EventScript_249839:: @ 8249839
 
 BattleFrontier_BattleDomeLobby_EventScript_249842:: @ 8249842
 	lockall
-	msgbox BattleFrontier_BattleDomeLobby_Text_24A45F, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24A45F, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 0
@@ -63,14 +63,14 @@ BattleFrontier_BattleDomeLobby_EventScript_24989B:: @ 824989B
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattleDomeLobby_EventScript_2498C1
-	msgbox BattleFrontier_BattleDomeLobby_Text_24A4E9, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24A4E9, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleDomeLobby_EventScript_2498C9
 
 BattleFrontier_BattleDomeLobby_EventScript_2498C1:: @ 82498C1
-	msgbox BattleFrontier_BattleDomeLobby_Text_24AD67, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24AD67, MSGBOX_DEFAULT
 
 BattleFrontier_BattleDomeLobby_EventScript_2498C9:: @ 82498C9
-	msgbox BattleFrontier_BattleDomeLobby_Text_24ADB1, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24ADB1, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 11
 	special CallFrontierUtilFunc
 	msgbox BattleFrontier_BattleDomeLobby_Text_241520, 9
@@ -100,7 +100,7 @@ BattleFrontier_BattleDomeLobby_EventScript_2498C9:: @ 82498C9
 
 BattleFrontier_BattleDomeLobby_EventScript_249940:: @ 8249940
 	lockall
-	msgbox BattleFrontier_BattleDomeLobby_Text_24A5BF, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24A5BF, MSGBOX_DEFAULT
 	message BattleFrontier_BattleDomeLobby_Text_24A5D6
 	waitmessage
 	special LoadPlayerParty
@@ -141,7 +141,7 @@ BattleFrontier_BattleDomeLobby_EventScript_2499E4:: @ 82499E4
 	call BattleFrontier_BattleDomeLobby_EventScript_23E8B4
 
 BattleFrontier_BattleDomeLobby_EventScript_2499E9:: @ 82499E9
-	msgbox BattleFrontier_BattleDomeLobby_Text_249F74, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_249F74, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
@@ -149,7 +149,7 @@ BattleFrontier_BattleDomeLobby_EventScript_2499E9:: @ 82499E9
 
 BattleFrontier_BattleDomeLobby_EventScript_2499F9:: @ 82499F9
 	lockall
-	msgbox BattleFrontier_BattleDomeLobby_Text_24A5FE, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24A5FE, MSGBOX_DEFAULT
 	message BattleFrontier_BattleDomeLobby_Text_24A61A
 	waitmessage
 	setvar VAR_0x8004, 13
@@ -215,7 +215,7 @@ BattleFrontier_BattleDomeLobby_EventScript_249ABF:: @ 8249ABF
 	setvar VAR_0x8005, 1
 	copyvar VAR_0x8006, VAR_RESULT
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleDomeLobby_Text_24A26E, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24A26E, MSGBOX_DEFAULT
 	fadescreen 1
 	call BattleFrontier_BattleDomeLobby_EventScript_23F2B7
 	copyvar VAR_0x8004, VAR_RESULT
@@ -224,7 +224,7 @@ BattleFrontier_BattleDomeLobby_EventScript_249ABF:: @ 8249ABF
 	waitstate
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattleDomeLobby_EventScript_249C61
-	msgbox BattleFrontier_BattleDomeLobby_Text_24A1C6, 5
+	msgbox BattleFrontier_BattleDomeLobby_Text_24A1C6, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattleDomeLobby_EventScript_249C61
 	case 1, BattleFrontier_BattleDomeLobby_EventScript_249B60
@@ -262,7 +262,7 @@ BattleFrontier_BattleDomeLobby_EventScript_249BC2:: @ 8249BC2
 	special CallFrontierUtilFunc
 	setvar VAR_0x8004, 15
 	special CallBattleDomeFunction
-	msgbox BattleFrontier_BattleDomeLobby_Text_24A437, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24A437, MSGBOX_DEFAULT
 	closemessage
 	call BattleFrontier_BattleDomeLobby_EventScript_249C6E
 	special HealPlayerParty
@@ -284,11 +284,11 @@ BattleFrontier_BattleDomeLobby_EventScript_249C15:: @ 8249C15
 	case 1, BattleFrontier_BattleDomeLobby_EventScript_249C3D
 
 BattleFrontier_BattleDomeLobby_EventScript_249C30:: @ 8249C30
-	msgbox BattleFrontier_BattleDomeLobby_Text_24A353, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24A353, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleDomeLobby_EventScript_249C6C
 
 BattleFrontier_BattleDomeLobby_EventScript_249C3D:: @ 8249C3D
-	msgbox BattleFrontier_BattleDomeLobby_Text_24A2AB, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24A2AB, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleDomeLobby_EventScript_249C6C
 
 BattleFrontier_BattleDomeLobby_EventScript_249C4A:: @ 8249C4A
@@ -302,7 +302,7 @@ BattleFrontier_BattleDomeLobby_EventScript_249C61:: @ 8249C61
 	special LoadPlayerParty
 
 BattleFrontier_BattleDomeLobby_EventScript_249C64:: @ 8249C64
-	msgbox BattleFrontier_BattleDomeLobby_Text_249F74, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_249F74, MSGBOX_DEFAULT
 
 BattleFrontier_BattleDomeLobby_EventScript_249C6C:: @ 8249C6C
 	release
@@ -350,11 +350,11 @@ BattleFrontier_BattleDomeLobby_EventScript_249CF5:: @ 8249CF5
 	return
 
 BattleFrontier_BattleDomeLobby_EventScript_249CFD:: @ 8249CFD
-	msgbox BattleFrontier_BattleDomeLobby_Text_249EB7, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_249EB7, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomeLobby_EventScript_249D06:: @ 8249D06
-	msgbox BattleFrontier_BattleDomeLobby_Text_24A664, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24A664, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomeLobby_EventScript_249D0F:: @ 8249D0F
@@ -366,11 +366,11 @@ BattleFrontier_BattleDomeLobby_EventScript_249D15:: @ 8249D15
 	return
 
 BattleFrontier_BattleDomeLobby_EventScript_249D1B:: @ 8249D1B
-	msgbox BattleFrontier_BattleDomeLobby_Text_249F8E, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_249F8E, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomeLobby_EventScript_249D24:: @ 8249D24
-	msgbox BattleFrontier_BattleDomeLobby_Text_24A721, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24A721, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomeLobby_EventScript_249D2D:: @ 8249D2D
@@ -449,56 +449,54 @@ BattleFrontier_BattleDomeLobby_EventScript_249D84:: @ 8249D84
 	end
 
 BattleFrontier_BattleDomeLobby_EventScript_249DC9:: @ 8249DC9
-	msgbox BattleFrontier_BattleDomeLobby_Text_24A966, 3
+	msgbox BattleFrontier_BattleDomeLobby_Text_24A966, MSGBOX_SIGN
 	return
 
 BattleFrontier_BattleDomeLobby_EventScript_249DD2:: @ 8249DD2
-	msgbox BattleFrontier_BattleDomeLobby_Text_24A9A9, 3
+	msgbox BattleFrontier_BattleDomeLobby_Text_24A9A9, MSGBOX_SIGN
 	return
 
 BattleFrontier_BattleDomeLobby_EventScript_249DDB:: @ 8249DDB
-	msgbox BattleFrontier_BattleDomeLobby_Text_24A9EC, 3
+	msgbox BattleFrontier_BattleDomeLobby_Text_24A9EC, MSGBOX_SIGN
 	return
 
 BattleFrontier_BattleDomeLobby_EventScript_249DE4:: @ 8249DE4
-	msgbox BattleFrontier_BattleDomeLobby_Text_24AA31, 3
+	msgbox BattleFrontier_BattleDomeLobby_Text_24AA31, MSGBOX_SIGN
 	return
 
 BattleFrontier_BattleDomeLobby_EventScript_249DED:: @ 8249DED
 	setvar VAR_0x8004, 20
 	special CallBattleDomeFunction
-	msgbox BattleFrontier_BattleDomeLobby_Text_24AA76, 2
+	msgbox BattleFrontier_BattleDomeLobby_Text_24AA76, MSGBOX_NPC
 	end
 
 BattleFrontier_BattleDomeLobby_EventScript_249DFE:: @ 8249DFE
-	msgbox BattleFrontier_BattleDomeLobby_Text_24AB94, 2
+	msgbox BattleFrontier_BattleDomeLobby_Text_24AB94, MSGBOX_NPC
 	end
 
 BattleFrontier_BattleDomeLobby_EventScript_249E07:: @ 8249E07
-	msgbox BattleFrontier_BattleDomeLobby_Text_24AC76, 2
+	msgbox BattleFrontier_BattleDomeLobby_Text_24AC76, MSGBOX_NPC
 	end
 
 BattleFrontier_BattleDomeLobby_EventScript_249E10:: @ 8249E10
-	msgbox BattleFrontier_BattleDomeLobby_Text_24ACD3, 2
+	msgbox BattleFrontier_BattleDomeLobby_Text_24ACD3, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_249E19:: @ 8249E19
-	msgbox BattleFrontier_OutsideWest_Text_24AB06, 2
+	msgbox BattleFrontier_OutsideWest_Text_24AB06, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_249E22:: @ 8249E22
-	loadword 0, BattleFrontier_OutsideWest_Text_24AB44
-	callstd 2
+	msgbox BattleFrontier_OutsideWest_Text_24AB44, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_249E2B:: @ 8249E2B
-	loadword 0, BattleFrontier_OutsideWest_Text_24AB75
-	callstd 2
+	msgbox BattleFrontier_OutsideWest_Text_24AB75, MSGBOX_NPC
 	end
 
 BattleFrontier_BattleDomeLobby_EventScript_249E34:: @ 8249E34
 	lockall
-	msgbox BattleFrontier_BattleDomeLobby_Text_24AE63, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24AE63, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleDomeLobby_EventScript_249E43
 	end
 
@@ -515,17 +513,17 @@ BattleFrontier_BattleDomeLobby_EventScript_249E43:: @ 8249E43
 	end
 
 BattleFrontier_BattleDomeLobby_EventScript_249E8B:: @ 8249E8B
-	msgbox BattleFrontier_BattleDomeLobby_Text_24AEAE, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24AEAE, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleDomeLobby_EventScript_249E43
 	end
 
 BattleFrontier_BattleDomeLobby_EventScript_249E99:: @ 8249E99
-	msgbox BattleFrontier_BattleDomeLobby_Text_24AF4C, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24AF4C, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleDomeLobby_EventScript_249E43
 	end
 
 BattleFrontier_BattleDomeLobby_EventScript_249EA7:: @ 8249EA7
-	msgbox BattleFrontier_BattleDomeLobby_Text_24B073, 4
+	msgbox BattleFrontier_BattleDomeLobby_Text_24B073, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleDomeLobby_EventScript_249E43
 	end
 

--- a/data/maps/BattleFrontier_BattleDomePreBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleDomePreBattleRoom/scripts.inc
@@ -69,7 +69,7 @@ BattleFrontier_BattleDomePreBattleRoom_EventScript_24B33F:: @ 824B33F
 	goto BattleFrontier_BattleDomePreBattleRoom_EventScript_24B24F
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B349:: @ 824B349
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24BA69, 5
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24BA69, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattleDomePreBattleRoom_EventScript_24B24F
 	case 1, BattleFrontier_BattleDomePreBattleRoom_EventScript_24B3BB
@@ -104,7 +104,7 @@ BattleFrontier_BattleDomePreBattleRoom_EventScript_24B3BB:: @ 824B3BB
 	end
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B3DD:: @ 824B3DD
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B9B5, 4
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B9B5, MSGBOX_DEFAULT
 	fadescreen 1
 	setvar VAR_0x8004, 6
 	special CallBattleDomeFunction
@@ -131,19 +131,19 @@ BattleFrontier_BattleDomePreBattleRoom_EventScript_24B40A:: @ 824B40A
 	return
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B449:: @ 824B449
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B9D9, 4
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B9D9, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B452:: @ 824B452
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B9FD, 4
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B9FD, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B45B:: @ 824B45B
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24BA21, 4
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24BA21, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B464:: @ 824B464
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24BA46, 4
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24BA46, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B46D:: @ 824B46D
@@ -167,7 +167,7 @@ BattleFrontier_BattleDomePreBattleRoom_EventScript_24B46D:: @ 824B46D
 	special CallBattleDomeFunction
 	setvar VAR_0x8004, 9
 	special CallBattleDomeFunction
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B748, 4
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B748, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, BattleFrontier_BattleDomePreBattleRoom_Movement_24B64F
 	waitmovement 0
@@ -221,28 +221,28 @@ BattleFrontier_BattleDomePreBattleRoom_EventScript_24B54C:: @ 824B54C
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B58B:: @ 824B58B
 	checkflag FLAG_TEMP_1
 	goto_eq BattleFrontier_BattleDomePreBattleRoom_EventScript_24B5B5
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24BB2E, 4
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24BB2E, MSGBOX_DEFAULT
 	setflag FLAG_TEMP_1
 	return
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B5A0:: @ 824B5A0
 	checkflag FLAG_TEMP_1
 	goto_eq BattleFrontier_BattleDomePreBattleRoom_EventScript_24B5BE
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24BBAC, 4
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24BBAC, MSGBOX_DEFAULT
 	setflag FLAG_TEMP_1
 	return
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B5B5:: @ 824B5B5
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24BC2A, 4
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24BC2A, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B5BE:: @ 824B5BE
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24BC63, 4
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24BC63, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B5C7:: @ 824B5C7
 	setvar VAR_TEMP_0, 1
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B760, 4
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B760, MSGBOX_DEFAULT
 	special LoadPlayerParty
 	setvar VAR_0x8004, 3
 	setvar VAR_0x8005, 3
@@ -268,15 +268,15 @@ BattleFrontier_BattleDomePreBattleRoom_EventScript_24B600:: @ 824B600
 	return
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B634:: @ 824B634
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B7A3, 4
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B7A3, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B63D:: @ 824B63D
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B7F1, 4
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B7F1, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_24B646:: @ 824B646
-	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B83F, 4
+	msgbox BattleFrontier_BattleDomePreBattleRoom_Text_24B83F, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleDomePreBattleRoom_Movement_24B64F: @ 824B64F

--- a/data/maps/BattleFrontier_BattleFactoryBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleFactoryBattleRoom/scripts.inc
@@ -51,7 +51,7 @@ BattleFrontier_BattleFactoryBattleRoom_MapScript2_25AE31: @ 825AE31
 	.2byte 0
 
 BattleFrontier_BattleFactoryBattleRoom_EventScript_25AE3B:: @ 825AE3B
-	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B1E2, 4
+	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B1E2, MSGBOX_DEFAULT
 	closemessage
 	applymovement 2, BattleFrontier_BattleFactoryBattleRoom_Movement_25B18B
 	applymovement 8, BattleFrontier_BattleFactoryBattleRoom_Movement_25B17B
@@ -82,7 +82,7 @@ BattleFrontier_BattleFactoryBattleRoom_EventScript_25AEA7:: @ 825AEA7
 	setvar VAR_0x8004, 5
 	special CallBattlePalaceFunction
 	lockall
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	waitmessage
 	closemessage
 	setvar VAR_0x8004, 2
@@ -153,13 +153,13 @@ BattleFrontier_BattleFactoryBattleRoom_EventScript_25AF9C:: @ 825AF9C
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattleFactoryBattleRoom_EventScript_25AFEF
-	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B1FB, 4
+	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B1FB, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 7
 	special CallFrontierUtilFunc
 
 BattleFrontier_BattleFactoryBattleRoom_EventScript_25AFEF:: @ 825AFEF
-	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B3F1, 4
+	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B3F1, MSGBOX_DEFAULT
 	call BattleFrontier_BattleFactoryBattleRoom_EventScript_25B0E0
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattleFactoryBattleRoom_EventScript_25B00C
@@ -170,7 +170,7 @@ BattleFrontier_BattleFactoryBattleRoom_EventScript_25B00C:: @ 825B00C
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattleFactoryBattleRoom_EventScript_25B105
-	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B42D, 4
+	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B42D, MSGBOX_DEFAULT
 	closemessage
 	applymovement 8, BattleFrontier_BattleFactoryBattleRoom_Movement_25B182
 	waitmovement 0
@@ -180,7 +180,7 @@ BattleFrontier_BattleFactoryBattleRoom_EventScript_25B00C:: @ 825B00C
 	waitfanfare
 	setvar VAR_0x8004, 13
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B498, 4
+	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B498, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleFactoryBattleRoom_EventScript_25B105
 
 BattleFrontier_BattleFactoryBattleRoom_EventScript_25B051:: @ 825B051
@@ -189,13 +189,13 @@ BattleFrontier_BattleFactoryBattleRoom_EventScript_25B051:: @ 825B051
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattleFactoryBattleRoom_EventScript_25B07E
-	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B517, 4
+	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B517, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 7
 	special CallFrontierUtilFunc
 
 BattleFrontier_BattleFactoryBattleRoom_EventScript_25B07E:: @ 825B07E
-	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B5CF, 4
+	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B5CF, MSGBOX_DEFAULT
 	call BattleFrontier_BattleFactoryBattleRoom_EventScript_25B0E0
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattleFactoryBattleRoom_EventScript_25B09B
@@ -206,7 +206,7 @@ BattleFrontier_BattleFactoryBattleRoom_EventScript_25B09B:: @ 825B09B
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 2
 	goto_eq BattleFrontier_BattleFactoryBattleRoom_EventScript_25B105
-	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B5E7, 4
+	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B5E7, MSGBOX_DEFAULT
 	waitmessage
 	applymovement 8, BattleFrontier_BattleFactoryBattleRoom_Movement_25B182
 	waitmovement 0
@@ -216,7 +216,7 @@ BattleFrontier_BattleFactoryBattleRoom_EventScript_25B09B:: @ 825B09B
 	waitfanfare
 	setvar VAR_0x8004, 13
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B66D, 4
+	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_25B66D, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleFactoryBattleRoom_EventScript_25B105
 
 BattleFrontier_BattleFactoryBattleRoom_EventScript_25B0E0:: @ 825B0E0

--- a/data/maps/BattleFrontier_BattleFactoryLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattleFactoryLobby/scripts.inc
@@ -27,7 +27,7 @@ BattleFrontier_BattleFactoryLobby_EventScript_258431:: @ 8258431
 
 BattleFrontier_BattleFactoryLobby_EventScript_25843A:: @ 825843A
 	lockall
-	msgbox BattleFrontier_BattleFactoryLobby_Text_258ECA, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_258ECA, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 8
 	special CallBattleFactoryFunction
@@ -57,16 +57,16 @@ BattleFrontier_BattleFactoryLobby_EventScript_25849B:: @ 825849B
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattleFactoryLobby_EventScript_2584BD
-	msgbox BattleFrontier_BattleFactoryLobby_Text_258D93, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_258D93, MSGBOX_DEFAULT
 	waitmessage
 	goto BattleFrontier_BattleFactoryLobby_EventScript_2584C6
 
 BattleFrontier_BattleFactoryLobby_EventScript_2584BD:: @ 82584BD
-	msgbox BattleFrontier_BattleFactoryLobby_Text_25926A, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_25926A, MSGBOX_DEFAULT
 	waitmessage
 
 BattleFrontier_BattleFactoryLobby_EventScript_2584C6:: @ 82584C6
-	msgbox BattleFrontier_BattleFactoryLobby_Text_2592BD, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_2592BD, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 11
 	special CallFrontierUtilFunc
 	msgbox BattleFrontier_BattleFactoryLobby_Text_241520, 9
@@ -116,7 +116,7 @@ BattleFrontier_BattleFactoryLobby_EventScript_25857D:: @ 825857D
 	call BattleFrontier_BattleFactoryLobby_EventScript_23E8B4
 
 BattleFrontier_BattleFactoryLobby_EventScript_258582:: @ 8258582
-	msgbox BattleFrontier_BattleFactoryLobby_Text_258BC5, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_258BC5, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
@@ -184,7 +184,7 @@ BattleFrontier_BattleFactoryLobby_EventScript_258653:: @ 8258653
 	setvar VAR_0x8005, 1
 	copyvar VAR_0x8006, VAR_RESULT
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleFactoryLobby_Text_258C27, 5
+	msgbox BattleFrontier_BattleFactoryLobby_Text_258C27, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattleFactoryLobby_EventScript_25879A
 	case 1, BattleFrontier_BattleFactoryLobby_EventScript_2586B9
@@ -216,7 +216,7 @@ BattleFrontier_BattleFactoryLobby_EventScript_2586B9:: @ 82586B9
 
 BattleFrontier_BattleFactoryLobby_EventScript_25871A:: @ 825871A
 	special SavePlayerParty
-	msgbox BattleFrontier_BattleFactoryLobby_Text_258CB1, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_258CB1, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_FRONTIER_BATTLE_MODE, 0
 	call_if 1, BattleFrontier_BattleFactoryLobby_EventScript_25875C
@@ -256,7 +256,7 @@ BattleFrontier_BattleFactoryLobby_EventScript_25879A:: @ 825879A
 	special LoadPlayerParty
 
 BattleFrontier_BattleFactoryLobby_EventScript_25879D:: @ 825879D
-	msgbox BattleFrontier_BattleFactoryLobby_Text_258BC5, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_258BC5, MSGBOX_DEFAULT
 	release
 	end
 
@@ -275,11 +275,11 @@ BattleFrontier_BattleFactoryLobby_Movement_2587AC: @ 82587AC
 	step_end
 
 BattleFrontier_BattleFactoryLobby_EventScript_2587B1:: @ 82587B1
-	msgbox BattleFrontier_BattleFactoryLobby_Text_2588EE, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_2588EE, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryLobby_EventScript_2587BA:: @ 82587BA
-	msgbox BattleFrontier_BattleFactoryLobby_Text_258F93, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_258F93, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryLobby_EventScript_2587C3:: @ 82587C3
@@ -291,11 +291,11 @@ BattleFrontier_BattleFactoryLobby_EventScript_2587C9:: @ 82587C9
 	return
 
 BattleFrontier_BattleFactoryLobby_EventScript_2587CF:: @ 82587CF
-	msgbox BattleFrontier_BattleFactoryLobby_Text_2589B3, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_2589B3, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryLobby_EventScript_2587D8:: @ 82587D8
-	msgbox BattleFrontier_BattleFactoryLobby_Text_259058, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_259058, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryLobby_EventScript_2587E1:: @ 82587E1
@@ -321,26 +321,26 @@ BattleFrontier_BattleFactoryLobby_EventScript_2587FA:: @ 82587FA
 	end
 
 BattleFrontier_BattleFactoryLobby_EventScript_258813:: @ 8258813
-	msgbox BattleFrontier_BattleFactoryLobby_Text_2593D7, 2
+	msgbox BattleFrontier_BattleFactoryLobby_Text_2593D7, MSGBOX_NPC
 	end
 
 BattleFrontier_BattleFactoryLobby_EventScript_25881C:: @ 825881C
-	msgbox BattleFrontier_BattleFactoryLobby_Text_2594E5, 2
+	msgbox BattleFrontier_BattleFactoryLobby_Text_2594E5, MSGBOX_NPC
 	end
 
 BattleFrontier_BattleFactoryLobby_EventScript_258825:: @ 8258825
 	lock
-	msgbox BattleFrontier_BattleFactoryLobby_Text_259547, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_259547, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattleFactoryLobby_EventScript_258830:: @ 8258830
-	msgbox BattleFrontier_BattleFactoryLobby_Text_2595C4, 2
+	msgbox BattleFrontier_BattleFactoryLobby_Text_2595C4, MSGBOX_NPC
 	end
 
 BattleFrontier_BattleFactoryLobby_EventScript_258839:: @ 8258839
 	lockall
-	msgbox BattleFrontier_BattleFactoryLobby_Text_259721, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_259721, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleFactoryLobby_EventScript_258848
 	end
 
@@ -359,27 +359,27 @@ BattleFrontier_BattleFactoryLobby_EventScript_258848:: @ 8258848
 	end
 
 BattleFrontier_BattleFactoryLobby_EventScript_2588A6:: @ 82588A6
-	msgbox BattleFrontier_BattleFactoryLobby_Text_259766, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_259766, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleFactoryLobby_EventScript_258848
 	end
 
 BattleFrontier_BattleFactoryLobby_EventScript_2588B4:: @ 82588B4
-	msgbox BattleFrontier_BattleFactoryLobby_Text_2597FB, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_2597FB, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleFactoryLobby_EventScript_258848
 	end
 
 BattleFrontier_BattleFactoryLobby_EventScript_2588C2:: @ 82588C2
-	msgbox BattleFrontier_BattleFactoryLobby_Text_25987E, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_25987E, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleFactoryLobby_EventScript_258848
 	end
 
 BattleFrontier_BattleFactoryLobby_EventScript_2588D0:: @ 82588D0
-	msgbox BattleFrontier_BattleFactoryLobby_Text_259920, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_259920, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleFactoryLobby_EventScript_258848
 	end
 
 BattleFrontier_BattleFactoryLobby_EventScript_2588DE:: @ 82588DE
-	msgbox BattleFrontier_BattleFactoryLobby_Text_259A5E, 4
+	msgbox BattleFrontier_BattleFactoryLobby_Text_259A5E, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleFactoryLobby_EventScript_258848
 	end
 

--- a/data/maps/BattleFrontier_BattleFactoryPreBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleFactoryPreBattleRoom/scripts.inc
@@ -43,7 +43,7 @@ BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259AF9:: @ 8259AF9
 	setorcopyvar VAR_0x8006, VAR_RESULT
 	call BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259E93
 	call BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A004
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A1C8, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A1C8, MSGBOX_DEFAULT
 	fadescreen 1
 	setvar VAR_0x8004, 8
 	special CallBattleFactoryFunction
@@ -52,7 +52,7 @@ BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259AF9:: @ 8259AF9
 	waitstate
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259B74:: @ 8259B74
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AB96, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AB96, MSGBOX_DEFAULT
 	closemessage
 	call BattleFrontier_BattleFactoryPreBattleRoom_EventScript_23F2B7
 	compare VAR_RESULT, 0
@@ -69,7 +69,7 @@ BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259BA5:: @ 8259BA5
 	special CallBattleFactoryFunction
 	setvar VAR_0x8004, 16
 	special CallBattleFactoryFunction
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A22D, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A22D, MSGBOX_DEFAULT
 	playfanfare MUS_ME_ASA
 	waitfanfare
 	special HealPlayerParty
@@ -79,15 +79,15 @@ BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259BA5:: @ 8259BA5
 	goto_eq BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259C26
 	playse 263
 	waitse
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AC15, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AC15, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, BattleFrontier_BattleFactoryPreBattleRoom_Movement_25A1BF
 	waitmovement 0
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AC58, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AC58, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, BattleFrontier_BattleFactoryPreBattleRoom_Movement_25A1C3
 	waitmovement 0
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AC89, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AC89, MSGBOX_DEFAULT
 	closemessage
 	delay 16
 	goto BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A0B9
@@ -148,7 +148,7 @@ BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259D2E:: @ 8259D2E
 	goto BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259C13
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259D38:: @ 8259D38
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A350, 5
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A350, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259C13
 	case 1, BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259E47
@@ -174,7 +174,7 @@ BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259D98:: @ 8259D98
 	setorcopyvar VAR_0x8006, VAR_RESULT
 	call BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259E93
 	call BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A004
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AB2E, 5
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AB2E, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259B74
 	case 1, BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259DF2
@@ -189,7 +189,7 @@ BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259DF2:: @ 8259DF2
 	goto_eq BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259B74
 	setvar VAR_0x8004, 8
 	special CallBattleFactoryFunction
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AB6C, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AB6C, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259B74
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259E1D:: @ 8259E1D
@@ -248,7 +248,7 @@ BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259E69:: @ 8259E69
 	goto BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259C13
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259E93:: @ 8259E93
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A3B4, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A3B4, MSGBOX_DEFAULT
 	compare VAR_0x8005, 0
 	call_if 1, BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259F62
 	compare VAR_0x8005, 1
@@ -288,75 +288,75 @@ BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259E93:: @ 8259E93
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259F62:: @ 8259F62
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A3F8, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A3F8, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259F6B:: @ 8259F6B
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A597, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A597, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259F74:: @ 8259F74
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A66B, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A66B, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259F7D:: @ 8259F7D
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A5DF, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A5DF, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259F86:: @ 8259F86
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A625, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A625, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259F8F:: @ 8259F8F
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A73B, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A73B, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259F98:: @ 8259F98
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A6F8, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A6F8, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259FA1:: @ 8259FA1
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A77F, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A77F, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259FAA:: @ 8259FAA
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A84E, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A84E, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259FB3:: @ 8259FB3
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A43E, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A43E, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259FBC:: @ 8259FBC
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A482, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A482, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259FC5:: @ 8259FC5
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A50F, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A50F, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259FCE:: @ 8259FCE
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A4C7, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A4C7, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259FD7:: @ 8259FD7
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A6B1, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A6B1, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259FE0:: @ 8259FE0
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A554, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A554, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259FE9:: @ 8259FE9
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A7C4, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A7C4, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259FF2:: @ 8259FF2
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A80A, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A80A, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259FFB:: @ 8259FFB
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A893, 4
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25A893, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A004:: @ 825A004
@@ -381,39 +381,39 @@ BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A004:: @ 825A004
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A068:: @ 825A068
-	msgbox Text_StyleUnrestrained, 4
+	msgbox Text_StyleUnrestrained, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A071:: @ 825A071
-	msgbox Text_StyleTotalPreparation, 4
+	msgbox Text_StyleTotalPreparation, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A07A:: @ 825A07A
-	msgbox Text_StyleSlowAndSteady, 4
+	msgbox Text_StyleSlowAndSteady, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A083:: @ 825A083
-	msgbox Text_StyleEndurance, 4
+	msgbox Text_StyleEndurance, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A08C:: @ 825A08C
-	msgbox Text_StyleHighRisk, 4
+	msgbox Text_StyleHighRisk, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A095:: @ 825A095
-	msgbox Text_StyleWeakenFoe, 4
+	msgbox Text_StyleWeakenFoe, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A09E:: @ 825A09E
-	msgbox Text_StyleImpossibleToPredict, 4
+	msgbox Text_StyleImpossibleToPredict, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A0A7:: @ 825A0A7
-	msgbox Text_StyleDependsOnFlow, 4
+	msgbox Text_StyleDependsOnFlow, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A0B0:: @ 825A0B0
-	msgbox Text_StyleFlexible, 4
+	msgbox Text_StyleFlexible, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A0B9:: @ 825A0B9
@@ -439,8 +439,8 @@ BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A110:: @ 825A110
 	case 127, BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A0B9
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_25A146:: @ 825A146
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AD61, 4
-	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AB2E, 5
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AD61, MSGBOX_DEFAULT
+	msgbox BattleFrontier_BattleFactoryPreBattleRoom_Text_25AB2E, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259B74
 	case 1, BattleFrontier_BattleFactoryPreBattleRoom_EventScript_259DF2

--- a/data/maps/BattleFrontier_BattlePalaceBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePalaceBattleRoom/scripts.inc
@@ -61,7 +61,7 @@ BattleFrontier_BattlePalaceBattleRoom_EventScript_24F8BF:: @ 824F8BF
 	waitmovement 0
 	setvar VAR_0x8004, 5
 	special CallBattlePalaceFunction
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	waitmessage
 	call BattleFrontier_BattlePalaceBattleRoom_EventScript_24FDF7
 	switch VAR_RESULT
@@ -92,7 +92,7 @@ BattleFrontier_BattlePalaceBattleRoom_EventScript_24F911:: @ 824F911
 	applymovement 1, BattleFrontier_BattlePalaceBattleRoom_Movement_24FE99
 	applymovement 3, BattleFrontier_BattlePalaceBattleRoom_Movement_24FEAC
 	waitmovement 0
-	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_24FF00, 4
+	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_24FF00, MSGBOX_DEFAULT
 	special LoadPlayerParty
 	special SavePlayerParty
 	setvar VAR_0x8004, 3
@@ -156,7 +156,7 @@ BattleFrontier_BattlePalaceBattleRoom_EventScript_24FAAA:: @ 824FAAA
 	goto BattleFrontier_BattlePalaceBattleRoom_EventScript_24F98A
 
 BattleFrontier_BattlePalaceBattleRoom_EventScript_24FAB4:: @ 824FAB4
-	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_250030, 5
+	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_250030, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattlePalaceBattleRoom_EventScript_24F98A
 	case 1, BattleFrontier_BattlePalaceBattleRoom_EventScript_24FB3F
@@ -200,7 +200,7 @@ BattleFrontier_BattlePalaceBattleRoom_EventScript_24FB3F:: @ 824FB3F
 BattleFrontier_BattlePalaceBattleRoom_EventScript_24FB61:: @ 824FB61
 	compare VAR_TEMP_2, 1
 	goto_eq BattleFrontier_BattlePalaceBattleRoom_EventScript_24FB79
-	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_2500DD, 4
+	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_2500DD, MSGBOX_DEFAULT
 	setvar VAR_TEMP_2, 1
 
 BattleFrontier_BattlePalaceBattleRoom_EventScript_24FB79:: @ 824FB79
@@ -227,7 +227,7 @@ BattleFrontier_BattlePalaceBattleRoom_EventScript_24FBD0:: @ 824FBD0
 
 BattleFrontier_BattlePalaceBattleRoom_EventScript_24FC06:: @ 824FC06
 	call BattleFrontier_BattlePalaceBattleRoom_EventScript_242170
-	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_25017C, 4
+	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_25017C, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, BattleFrontier_BattlePalaceBattleRoom_Movement_24FE97
 	applymovement 3, BattleFrontier_BattlePalaceBattleRoom_Movement_24FE97
@@ -249,13 +249,13 @@ BattleFrontier_BattlePalaceBattleRoom_EventScript_24FC06:: @ 824FC06
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattlePalaceBattleRoom_EventScript_24FCAA
-	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_2501C1, 4
+	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_2501C1, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 7
 	special CallFrontierUtilFunc
 
 BattleFrontier_BattlePalaceBattleRoom_EventScript_24FCAA:: @ 824FCAA
-	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_2502C4, 4
+	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_2502C4, MSGBOX_DEFAULT
 	call BattleFrontier_BattlePalaceBattleRoom_EventScript_24FDF7
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattlePalaceBattleRoom_EventScript_24FCC7
@@ -268,10 +268,10 @@ BattleFrontier_BattlePalaceBattleRoom_EventScript_24FCC7:: @ 824FCC7
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattlePalaceBattleRoom_EventScript_24FB28
-	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_2502FF, 4
+	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_2502FF, MSGBOX_DEFAULT
 	applymovement 1, BattleFrontier_BattlePalaceBattleRoom_Movement_24FE99
 	applymovement 3, BattleFrontier_BattlePalaceBattleRoom_Movement_24FEAC
-	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_25036D, 4
+	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_25036D, MSGBOX_DEFAULT
 	playfanfare MUS_ME_SYMBOLGET
 	message BattleFrontier_BattlePalaceBattleRoom_Text_2503DC
 	waitmessage
@@ -283,7 +283,7 @@ BattleFrontier_BattlePalaceBattleRoom_EventScript_24FCC7:: @ 824FCC7
 	applymovement 1, BattleFrontier_BattlePalaceBattleRoom_Movement_2725A8
 	applymovement 3, BattleFrontier_BattlePalaceBattleRoom_Movement_2725A8
 	waitmovement 0
-	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_250412, 4
+	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_250412, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePalaceBattleRoom_EventScript_24FB28
 
 BattleFrontier_BattlePalaceBattleRoom_EventScript_24FD3A:: @ 824FD3A
@@ -292,13 +292,13 @@ BattleFrontier_BattlePalaceBattleRoom_EventScript_24FD3A:: @ 824FD3A
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattlePalaceBattleRoom_EventScript_24FD67
-	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_250485, 4
+	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_250485, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 7
 	special CallFrontierUtilFunc
 
 BattleFrontier_BattlePalaceBattleRoom_EventScript_24FD67:: @ 824FD67
-	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_250572, 4
+	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_250572, MSGBOX_DEFAULT
 	call BattleFrontier_BattlePalaceBattleRoom_EventScript_24FDF7
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattlePalaceBattleRoom_EventScript_24FD84
@@ -311,10 +311,10 @@ BattleFrontier_BattlePalaceBattleRoom_EventScript_24FD84:: @ 824FD84
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 2
 	goto_eq BattleFrontier_BattlePalaceBattleRoom_EventScript_24FB28
-	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_25057E, 4
+	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_25057E, MSGBOX_DEFAULT
 	applymovement 1, BattleFrontier_BattlePalaceBattleRoom_Movement_24FE99
 	applymovement 3, BattleFrontier_BattlePalaceBattleRoom_Movement_24FEAC
-	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_250629, 4
+	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_250629, MSGBOX_DEFAULT
 	playfanfare MUS_ME_SYMBOLGET
 	message BattleFrontier_BattlePalaceBattleRoom_Text_250699
 	waitmessage
@@ -326,7 +326,7 @@ BattleFrontier_BattlePalaceBattleRoom_EventScript_24FD84:: @ 824FD84
 	applymovement 1, BattleFrontier_BattlePalaceBattleRoom_Movement_2725A8
 	applymovement 3, BattleFrontier_BattlePalaceBattleRoom_Movement_2725A8
 	waitmovement 0
-	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_2506C4, 4
+	msgbox BattleFrontier_BattlePalaceBattleRoom_Text_2506C4, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePalaceBattleRoom_EventScript_24FB28
 
 BattleFrontier_BattlePalaceBattleRoom_EventScript_24FDF7:: @ 824FDF7

--- a/data/maps/BattleFrontier_BattlePalaceCorridor/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePalaceCorridor/scripts.inc
@@ -60,23 +60,23 @@ BattleFrontier_BattlePalaceCorridor_EventScript_24F581:: @ 824F581
 	end
 
 BattleFrontier_BattlePalaceCorridor_EventScript_24F58B:: @ 824F58B
-	msgbox BattleFrontier_BattlePalaceCorridor_Text_24F5DD, 4
+	msgbox BattleFrontier_BattlePalaceCorridor_Text_24F5DD, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePalaceCorridor_EventScript_24F594:: @ 824F594
-	msgbox BattleFrontier_BattlePalaceCorridor_Text_24F65B, 4
+	msgbox BattleFrontier_BattlePalaceCorridor_Text_24F65B, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePalaceCorridor_EventScript_24F59D:: @ 824F59D
-	msgbox BattleFrontier_BattlePalaceCorridor_Text_24F718, 4
+	msgbox BattleFrontier_BattlePalaceCorridor_Text_24F718, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePalaceCorridor_EventScript_24F5A6:: @ 824F5A6
-	msgbox BattleFrontier_BattlePalaceCorridor_Text_24F78C, 4
+	msgbox BattleFrontier_BattlePalaceCorridor_Text_24F78C, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePalaceCorridor_EventScript_24F5AF:: @ 824F5AF
-	msgbox BattleFrontier_BattlePalaceCorridor_Text_24F7D4, 4
+	msgbox BattleFrontier_BattlePalaceCorridor_Text_24F7D4, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePalaceCorridor_Movement_24F5B8: @ 824F5B8

--- a/data/maps/BattleFrontier_BattlePalaceLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePalaceLobby/scripts.inc
@@ -27,7 +27,7 @@ BattleFrontier_BattlePalaceLobby_EventScript_24D7C7:: @ 824D7C7
 
 BattleFrontier_BattlePalaceLobby_EventScript_24D7D0:: @ 824D7D0
 	lockall
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24E636, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24E636, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 1
@@ -51,21 +51,21 @@ BattleFrontier_BattlePalaceLobby_EventScript_24D817:: @ 824D817
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattlePalaceLobby_EventScript_24D838
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24E497, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24E497, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePalaceLobby_EventScript_24D840
 
 BattleFrontier_BattlePalaceLobby_EventScript_24D838:: @ 824D838
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24EE81, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24EE81, MSGBOX_DEFAULT
 
 BattleFrontier_BattlePalaceLobby_EventScript_24D840:: @ 824D840
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24EEB9, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24EEB9, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 11
 	special CallFrontierUtilFunc
 	msgbox BattleFrontier_BattlePalaceLobby_Text_241520, 9
 	message BattleFrontier_BattlePalaceLobby_Text_24E4F7
 	waitmessage
 	call BattleFrontier_BattlePalaceLobby_EventScript_24D8A1
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24E0D8, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24E0D8, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
@@ -80,7 +80,7 @@ BattleFrontier_BattlePalaceLobby_EventScript_24D873:: @ 824D873
 	setvar VAR_0x8006, 0
 	special CallBattlePalaceFunction
 	call BattleFrontier_BattlePalaceLobby_EventScript_24D8A1
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24E0D8, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24E0D8, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
@@ -115,7 +115,7 @@ BattleFrontier_BattlePalaceLobby_EventScript_24D907:: @ 824D907
 
 BattleFrontier_BattlePalaceLobby_EventScript_24D908:: @ 824D908
 	lockall
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24E5D8, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24E5D8, MSGBOX_DEFAULT
 	message BattleFrontier_BattlePalaceLobby_Text_24E5F6
 	waitmessage
 	setvar VAR_0x8004, 7
@@ -186,7 +186,7 @@ BattleFrontier_BattlePalaceLobby_EventScript_24D9E6:: @ 824D9E6
 	setvar VAR_0x8005, 1
 	copyvar VAR_0x8006, VAR_RESULT
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24E399, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24E399, MSGBOX_DEFAULT
 	fadescreen 1
 	call BattleFrontier_BattlePalaceLobby_EventScript_23F2B7
 	copyvar VAR_0x8004, VAR_RESULT
@@ -195,7 +195,7 @@ BattleFrontier_BattlePalaceLobby_EventScript_24D9E6:: @ 824D9E6
 	waitstate
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePalaceLobby_EventScript_24DB91
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24E3C8, 5
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24E3C8, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattlePalaceLobby_EventScript_24DB91
 	case 1, BattleFrontier_BattlePalaceLobby_EventScript_24DA87
@@ -233,7 +233,7 @@ BattleFrontier_BattlePalaceLobby_EventScript_24DAF3:: @ 824DAF3
 	setvar VAR_0x8004, 3
 	setvar VAR_0x8005, 3
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24E408, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24E408, MSGBOX_DEFAULT
 	closemessage
 	call BattleFrontier_BattlePalaceLobby_EventScript_24DBBC
 	warp MAP_BATTLE_FRONTIER_BATTLE_PALACE_CORRIDOR, 255, 8, 13
@@ -244,11 +244,11 @@ BattleFrontier_BattlePalaceLobby_EventScript_24DAF3:: @ 824DAF3
 BattleFrontier_BattlePalaceLobby_EventScript_24DB20:: @ 824DB20
 	compare VAR_FRONTIER_BATTLE_MODE, 1
 	goto_eq BattleFrontier_BattlePalaceLobby_EventScript_24DB38
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24DE17, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24DE17, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePalaceLobby_EventScript_24D999
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DB38:: @ 824DB38
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24EBC2, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24EBC2, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePalaceLobby_EventScript_24D999
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DB45:: @ 824DB45
@@ -257,11 +257,11 @@ BattleFrontier_BattlePalaceLobby_EventScript_24DB45:: @ 824DB45
 	case 1, BattleFrontier_BattlePalaceLobby_EventScript_24DB6D
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DB60:: @ 824DB60
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24E173, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24E173, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePalaceLobby_EventScript_24DB9C
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DB6D:: @ 824DB6D
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24E29E, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24E29E, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePalaceLobby_EventScript_24DB9C
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DB7A:: @ 824DB7A
@@ -275,18 +275,18 @@ BattleFrontier_BattlePalaceLobby_EventScript_24DB91:: @ 824DB91
 	special LoadPlayerParty
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DB94:: @ 824DB94
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24E0D8, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24E0D8, MSGBOX_DEFAULT
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DB9C:: @ 824DB9C
 	release
 	end
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DB9E:: @ 824DB9E
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24DD5B, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24DD5B, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DBA7:: @ 824DBA7
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24EB06, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24EB06, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DBB0:: @ 824DBB0
@@ -382,24 +382,24 @@ BattleFrontier_BattlePalaceLobby_EventScript_24DC69:: @ 824DC69
 	end
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DC82:: @ 824DC82
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24E6E3, 2
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24E6E3, MSGBOX_NPC
 	end
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DC8B:: @ 824DC8B
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24E851, 2
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24E851, MSGBOX_NPC
 	end
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DC94:: @ 824DC94
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24E992, 2
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24E992, MSGBOX_NPC
 	end
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DC9D:: @ 824DC9D
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24EA4B, 2
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24EA4B, MSGBOX_NPC
 	end
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DCA6:: @ 824DCA6
 	lockall
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24EF66, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24EF66, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePalaceLobby_EventScript_24DCB5
 	end
 
@@ -418,27 +418,27 @@ BattleFrontier_BattlePalaceLobby_EventScript_24DCB5:: @ 824DCB5
 	end
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DD13:: @ 824DD13
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24EFAB, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24EFAB, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePalaceLobby_EventScript_24DCB5
 	end
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DD21:: @ 824DD21
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24F049, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24F049, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePalaceLobby_EventScript_24DCB5
 	end
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DD2F:: @ 824DD2F
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24F190, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24F190, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePalaceLobby_EventScript_24DCB5
 	end
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DD3D:: @ 824DD3D
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24F2E8, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24F2E8, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePalaceLobby_EventScript_24DCB5
 	end
 
 BattleFrontier_BattlePalaceLobby_EventScript_24DD4B:: @ 824DD4B
-	msgbox BattleFrontier_BattlePalaceLobby_Text_24F3F4, 4
+	msgbox BattleFrontier_BattlePalaceLobby_Text_24F3F4, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePalaceLobby_EventScript_24DCB5
 	end
 

--- a/data/maps/BattleFrontier_BattlePikeCorridor/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeCorridor/scripts.inc
@@ -22,7 +22,7 @@ BattleFrontier_BattlePikeCorridor_EventScript_25C786:: @ 825C786
 	applymovement 1, BattleFrontier_BattlePikeCorridor_Movement_25C812
 	waitmovement 0
 	lockall
-	msgbox BattleFrontier_BattlePikeCorridor_Text_25C817, 4
+	msgbox BattleFrontier_BattlePikeCorridor_Text_25C817, MSGBOX_DEFAULT
 	closemessage
 	releaseall
 	applymovement 255, BattleFrontier_BattlePikeCorridor_Movement_25C80E

--- a/data/maps/BattleFrontier_BattlePikeLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeLobby/scripts.inc
@@ -29,7 +29,7 @@ BattleFrontier_BattlePikeLobby_EventScript_25B710:: @ 825B710
 	setvar VAR_0x8004, 27
 	special CallBattlePikeFunction
 	lockall
-	msgbox BattleFrontier_BattlePikeLobby_Text_25C2E0, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25C2E0, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 1
@@ -53,16 +53,16 @@ BattleFrontier_BattlePikeLobby_EventScript_25B762:: @ 825B762
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattlePikeLobby_EventScript_25B784
-	msgbox BattleFrontier_BattlePikeLobby_Text_25C18A, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25C18A, MSGBOX_DEFAULT
 	waitmessage
 	goto BattleFrontier_BattlePikeLobby_EventScript_25B78D
 
 BattleFrontier_BattlePikeLobby_EventScript_25B784:: @ 825B784
-	msgbox BattleFrontier_BattlePikeLobby_Text_25C383, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25C383, MSGBOX_DEFAULT
 	waitmessage
 
 BattleFrontier_BattlePikeLobby_EventScript_25B78D:: @ 825B78D
-	msgbox BattleFrontier_BattlePikeLobby_Text_25C3D9, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25C3D9, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 11
 	special CallFrontierUtilFunc
 	msgbox BattleFrontier_BattlePikeLobby_Text_241520, 9
@@ -87,7 +87,7 @@ BattleFrontier_BattlePikeLobby_EventScript_25B78D:: @ 825B78D
 	special CallBattlePikeFunction
 	playse SE_SAVE
 	waitse
-	msgbox BattleFrontier_BattlePikeLobby_Text_25BE02, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25BE02, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
@@ -116,7 +116,7 @@ BattleFrontier_BattlePikeLobby_EventScript_25B806:: @ 825B806
 	special CallBattlePikeFunction
 	playse SE_SAVE
 	waitse
-	msgbox BattleFrontier_BattlePikeLobby_Text_25BE02, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25BE02, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
@@ -128,7 +128,7 @@ BattleFrontier_BattlePikeLobby_EventScript_25B868:: @ 825B868
 	setvar VAR_FRONTIER_FACILITY, 5
 	setvar VAR_FRONTIER_BATTLE_MODE, 0
 	special SavePlayerParty
-	msgbox BattleFrontier_BattlePikeLobby_Text_25BB52, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25BB52, MSGBOX_DEFAULT
 
 BattleFrontier_BattlePikeLobby_EventScript_25B87F:: @ 825B87F
 	message BattleFrontier_BattlePikeLobby_Text_25BBC1
@@ -155,7 +155,7 @@ BattleFrontier_BattlePikeLobby_EventScript_25B8BB:: @ 825B8BB
 	setvar VAR_0x8005, 1
 	copyvar VAR_0x8006, VAR_RESULT
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattlePikeLobby_Text_25C094, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25C094, MSGBOX_DEFAULT
 	fadescreen 1
 	call BattleFrontier_BattlePikeLobby_EventScript_23F2B7
 	copyvar VAR_0x8004, VAR_RESULT
@@ -164,7 +164,7 @@ BattleFrontier_BattlePikeLobby_EventScript_25B8BB:: @ 825B8BB
 	waitstate
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePikeLobby_EventScript_25BA73
-	msgbox BattleFrontier_BattlePikeLobby_Text_25C0D8, 5
+	msgbox BattleFrontier_BattlePikeLobby_Text_25C0D8, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattlePikeLobby_EventScript_25BA73
 	case 1, BattleFrontier_BattlePikeLobby_EventScript_25B95C
@@ -205,7 +205,7 @@ BattleFrontier_BattlePikeLobby_EventScript_25B95C:: @ 825B95C
 	setvar VAR_0x8004, 3
 	setvar VAR_0x8005, 3
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattlePikeLobby_Text_25C130, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25C130, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 5
 	special CallFrontierUtilFunc
@@ -218,7 +218,7 @@ BattleFrontier_BattlePikeLobby_EventScript_25B95C:: @ 825B95C
 	end
 
 BattleFrontier_BattlePikeLobby_EventScript_25BA1A:: @ 825BA1A
-	msgbox BattleFrontier_BattlePikeLobby_Text_25BBF5, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25BBF5, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeLobby_EventScript_25B87F
 
 BattleFrontier_BattlePikeLobby_EventScript_25BA27:: @ 825BA27
@@ -227,11 +227,11 @@ BattleFrontier_BattlePikeLobby_EventScript_25BA27:: @ 825BA27
 	case 1, BattleFrontier_BattlePikeLobby_EventScript_25BA4F
 
 BattleFrontier_BattlePikeLobby_EventScript_25BA42:: @ 825BA42
-	msgbox BattleFrontier_BattlePikeLobby_Text_25BE8C, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25BE8C, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeLobby_EventScript_25BA7E
 
 BattleFrontier_BattlePikeLobby_EventScript_25BA4F:: @ 825BA4F
-	msgbox BattleFrontier_BattlePikeLobby_Text_25BF9A, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25BF9A, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeLobby_EventScript_25BA7E
 
 BattleFrontier_BattlePikeLobby_EventScript_25BA5C:: @ 825BA5C
@@ -245,7 +245,7 @@ BattleFrontier_BattlePikeLobby_EventScript_25BA73:: @ 825BA73
 	special LoadPlayerParty
 
 BattleFrontier_BattlePikeLobby_EventScript_25BA76:: @ 825BA76
-	msgbox BattleFrontier_BattlePikeLobby_Text_25BE02, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25BE02, MSGBOX_DEFAULT
 
 BattleFrontier_BattlePikeLobby_EventScript_25BA7E:: @ 825BA7E
 	release
@@ -277,20 +277,20 @@ BattleFrontier_BattlePikeLobby_Movement_25BAA7: @ 825BAA7
 	step_end
 
 BattleFrontier_BattlePikeLobby_EventScript_25BAAB:: @ 825BAAB
-	msgbox BattleFrontier_BattlePikeLobby_Text_25C422, 2
+	msgbox BattleFrontier_BattlePikeLobby_Text_25C422, MSGBOX_NPC
 	end
 
 BattleFrontier_BattlePikeLobby_EventScript_25BAB4:: @ 825BAB4
-	msgbox BattleFrontier_BattlePikeLobby_Text_25C4A5, 2
+	msgbox BattleFrontier_BattlePikeLobby_Text_25C4A5, MSGBOX_NPC
 	end
 
 BattleFrontier_BattlePikeLobby_EventScript_25BABD:: @ 825BABD
-	msgbox BattleFrontier_BattlePikeLobby_Text_25C4FD, 2
+	msgbox BattleFrontier_BattlePikeLobby_Text_25C4FD, MSGBOX_NPC
 	end
 
 BattleFrontier_BattlePikeLobby_EventScript_25BAC6:: @ 825BAC6
 	lockall
-	msgbox BattleFrontier_BattlePikeLobby_Text_25C5FB, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25C5FB, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeLobby_EventScript_25BAD5
 	end
 
@@ -307,17 +307,17 @@ BattleFrontier_BattlePikeLobby_EventScript_25BAD5:: @ 825BAD5
 	end
 
 BattleFrontier_BattlePikeLobby_EventScript_25BB1D:: @ 825BB1D
-	msgbox BattleFrontier_BattlePikeLobby_Text_25C644, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25C644, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeLobby_EventScript_25BAD5
 	end
 
 BattleFrontier_BattlePikeLobby_EventScript_25BB2B:: @ 825BB2B
-	msgbox BattleFrontier_BattlePikeLobby_Text_25C68A, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25C68A, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeLobby_EventScript_25BAD5
 	end
 
 BattleFrontier_BattlePikeLobby_EventScript_25BB39:: @ 825BB39
-	msgbox BattleFrontier_BattlePikeLobby_Text_25C6EB, 4
+	msgbox BattleFrontier_BattlePikeLobby_Text_25C6EB, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeLobby_EventScript_25BAD5
 	end
 

--- a/data/maps/BattleFrontier_BattlePikeRandomRoom1/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeRandomRoom1/scripts.inc
@@ -30,7 +30,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D1C6:: @ 825D1C6
 	setvar VAR_0x8004, 21
 	setvar VAR_0x8005, 0
 	special CallBattlePikeFunction
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	waitmessage
 	closemessage
 	releaseall
@@ -58,7 +58,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D226:: @ 825D226
 BattleFrontier_BattlePikeRandomRoom1_EventScript_25D231:: @ 825D231
 	lockall
 	delay 16
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DDFE, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DDFE, MSGBOX_DEFAULT
 	waitmessage
 	closemessage
 	applymovement 1, BattleFrontier_BattlePikeRandomRoom1_Movement_25D795
@@ -66,7 +66,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D231:: @ 825D231
 	setvar VAR_0x8004, 21
 	setvar VAR_0x8005, 0
 	special CallBattlePikeFunction
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	waitmessage
 	closemessage
 	releaseall
@@ -86,11 +86,11 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D285:: @ 825D285
 	waitmovement 0
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DE3F, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DE3F, MSGBOX_DEFAULT
 	playfanfare MUS_ME_ASA
 	waitfanfare
 	special HealPlayerParty
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DE94, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DE94, MSGBOX_DEFAULT
 	closemessage
 	release
 	applymovement 2, BattleFrontier_BattlePikeRandomRoom1_Movement_25D798
@@ -110,7 +110,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D2BF:: @ 825D2BF
 	case 2, BattleFrontier_BattlePikeRandomRoom1_EventScript_25D4FC
 
 BattleFrontier_BattlePikeRandomRoom1_EventScript_25D2FB:: @ 825D2FB
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E311, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E311, MSGBOX_DEFAULT
 	closemessage
 	special SpawnScriptEventObject
 	applymovement 127, BattleFrontier_BattlePikeRandomRoom1_Movement_25D9B0
@@ -147,13 +147,13 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D2FB:: @ 825D2FB
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattlePikeRandomRoom1_EventScript_25D3BD
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DED2, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DED2, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 7
 	special CallFrontierUtilFunc
 
 BattleFrontier_BattlePikeRandomRoom1_EventScript_25D3BD:: @ 825D3BD
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DF71, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DF71, MSGBOX_DEFAULT
 	call BattleFrontier_BattlePikeRandomRoom1_EventScript_25D77B
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattlePikeRandomRoom1_EventScript_25D3DA
@@ -164,7 +164,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D3DA:: @ 825D3DA
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattlePikeRandomRoom1_EventScript_25D49D
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DFA2, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DFA2, MSGBOX_DEFAULT
 	waitmessage
 	playfanfare MUS_ME_SYMBOLGET
 	message BattleFrontier_BattlePikeRandomRoom1_Text_25DFD0
@@ -172,7 +172,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D3DA:: @ 825D3DA
 	waitfanfare
 	setvar VAR_0x8004, 13
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E003, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E003, MSGBOX_DEFAULT
 	closemessage
 	goto BattleFrontier_BattlePikeRandomRoom1_EventScript_25D49D
 
@@ -182,13 +182,13 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D416:: @ 825D416
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattlePikeRandomRoom1_EventScript_25D443
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E02C, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E02C, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 7
 	special CallFrontierUtilFunc
 
 BattleFrontier_BattlePikeRandomRoom1_EventScript_25D443:: @ 825D443
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E0E8, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E0E8, MSGBOX_DEFAULT
 	call BattleFrontier_BattlePikeRandomRoom1_EventScript_25D77B
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattlePikeRandomRoom1_EventScript_25D460
@@ -199,7 +199,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D460:: @ 825D460
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 2
 	goto_eq BattleFrontier_BattlePikeRandomRoom1_EventScript_25D49D
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E0F6, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E0F6, MSGBOX_DEFAULT
 	waitmessage
 	playfanfare MUS_ME_SYMBOLGET
 	message BattleFrontier_BattlePikeRandomRoom1_Text_25E118
@@ -207,7 +207,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D460:: @ 825D460
 	waitfanfare
 	setvar VAR_0x8004, 13
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E140, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E140, MSGBOX_DEFAULT
 	closemessage
 	goto BattleFrontier_BattlePikeRandomRoom1_EventScript_25D49D
 	end
@@ -230,19 +230,19 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D49D:: @ 825D49D
 	end
 
 BattleFrontier_BattlePikeRandomRoom1_EventScript_25D4DC:: @ 825D4DC
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E15D, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E15D, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeRandomRoom1_EventScript_25D2FB
 	end
 
 BattleFrontier_BattlePikeRandomRoom1_EventScript_25D4EA:: @ 825D4EA
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E1DD, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E1DD, MSGBOX_DEFAULT
 	playfanfare MUS_ME_ASA
 	waitfanfare
 	goto BattleFrontier_BattlePikeRandomRoom1_EventScript_25D2FB
 	end
 
 BattleFrontier_BattlePikeRandomRoom1_EventScript_25D4FC:: @ 825D4FC
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E238, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E238, MSGBOX_DEFAULT
 	playfanfare MUS_ME_ASA
 	waitfanfare
 	goto BattleFrontier_BattlePikeRandomRoom1_EventScript_25D2FB
@@ -258,7 +258,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D50E:: @ 825D50E
 	playfanfare MUS_ME_ASA
 	waitfanfare
 	special HealPlayerParty
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DA13, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DA13, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, BattleFrontier_BattlePikeRandomRoom1_Movement_25D798
 	waitmovement 0
@@ -282,7 +282,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D53E:: @ 825D53E
 	setvar VAR_0x8004, 21
 	setvar VAR_0x8005, 0
 	special CallBattlePikeFunction
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	closemessage
 	delay 16
 	applymovement 255, BattleFrontier_BattlePikeRandomRoom1_Movement_25D7BD
@@ -290,7 +290,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D53E:: @ 825D53E
 	setvar VAR_0x8004, 21
 	setvar VAR_0x8005, 1
 	special CallBattlePikeFunction
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, SPECIAL_BATTLE_PIKE_DOUBLE
 	setvar VAR_0x8005, 0
@@ -324,13 +324,13 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D605:: @ 825D605
 	call_if 1, BattleFrontier_BattlePikeRandomRoom1_EventScript_25D643
 	compare VAR_0x8004, 1
 	call_if 1, BattleFrontier_BattlePikeRandomRoom1_EventScript_25D6D5
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DD3F, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DD3F, MSGBOX_DEFAULT
 	closemessage
 	releaseall
 	end
 
 BattleFrontier_BattlePikeRandomRoom1_EventScript_25D643:: @ 825D643
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DBE4, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DBE4, MSGBOX_DEFAULT
 	closemessage
 	waitse
 	playmoncry SPECIES_KIRLIA, 0
@@ -355,7 +355,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D643:: @ 825D643
 	waitse
 	playmoncry SPECIES_KIRLIA, 0
 	waitmoncry
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DCAF, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DCAF, MSGBOX_DEFAULT
 	waitse
 	playmoncry SPECIES_KIRLIA, 0
 	waitmoncry
@@ -363,11 +363,11 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D643:: @ 825D643
 	applymovement 2, BattleFrontier_BattlePikeRandomRoom1_Movement_25D7B3
 	applymovement 1, BattleFrontier_BattlePikeRandomRoom1_Movement_25D7A4
 	waitmovement 0
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DCCF, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DCCF, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePikeRandomRoom1_EventScript_25D6D5:: @ 825D6D5
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DC01, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DC01, MSGBOX_DEFAULT
 	closemessage
 	waitse
 	playmoncry SPECIES_DUSCLOPS, 0
@@ -388,7 +388,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D6D5:: @ 825D6D5
 	waitse
 	playmoncry SPECIES_DUSCLOPS, 0
 	waitmoncry
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DCAF, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DCAF, MSGBOX_DEFAULT
 	waitse
 	playmoncry SPECIES_DUSCLOPS, 0
 	waitmoncry
@@ -396,7 +396,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D6D5:: @ 825D6D5
 	applymovement 2, BattleFrontier_BattlePikeRandomRoom1_Movement_25D7B3
 	applymovement 1, BattleFrontier_BattlePikeRandomRoom1_Movement_25D7A4
 	waitmovement 0
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DD06, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DD06, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePikeRandomRoom1_EventScript_25D751:: @ 825D751
@@ -590,7 +590,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D81B:: @ 825D81B
 	faceplayer
 	setvar VAR_0x8004, 14
 	special CallBattlePikeFunction
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	waitmessage
 	closemessage
 	release
@@ -599,7 +599,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D81B:: @ 825D81B
 BattleFrontier_BattlePikeRandomRoom1_EventScript_25D831:: @ 825D831
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DDA3, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DDA3, MSGBOX_DEFAULT
 	closemessage
 	release
 	end
@@ -613,7 +613,7 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D83E:: @ 825D83E
 	call_if 1, BattleFrontier_BattlePikeRandomRoom1_EventScript_25D875
 	playfanfare MUS_ME_ASA
 	waitfanfare
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DABE, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DABE, MSGBOX_DEFAULT
 	closemessage
 	release
 	applymovement 1, BattleFrontier_BattlePikeRandomRoom1_Movement_25D79E
@@ -623,21 +623,21 @@ BattleFrontier_BattlePikeRandomRoom1_EventScript_25D83E:: @ 825D83E
 BattleFrontier_BattlePikeRandomRoom1_EventScript_25D875:: @ 825D875
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DA51, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DA51, MSGBOX_DEFAULT
 	closemessage
 	return
 
 BattleFrontier_BattlePikeRandomRoom1_EventScript_25D881:: @ 825D881
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E32E, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25E32E, MSGBOX_DEFAULT
 	closemessage
 	return
 
 BattleFrontier_BattlePikeRandomRoom1_EventScript_25D88D:: @ 825D88D
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DDE6, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom1_Text_25DDE6, MSGBOX_DEFAULT
 	closemessage
 	release
 	applymovement 2, BattleFrontier_BattlePikeRandomRoom1_Movement_25D7B4

--- a/data/maps/BattleFrontier_BattlePikeRandomRoom2/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeRandomRoom2/scripts.inc
@@ -16,7 +16,7 @@ BattleFrontier_BattlePikeRandomRoom2_EventScript_25E3A7:: @ 825E3A7
 	setvar VAR_0x8006, 3
 	special CallFrontierUtilFunc
 	lockall
-	msgbox BattleFrontier_BattlePikeRandomRoom2_Text_25E3F2, 4
+	msgbox BattleFrontier_BattlePikeRandomRoom2_Text_25E3F2, MSGBOX_DEFAULT
 	closemessage
 	releaseall
 	warp MAP_BATTLE_FRONTIER_BATTLE_PIKE_LOBBY, 255, 5, 6

--- a/data/maps/BattleFrontier_BattlePikeThreePathRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeThreePathRoom/scripts.inc
@@ -49,7 +49,7 @@ BattleFrontier_BattlePikeThreePathRoom_EventScript_25C8A4:: @ 825C8A4
 	setvar VAR_0x8004, 3
 	setvar VAR_0x8005, 3
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CDDA, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CDDA, MSGBOX_DEFAULT
 	closemessage
 	releaseall
 	setvar VAR_0x8004, 5
@@ -77,54 +77,54 @@ BattleFrontier_BattlePikeThreePathRoom_EventScript_25C908:: @ 825C908
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25C968:: @ 825C968
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CBDD, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CBDD, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeThreePathRoom_EventScript_25C9D8
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25C978:: @ 825C978
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CC00, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CC00, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeThreePathRoom_EventScript_25C9D8
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25C988:: @ 825C988
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CC23, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CC23, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeThreePathRoom_EventScript_25C9D8
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25C998:: @ 825C998
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CC46, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CC46, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeThreePathRoom_EventScript_25C9D8
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25C9A8:: @ 825C9A8
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CC69, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CC69, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeThreePathRoom_EventScript_25C9D8
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25C9B8:: @ 825C9B8
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CC8C, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CC8C, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeThreePathRoom_EventScript_25C9D8
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25C9C8:: @ 825C9C8
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CCB0, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CCB0, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeThreePathRoom_EventScript_25C9D8
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25C9D8:: @ 825C9D8
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CCD4, 5
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CCD4, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattlePikeThreePathRoom_EventScript_25CA2A
 	case 127, BattleFrontier_BattlePikeThreePathRoom_EventScript_25CA2A
@@ -148,7 +148,7 @@ BattleFrontier_BattlePikeThreePathRoom_EventScript_25C9FD:: @ 825C9FD
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25CA2A:: @ 825CA2A
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CCFB, 5
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CCFB, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 1, BattleFrontier_BattlePikeThreePathRoom_EventScript_25C9FD
 	case 0, BattleFrontier_BattlePikeThreePathRoom_EventScript_25CA5A
@@ -181,7 +181,7 @@ BattleFrontier_BattlePikeThreePathRoom_EventScript_25CA97:: @ 825CA97
 	applymovement 2, BattleFrontier_BattlePikeThreePathRoom_Movement_25CBCE
 	waitmovement 0
 	lockall
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25D094, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25D094, MSGBOX_DEFAULT
 	releaseall
 	applymovement 2, BattleFrontier_BattlePikeThreePathRoom_Movement_25CBD5
 	waitmovement 0
@@ -195,7 +195,7 @@ BattleFrontier_BattlePikeThreePathRoom_EventScript_25CABB:: @ 825CABB
 	goto_eq BattleFrontier_BattlePikeThreePathRoom_EventScript_25CBC2
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CE69, 5
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CE69, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 1, BattleFrontier_BattlePikeThreePathRoom_EventScript_25CB0A
 	case 0, BattleFrontier_BattlePikeThreePathRoom_EventScript_25CB00
@@ -204,7 +204,7 @@ BattleFrontier_BattlePikeThreePathRoom_EventScript_25CABB:: @ 825CABB
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25CB00:: @ 825CB00
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CEBB, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CEBB, MSGBOX_DEFAULT
 	release
 	end
 
@@ -218,15 +218,15 @@ BattleFrontier_BattlePikeThreePathRoom_EventScript_25CB0A:: @ 825CB0A
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25CB39:: @ 825CB39
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CF64, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CF64, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeThreePathRoom_EventScript_25CB60
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25CB46:: @ 825CB46
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CF23, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CF23, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeThreePathRoom_EventScript_25CB60
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25CB53:: @ 825CB53
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CEE3, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CEE3, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePikeThreePathRoom_EventScript_25CB60
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25CB60:: @ 825CB60
@@ -240,29 +240,29 @@ BattleFrontier_BattlePikeThreePathRoom_EventScript_25CB60:: @ 825CB60
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25CB9A:: @ 825CB9A
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25D054, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25D054, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25CBA4:: @ 825CBA4
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25D017, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25D017, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25CBAE:: @ 825CBAE
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CFA3, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CFA3, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25CBB8:: @ 825CBB8
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CFE5, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25CFE5, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_25CBC2:: @ 825CBC2
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25D125, 4
+	msgbox BattleFrontier_BattlePikeThreePathRoom_Text_25D125, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/BattleFrontier_BattlePointExchangeServiceCorner/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePointExchangeServiceCorner/scripts.inc
@@ -2,12 +2,12 @@ BattleFrontier_BattlePointExchangeServiceCorner_MapScripts:: @ 825F070
 	.byte 0
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F071:: @ 825F071
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F7FA, 4
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F7FA, MSGBOX_DEFAULT
 	special sub_813A958
 	return
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F07D:: @ 825F07D
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FF12, 4
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FF12, MSGBOX_DEFAULT
 	special sub_813A988
 	release
 	end
@@ -16,7 +16,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F08A:: @ 825F08A
 	specialvar VAR_TEMP_1, sub_813AA04
 	compare VAR_TEMP_1, VAR_0x8008
 	goto_if 4, BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F0C9
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FE86, 4
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FE86, MSGBOX_DEFAULT
 	compare VAR_TEMP_2, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F185
 	compare VAR_TEMP_2, 1
@@ -43,14 +43,14 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F0E5:: @ 825F0E5
 	givedecoration VAR_0x8009
 	special sub_813A8FC
 	playse SE_REGI
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FE45, 4
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FE45, MSGBOX_DEFAULT
 	compare VAR_TEMP_2, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F185
 	goto BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F38E
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F11D:: @ 825F11D
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FEB9, 4
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FEB9, MSGBOX_DEFAULT
 	special sub_813A988
 	release
 	end
@@ -64,14 +64,14 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F12A:: @ 825F12A
 	giveitem VAR_0x8009, 1
 	special sub_813A8FC
 	playse SE_REGI
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FE72, 4
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FE72, MSGBOX_DEFAULT
 	compare VAR_TEMP_2, 2
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F4B1
 	goto BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F602
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F166:: @ 825F166
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FEE3, 4
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FEE3, MSGBOX_DEFAULT
 	special sub_813A988
 	release
 	end
@@ -106,7 +106,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F185:: @ 825F185
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F21E:: @ 825F21E
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F8B6, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F8B6, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F185
 	setvar VAR_0x8008, 16
@@ -115,7 +115,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F21E:: @ 825F21E
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F241:: @ 825F241
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F8E6, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F8E6, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F185
 	setvar VAR_0x8008, 32
@@ -124,7 +124,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F241:: @ 825F241
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F264:: @ 825F264
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F917, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F917, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F185
 	setvar VAR_0x8008, 32
@@ -133,7 +133,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F264:: @ 825F264
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F287:: @ 825F287
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F949, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F949, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F185
 	setvar VAR_0x8008, 48
@@ -142,7 +142,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F287:: @ 825F287
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F2AA:: @ 825F2AA
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F979, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F979, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F185
 	setvar VAR_0x8008, 48
@@ -151,7 +151,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F2AA:: @ 825F2AA
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F2CD:: @ 825F2CD
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F9A9, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F9A9, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F185
 	setvar VAR_0x8008, 48
@@ -160,7 +160,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F2CD:: @ 825F2CD
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F2F0:: @ 825F2F0
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F9DB, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25F9DB, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F185
 	setvar VAR_0x8008, 48
@@ -169,7 +169,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F2F0:: @ 825F2F0
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F313:: @ 825F313
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FA0A, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FA0A, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F185
 	setvar VAR_0x8008, 80
@@ -178,7 +178,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F313:: @ 825F313
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F336:: @ 825F336
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FA3D, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FA3D, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F185
 	setvar VAR_0x8008, 80
@@ -187,7 +187,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F336:: @ 825F336
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F359:: @ 825F359
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FA70, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FA70, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F185
 	setvar VAR_0x8008, 80
@@ -220,7 +220,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F38E:: @ 825F38E
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F3F0:: @ 825F3F0
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FAA2, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FAA2, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F38E
 	setvar VAR_0x8008, 128
@@ -229,7 +229,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F3F0:: @ 825F3F0
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F413:: @ 825F413
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FAD2, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FAD2, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F38E
 	setvar VAR_0x8008, 128
@@ -238,7 +238,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F413:: @ 825F413
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F436:: @ 825F436
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FB03, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FB03, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F38E
 	setvar VAR_0x8008, 256
@@ -247,7 +247,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F436:: @ 825F436
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F459:: @ 825F459
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FB35, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FB35, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F38E
 	setvar VAR_0x8008, 256
@@ -256,7 +256,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F459:: @ 825F459
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F47C:: @ 825F47C
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FB68, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FB68, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F38E
 	setvar VAR_0x8008, 256
@@ -290,7 +290,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F4B1:: @ 825F4B1
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F51E:: @ 825F51E
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FB9B, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FB9B, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F4B1
 	setvar VAR_0x8008, 1
@@ -299,7 +299,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F51E:: @ 825F51E
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F541:: @ 825F541
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FBC7, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FBC7, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F4B1
 	setvar VAR_0x8008, 1
@@ -308,7 +308,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F541:: @ 825F541
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F564:: @ 825F564
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FBF3, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FBF3, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F4B1
 	setvar VAR_0x8008, 1
@@ -317,7 +317,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F564:: @ 825F564
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F587:: @ 825F587
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FC1C, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FC1C, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F4B1
 	setvar VAR_0x8008, 1
@@ -326,7 +326,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F587:: @ 825F587
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F5AA:: @ 825F5AA
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FC45, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FC45, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F4B1
 	setvar VAR_0x8008, 1
@@ -335,7 +335,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F5AA:: @ 825F5AA
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F5CD:: @ 825F5CD
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FC70, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FC70, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F4B1
 	setvar VAR_0x8008, 1
@@ -372,7 +372,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F602:: @ 825F602
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F690:: @ 825F690
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FE17, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FE17, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F602
 	setvar VAR_0x8008, 48
@@ -381,7 +381,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F690:: @ 825F690
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F6B3:: @ 825F6B3
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FCCB, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FCCB, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F602
 	setvar VAR_0x8008, 48
@@ -390,7 +390,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F6B3:: @ 825F6B3
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F6D6:: @ 825F6D6
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FCFA, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FCFA, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F602
 	setvar VAR_0x8008, 48
@@ -399,7 +399,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F6D6:: @ 825F6D6
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F6F9:: @ 825F6F9
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FD29, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FD29, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F602
 	setvar VAR_0x8008, 48
@@ -408,7 +408,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F6F9:: @ 825F6F9
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F71C:: @ 825F71C
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FC9A, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FC9A, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F602
 	setvar VAR_0x8008, 64
@@ -417,7 +417,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F71C:: @ 825F71C
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F73F:: @ 825F73F
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FD59, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FD59, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F602
 	setvar VAR_0x8008, 64
@@ -426,7 +426,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F73F:: @ 825F73F
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F762:: @ 825F762
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FD89, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FD89, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F602
 	setvar VAR_0x8008, 64
@@ -435,7 +435,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F762:: @ 825F762
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F785:: @ 825F785
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FDB9, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FDB9, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F602
 	setvar VAR_0x8008, 64
@@ -444,7 +444,7 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F785:: @ 825F785
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F7A8:: @ 825F7A8
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FDE8, 5
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FDE8, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F602
 	setvar VAR_0x8008, 64
@@ -453,25 +453,25 @@ BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F7A8:: @ 825F7A8
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F7CB:: @ 825F7CB
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_260099, 2
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_260099, MSGBOX_NPC
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F7D4:: @ 825F7D4
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_26002E, 2
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_26002E, MSGBOX_NPC
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F7DD:: @ 825F7DD
 	lock
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FFD0, 4
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FFD0, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F7E8:: @ 825F7E8
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FF5D, 2
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_25FF5D, MSGBOX_NPC
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_EventScript_25F7F1:: @ 825F7F1
-	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_26012D, 2
+	msgbox BattleFrontier_BattlePointExchangeServiceCorner_Text_26012D, MSGBOX_NPC
 	end
 
 BattleFrontier_BattlePointExchangeServiceCorner_Text_25F7FA: @ 825F7FA

--- a/data/maps/BattleFrontier_BattlePyramidEmptySquare/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePyramidEmptySquare/scripts.inc
@@ -165,7 +165,7 @@ BattleFrontier_BattlePyramidEmptySquare_EventScript_252C4F:: @ 8252C4F
 BattleFrontier_BattlePyramidEmptySquare_EventScript_252C6A:: @ 8252C6A
 	setvar VAR_0x8004, 7
 	special CallBattlePyramidFunction
-	callstd 1
+	callstd STD_FIND_ITEM
 	compare VAR_0x8007, 0
 	goto_eq BattleFrontier_BattlePyramidEmptySquare_EventScript_252C87
 	setvar VAR_0x8004, 8
@@ -781,4 +781,3 @@ BattleFrontier_BattlePyramidEmptySquare_Text_25502F:: @ 825502F
 BattleFrontier_BattlePyramidEmptySquare_Text_255068:: @ 8255068
 	.string "There aren’t any TRAINERS left that\n"
 	.string "can take you on now…$"
-

--- a/data/maps/BattleFrontier_BattlePyramidLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePyramidLobby/scripts.inc
@@ -54,11 +54,11 @@ BattleFrontier_BattlePyramidLobby_EventScript_2507B1:: @ 82507B1
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattlePyramidLobby_EventScript_2507D2
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2517B5, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2517B5, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePyramidLobby_EventScript_2507DA
 
 BattleFrontier_BattlePyramidLobby_EventScript_2507D2:: @ 82507D2
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2525F4, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2525F4, MSGBOX_DEFAULT
 
 BattleFrontier_BattlePyramidLobby_EventScript_2507DA:: @ 82507DA
 	special sub_81B95E0
@@ -75,7 +75,7 @@ BattleFrontier_BattlePyramidLobby_EventScript_2507DA:: @ 82507DA
 	waitmessage
 	playse SE_EXPMAX
 	waitse
-	msgbox BattleFrontier_BattlePyramidLobby_Text_252662, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_252662, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 11
 	special CallFrontierUtilFunc
 	msgbox BattleFrontier_BattlePyramidLobby_Text_241520, 9
@@ -88,7 +88,7 @@ BattleFrontier_BattlePyramidLobby_EventScript_2507DA:: @ 82507DA
 	special CallBattlePyramidFunction
 	playse SE_SAVE
 	waitse
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251BB6, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251BB6, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
@@ -117,7 +117,7 @@ BattleFrontier_BattlePyramidLobby_EventScript_250852:: @ 8250852
 	special CallBattlePyramidFunction
 	playse SE_SAVE
 	waitse
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251BB6, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251BB6, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
@@ -132,7 +132,7 @@ BattleFrontier_BattlePyramidLobby_EventScript_2508B1:: @ 82508B1
 	setvar VAR_FRONTIER_FACILITY, 6
 	setvar VAR_FRONTIER_BATTLE_MODE, 0
 	special SavePlayerParty
-	msgbox BattleFrontier_BattlePyramidLobby_Text_250F31, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_250F31, MSGBOX_DEFAULT
 
 BattleFrontier_BattlePyramidLobby_EventScript_2508C8:: @ 82508C8
 	message BattleFrontier_BattlePyramidLobby_Text_250FA7
@@ -159,7 +159,7 @@ BattleFrontier_BattlePyramidLobby_EventScript_250904:: @ 8250904
 	setvar VAR_0x8005, 1
 	copyvar VAR_0x8006, VAR_RESULT
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251297, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251297, MSGBOX_DEFAULT
 	fadescreen 1
 	call BattleFrontier_BattlePyramidLobby_EventScript_23F2B7
 	copyvar VAR_0x8004, VAR_RESULT
@@ -168,7 +168,7 @@ BattleFrontier_BattlePyramidLobby_EventScript_250904:: @ 8250904
 	waitstate
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePyramidLobby_EventScript_250AC1
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2514E6, 5
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2514E6, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattlePyramidLobby_EventScript_250AC1
 	case 1, BattleFrontier_BattlePyramidLobby_EventScript_2509A5
@@ -210,7 +210,7 @@ BattleFrontier_BattlePyramidLobby_EventScript_250A21:: @ 8250A21
 	setvar VAR_0x8004, 3
 	setvar VAR_0x8005, 3
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251531, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251531, MSGBOX_DEFAULT
 	closemessage
 	call BattleFrontier_BattlePyramidLobby_EventScript_250D56
 	setvar VAR_0x8004, 2
@@ -225,7 +225,7 @@ BattleFrontier_BattlePyramidLobby_EventScript_250A21:: @ 8250A21
 	end
 
 BattleFrontier_BattlePyramidLobby_EventScript_250A68:: @ 8250A68
-	msgbox BattleFrontier_BattlePyramidLobby_Text_25100C, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_25100C, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePyramidLobby_EventScript_2508C8
 
 BattleFrontier_BattlePyramidLobby_EventScript_250A75:: @ 8250A75
@@ -234,11 +234,11 @@ BattleFrontier_BattlePyramidLobby_EventScript_250A75:: @ 8250A75
 	case 1, BattleFrontier_BattlePyramidLobby_EventScript_250A9D
 
 BattleFrontier_BattlePyramidLobby_EventScript_250A90:: @ 8250A90
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2513C1, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2513C1, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePyramidLobby_EventScript_250ACC
 
 BattleFrontier_BattlePyramidLobby_EventScript_250A9D:: @ 8250A9D
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2512E2, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2512E2, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePyramidLobby_EventScript_250ACC
 
 BattleFrontier_BattlePyramidLobby_EventScript_250AAA:: @ 8250AAA
@@ -252,7 +252,7 @@ BattleFrontier_BattlePyramidLobby_EventScript_250AC1:: @ 8250AC1
 	special LoadPlayerParty
 
 BattleFrontier_BattlePyramidLobby_EventScript_250AC4:: @ 8250AC4
-	msgbox BattleFrontier_BattlePyramidLobby_Text_250FE5, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_250FE5, MSGBOX_DEFAULT
 
 BattleFrontier_BattlePyramidLobby_EventScript_250ACC:: @ 8250ACC
 	release
@@ -262,9 +262,9 @@ BattleFrontier_BattlePyramidLobby_EventScript_250ACE:: @ 8250ACE
 	lockall
 	applymovement 2, BattleFrontier_BattlePyramidLobby_Movement_27259E
 	waitmovement 0
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251C3B, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251C3B, MSGBOX_DEFAULT
 	call BattleFrontier_BattlePyramidLobby_EventScript_250AF0
-	msgbox BattleFrontier_BattlePyramidLobby_Text_252461, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_252461, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -281,7 +281,7 @@ BattleFrontier_BattlePyramidLobby_EventScript_250B27:: @ 8250B27
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250B28:: @ 8250B28
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251C8A, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251C8A, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 1
 	setvar VAR_0x8005, 5
 	special CallBattlePyramidFunction
@@ -299,7 +299,7 @@ BattleFrontier_BattlePyramidLobby_EventScript_250B53:: @ 8250B53
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250B66:: @ 8250B66
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251C8A, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251C8A, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 1
 	setvar VAR_0x8005, 6
 	special CallBattlePyramidFunction
@@ -343,83 +343,83 @@ BattleFrontier_BattlePyramidLobby_EventScript_250BA4:: @ 8250BA4
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250C8E:: @ 8250C8E
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251CB3, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251CB3, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250C97:: @ 8250C97
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251D07, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251D07, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250CA0:: @ 8250CA0
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251D54, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251D54, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250CA9:: @ 8250CA9
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251D9C, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251D9C, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250CB2:: @ 8250CB2
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251E3D, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251E3D, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250CBB:: @ 8250CBB
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251EA1, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251EA1, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250CC4:: @ 8250CC4
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251F17, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251F17, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250CCD:: @ 8250CCD
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251F6E, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251F6E, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250CD6:: @ 8250CD6
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251FC7, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251FC7, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250CDF:: @ 8250CDF
-	msgbox BattleFrontier_BattlePyramidLobby_Text_25201B, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_25201B, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250CE8:: @ 8250CE8
-	msgbox BattleFrontier_BattlePyramidLobby_Text_252068, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_252068, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250CF1:: @ 8250CF1
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2520BA, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2520BA, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250CFA:: @ 8250CFA
-	msgbox BattleFrontier_BattlePyramidLobby_Text_252158, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_252158, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250D03:: @ 8250D03
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2521B4, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2521B4, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250D0C:: @ 8250D0C
-	msgbox BattleFrontier_BattlePyramidLobby_Text_252206, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_252206, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250D15:: @ 8250D15
-	msgbox BattleFrontier_BattlePyramidLobby_Text_25225A, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_25225A, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250D1E:: @ 8250D1E
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2522AE, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2522AE, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250D27:: @ 8250D27
-	msgbox BattleFrontier_BattlePyramidLobby_Text_25230B, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_25230B, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250D30:: @ 8250D30
-	msgbox BattleFrontier_BattlePyramidLobby_Text_252364, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_252364, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250D39:: @ 8250D39
-	msgbox BattleFrontier_BattlePyramidLobby_Text_252403, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_252403, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250D42:: @ 8250D42
@@ -436,24 +436,24 @@ BattleFrontier_BattlePyramidLobby_EventScript_250D56:: @ 8250D56
 	applymovement 1, BattleFrontier_BattlePyramidLobby_Movement_250DC4
 	applymovement 255, BattleFrontier_BattlePyramidLobby_Movement_250DCD
 	waitmovement 0
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251569, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251569, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 1
 	setvar VAR_0x8005, 1
 	special CallBattlePyramidFunction
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattlePyramidLobby_EventScript_250D94
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2515AD, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2515AD, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePyramidLobby_EventScript_250D9C
 
 BattleFrontier_BattlePyramidLobby_EventScript_250D94:: @ 8250D94
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2515F4, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2515F4, MSGBOX_DEFAULT
 
 BattleFrontier_BattlePyramidLobby_EventScript_250D9C:: @ 8250D9C
 	message BattleFrontier_BattlePyramidLobby_Text_25161E
 	waitmessage
 	playse SE_EXPMAX
 	waitse
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251647, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251647, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, BattleFrontier_BattlePyramidLobby_Movement_250DD5
 	waitmovement 0
@@ -493,7 +493,7 @@ BattleFrontier_BattlePyramidLobby_Movement_250DD8: @ 8250DD8
 	step_end
 
 BattleFrontier_BattlePyramidLobby_EventScript_250DDB:: @ 8250DDB
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2517FC, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2517FC, MSGBOX_DEFAULT
 	setflag FLAG_SPECIAL_FLAG_0x4004
 	special sub_81C6A94
 	compare VAR_RESULT, 0
@@ -504,7 +504,7 @@ BattleFrontier_BattlePyramidLobby_EventScript_250DDB:: @ 8250DDB
 	end
 
 BattleFrontier_BattlePyramidLobby_EventScript_250E00:: @ 8250E00
-	msgbox BattleFrontier_BattlePyramidLobby_Text_251881, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_251881, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250E09:: @ 8250E09
@@ -539,23 +539,23 @@ BattleFrontier_BattlePyramidLobby_EventScript_250E60:: @ 8250E60
 	return
 
 BattleFrontier_BattlePyramidLobby_EventScript_250E6F:: @ 8250E6F
-	msgbox BattleFrontier_BattlePyramidLobby_Text_25194F, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_25194F, MSGBOX_DEFAULT
 	message BattleFrontier_BattlePyramidLobby_Text_25197E
 	waitmessage
 	goto BattleFrontier_BattlePyramidLobby_EventScript_250E09
 	end
 
 BattleFrontier_BattlePyramidLobby_EventScript_250E83:: @ 8250E83
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2524DA, 2
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2524DA, MSGBOX_NPC
 	end
 
 BattleFrontier_BattlePyramidLobby_EventScript_250E8C:: @ 8250E8C
-	msgbox BattleFrontier_BattlePyramidLobby_Text_252595, 2
+	msgbox BattleFrontier_BattlePyramidLobby_Text_252595, MSGBOX_NPC
 	end
 
 BattleFrontier_BattlePyramidLobby_EventScript_250E95:: @ 8250E95
 	lockall
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2526B6, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2526B6, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePyramidLobby_EventScript_250EA4
 	end
 
@@ -573,22 +573,22 @@ BattleFrontier_BattlePyramidLobby_EventScript_250EA4:: @ 8250EA4
 	end
 
 BattleFrontier_BattlePyramidLobby_EventScript_250EF7:: @ 8250EF7
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2526FC, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2526FC, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePyramidLobby_EventScript_250EA4
 	end
 
 BattleFrontier_BattlePyramidLobby_EventScript_250F05:: @ 8250F05
-	msgbox BattleFrontier_BattlePyramidLobby_Text_2527A9, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_2527A9, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePyramidLobby_EventScript_250EA4
 	end
 
 BattleFrontier_BattlePyramidLobby_EventScript_250F13:: @ 8250F13
-	msgbox BattleFrontier_BattlePyramidLobby_Text_25285A, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_25285A, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePyramidLobby_EventScript_250EA4
 	end
 
 BattleFrontier_BattlePyramidLobby_EventScript_250F21:: @ 8250F21
-	msgbox BattleFrontier_BattlePyramidLobby_Text_252924, 4
+	msgbox BattleFrontier_BattlePyramidLobby_Text_252924, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePyramidLobby_EventScript_250EA4
 	end
 

--- a/data/maps/BattleFrontier_BattlePyramidTop/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePyramidTop/scripts.inc
@@ -92,7 +92,7 @@ BattleFrontier_BattlePyramidTop_EventScript_2551D0:: @ 82551D0
 	goto_if 5, BattleFrontier_BattlePyramidTop_EventScript_255236
 	compare VAR_TEMP_C, 0
 	goto_if 5, BattleFrontier_BattlePyramidTop_EventScript_255240
-	msgbox BattleFrontier_BattlePyramidTop_Text_255410, 4
+	msgbox BattleFrontier_BattlePyramidTop_Text_255410, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, BattleFrontier_BattlePyramidTop_Movement_2553FD
 	waitmovement 0
@@ -116,12 +116,12 @@ BattleFrontier_BattlePyramidTop_EventScript_25521A:: @ 825521A
 	end
 
 BattleFrontier_BattlePyramidTop_EventScript_255236:: @ 8255236
-	msgbox BattleFrontier_BattlePyramidTop_Text_255BFE, 4
+	msgbox BattleFrontier_BattlePyramidTop_Text_255BFE, MSGBOX_DEFAULT
 	closemessage
 	end
 
 BattleFrontier_BattlePyramidTop_EventScript_255240:: @ 8255240
-	msgbox BattleFrontier_BattlePyramidTop_Text_25551F, 4
+	msgbox BattleFrontier_BattlePyramidTop_Text_25551F, MSGBOX_DEFAULT
 	applymovement 1, BattleFrontier_BattlePyramidTop_Movement_2553FD
 	setvar VAR_TEMP_D, 1
 	closemessage
@@ -141,14 +141,14 @@ BattleFrontier_BattlePyramidTop_EventScript_255256:: @ 8255256
 	special SpawnScriptEventObject
 	applymovement 127, BattleFrontier_BattlePyramidTop_Movement_25540C
 	waitmovement 0
-	msgbox BattleFrontier_BattlePyramidTop_Text_255669, 4
+	msgbox BattleFrontier_BattlePyramidTop_Text_255669, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 7
 	special CallFrontierUtilFunc
 	applymovement 2, BattleFrontier_BattlePyramidTop_Movement_25540A
 	waitmovement 0
-	msgbox BattleFrontier_BattlePyramidTop_Text_25573E, 4
+	msgbox BattleFrontier_BattlePyramidTop_Text_25573E, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePyramidTop_EventScript_2552DA
 	end
 
@@ -157,7 +157,7 @@ BattleFrontier_BattlePyramidTop_EventScript_2552D0:: @ 82552D0
 	waitmovement 0
 
 BattleFrontier_BattlePyramidTop_EventScript_2552DA:: @ 82552DA
-	msgbox BattleFrontier_BattlePyramidTop_Text_255846, 4
+	msgbox BattleFrontier_BattlePyramidTop_Text_255846, MSGBOX_DEFAULT
 	call BattleFrontier_BattlePyramidTop_EventScript_2553ED
 	playbgm MUS_PYRAMID_TOP, 0
 	compare VAR_RESULT, 1
@@ -169,14 +169,14 @@ BattleFrontier_BattlePyramidTop_EventScript_2552FB:: @ 82552FB
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattlePyramidTop_EventScript_25521A
-	msgbox BattleFrontier_BattlePyramidTop_Text_255873, 4
+	msgbox BattleFrontier_BattlePyramidTop_Text_255873, MSGBOX_DEFAULT
 	playfanfare MUS_ME_SYMBOLGET
 	message BattleFrontier_BattlePyramidTop_Text_2558E9
 	waitmessage
 	waitfanfare
 	setvar VAR_0x8004, 13
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattlePyramidTop_Text_25591D, 4
+	msgbox BattleFrontier_BattlePyramidTop_Text_25591D, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePyramidTop_EventScript_25521A
 
 BattleFrontier_BattlePyramidTop_EventScript_255335:: @ 8255335
@@ -188,14 +188,14 @@ BattleFrontier_BattlePyramidTop_EventScript_255335:: @ 8255335
 	special SpawnScriptEventObject
 	applymovement 127, BattleFrontier_BattlePyramidTop_Movement_25540C
 	waitmovement 0
-	msgbox BattleFrontier_BattlePyramidTop_Text_255951, 4
+	msgbox BattleFrontier_BattlePyramidTop_Text_255951, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 7
 	special CallFrontierUtilFunc
 	applymovement 2, BattleFrontier_BattlePyramidTop_Movement_25540A
 	waitmovement 0
-	msgbox BattleFrontier_BattlePyramidTop_Text_255A6D, 4
+	msgbox BattleFrontier_BattlePyramidTop_Text_255A6D, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePyramidTop_EventScript_255392
 	end
 
@@ -204,7 +204,7 @@ BattleFrontier_BattlePyramidTop_EventScript_255388:: @ 8255388
 	waitmovement 0
 
 BattleFrontier_BattlePyramidTop_EventScript_255392:: @ 8255392
-	msgbox BattleFrontier_BattlePyramidTop_Text_255AA1, 4
+	msgbox BattleFrontier_BattlePyramidTop_Text_255AA1, MSGBOX_DEFAULT
 	call BattleFrontier_BattlePyramidTop_EventScript_2553ED
 	playbgm MUS_PYRAMID_TOP, 0
 	compare VAR_RESULT, 1
@@ -216,14 +216,14 @@ BattleFrontier_BattlePyramidTop_EventScript_2553B3:: @ 82553B3
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 2
 	goto_eq BattleFrontier_BattlePyramidTop_EventScript_25521A
-	msgbox BattleFrontier_BattlePyramidTop_Text_255ACD, 4
+	msgbox BattleFrontier_BattlePyramidTop_Text_255ACD, MSGBOX_DEFAULT
 	playfanfare MUS_ME_SYMBOLGET
 	message BattleFrontier_BattlePyramidTop_Text_255B59
 	waitmessage
 	waitfanfare
 	setvar VAR_0x8004, 13
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattlePyramidTop_Text_255B82, 4
+	msgbox BattleFrontier_BattlePyramidTop_Text_255B82, MSGBOX_DEFAULT
 	goto BattleFrontier_BattlePyramidTop_EventScript_25521A
 
 BattleFrontier_BattlePyramidTop_EventScript_2553ED:: @ 82553ED

--- a/data/maps/BattleFrontier_BattleTowerBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerBattleRoom/scripts.inc
@@ -45,7 +45,7 @@ BattleFrontier_BattleTowerBattleRoom_EventScript_241BC3:: @ 8241BC3
 	setvar VAR_0x8004, 7
 	setvar VAR_0x8005, 0
 	special sub_8161F74
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	waitmessage
 	call BattleFrontier_BattleTowerBattleRoom_EventScript_24210E
 	switch VAR_RESULT
@@ -81,7 +81,7 @@ BattleFrontier_BattleTowerBattleRoom_EventScript_241C2F:: @ 8241C2F
 	waitmovement 0
 	applymovement 255, BattleFrontier_BattleTowerBattleRoom_Movement_24217E
 	waitmovement 0
-	msgbox BattleFrontier_BattleTowerBattleRoom_Text_242217, 4
+	msgbox BattleFrontier_BattleTowerBattleRoom_Text_242217, MSGBOX_DEFAULT
 	playfanfare MUS_ME_ASA
 	waitfanfare
 	special HealPlayerParty
@@ -129,7 +129,7 @@ BattleFrontier_BattleTowerBattleRoom_EventScript_241D72:: @ 8241D72
 	goto BattleFrontier_BattleTowerBattleRoom_EventScript_241C8F
 
 BattleFrontier_BattleTowerBattleRoom_EventScript_241D7C:: @ 8241D7C
-	msgbox BattleFrontier_BattleTowerBattleRoom_Text_2423FC, 5
+	msgbox BattleFrontier_BattleTowerBattleRoom_Text_2423FC, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattleTowerBattleRoom_EventScript_241C8F
 	case 1, BattleFrontier_BattleTowerBattleRoom_EventScript_241E22
@@ -247,7 +247,7 @@ BattleFrontier_BattleTowerBattleRoom_EventScript_241EC3:: @ 8241EC3
 BattleFrontier_BattleTowerBattleRoom_EventScript_241F0A:: @ 8241F0A
 	compare VAR_TEMP_2, 1
 	goto_eq BattleFrontier_BattleTowerBattleRoom_EventScript_241F22
-	msgbox BattleFrontier_BattleTowerBattleRoom_Text_2424C2, 4
+	msgbox BattleFrontier_BattleTowerBattleRoom_Text_2424C2, MSGBOX_DEFAULT
 	setvar VAR_TEMP_2, 1
 
 BattleFrontier_BattleTowerBattleRoom_EventScript_241F22:: @ 8241F22
@@ -291,13 +291,13 @@ BattleFrontier_BattleTowerBattleRoom_EventScript_241FAF:: @ 8241FAF
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattleTowerBattleRoom_EventScript_242029
-	msgbox BattleFrontier_BattleTowerBattleRoom_Text_242579, 4
+	msgbox BattleFrontier_BattleTowerBattleRoom_Text_242579, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 7
 	special CallFrontierUtilFunc
 
 BattleFrontier_BattleTowerBattleRoom_EventScript_242029:: @ 8242029
-	msgbox BattleFrontier_BattleTowerBattleRoom_Text_24268C, 4
+	msgbox BattleFrontier_BattleTowerBattleRoom_Text_24268C, MSGBOX_DEFAULT
 	call BattleFrontier_BattleTowerBattleRoom_EventScript_24210E
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattleTowerBattleRoom_EventScript_242046
@@ -309,14 +309,14 @@ BattleFrontier_BattleTowerBattleRoom_EventScript_242046:: @ 8242046
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattleTowerBattleRoom_EventScript_241DF6
-	msgbox BattleFrontier_BattleTowerBattleRoom_Text_2426B4, 4
+	msgbox BattleFrontier_BattleTowerBattleRoom_Text_2426B4, MSGBOX_DEFAULT
 	playfanfare MUS_ME_SYMBOLGET
 	message BattleFrontier_BattleTowerBattleRoom_Text_24270E
 	waitmessage
 	waitfanfare
 	setvar VAR_0x8004, 13
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleTowerBattleRoom_Text_242744, 4
+	msgbox BattleFrontier_BattleTowerBattleRoom_Text_242744, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerBattleRoom_EventScript_241DF6
 
 BattleFrontier_BattleTowerBattleRoom_EventScript_242085:: @ 8242085
@@ -325,13 +325,13 @@ BattleFrontier_BattleTowerBattleRoom_EventScript_242085:: @ 8242085
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 0
 	goto_if 5, BattleFrontier_BattleTowerBattleRoom_EventScript_2420B2
-	msgbox BattleFrontier_BattleTowerBattleRoom_Text_2427F9, 4
+	msgbox BattleFrontier_BattleTowerBattleRoom_Text_2427F9, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 7
 	special CallFrontierUtilFunc
 
 BattleFrontier_BattleTowerBattleRoom_EventScript_2420B2:: @ 82420B2
-	msgbox BattleFrontier_BattleTowerBattleRoom_Text_2428E0, 4
+	msgbox BattleFrontier_BattleTowerBattleRoom_Text_2428E0, MSGBOX_DEFAULT
 	call BattleFrontier_BattleTowerBattleRoom_EventScript_24210E
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_BattleTowerBattleRoom_EventScript_2420CF
@@ -343,14 +343,14 @@ BattleFrontier_BattleTowerBattleRoom_EventScript_2420CF:: @ 82420CF
 	special CallFrontierUtilFunc
 	compare VAR_RESULT, 2
 	goto_eq BattleFrontier_BattleTowerBattleRoom_EventScript_241DF6
-	msgbox BattleFrontier_BattleTowerBattleRoom_Text_2428F7, 4
+	msgbox BattleFrontier_BattleTowerBattleRoom_Text_2428F7, MSGBOX_DEFAULT
 	playfanfare MUS_ME_SYMBOLGET
 	message BattleFrontier_BattleTowerBattleRoom_Text_242932
 	waitmessage
 	waitfanfare
 	setvar VAR_0x8004, 13
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleTowerBattleRoom_Text_24295D, 4
+	msgbox BattleFrontier_BattleTowerBattleRoom_Text_24295D, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerBattleRoom_EventScript_241DF6
 
 BattleFrontier_BattleTowerBattleRoom2_EventScript_24210E:: @ 824210E

--- a/data/maps/BattleFrontier_BattleTowerBattleRoom2/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerBattleRoom2/scripts.inc
@@ -78,14 +78,14 @@ BattleFrontier_BattleTowerBattleRoom2_EventScript_248FB4:: @ 8248FB4
 	delay 15
 	applymovement 1, BattleFrontier_BattleTowerBattleRoom2_Movement_249545
 	waitmovement 0
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	waitmessage
 	setvar VAR_0x8004, 7
 	setvar VAR_0x8005, 1
 	special sub_8161F74
 	applymovement 4, BattleFrontier_BattleTowerBattleRoom2_Movement_249545
 	waitmovement 0
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	waitmessage
 	goto BattleFrontier_BattleTowerBattleRoom2_EventScript_249069
 
@@ -144,7 +144,7 @@ BattleFrontier_BattleTowerBattleRoom2_EventScript_2490AA:: @ 82490AA
 	waitmovement 0
 	compare VAR_FRONTIER_BATTLE_MODE, 3
 	goto_eq BattleFrontier_BattleTowerBattleRoom2_EventScript_249118
-	msgbox BattleFrontier_BattleTowerBattleRoom2_Text_242217, 4
+	msgbox BattleFrontier_BattleTowerBattleRoom2_Text_242217, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerBattleRoom2_EventScript_249121
 
 BattleFrontier_BattleTowerBattleRoom2_EventScript_249118:: @ 8249118
@@ -203,7 +203,7 @@ BattleFrontier_BattleTowerBattleRoom2_EventScript_249219:: @ 8249219
 	goto BattleFrontier_BattleTowerBattleRoom2_EventScript_249143
 
 BattleFrontier_BattleTowerBattleRoom2_EventScript_249223:: @ 8249223
-	msgbox BattleFrontier_BattleTowerBattleRoom2_Text_2423FC, 5
+	msgbox BattleFrontier_BattleTowerBattleRoom2_Text_2423FC, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattleTowerBattleRoom2_EventScript_249143
 	case 1, BattleFrontier_BattleTowerBattleRoom2_EventScript_2492DB

--- a/data/maps/BattleFrontier_BattleTowerLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerLobby/scripts.inc
@@ -55,7 +55,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23E707:: @ 823E707
 BattleFrontier_BattleTowerLobby_EventScript_23E710:: @ 823E710
 	lock
 	faceplayer
-	msgbox BattleFrontier_BattleTowerLobby_Text_23F583, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_23F583, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 1
@@ -85,7 +85,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23E758:: @ 823E758
 	goto BattleFrontier_BattleTowerLobby_EventScript_23E780
 
 BattleFrontier_BattleTowerLobby_EventScript_23E778:: @ 823E778
-	msgbox BattleFrontier_BattleTowerLobby_Text_241486, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_241486, MSGBOX_DEFAULT
 
 BattleFrontier_BattleTowerLobby_EventScript_23E780:: @ 823E780
 	setvar VAR_0x8004, 5
@@ -96,10 +96,10 @@ BattleFrontier_BattleTowerLobby_EventScript_23E780:: @ 823E780
 	waitmessage
 	playfanfare MUS_FANFA4
 	waitfanfare
-	msgbox BattleFrontier_BattleTowerLobby_Text_23F89F, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_23F89F, MSGBOX_DEFAULT
 
 BattleFrontier_BattleTowerLobby_EventScript_23E7A5:: @ 823E7A5
-	msgbox BattleFrontier_BattleTowerLobby_Text_2414D4, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_2414D4, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 11
 	special CallFrontierUtilFunc
 	msgbox BattleFrontier_BattleTowerLobby_Text_241520, 9
@@ -109,10 +109,10 @@ BattleFrontier_BattleTowerLobby_EventScript_23E7A5:: @ 823E7A5
 	special sub_8161F74
 	compare VAR_RESULT, 49
 	goto_if 5, BattleFrontier_BattleTowerLobby_EventScript_23E7E2
-	msgbox BattleFrontier_BattleTowerLobby_Text_23F79D, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_23F79D, MSGBOX_DEFAULT
 
 BattleFrontier_BattleTowerLobby_EventScript_23E7E2:: @ 823E7E2
-	msgbox BattleFrontier_BattleTowerLobby_Text_23FD07, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_23FD07, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	release
@@ -141,7 +141,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23E830:: @ 823E830
 	message BattleFrontier_BattleTowerLobby_Text_23F6F7
 	waitmessage
 	call BattleFrontier_BattleTowerLobby_EventScript_23E84D
-	msgbox BattleFrontier_BattleTowerLobby_Text_23FD07, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_23FD07, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	release
@@ -186,11 +186,11 @@ BattleFrontier_BattleTowerLobby_EventScript_23E8B4:: @ 823E8B4
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattleTowerLobby_EventScript_23E8D7
 	playse SE_SAVE
-	msgbox BattleFrontier_BattleTowerLobby_Text_2423CD, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_2423CD, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23E8DF
 
 BattleFrontier_BattleTowerLobby_EventScript_23E8D7:: @ 823E8D7
-	msgbox gText_BattleRecordCouldntBeSaved, 4
+	msgbox gText_BattleRecordCouldntBeSaved, MSGBOX_DEFAULT
 
 BattleFrontier_BattleTowerLobby_EventScript_23E8DF:: @ 823E8DF
 	return
@@ -241,7 +241,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23E936:: @ 823E936
 	faceplayer
 	setvar VAR_FRONTIER_FACILITY, 0
 	special SavePlayerParty
-	msgbox BattleFrontier_BattleTowerLobby_Text_240537, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_240537, MSGBOX_DEFAULT
 
 BattleFrontier_BattleTowerLobby_EventScript_23E948:: @ 823E948
 	message BattleFrontier_BattleTowerLobby_Text_2405B3
@@ -269,7 +269,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23E984:: @ 823E984
 	setvar VAR_0x8005, 1
 	copyvar VAR_0x8006, VAR_RESULT
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleTowerLobby_Text_2407A6, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_2407A6, MSGBOX_DEFAULT
 	fadescreen 1
 	call BattleFrontier_BattleTowerLobby_EventScript_23F2B7
 	copyvar VAR_0x8004, VAR_RESULT
@@ -278,7 +278,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23E984:: @ 823E984
 	waitstate
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattleTowerLobby_EventScript_23F0E3
-	msgbox BattleFrontier_BattleTowerLobby_Text_23FDC7, 5
+	msgbox BattleFrontier_BattleTowerLobby_Text_23FDC7, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattleTowerLobby_EventScript_23F0E3
 	case 1, BattleFrontier_BattleTowerLobby_EventScript_23EA2A
@@ -312,7 +312,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23EA2A:: @ 823EA2A
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23EA91:: @ 823EA91
-	msgbox BattleFrontier_BattleTowerLobby_Text_2405EC, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_2405EC, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23E948
 	end
 
@@ -321,7 +321,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23EA9F:: @ 823EA9F
 	faceplayer
 	setvar VAR_FRONTIER_FACILITY, 0
 	special SavePlayerParty
-	msgbox BattleFrontier_BattleTowerLobby_Text_2407E2, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_2407E2, MSGBOX_DEFAULT
 
 BattleFrontier_BattleTowerLobby_EventScript_23EAB1:: @ 823EAB1
 	message BattleFrontier_BattleTowerLobby_Text_24085E
@@ -349,7 +349,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23EAED:: @ 823EAED
 	setvar VAR_0x8005, 1
 	copyvar VAR_0x8006, VAR_RESULT
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleTowerLobby_Text_240A50, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_240A50, MSGBOX_DEFAULT
 	fadescreen 1
 	call BattleFrontier_BattleTowerLobby_EventScript_23F2B7
 	copyvar VAR_0x8004, VAR_RESULT
@@ -358,7 +358,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23EAED:: @ 823EAED
 	waitstate
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattleTowerLobby_EventScript_23F0E3
-	msgbox BattleFrontier_BattleTowerLobby_Text_23FDC7, 5
+	msgbox BattleFrontier_BattleTowerLobby_Text_23FDC7, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattleTowerLobby_EventScript_23F0E3
 	case 1, BattleFrontier_BattleTowerLobby_EventScript_23EB93
@@ -392,7 +392,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23EB93:: @ 823EB93
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23EBFA:: @ 823EBFA
-	msgbox BattleFrontier_BattleTowerLobby_Text_240897, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_240897, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23EAB1
 	end
 
@@ -402,7 +402,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23EC08:: @ 823EC08
 	setvar VAR_FRONTIER_FACILITY, 0
 	clearflag FLAG_0x152
 	special SavePlayerParty
-	msgbox BattleFrontier_BattleTowerLobby_Text_240A8B, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_240A8B, MSGBOX_DEFAULT
 
 BattleFrontier_BattleTowerLobby_EventScript_23EC1D:: @ 823EC1D
 	message BattleFrontier_BattleTowerLobby_Text_240B06
@@ -430,7 +430,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23EC59:: @ 823EC59
 	setvar VAR_0x8005, 1
 	copyvar VAR_0x8006, VAR_RESULT
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleTowerLobby_Text_240DDB, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_240DDB, MSGBOX_DEFAULT
 	fadescreen 1
 	call BattleFrontier_BattleTowerLobby_EventScript_23F2B7
 	copyvar VAR_0x8004, VAR_RESULT
@@ -439,7 +439,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23EC59:: @ 823EC59
 	waitstate
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattleTowerLobby_EventScript_23F0E3
-	msgbox BattleFrontier_BattleTowerLobby_Text_23FDC7, 5
+	msgbox BattleFrontier_BattleTowerLobby_Text_23FDC7, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattleTowerLobby_EventScript_23F0E3
 	case 1, BattleFrontier_BattleTowerLobby_EventScript_23ECFF
@@ -473,7 +473,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23ECFF:: @ 823ECFF
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23ED66:: @ 823ED66
-	msgbox BattleFrontier_BattleTowerLobby_Text_240B3E, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_240B3E, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23EC1D
 	end
 
@@ -482,7 +482,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23ED74:: @ 823ED74
 	faceplayer
 	setvar VAR_FRONTIER_FACILITY, 0
 	special SavePlayerParty
-	msgbox BattleFrontier_BattleTowerLobby_Text_240E15, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_240E15, MSGBOX_DEFAULT
 
 BattleFrontier_BattleTowerLobby_EventScript_23ED86:: @ 823ED86
 	message BattleFrontier_BattleTowerLobby_Text_240E95
@@ -510,7 +510,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23EDC2:: @ 823EDC2
 	setvar VAR_0x8005, 1
 	copyvar VAR_0x8006, VAR_RESULT
 	special CallFrontierUtilFunc
-	msgbox BattleFrontier_BattleTowerLobby_Text_24115E, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_24115E, MSGBOX_DEFAULT
 	fadescreen 1
 	call BattleFrontier_BattleTowerLobby_EventScript_23F2B7
 	copyvar VAR_0x8004, VAR_RESULT
@@ -519,7 +519,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23EDC2:: @ 823EDC2
 	waitstate
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattleTowerLobby_EventScript_23F0E3
-	msgbox BattleFrontier_BattleTowerLobby_Text_23FDC7, 5
+	msgbox BattleFrontier_BattleTowerLobby_Text_23FDC7, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, BattleFrontier_BattleTowerLobby_EventScript_23F0E3
 	case 1, BattleFrontier_BattleTowerLobby_EventScript_23EE68
@@ -573,7 +573,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23EEE7:: @ 823EEE7
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23EF32:: @ 823EF32
-	msgbox BattleFrontier_BattleTowerLobby_Text_23F969, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_23F969, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 1
 	call BattleFrontier_BattleTowerLobby_EventScript_271E7C
 	lock
@@ -582,7 +582,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23EF32:: @ 823EF32
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23EF4C:: @ 823EF4C
-	msgbox BattleFrontier_BattleTowerLobby_Text_23F9AA, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_23F9AA, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 2
 	call BattleFrontier_BattleTowerLobby_EventScript_271E7C
 	lock
@@ -591,7 +591,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23EF4C:: @ 823EF4C
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23EF66:: @ 823EF66
-	msgbox BattleFrontier_BattleTowerLobby_Text_23F9D4, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_23F9D4, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 3
 	call BattleFrontier_BattleTowerLobby_EventScript_271E7C
 	lock
@@ -600,7 +600,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23EF66:: @ 823EF66
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23EF80:: @ 823EF80
-	msgbox BattleFrontier_BattleTowerLobby_Text_23FA0F, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_23FA0F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -612,21 +612,21 @@ BattleFrontier_BattleTowerLobby_EventScript_23EF8A:: @ 823EF8A
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23EFA1:: @ 823EFA1
-	msgbox BattleFrontier_BattleTowerLobby_Text_23FA4F, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_23FA4F, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23EFAB:: @ 823EFAB
-	msgbox BattleFrontier_BattleTowerLobby_Text_23FA83, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_23FA83, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23EFB5:: @ 823EFB5
-	msgbox BattleFrontier_BattleTowerLobby_Text_23FAC0, 2
+	msgbox BattleFrontier_BattleTowerLobby_Text_23FAC0, MSGBOX_NPC
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23EFBE:: @ 823EFBE
-	msgbox BattleFrontier_BattleTowerLobby_Text_23FB26, 2
+	msgbox BattleFrontier_BattleTowerLobby_Text_23FB26, MSGBOX_NPC
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23EFC7:: @ 823EFC7
@@ -682,17 +682,17 @@ BattleFrontier_BattleTowerLobby_EventScript_23F046:: @ 823F046
 	switch VAR_FRONTIER_BATTLE_MODE
 	case 0, BattleFrontier_BattleTowerLobby_EventScript_23F06F
 	case 1, BattleFrontier_BattleTowerLobby_EventScript_23F07D
-	msgbox BattleFrontier_BattleTowerLobby_Text_24038B, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_24038B, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23F0F1
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23F06F:: @ 823F06F
-	msgbox BattleFrontier_BattleTowerLobby_Text_240027, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_240027, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23F0F1
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23F07D:: @ 823F07D
-	msgbox BattleFrontier_BattleTowerLobby_Text_2401DB, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_2401DB, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23F0F1
 	end
 
@@ -700,17 +700,17 @@ BattleFrontier_BattleTowerLobby_EventScript_23F08B:: @ 823F08B
 	switch VAR_FRONTIER_BATTLE_MODE
 	case 0, BattleFrontier_BattleTowerLobby_EventScript_23F0B4
 	case 1, BattleFrontier_BattleTowerLobby_EventScript_23F0C2
-	msgbox BattleFrontier_BattleTowerLobby_Text_24046B, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_24046B, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23F0F1
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23F0B4:: @ 823F0B4
-	msgbox BattleFrontier_BattleTowerLobby_Text_24010B, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_24010B, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23F0F1
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23F0C2:: @ 823F0C2
-	msgbox BattleFrontier_BattleTowerLobby_Text_2402BD, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_2402BD, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23F0F1
 	end
 
@@ -726,7 +726,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23F0E3:: @ 823F0E3
 
 BattleFrontier_BattleTowerLobby_EventScript_23F0E6:: @ 823F0E6
 	special CloseLink
-	msgbox BattleFrontier_BattleTowerLobby_Text_23FD07, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_23FD07, MSGBOX_DEFAULT
 
 BattleFrontier_BattleTowerLobby_EventScript_23F0F1:: @ 823F0F1
 	release
@@ -756,7 +756,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23F135:: @ 823F135
 	call BattleFrontier_BattleTowerLobby_EventScript_23F1A7
 	compare VAR_FRONTIER_BATTLE_MODE, 3
 	goto_eq BattleFrontier_BattleTowerLobby_EventScript_23F152
-	msgbox BattleFrontier_BattleTowerLobby_Text_23FE11, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_23FE11, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23F15B
 
 BattleFrontier_BattleTowerLobby_EventScript_23F152:: @ 823F152
@@ -954,20 +954,20 @@ BattleFrontier_BattleTowerLobby_EventScript_23F327:: @ 823F327
 	special CloseLink
 	compare VAR_0x8005, 3
 	goto_eq BattleFrontier_BattleTowerLobby_EventScript_23F33F
-	msgbox BattleFrontier_BattleTowerLobby_Text_278255, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_278255, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23F33F:: @ 823F33F
-	msgbox BattleFrontier_BattleTowerLobby_Text_2412E8, 4
-	msgbox BattleFrontier_BattleTowerLobby_Text_2413DE, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_2412E8, MSGBOX_DEFAULT
+	msgbox BattleFrontier_BattleTowerLobby_Text_2413DE, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23F351:: @ 823F351
-	msgbox BattleFrontier_BattleTowerLobby_Text_241240, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_241240, MSGBOX_DEFAULT
 	special CloseLink
-	msgbox BattleFrontier_BattleTowerLobby_Text_2782A8, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_2782A8, MSGBOX_DEFAULT
 	release
 	end
 
@@ -979,20 +979,20 @@ BattleFrontier_BattleTowerLobby_EventScript_23F366:: @ 823F366
 	call_if 1, BattleFrontier_BattleTowerLobby_EventScript_23F39D
 	compare VAR_0x8005, 2
 	call_if 1, BattleFrontier_BattleTowerLobby_EventScript_23F3A6
-	msgbox BattleFrontier_BattleTowerLobby_Text_2413DE, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_2413DE, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23F394:: @ 823F394
-	msgbox BattleFrontier_BattleTowerLobby_Text_2412E8, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_2412E8, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleTowerLobby_EventScript_23F39D:: @ 823F39D
-	msgbox BattleFrontier_BattleTowerLobby_Text_241285, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_241285, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleTowerLobby_EventScript_23F3A6:: @ 823F3A6
-	msgbox BattleFrontier_BattleTowerLobby_Text_2412B3, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_2412B3, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_BattleTowerLobby_EventScript_23F3AF:: @ 823F3AF
@@ -1012,7 +1012,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23F3AF:: @ 823F3AF
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23F3DA:: @ 823F3DA
-	msgbox BattleFrontier_BattleTowerLobby_Text_240ED2, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_240ED2, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23ED86
 	end
 
@@ -1075,7 +1075,7 @@ BattleFrontier_BattleTowerLobby_EventScript_23F496:: @ 823F496
 
 BattleFrontier_BattleTowerLobby_EventScript_23F4BE:: @ 823F4BE
 	lockall
-	msgbox BattleFrontier_BattleTowerLobby_Text_241540, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_241540, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23F4CD
 	end
 
@@ -1093,22 +1093,22 @@ BattleFrontier_BattleTowerLobby_EventScript_23F4CD:: @ 823F4CD
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23F520:: @ 823F520
-	msgbox BattleFrontier_BattleTowerLobby_Text_241586, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_241586, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23F4CD
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23F52E:: @ 823F52E
-	msgbox BattleFrontier_BattleTowerLobby_Text_241693, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_241693, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23F4CD
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23F53C:: @ 823F53C
-	msgbox BattleFrontier_BattleTowerLobby_Text_241777, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_241777, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23F4CD
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_23F54A:: @ 823F54A
-	msgbox BattleFrontier_BattleTowerLobby_Text_24187E, 4
+	msgbox BattleFrontier_BattleTowerLobby_Text_24187E, MSGBOX_DEFAULT
 	goto BattleFrontier_BattleTowerLobby_EventScript_23F4CD
 	end
 

--- a/data/maps/BattleFrontier_BattleTowerMultiBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerMultiBattleRoom/scripts.inc
@@ -67,7 +67,7 @@ BattleFrontier_BattleTowerMultiBattleRoom_EventScript_243E41:: @ 8243E41
 	moveobjectoffscreen 1
 	applymovement 255, BattleFrontier_BattleTowerMultiBattleRoom_Movement_2725A6
 	waitmovement 0
-	msgbox BattleFrontier_BattleTowerMultiBattleRoom_Text_244056, 4
+	msgbox BattleFrontier_BattleTowerMultiBattleRoom_Text_244056, MSGBOX_DEFAULT
 	special HealPlayerParty
 	setvar VAR_TEMP_1, 1
 	releaseall
@@ -90,7 +90,7 @@ BattleFrontier_BattleTowerMultiBattleRoom_EventScript_243E7A:: @ 8243E7A
 	multichoicedefault 20, 8, 94, 1, 0
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_BattleTowerMultiBattleRoom_EventScript_243E9D
-	msgbox BattleFrontier_BattleTowerMultiBattleRoom_Text_24410C, 4
+	msgbox BattleFrontier_BattleTowerMultiBattleRoom_Text_24410C, MSGBOX_DEFAULT
 	release
 	end
 
@@ -103,7 +103,7 @@ BattleFrontier_BattleTowerMultiBattleRoom_EventScript_243E9D:: @ 8243E9D
 	end
 
 BattleFrontier_BattleTowerMultiBattleRoom_EventScript_243EB5:: @ 8243EB5
-	msgbox BattleFrontier_BattleTowerMultiBattleRoom_Text_244149, 4
+	msgbox BattleFrontier_BattleTowerMultiBattleRoom_Text_244149, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, BattleFrontier_BattleTowerMultiBattleRoom_Movement_2725A6
 	waitmovement 0

--- a/data/maps/BattleFrontier_Lounge1/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge1/scripts.inc
@@ -22,11 +22,11 @@ BattleFrontier_Lounge1_EventScript_25E792:: @ 825E792
 	end
 
 BattleFrontier_Lounge1_EventScript_25E7AD:: @ 825E7AD
-	msgbox BattleFrontier_Lounge1_Text_25E95F, 4
+	msgbox BattleFrontier_Lounge1_Text_25E95F, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_Lounge1_EventScript_25E7B6:: @ 825E7B6
-	msgbox BattleFrontier_Lounge1_Text_25EEF6, 4
+	msgbox BattleFrontier_Lounge1_Text_25EEF6, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_Lounge1_EventScript_25E7BF:: @ 825E7BF
@@ -45,7 +45,7 @@ BattleFrontier_Lounge1_EventScript_25E7BF:: @ 825E7BF
 	end
 
 BattleFrontier_Lounge1_EventScript_25E7FF:: @ 825E7FF
-	msgbox BattleFrontier_Lounge1_Text_25EF5E, 4
+	msgbox BattleFrontier_Lounge1_Text_25EF5E, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E792
 	end
 
@@ -80,86 +80,86 @@ BattleFrontier_Lounge1_EventScript_25E87D:: @ 825E87D
 	end
 
 BattleFrontier_Lounge1_EventScript_25E87F:: @ 825E87F
-	msgbox BattleFrontier_Lounge1_Text_25EA92, 4
+	msgbox BattleFrontier_Lounge1_Text_25EA92, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E80D
 	end
 
 BattleFrontier_Lounge1_EventScript_25E88D:: @ 825E88D
-	msgbox BattleFrontier_Lounge1_Text_25EAD9, 4
+	msgbox BattleFrontier_Lounge1_Text_25EAD9, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E80D
 	end
 
 BattleFrontier_Lounge1_EventScript_25E89B:: @ 825E89B
-	msgbox BattleFrontier_Lounge1_Text_25EB2A, 4
+	msgbox BattleFrontier_Lounge1_Text_25EB2A, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E80D
 	end
 
 BattleFrontier_Lounge1_EventScript_25E8A9:: @ 825E8A9
-	msgbox BattleFrontier_Lounge1_Text_25EB6F, 4
+	msgbox BattleFrontier_Lounge1_Text_25EB6F, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E80D
 	end
 
 BattleFrontier_Lounge1_EventScript_25E8B7:: @ 825E8B7
-	msgbox BattleFrontier_Lounge1_Text_25EBBB, 4
+	msgbox BattleFrontier_Lounge1_Text_25EBBB, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E850
 	end
 
 BattleFrontier_Lounge1_EventScript_25E8C5:: @ 825E8C5
-	msgbox BattleFrontier_Lounge1_Text_25EBF8, 4
+	msgbox BattleFrontier_Lounge1_Text_25EBF8, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E850
 	end
 
 BattleFrontier_Lounge1_EventScript_25E8D3:: @ 825E8D3
-	msgbox BattleFrontier_Lounge1_Text_25EC39, 4
+	msgbox BattleFrontier_Lounge1_Text_25EC39, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E850
 	end
 
 BattleFrontier_Lounge1_EventScript_25E8E1:: @ 825E8E1
-	msgbox BattleFrontier_Lounge1_Text_25ED0E, 4
+	msgbox BattleFrontier_Lounge1_Text_25ED0E, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E850
 	end
 
 BattleFrontier_Lounge1_EventScript_25E8EF:: @ 825E8EF
-	msgbox BattleFrontier_Lounge1_Text_25EC7B, 4
+	msgbox BattleFrontier_Lounge1_Text_25EC7B, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E850
 	end
 
 BattleFrontier_Lounge1_EventScript_25E8FD:: @ 825E8FD
-	msgbox BattleFrontier_Lounge1_Text_25ECC4, 4
+	msgbox BattleFrontier_Lounge1_Text_25ECC4, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E850
 	end
 
 BattleFrontier_Lounge1_EventScript_25E90B:: @ 825E90B
-	msgbox BattleFrontier_Lounge1_Text_25ED4E, 4
+	msgbox BattleFrontier_Lounge1_Text_25ED4E, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E87D
 	end
 
 BattleFrontier_Lounge1_EventScript_25E919:: @ 825E919
-	msgbox BattleFrontier_Lounge1_Text_25ED87, 4
+	msgbox BattleFrontier_Lounge1_Text_25ED87, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E87D
 	end
 
 BattleFrontier_Lounge1_EventScript_25E927:: @ 825E927
-	msgbox BattleFrontier_Lounge1_Text_25EDC1, 4
+	msgbox BattleFrontier_Lounge1_Text_25EDC1, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E87D
 	end
 
 BattleFrontier_Lounge1_EventScript_25E935:: @ 825E935
-	msgbox BattleFrontier_Lounge1_Text_25EDF6, 4
+	msgbox BattleFrontier_Lounge1_Text_25EDF6, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge1_EventScript_25E87D
 	end
 
 BattleFrontier_Lounge1_EventScript_25E943:: @ 825E943
-	msgbox BattleFrontier_Lounge1_Text_25EE37, 4
+	msgbox BattleFrontier_Lounge1_Text_25EE37, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_Lounge1_EventScript_25E94D:: @ 825E94D
-	msgbox BattleFrontier_Lounge1_Text_25EFDD, 2
+	msgbox BattleFrontier_Lounge1_Text_25EFDD, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge1_EventScript_25E956:: @ 825E956
-	msgbox BattleFrontier_Lounge1_Text_25F020, 2
+	msgbox BattleFrontier_Lounge1_Text_25F020, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge1_Text_25E95F: @ 825E95F

--- a/data/maps/BattleFrontier_Lounge2/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge2/scripts.inc
@@ -7,12 +7,12 @@ BattleFrontier_Lounge2_EventScript_260643:: @ 8260643
 	checkflag FLAG_0x154
 	goto_eq BattleFrontier_Lounge2_EventScript_26065F
 	setflag FLAG_0x154
-	msgbox BattleFrontier_Lounge2_Text_260766, 4
+	msgbox BattleFrontier_Lounge2_Text_260766, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge2_EventScript_26066D
 	end
 
 BattleFrontier_Lounge2_EventScript_26065F:: @ 826065F
-	msgbox BattleFrontier_Lounge2_Text_260857, 4
+	msgbox BattleFrontier_Lounge2_Text_260857, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge2_EventScript_26066D
 	end
 
@@ -48,11 +48,11 @@ BattleFrontier_Lounge2_EventScript_26066D:: @ 826066D
 	end
 
 BattleFrontier_Lounge2_EventScript_2606F8:: @ 82606F8
-	msgbox BattleFrontier_Lounge2_Text_260933, 4
+	msgbox BattleFrontier_Lounge2_Text_260933, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_Lounge2_EventScript_260701:: @ 8260701
-	msgbox BattleFrontier_Lounge2_Text_2608F2, 4
+	msgbox BattleFrontier_Lounge2_Text_2608F2, MSGBOX_DEFAULT
 	return
 
 BattleFrontier_Lounge2_EventScript_26070A:: @ 826070A
@@ -97,24 +97,24 @@ BattleFrontier_Lounge2_EventScript_260737:: @ 8260737
 
 BattleFrontier_Lounge2_EventScript_26073C:: @ 826073C
 	lock
-	msgbox BattleFrontier_Lounge2_Text_261C9C, 4
+	msgbox BattleFrontier_Lounge2_Text_261C9C, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_Lounge2_EventScript_260747:: @ 8260747
 	lock
-	msgbox BattleFrontier_Lounge2_Text_261CDC, 4
+	msgbox BattleFrontier_Lounge2_Text_261CDC, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_Lounge2_EventScript_260752:: @ 8260752
 	lock
-	msgbox BattleFrontier_Lounge2_Text_261D1D, 4
+	msgbox BattleFrontier_Lounge2_Text_261D1D, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_Lounge2_EventScript_26075D:: @ 826075D
-	msgbox BattleFrontier_Lounge2_Text_261D5C, 2
+	msgbox BattleFrontier_Lounge2_Text_261D5C, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge2_Text_260766:: @ 8260766

--- a/data/maps/BattleFrontier_Lounge3/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge3/scripts.inc
@@ -10,7 +10,7 @@ BattleFrontier_Lounge3_EventScript_261D83:: @ 8261D83
 	compare VAR_0x8004, 2
 	goto_if 3, BattleFrontier_Lounge3_EventScript_261EEB
 	setflag FLAG_0x157
-	msgbox BattleFrontier_Lounge3_Text_262061, 4
+	msgbox BattleFrontier_Lounge3_Text_262061, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge3_EventScript_261DAF
 	end
 
@@ -18,10 +18,10 @@ BattleFrontier_Lounge3_EventScript_261DAF:: @ 8261DAF
 	special sub_813A820
 	waitmessage
 	waitbuttonpress
-	msgbox BattleFrontier_Lounge3_Text_262A60, 5
+	msgbox BattleFrontier_Lounge3_Text_262A60, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_Lounge3_EventScript_261FA5
-	msgbox BattleFrontier_Lounge3_Text_262ABD, 5
+	msgbox BattleFrontier_Lounge3_Text_262ABD, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_Lounge3_EventScript_261FA5
 	message BattleFrontier_Lounge3_Text_262B42
@@ -60,7 +60,7 @@ BattleFrontier_Lounge3_EventScript_261E51:: @ 8261E51
 	specialvar VAR_TEMP_1, sub_813AA04
 	compare VAR_TEMP_1, VAR_0x8008
 	goto_if 4, BattleFrontier_Lounge3_EventScript_261E75
-	msgbox BattleFrontier_Lounge3_Text_262B6E, 4
+	msgbox BattleFrontier_Lounge3_Text_262B6E, MSGBOX_DEFAULT
 	message BattleFrontier_Lounge3_Text_262B42
 	waitmessage
 	goto BattleFrontier_Lounge3_EventScript_261DE9
@@ -72,7 +72,7 @@ BattleFrontier_Lounge3_EventScript_261E75:: @ 8261E75
 	setvar VAR_FRONTIER_GAMBLER_PLACED_BET_F, 1
 	special sub_813A8FC
 	playse SE_REGI
-	msgbox BattleFrontier_Lounge3_Text_262BE0, 4
+	msgbox BattleFrontier_Lounge3_Text_262BE0, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge3_EventScript_261E96
 	end
 
@@ -107,12 +107,12 @@ BattleFrontier_Lounge3_EventScript_261EE5:: @ 8261EE5
 	return
 
 BattleFrontier_Lounge3_EventScript_261EEB:: @ 8261EEB
-	msgbox BattleFrontier_Lounge3_Text_261FFE, 4
+	msgbox BattleFrontier_Lounge3_Text_261FFE, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge3_EventScript_261FF1
 	end
 
 BattleFrontier_Lounge3_EventScript_261EF9:: @ 8261EF9
-	msgbox BattleFrontier_Lounge3_Text_26346B, 4
+	msgbox BattleFrontier_Lounge3_Text_26346B, MSGBOX_DEFAULT
 	compare VAR_FRONTIER_GAMBLER_PLACED_BET_F, 1
 	goto_if 4, BattleFrontier_Lounge3_EventScript_261F12
 	goto BattleFrontier_Lounge3_EventScript_261DAF
@@ -127,7 +127,7 @@ BattleFrontier_Lounge3_EventScript_261F12:: @ 8261F12
 	end
 
 BattleFrontier_Lounge3_EventScript_261F2E:: @ 8261F2E
-	msgbox BattleFrontier_Lounge3_Text_263334, 4
+	msgbox BattleFrontier_Lounge3_Text_263334, MSGBOX_DEFAULT
 	compare VAR_FRONTIER_GAMBLER_AMOUNT_BET, 0
 	call_if 1, BattleFrontier_Lounge3_EventScript_261F80
 	compare VAR_FRONTIER_GAMBLER_AMOUNT_BET, 1
@@ -136,13 +136,13 @@ BattleFrontier_Lounge3_EventScript_261F2E:: @ 8261F2E
 	call_if 1, BattleFrontier_Lounge3_EventScript_261F94
 	msgbox BattleFrontier_Lounge3_Text_2633D4, 9
 	special sub_813A9D0
-	msgbox BattleFrontier_Lounge3_Text_2633F2, 4
+	msgbox BattleFrontier_Lounge3_Text_2633F2, MSGBOX_DEFAULT
 	setvar VAR_FRONTIER_GAMBLER_PLACED_BET_F, 0
 	release
 	end
 
 BattleFrontier_Lounge3_EventScript_261F71:: @ 8261F71
-	msgbox BattleFrontier_Lounge3_Text_263298, 4
+	msgbox BattleFrontier_Lounge3_Text_263298, MSGBOX_DEFAULT
 	setvar VAR_FRONTIER_GAMBLER_PLACED_BET_F, 0
 	release
 	end
@@ -170,7 +170,7 @@ BattleFrontier_Lounge3_EventScript_261F9E:: @ 8261F9E
 	end
 
 BattleFrontier_Lounge3_EventScript_261FA5:: @ 8261FA5
-	msgbox BattleFrontier_Lounge3_Text_26342D, 4
+	msgbox BattleFrontier_Lounge3_Text_26342D, MSGBOX_DEFAULT
 	release
 	end
 
@@ -180,27 +180,27 @@ BattleFrontier_Lounge3_EventScript_261FAF:: @ 8261FAF
 	end
 
 BattleFrontier_Lounge3_EventScript_261FB8:: @ 8261FB8
-	msgbox BattleFrontier_Lounge3_Text_263545, 2
+	msgbox BattleFrontier_Lounge3_Text_263545, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge3_EventScript_261FC1:: @ 8261FC1
 	lock
 	faceplayer
-	msgbox BattleFrontier_Lounge3_Text_26346F, 4
+	msgbox BattleFrontier_Lounge3_Text_26346F, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge3_EventScript_261FF1
 	end
 
 BattleFrontier_Lounge3_EventScript_261FD1:: @ 8261FD1
 	lock
 	faceplayer
-	msgbox BattleFrontier_Lounge3_Text_26351D, 4
+	msgbox BattleFrontier_Lounge3_Text_26351D, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge3_EventScript_261FF1
 	end
 
 BattleFrontier_Lounge3_EventScript_261FE1:: @ 8261FE1
 	lock
 	faceplayer
-	msgbox BattleFrontier_Lounge3_Text_2634C9, 4
+	msgbox BattleFrontier_Lounge3_Text_2634C9, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge3_EventScript_261FF1
 	end
 

--- a/data/maps/BattleFrontier_Lounge4/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge4/scripts.inc
@@ -2,15 +2,15 @@ BattleFrontier_Lounge4_MapScripts:: @ 826358C
 	.byte 0
 
 BattleFrontier_Lounge4_EventScript_26358D:: @ 826358D
-	msgbox BattleFrontier_Lounge4_Text_2635A8, 2
+	msgbox BattleFrontier_Lounge4_Text_2635A8, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge4_EventScript_263596:: @ 8263596
-	msgbox BattleFrontier_Lounge4_Text_2635EC, 2
+	msgbox BattleFrontier_Lounge4_Text_2635EC, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge4_EventScript_26359F:: @ 826359F
-	msgbox BattleFrontier_Lounge4_Text_263625, 2
+	msgbox BattleFrontier_Lounge4_Text_263625, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge4_Text_2635A8: @ 82635A8

--- a/data/maps/BattleFrontier_Lounge5/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge5/scripts.inc
@@ -4,7 +4,7 @@ BattleFrontier_Lounge5_MapScripts:: @ 82645C5
 BattleFrontier_Lounge5_EventScript_2645C6:: @ 82645C6
 	lock
 	faceplayer
-	msgbox BattleFrontier_Lounge5_Text_264632, 5
+	msgbox BattleFrontier_Lounge5_Text_264632, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_Lounge5_EventScript_26460D
 	special sub_81B94B0
@@ -23,25 +23,25 @@ BattleFrontier_Lounge5_EventScript_2645C6:: @ 82645C6
 	end
 
 BattleFrontier_Lounge5_EventScript_264603:: @ 8264603
-	msgbox BattleFrontier_Lounge5_Text_264EEE, 4
+	msgbox BattleFrontier_Lounge5_Text_264EEE, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_Lounge5_EventScript_26460D:: @ 826460D
-	msgbox BattleFrontier_Lounge5_Text_26467F, 4
+	msgbox BattleFrontier_Lounge5_Text_26467F, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_Lounge5_EventScript_264617:: @ 8264617
-	msgbox BattleFrontier_Lounge5_Text_264F22, 2
+	msgbox BattleFrontier_Lounge5_Text_264F22, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge5_EventScript_264620:: @ 8264620
-	msgbox BattleFrontier_Lounge5_Text_264F64, 2
+	msgbox BattleFrontier_Lounge5_Text_264F64, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge5_EventScript_264629:: @ 8264629
-	msgbox BattleFrontier_Lounge5_Text_264FAB, 2
+	msgbox BattleFrontier_Lounge5_Text_264FAB, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge5_Text_264632:: @ 8264632

--- a/data/maps/BattleFrontier_Lounge6/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge6/scripts.inc
@@ -10,7 +10,7 @@ BattleFrontier_Lounge6_EventScript_264FED:: @ 8264FED
 	copyvar VAR_0x8004, VAR_0x8008
 	specialvar VAR_RESULT, sub_807E73C
 	copyvar VAR_0x8009, VAR_RESULT
-	msgbox BattleFrontier_Lounge6_Text_26508D, 5
+	msgbox BattleFrontier_Lounge6_Text_26508D, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_Lounge6_EventScript_26506B
 	special sub_81B94B0
@@ -28,24 +28,24 @@ BattleFrontier_Lounge6_EventScript_264FED:: @ 8264FED
 	special sub_807EA10
 	special sub_807F0E4
 	waitstate
-	msgbox BattleFrontier_Lounge6_Text_265128, 4
+	msgbox BattleFrontier_Lounge6_Text_265128, MSGBOX_DEFAULT
 	setflag FLAG_0x09C
 	release
 	end
 
 BattleFrontier_Lounge6_EventScript_26506B:: @ 826506B
-	msgbox BattleFrontier_Lounge6_Text_2651CB, 4
+	msgbox BattleFrontier_Lounge6_Text_2651CB, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_Lounge6_EventScript_265075:: @ 8265075
 	bufferspeciesname 0, VAR_0x8009
-	msgbox BattleFrontier_Lounge6_Text_26518D, 4
+	msgbox BattleFrontier_Lounge6_Text_26518D, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_Lounge6_EventScript_265083:: @ 8265083
-	msgbox BattleFrontier_Lounge6_Text_26520E, 4
+	msgbox BattleFrontier_Lounge6_Text_26520E, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/BattleFrontier_Lounge7/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge7/scripts.inc
@@ -7,13 +7,13 @@ BattleFrontier_Lounge7_EventScript_265255:: @ 8265255
 	setvar VAR_TEMP_C, 9
 	checkflag FLAG_0x15A
 	goto_eq BattleFrontier_Lounge7_EventScript_265276
-	msgbox BattleFrontier_Lounge7_Text_2656ED, 4
+	msgbox BattleFrontier_Lounge7_Text_2656ED, MSGBOX_DEFAULT
 	setflag FLAG_0x15A
 	goto BattleFrontier_Lounge7_EventScript_265284
 	end
 
 BattleFrontier_Lounge7_EventScript_265276:: @ 8265276
-	msgbox BattleFrontier_Lounge7_Text_2658AB, 4
+	msgbox BattleFrontier_Lounge7_Text_2658AB, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge7_EventScript_265284
 	end
 
@@ -122,13 +122,13 @@ BattleFrontier_Lounge7_EventScript_265445:: @ 8265445
 	setvar VAR_TEMP_C, 10
 	checkflag FLAG_0x15B
 	goto_eq BattleFrontier_Lounge7_EventScript_265466
-	msgbox BattleFrontier_Lounge7_Text_265A6C, 4
+	msgbox BattleFrontier_Lounge7_Text_265A6C, MSGBOX_DEFAULT
 	setflag FLAG_0x15B
 	goto BattleFrontier_Lounge7_EventScript_265474
 	end
 
 BattleFrontier_Lounge7_EventScript_265466:: @ 8265466
-	msgbox BattleFrontier_Lounge7_Text_265C2C, 4
+	msgbox BattleFrontier_Lounge7_Text_265C2C, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge7_EventScript_265474
 	end
 
@@ -234,12 +234,12 @@ BattleFrontier_Lounge7_EventScript_26562A:: @ 826562A
 BattleFrontier_Lounge7_EventScript_265635:: @ 8265635
 	special sub_813ADB8
 	special sub_813A988
-	msgbox BattleFrontier_Lounge7_Text_265A0E, 4
+	msgbox BattleFrontier_Lounge7_Text_265A0E, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_Lounge7_EventScript_265645:: @ 8265645
-	msgbox BattleFrontier_Lounge7_Text_265A0E, 4
+	msgbox BattleFrontier_Lounge7_Text_265A0E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -249,18 +249,18 @@ BattleFrontier_Lounge7_EventScript_26564F:: @ 826564F
 	special sub_813AC7C
 	buffernumberstring 1, VAR_0x8008
 	copyvar VAR_0x8004, VAR_TEMP_C
-	msgbox BattleFrontier_Lounge7_Text_265921, 5
+	msgbox BattleFrontier_Lounge7_Text_265921, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_Lounge7_EventScript_2656CA
 	specialvar VAR_TEMP_1, sub_813AA04
 	compare VAR_TEMP_1, VAR_0x8008
 	goto_if 4, BattleFrontier_Lounge7_EventScript_265696
-	msgbox BattleFrontier_Lounge7_Text_265997, 4
+	msgbox BattleFrontier_Lounge7_Text_265997, MSGBOX_DEFAULT
 	goto BattleFrontier_Lounge7_EventScript_2656CA
 	end
 
 BattleFrontier_Lounge7_EventScript_265696:: @ 8265696
-	msgbox BattleFrontier_Lounge7_Text_26595A, 4
+	msgbox BattleFrontier_Lounge7_Text_26595A, MSGBOX_DEFAULT
 	special sub_813AEB4
 	fadescreen 1
 	special sub_813A988
@@ -269,7 +269,7 @@ BattleFrontier_Lounge7_EventScript_265696:: @ 8265696
 	waitstate
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_Lounge7_EventScript_265645
-	msgbox BattleFrontier_Lounge7_Text_2659C7, 4
+	msgbox BattleFrontier_Lounge7_Text_2659C7, MSGBOX_DEFAULT
 	copyvar VAR_0x8004, VAR_0x8008
 	special sub_813A9A4
 	release
@@ -282,11 +282,11 @@ BattleFrontier_Lounge7_EventScript_2656CA:: @ 82656CA
 	end
 
 BattleFrontier_Lounge7_EventScript_2656DB:: @ 82656DB
-	msgbox BattleFrontier_Lounge7_Text_265C6F, 2
+	msgbox BattleFrontier_Lounge7_Text_265C6F, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge7_EventScript_2656E4:: @ 82656E4
-	msgbox BattleFrontier_Lounge7_Text_265D17, 2
+	msgbox BattleFrontier_Lounge7_Text_265D17, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge7_Text_2656ED: @ 82656ED

--- a/data/maps/BattleFrontier_Lounge8/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge8/scripts.inc
@@ -2,15 +2,15 @@ BattleFrontier_Lounge8_MapScripts:: @ 82676C9
 	.byte 0
 
 BattleFrontier_Lounge8_EventScript_2676CA:: @ 82676CA
-	msgbox BattleFrontier_Lounge8_Text_2676E5, 2
+	msgbox BattleFrontier_Lounge8_Text_2676E5, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge8_EventScript_2676D3:: @ 82676D3
-	msgbox BattleFrontier_Lounge8_Text_26779C, 2
+	msgbox BattleFrontier_Lounge8_Text_26779C, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge8_EventScript_2676DC:: @ 82676DC
-	msgbox BattleFrontier_Lounge8_Text_26782C, 2
+	msgbox BattleFrontier_Lounge8_Text_26782C, MSGBOX_NPC
 	end
 
 BattleFrontier_Lounge8_Text_2676E5: @ 82676E5

--- a/data/maps/BattleFrontier_Mart/scripts.inc
+++ b/data/maps/BattleFrontier_Mart/scripts.inc
@@ -7,7 +7,7 @@ BattleFrontier_Mart_EventScript_267ACC:: @ 8267ACC
 	message gUnknown_08272A21
 	waitmessage
 	pokemart BattleFrontier_Mart_Pokemart_267AE4
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -31,19 +31,19 @@ BattleFrontier_Mart_Pokemart_267AE4: @ 8267AE4
 	end
 
 BattleFrontier_Mart_EventScript_267B02:: @ 8267B02
-	msgbox BattleFrontier_Mart_Text_267B29, 2
+	msgbox BattleFrontier_Mart_Text_267B29, MSGBOX_NPC
 	end
 
 BattleFrontier_Mart_EventScript_267B0B:: @ 8267B0B
 	lock
 	applymovement 2, BattleFrontier_Mart_Movement_2725B0
 	waitmovement 0
-	msgbox BattleFrontier_Mart_Text_267B8F, 4
+	msgbox BattleFrontier_Mart_Text_267B8F, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_Mart_EventScript_267B20:: @ 8267B20
-	msgbox BattleFrontier_Mart_Text_267C01, 2
+	msgbox BattleFrontier_Mart_Text_267C01, MSGBOX_NPC
 	end
 
 BattleFrontier_Mart_Text_267B29: @ 8267B29

--- a/data/maps/BattleFrontier_OutsideEast/scripts.inc
+++ b/data/maps/BattleFrontier_OutsideEast/scripts.inc
@@ -27,44 +27,44 @@ BattleFrontier_OutsideEast_EventScript_242C3F:: @ 8242C3F
 	return
 
 BattleFrontier_OutsideEast_EventScript_242C43:: @ 8242C43
-	msgbox BattleFrontier_OutsideEast_Text_242E11, 3
+	msgbox BattleFrontier_OutsideEast_Text_242E11, MSGBOX_SIGN
 	end
 
 BattleFrontier_OutsideEast_EventScript_242C4C:: @ 8242C4C
-	msgbox BattleFrontier_OutsideEast_Text_242E58, 3
+	msgbox BattleFrontier_OutsideEast_Text_242E58, MSGBOX_SIGN
 	end
 
 BattleFrontier_OutsideEast_EventScript_242C55:: @ 8242C55
-	msgbox BattleFrontier_OutsideEast_Text_242E96, 3
+	msgbox BattleFrontier_OutsideEast_Text_242E96, MSGBOX_SIGN
 	end
 
 BattleFrontier_OutsideEast_EventScript_242C5E:: @ 8242C5E
-	msgbox BattleFrontier_OutsideEast_Text_242ECF, 3
+	msgbox BattleFrontier_OutsideEast_Text_242ECF, MSGBOX_SIGN
 	end
 
 BattleFrontier_OutsideEast_EventScript_242C67:: @ 8242C67
-	msgbox BattleFrontier_OutsideEast_Text_242F8C, 2
+	msgbox BattleFrontier_OutsideEast_Text_242F8C, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242C70:: @ 8242C70
-	msgbox BattleFrontier_OutsideEast_Text_242FDC, 2
+	msgbox BattleFrontier_OutsideEast_Text_242FDC, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242C79:: @ 8242C79
-	msgbox BattleFrontier_OutsideEast_Text_24308C, 2
+	msgbox BattleFrontier_OutsideEast_Text_24308C, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242C82:: @ 8242C82
-	msgbox BattleFrontier_OutsideEast_Text_243106, 2
+	msgbox BattleFrontier_OutsideEast_Text_243106, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242C8B:: @ 8242C8B
-	msgbox BattleFrontier_OutsideEast_Text_2431A5, 2
+	msgbox BattleFrontier_OutsideEast_Text_2431A5, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242C94:: @ 8242C94
 	lock
-	msgbox BattleFrontier_OutsideEast_Text_2432DD, 4
+	msgbox BattleFrontier_OutsideEast_Text_2432DD, MSGBOX_DEFAULT
 	release
 	end
 
@@ -73,35 +73,35 @@ BattleFrontier_OutsideEast_EventScript_242C9F:: @ 8242C9F
 	faceplayer
 	waitse
 	playmoncry SPECIES_ZIGZAGOON, 0
-	msgbox BattleFrontier_OutsideEast_Text_24334B, 4
+	msgbox BattleFrontier_OutsideEast_Text_24334B, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
 
 BattleFrontier_OutsideEast_EventScript_242CB2:: @ 8242CB2
-	msgbox BattleFrontier_OutsideEast_Text_243363, 2
+	msgbox BattleFrontier_OutsideEast_Text_243363, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242CBB:: @ 8242CBB
-	msgbox BattleFrontier_OutsideEast_Text_243425, 2
+	msgbox BattleFrontier_OutsideEast_Text_243425, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242CC4:: @ 8242CC4
-	msgbox BattleFrontier_OutsideEast_Text_2434A0, 2
+	msgbox BattleFrontier_OutsideEast_Text_2434A0, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242CCD:: @ 8242CCD
-	msgbox BattleFrontier_OutsideEast_Text_243504, 2
+	msgbox BattleFrontier_OutsideEast_Text_243504, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242CD6:: @ 8242CD6
 	lock
-	msgbox BattleFrontier_OutsideEast_Text_243529, 4
+	msgbox BattleFrontier_OutsideEast_Text_243529, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_OutsideEast_EventScript_242CE1:: @ 8242CE1
-	msgbox BattleFrontier_OutsideEast_Text_243230, 2
+	msgbox BattleFrontier_OutsideEast_Text_243230, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242CEA:: @ 8242CEA
@@ -123,7 +123,7 @@ BattleFrontier_OutsideEast_EventScript_242CFC:: @ 8242CFC
 	playse 269
 	applymovement 14, BattleFrontier_OutsideEast_Movement_242D69
 	waitmovement 0
-	msgbox gUnknown_082731BD, 4
+	msgbox gUnknown_082731BD, MSGBOX_DEFAULT
 	closemessage
 	waitse
 	playmoncry SPECIES_SUDOWOODO, 2
@@ -169,55 +169,55 @@ BattleFrontier_OutsideEast_Movement_242D69: @ 8242D69
 	step_end
 
 BattleFrontier_OutsideEast_EventScript_242D79:: @ 8242D79
-	msgbox BattleFrontier_OutsideEast_Text_243598, 2
+	msgbox BattleFrontier_OutsideEast_Text_243598, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242D82:: @ 8242D82
-	msgbox BattleFrontier_OutsideEast_Text_243668, 2
+	msgbox BattleFrontier_OutsideEast_Text_243668, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242D8B:: @ 8242D8B
-	msgbox BattleFrontier_OutsideEast_Text_2436F2, 2
+	msgbox BattleFrontier_OutsideEast_Text_2436F2, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242D94:: @ 8242D94
-	msgbox BattleFrontier_OutsideEast_Text_243809, 2
+	msgbox BattleFrontier_OutsideEast_Text_243809, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242D9D:: @ 8242D9D
-	msgbox BattleFrontier_OutsideEast_Text_243895, 2
+	msgbox BattleFrontier_OutsideEast_Text_243895, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242DA6:: @ 8242DA6
-	msgbox BattleFrontier_OutsideEast_Text_243943, 2
+	msgbox BattleFrontier_OutsideEast_Text_243943, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242DAF:: @ 8242DAF
-	msgbox BattleFrontier_OutsideEast_Text_2439A0, 2
+	msgbox BattleFrontier_OutsideEast_Text_2439A0, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242DB8:: @ 8242DB8
 	lock
-	msgbox BattleFrontier_OutsideEast_Text_243A2B, 4
+	msgbox BattleFrontier_OutsideEast_Text_243A2B, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_OutsideEast_EventScript_242DC3:: @ 8242DC3
 	lock
-	msgbox BattleFrontier_OutsideEast_Text_243A53, 4
+	msgbox BattleFrontier_OutsideEast_Text_243A53, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_OutsideEast_EventScript_242DCE:: @ 8242DCE
-	msgbox BattleFrontier_OutsideEast_Text_242F0D, 3
+	msgbox BattleFrontier_OutsideEast_Text_242F0D, MSGBOX_SIGN
 	end
 
 BattleFrontier_OutsideEast_EventScript_242DD7:: @ 8242DD7
-	msgbox BattleFrontier_OutsideEast_Text_242F4A, 3
+	msgbox BattleFrontier_OutsideEast_Text_242F4A, MSGBOX_SIGN
 	end
 
 BattleFrontier_OutsideEast_EventScript_242DE0:: @ 8242DE0
-	msgbox BattleFrontier_OutsideEast_Text_243B68, 2
+	msgbox BattleFrontier_OutsideEast_Text_243B68, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_EventScript_242DE9:: @ 8242DE9
@@ -225,17 +225,17 @@ BattleFrontier_OutsideEast_EventScript_242DE9:: @ 8242DE9
 	faceplayer
 	checkflag FLAG_0x1C6
 	goto_eq BattleFrontier_OutsideEast_EventScript_242DFE
-	msgbox BattleFrontier_OutsideEast_Text_243C2C, 4
+	msgbox BattleFrontier_OutsideEast_Text_243C2C, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_OutsideEast_EventScript_242DFE:: @ 8242DFE
-	msgbox BattleFrontier_OutsideEast_Text_243CA3, 4
+	msgbox BattleFrontier_OutsideEast_Text_243CA3, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_OutsideEast_EventScript_242E08:: @ 8242E08
-	msgbox BattleFrontier_OutsideEast_Text_243D0B, 2
+	msgbox BattleFrontier_OutsideEast_Text_243D0B, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideEast_Text_242E11: @ 8242E11

--- a/data/maps/BattleFrontier_OutsideWest/scripts.inc
+++ b/data/maps/BattleFrontier_OutsideWest/scripts.inc
@@ -10,7 +10,7 @@ BattleFrontier_OutsideWest_MapScript1_23D3E7: @ 823D3E7
 BattleFrontier_OutsideWest_EventScript_23D3F0:: @ 823D3F0
 	lock
 	faceplayer
-	msgbox BattleFrontier_OutsideWest_Text_23D808, 4
+	msgbox BattleFrontier_OutsideWest_Text_23D808, MSGBOX_DEFAULT
 	checkitem ITEM_SS_TICKET, 1
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_OutsideWest_EventScript_23D44E
@@ -29,15 +29,15 @@ BattleFrontier_OutsideWest_EventScript_23D416:: @ 823D416
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D44E:: @ 823D44E
-	msgbox BattleFrontier_OutsideWest_Text_23D842, 4
+	msgbox BattleFrontier_OutsideWest_Text_23D842, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D458:: @ 823D458
-	msgbox BattleFrontier_OutsideWest_Text_23D8F2, 5
+	msgbox BattleFrontier_OutsideWest_Text_23D8F2, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_OutsideWest_EventScript_23D4AE
-	msgbox BattleFrontier_OutsideWest_Text_23D94B, 4
+	msgbox BattleFrontier_OutsideWest_Text_23D94B, MSGBOX_DEFAULT
 	call BattleFrontier_OutsideWest_EventScript_23D4BA
 	warp MAP_SLATEPORT_CITY_HARBOR, 255, 8, 11
 	waitstate
@@ -45,10 +45,10 @@ BattleFrontier_OutsideWest_EventScript_23D458:: @ 823D458
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D483:: @ 823D483
-	msgbox BattleFrontier_OutsideWest_Text_23D90E, 5
+	msgbox BattleFrontier_OutsideWest_Text_23D90E, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_OutsideWest_EventScript_23D4AE
-	msgbox BattleFrontier_OutsideWest_Text_23D94B, 4
+	msgbox BattleFrontier_OutsideWest_Text_23D94B, MSGBOX_DEFAULT
 	call BattleFrontier_OutsideWest_EventScript_23D4BA
 	warp MAP_LILYCOVE_CITY_HARBOR, 255, 8, 11
 	waitstate
@@ -72,32 +72,32 @@ BattleFrontier_OutsideWest_EventScript_23D4BA:: @ 823D4BA
 	return
 
 BattleFrontier_OutsideWest_EventScript_23D4D8:: @ 823D4D8
-	msgbox BattleFrontier_OutsideWest_Text_23D929, 4
+	msgbox BattleFrontier_OutsideWest_Text_23D929, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D4E2:: @ 823D4E2
-	msgbox BattleFrontier_OutsideWest_Text_23D6F7, 3
+	msgbox BattleFrontier_OutsideWest_Text_23D6F7, MSGBOX_SIGN
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D4EB:: @ 823D4EB
-	msgbox BattleFrontier_OutsideWest_Text_23D737, 3
+	msgbox BattleFrontier_OutsideWest_Text_23D737, MSGBOX_SIGN
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D4F4:: @ 823D4F4
-	msgbox BattleFrontier_OutsideWest_Text_23D772, 3
+	msgbox BattleFrontier_OutsideWest_Text_23D772, MSGBOX_SIGN
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D4FD:: @ 823D4FD
-	msgbox BattleFrontier_OutsideWest_Text_23D7A6, 2
+	msgbox BattleFrontier_OutsideWest_Text_23D7A6, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D506:: @ 823D4FD
-	msgbox BattleFrontier_OutsideWest_Text_23D9DD, 2
+	msgbox BattleFrontier_OutsideWest_Text_23D9DD, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D50F:: @ 823D50F
-	msgbox BattleFrontier_OutsideWest_Text_23D99C, 2
+	msgbox BattleFrontier_OutsideWest_Text_23D99C, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D518:: @ 823D518
@@ -112,7 +112,7 @@ BattleFrontier_OutsideWest_EventScript_23D518:: @ 823D518
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D52D:: @ 823D52D
-	msgbox BattleFrontier_OutsideWest_Text_23DABF, 2
+	msgbox BattleFrontier_OutsideWest_Text_23DABF, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D536:: @ 823D536
@@ -128,10 +128,10 @@ BattleFrontier_OutsideWest_EventScript_23D53D:: @ 823D53D
 BattleFrontier_OutsideWest_EventScript_23D544:: @ 823D544
 	applymovement 9, BattleFrontier_OutsideWest_Movement_2725A8
 	waitmovement 0
-	msgbox BattleFrontier_OutsideWest_Text_23DB7D, 4
+	msgbox BattleFrontier_OutsideWest_Text_23DB7D, MSGBOX_DEFAULT
 	applymovement 10, BattleFrontier_OutsideWest_Movement_2725A4
 	waitmovement 0
-	msgbox BattleFrontier_OutsideWest_Text_23DBCE, 4
+	msgbox BattleFrontier_OutsideWest_Text_23DBCE, MSGBOX_DEFAULT
 	closemessage
 	delay 25
 	applymovement 9, BattleFrontier_OutsideWest_Movement_2725A6
@@ -152,7 +152,7 @@ BattleFrontier_OutsideWest_EventScript_23D57F:: @ 823D57F
 	call_if 1, BattleFrontier_OutsideWest_EventScript_23D5BA
 	compare VAR_FACING, 4
 	call_if 1, BattleFrontier_OutsideWest_EventScript_23D5BA
-	msgbox BattleFrontier_OutsideWest_Text_23DC36, 4
+	msgbox BattleFrontier_OutsideWest_Text_23DC36, MSGBOX_DEFAULT
 	release
 	end
 
@@ -224,7 +224,7 @@ BattleFrontier_OutsideWest_Movement_23D632: @ 823D632
 BattleFrontier_OutsideWest_EventScript_23D635:: @ 823D635
 	lock
 	faceplayer
-	msgbox BattleFrontier_OutsideWest_Text_23DD3B, 4
+	msgbox BattleFrontier_OutsideWest_Text_23DD3B, MSGBOX_DEFAULT
 	random 2
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_OutsideWest_EventScript_23D653
@@ -232,71 +232,71 @@ BattleFrontier_OutsideWest_EventScript_23D635:: @ 823D635
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D653:: @ 823D653
-	msgbox BattleFrontier_OutsideWest_Text_23DD7A, 4
+	msgbox BattleFrontier_OutsideWest_Text_23DD7A, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D65D:: @ 823D65D
-	msgbox BattleFrontier_OutsideWest_Text_23DDAD, 4
+	msgbox BattleFrontier_OutsideWest_Text_23DDAD, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D667:: @ 823D667
-	msgbox BattleFrontier_OutsideWest_Text_23DE15, 2
+	msgbox BattleFrontier_OutsideWest_Text_23DE15, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D670:: @ 823D670
-	msgbox BattleFrontier_OutsideWest_Text_23DF7D, 2
+	msgbox BattleFrontier_OutsideWest_Text_23DF7D, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D679:: @ 823D679
-	msgbox BattleFrontier_OutsideWest_Text_23DEFD, 2
+	msgbox BattleFrontier_OutsideWest_Text_23DEFD, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D682:: @ 823D682
-	msgbox BattleFrontier_OutsideWest_Text_23DEB4, 2
+	msgbox BattleFrontier_OutsideWest_Text_23DEB4, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D68B:: @ 823D68B
-	msgbox BattleFrontier_OutsideWest_Text_23DFBF, 2
+	msgbox BattleFrontier_OutsideWest_Text_23DFBF, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D694:: @ 823D694
-	msgbox BattleFrontier_OutsideWest_Text_23E01E, 2
+	msgbox BattleFrontier_OutsideWest_Text_23E01E, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D69D:: @ 823D69D
-	msgbox BattleFrontier_OutsideWest_Text_23E09F, 2
+	msgbox BattleFrontier_OutsideWest_Text_23E09F, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D6A6:: @ 823D6A6
-	msgbox BattleFrontier_OutsideWest_Text_23E102, 2
+	msgbox BattleFrontier_OutsideWest_Text_23E102, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D6AF:: @ 823D6AF
-	msgbox BattleFrontier_OutsideWest_Text_23E154, 2
+	msgbox BattleFrontier_OutsideWest_Text_23E154, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D6B8:: @ 823D6B8
 	lock
-	msgbox BattleFrontier_OutsideWest_Text_23E273, 4
+	msgbox BattleFrontier_OutsideWest_Text_23E273, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D6C3:: @ 823D6C3
 	lock
-	msgbox BattleFrontier_OutsideWest_Text_23E2E9, 4
+	msgbox BattleFrontier_OutsideWest_Text_23E2E9, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D6CE:: @ 823D6CE
-	msgbox BattleFrontier_OutsideWest_Text_23E37E, 2
+	msgbox BattleFrontier_OutsideWest_Text_23E37E, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D6D7:: @ 823D6D7
 	lock
 	faceplayer
-	msgbox BattleFrontier_OutsideWest_Text_23E410, 4
+	msgbox BattleFrontier_OutsideWest_Text_23E410, MSGBOX_DEFAULT
 	closemessage
 	applymovement 23, BattleFrontier_OutsideWest_Movement_2725A2
 	waitmovement 0
@@ -304,7 +304,7 @@ BattleFrontier_OutsideWest_EventScript_23D6D7:: @ 823D6D7
 	end
 
 BattleFrontier_OutsideWest_EventScript_23D6EE:: @ 823D6EE
-	msgbox BattleFrontier_OutsideWest_Text_23E5A5, 2
+	msgbox BattleFrontier_OutsideWest_Text_23E5A5, MSGBOX_NPC
 	end
 
 BattleFrontier_OutsideWest_Text_23D6F7: @ 823D6F7

--- a/data/maps/BattleFrontier_PokemonCenter_1F/scripts.inc
+++ b/data/maps/BattleFrontier_PokemonCenter_1F/scripts.inc
@@ -16,15 +16,15 @@ BattleFrontier_PokemonCenter_1F_EventScript_267908:: @ 8267908
 	end
 
 BattleFrontier_PokemonCenter_1F_EventScript_267916:: @ 8267916
-	msgbox BattleFrontier_PokemonCenter_1F_Text_267944, 2
+	msgbox BattleFrontier_PokemonCenter_1F_Text_267944, MSGBOX_NPC
 	end
 
 BattleFrontier_PokemonCenter_1F_EventScript_26791F:: @ 826791F
-	msgbox BattleFrontier_PokemonCenter_1F_Text_2679EB, 2
+	msgbox BattleFrontier_PokemonCenter_1F_Text_2679EB, MSGBOX_NPC
 	end
 
 BattleFrontier_PokemonCenter_1F_EventScript_267928:: @ 8267928
-	msgbox BattleFrontier_PokemonCenter_1F_Text_267A4B, 2
+	msgbox BattleFrontier_PokemonCenter_1F_Text_267A4B, MSGBOX_NPC
 	end
 
 BattleFrontier_PokemonCenter_1F_EventScript_267931:: @ 8267931
@@ -32,7 +32,7 @@ BattleFrontier_PokemonCenter_1F_EventScript_267931:: @ 8267931
 	faceplayer
 	waitse
 	playmoncry SPECIES_SKITTY, 0
-	msgbox BattleFrontier_PokemonCenter_1F_Text_267A90, 4
+	msgbox BattleFrontier_PokemonCenter_1F_Text_267A90, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/BattleFrontier_RankingHall/scripts.inc
+++ b/data/maps/BattleFrontier_RankingHall/scripts.inc
@@ -71,34 +71,34 @@ BattleFrontier_RankingHall_EventScript_25E522:: @ 825E522
 	end
 
 BattleFrontier_RankingHall_EventScript_25E52F:: @ 825E52F
-	msgbox BattleFrontier_RankingHall_Text_25E57C, 2
+	msgbox BattleFrontier_RankingHall_Text_25E57C, MSGBOX_NPC
 	end
 
 BattleFrontier_RankingHall_EventScript_25E538:: @ 825E538
-	msgbox BattleFrontier_RankingHall_Text_25E5F9, 3
+	msgbox BattleFrontier_RankingHall_Text_25E5F9, MSGBOX_SIGN
 	end
 
 BattleFrontier_RankingHall_EventScript_25E541:: @ 825E541
-	msgbox BattleFrontier_RankingHall_Text_25E62E, 3
+	msgbox BattleFrontier_RankingHall_Text_25E62E, MSGBOX_SIGN
 	end
 
 BattleFrontier_RankingHall_EventScript_25E54A:: @ 825E54A
 	lock
 	faceplayer
-	msgbox BattleFrontier_RankingHall_Text_25E666, 5
+	msgbox BattleFrontier_RankingHall_Text_25E666, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq BattleFrontier_RankingHall_EventScript_25E569
-	msgbox BattleFrontier_RankingHall_Text_25E6B6, 4
+	msgbox BattleFrontier_RankingHall_Text_25E6B6, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_RankingHall_EventScript_25E569:: @ 825E569
-	msgbox BattleFrontier_RankingHall_Text_25E685, 4
+	msgbox BattleFrontier_RankingHall_Text_25E685, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_RankingHall_EventScript_25E573:: @ 825E573
-	msgbox BattleFrontier_RankingHall_Text_25E715, 2
+	msgbox BattleFrontier_RankingHall_Text_25E715, MSGBOX_NPC
 	end
 
 BattleFrontier_RankingHall_Text_25E57C: @ 825E57C

--- a/data/maps/BattleFrontier_ReceptionGate/scripts.inc
+++ b/data/maps/BattleFrontier_ReceptionGate/scripts.inc
@@ -19,7 +19,7 @@ BattleFrontier_ReceptionGate_EventScript_2661F3:: @ 82661F3
 	waitmovement 0
 	applymovement 1, BattleFrontier_ReceptionGate_Movement_27259A
 	waitmovement 0
-	msgbox BattleFrontier_ReceptionGate_Text_266580, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266580, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, BattleFrontier_ReceptionGate_Movement_2662D2
 	waitmovement 0
@@ -27,16 +27,16 @@ BattleFrontier_ReceptionGate_EventScript_2661F3:: @ 82661F3
 	end
 
 BattleFrontier_ReceptionGate_EventScript_266229:: @ 8266229
-	msgbox BattleFrontier_ReceptionGate_Text_2665B2, 4
-	msgbox BattleFrontier_ReceptionGate_Text_2665F7, 4
+	msgbox BattleFrontier_ReceptionGate_Text_2665B2, MSGBOX_DEFAULT
+	msgbox BattleFrontier_ReceptionGate_Text_2665F7, MSGBOX_DEFAULT
 	playfanfare MUS_FANFA4
 	message BattleFrontier_ReceptionGate_Text_266676
 	waitfanfare
 	waitmessage
-	msgbox BattleFrontier_ReceptionGate_Text_266695, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266695, MSGBOX_DEFAULT
 	setflag FLAG_SYS_FRONTIER_PASS
-	msgbox BattleFrontier_ReceptionGate_Text_2666C6, 4
-	msgbox BattleFrontier_ReceptionGate_Text_266703, 4
+	msgbox BattleFrontier_ReceptionGate_Text_2666C6, MSGBOX_DEFAULT
+	msgbox BattleFrontier_ReceptionGate_Text_266703, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, BattleFrontier_ReceptionGate_Movement_2725A6
 	applymovement 2, BattleFrontier_ReceptionGate_Movement_2725A6
@@ -47,14 +47,14 @@ BattleFrontier_ReceptionGate_EventScript_266229:: @ 8266229
 	applymovement 2, BattleFrontier_ReceptionGate_Movement_272598
 	applymovement 255, BattleFrontier_ReceptionGate_Movement_272598
 	waitmovement 0
-	msgbox BattleFrontier_ReceptionGate_Text_266733, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266733, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, BattleFrontier_ReceptionGate_Movement_2662F0
 	applymovement 2, BattleFrontier_ReceptionGate_Movement_2662F6
 	applymovement 255, BattleFrontier_ReceptionGate_Movement_2662D7
 	applymovement 4, BattleFrontier_ReceptionGate_Movement_2662E0
 	waitmovement 0
-	msgbox BattleFrontier_ReceptionGate_Text_266764, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266764, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, BattleFrontier_ReceptionGate_Movement_2662E8
 	waitmovement 0
@@ -121,15 +121,15 @@ BattleFrontier_ReceptionGate_Movement_2662F6: @ 82662F6
 BattleFrontier_ReceptionGate_EventScript_2662FC:: @ 82662FC
 	lock
 	faceplayer
-	msgbox BattleFrontier_ReceptionGate_Text_2665B2, 4
-	msgbox BattleFrontier_ReceptionGate_Text_2666C6, 4
+	msgbox BattleFrontier_ReceptionGate_Text_2665B2, MSGBOX_DEFAULT
+	msgbox BattleFrontier_ReceptionGate_Text_2666C6, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_ReceptionGate_EventScript_266310:: @ 8266310
 	lock
 	faceplayer
-	msgbox BattleFrontier_ReceptionGate_Text_266857, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266857, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266320
 	end
 
@@ -154,59 +154,59 @@ BattleFrontier_ReceptionGate_EventScript_266320:: @ 8266320
 	end
 
 BattleFrontier_ReceptionGate_EventScript_2663AE:: @ 82663AE
-	msgbox BattleFrontier_ReceptionGate_Text_2668C2, 4
+	msgbox BattleFrontier_ReceptionGate_Text_2668C2, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266320
 	end
 
 BattleFrontier_ReceptionGate_EventScript_2663BC:: @ 82663BC
-	msgbox BattleFrontier_ReceptionGate_Text_26696F, 4
+	msgbox BattleFrontier_ReceptionGate_Text_26696F, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266320
 	end
 
 BattleFrontier_ReceptionGate_EventScript_2663CA:: @ 82663CA
-	msgbox BattleFrontier_ReceptionGate_Text_266A34, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266A34, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266320
 	end
 
 BattleFrontier_ReceptionGate_EventScript_2663D8:: @ 82663D8
-	msgbox BattleFrontier_ReceptionGate_Text_266AC2, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266AC2, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266320
 	end
 
 BattleFrontier_ReceptionGate_EventScript_2663E6:: @ 82663E6
-	msgbox BattleFrontier_ReceptionGate_Text_266B5D, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266B5D, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266320
 	end
 
 BattleFrontier_ReceptionGate_EventScript_2663F4:: @ 82663F4
-	msgbox BattleFrontier_ReceptionGate_Text_266C24, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266C24, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266320
 	end
 
 BattleFrontier_ReceptionGate_EventScript_266402:: @ 8266402
-	msgbox BattleFrontier_ReceptionGate_Text_266CBB, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266CBB, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266320
 	end
 
 BattleFrontier_ReceptionGate_EventScript_266410:: @ 8266410
-	msgbox BattleFrontier_ReceptionGate_Text_266D1C, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266D1C, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266320
 	end
 
 BattleFrontier_ReceptionGate_EventScript_26641E:: @ 826641E
-	msgbox BattleFrontier_ReceptionGate_Text_266DCB, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266DCB, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266320
 	end
 
 BattleFrontier_ReceptionGate_EventScript_26642C:: @ 826642C
-	msgbox BattleFrontier_ReceptionGate_Text_2666C6, 4
+	msgbox BattleFrontier_ReceptionGate_Text_2666C6, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_ReceptionGate_EventScript_266436:: @ 8266436
 	lock
 	faceplayer
-	msgbox BattleFrontier_ReceptionGate_Text_266E66, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266E66, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266446
 	end
 
@@ -225,39 +225,39 @@ BattleFrontier_ReceptionGate_EventScript_266446:: @ 8266446
 	end
 
 BattleFrontier_ReceptionGate_EventScript_2664A4:: @ 82664A4
-	msgbox BattleFrontier_ReceptionGate_Text_266F04, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266F04, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266446
 	end
 
 BattleFrontier_ReceptionGate_EventScript_2664B2:: @ 82664B2
-	msgbox BattleFrontier_ReceptionGate_Text_266F69, 4
+	msgbox BattleFrontier_ReceptionGate_Text_266F69, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266446
 	end
 
 BattleFrontier_ReceptionGate_EventScript_2664C0:: @ 82664C0
-	msgbox BattleFrontier_ReceptionGate_Text_267080, 4
+	msgbox BattleFrontier_ReceptionGate_Text_267080, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266446
 	end
 
 BattleFrontier_ReceptionGate_EventScript_2664CE:: @ 82664CE
-	msgbox BattleFrontier_ReceptionGate_Text_26716A, 4
+	msgbox BattleFrontier_ReceptionGate_Text_26716A, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266446
 	end
 
 BattleFrontier_ReceptionGate_EventScript_2664DC:: @ 82664DC
-	msgbox BattleFrontier_ReceptionGate_Text_267298, 4
+	msgbox BattleFrontier_ReceptionGate_Text_267298, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266446
 	end
 
 BattleFrontier_ReceptionGate_EventScript_2664EA:: @ 82664EA
-	msgbox BattleFrontier_ReceptionGate_Text_2666C6, 4
+	msgbox BattleFrontier_ReceptionGate_Text_2666C6, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_ReceptionGate_EventScript_2664F4:: @ 82664F4
 	lock
 	faceplayer
-	msgbox BattleFrontier_ReceptionGate_Text_267357, 4
+	msgbox BattleFrontier_ReceptionGate_Text_267357, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266504
 	end
 
@@ -274,22 +274,22 @@ BattleFrontier_ReceptionGate_EventScript_266504:: @ 8266504
 	end
 
 BattleFrontier_ReceptionGate_EventScript_26654C:: @ 826654C
-	msgbox BattleFrontier_ReceptionGate_Text_2673A1, 4
+	msgbox BattleFrontier_ReceptionGate_Text_2673A1, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266504
 	end
 
 BattleFrontier_ReceptionGate_EventScript_26655A:: @ 826655A
-	msgbox BattleFrontier_ReceptionGate_Text_2674F3, 4
+	msgbox BattleFrontier_ReceptionGate_Text_2674F3, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266504
 	end
 
 BattleFrontier_ReceptionGate_EventScript_266568:: @ 8266568
-	msgbox BattleFrontier_ReceptionGate_Text_26761C, 4
+	msgbox BattleFrontier_ReceptionGate_Text_26761C, MSGBOX_DEFAULT
 	goto BattleFrontier_ReceptionGate_EventScript_266504
 	end
 
 BattleFrontier_ReceptionGate_EventScript_266576:: @ 8266576
-	msgbox BattleFrontier_ReceptionGate_Text_2666C6, 4
+	msgbox BattleFrontier_ReceptionGate_Text_2666C6, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/BattleFrontier_ScottsHouse/scripts.inc
+++ b/data/maps/BattleFrontier_ScottsHouse/scripts.inc
@@ -46,7 +46,7 @@ BattleFrontier_ScottsHouse_EventScript_263704:: @ 8263704
 	goto_if 0, BattleFrontier_ScottsHouse_EventScript_2636EC
 	checkflag FLAG_SYS_PYRAMID_SILVER
 	goto_if 0, BattleFrontier_ScottsHouse_EventScript_2636EC
-	msgbox BattleFrontier_ScottsHouse_Text_2640BC, 4
+	msgbox BattleFrontier_ScottsHouse_Text_2640BC, MSGBOX_DEFAULT
 	giveitem_std ITEM_LANSAT_BERRY
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_ScottsHouse_EventScript_2637D0
@@ -70,7 +70,7 @@ BattleFrontier_ScottsHouse_EventScript_26376A:: @ 826376A
 	goto_if 0, BattleFrontier_ScottsHouse_EventScript_2636EC
 	checkflag FLAG_SYS_PYRAMID_GOLD
 	goto_if 0, BattleFrontier_ScottsHouse_EventScript_2636EC
-	msgbox BattleFrontier_ScottsHouse_Text_264216, 4
+	msgbox BattleFrontier_ScottsHouse_Text_264216, MSGBOX_DEFAULT
 	giveitem_std ITEM_STARF_BERRY
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_ScottsHouse_EventScript_2637D0
@@ -80,12 +80,12 @@ BattleFrontier_ScottsHouse_EventScript_26376A:: @ 826376A
 	end
 
 BattleFrontier_ScottsHouse_EventScript_2637D0:: @ 82637D0
-	msgbox BattleFrontier_ScottsHouse_Text_2643EB, 4
+	msgbox BattleFrontier_ScottsHouse_Text_2643EB, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_ScottsHouse_EventScript_2637DA:: @ 82637DA
-	msgbox BattleFrontier_ScottsHouse_Text_264373, 4
+	msgbox BattleFrontier_ScottsHouse_Text_264373, MSGBOX_DEFAULT
 	release
 	end
 
@@ -95,17 +95,17 @@ BattleFrontier_ScottsHouse_EventScript_2637E4:: @ 82637E4
 	goto_eq BattleFrontier_ScottsHouse_EventScript_263807
 	compare VAR_RESULT, 2
 	goto_eq BattleFrontier_ScottsHouse_EventScript_263811
-	msgbox BattleFrontier_ScottsHouse_Text_263DDD, 4
+	msgbox BattleFrontier_ScottsHouse_Text_263DDD, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_ScottsHouse_EventScript_263807:: @ 8263807
-	msgbox BattleFrontier_ScottsHouse_Text_263F12, 4
+	msgbox BattleFrontier_ScottsHouse_Text_263F12, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_ScottsHouse_EventScript_263811:: @ 8263811
-	msgbox BattleFrontier_ScottsHouse_Text_263FFE, 4
+	msgbox BattleFrontier_ScottsHouse_Text_263FFE, MSGBOX_DEFAULT
 	release
 	end
 
@@ -133,7 +133,7 @@ BattleFrontier_ScottsHouse_EventScript_26381B:: @ 826381B
 	end
 
 BattleFrontier_ScottsHouse_EventScript_26387A:: @ 826387A
-	msgbox BattleFrontier_ScottsHouse_Text_264412, 4
+	msgbox BattleFrontier_ScottsHouse_Text_264412, MSGBOX_DEFAULT
 	givedecoration_std 42
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_ScottsHouse_EventScript_2638A0
@@ -143,12 +143,12 @@ BattleFrontier_ScottsHouse_EventScript_26387A:: @ 826387A
 	end
 
 BattleFrontier_ScottsHouse_EventScript_2638A0:: @ 82638A0
-	msgbox BattleFrontier_ScottsHouse_Text_264583, 4
+	msgbox BattleFrontier_ScottsHouse_Text_264583, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_ScottsHouse_EventScript_2638AA:: @ 82638AA
-	msgbox BattleFrontier_ScottsHouse_Text_264546, 4
+	msgbox BattleFrontier_ScottsHouse_Text_264546, MSGBOX_DEFAULT
 	release
 	end
 
@@ -176,7 +176,7 @@ BattleFrontier_ScottsHouse_EventScript_2638B4:: @ 82638B4
 	end
 
 BattleFrontier_ScottsHouse_EventScript_263913:: @ 8263913
-	msgbox BattleFrontier_ScottsHouse_Text_26449F, 4
+	msgbox BattleFrontier_ScottsHouse_Text_26449F, MSGBOX_DEFAULT
 	givedecoration_std 43
 	compare VAR_RESULT, 0
 	goto_eq BattleFrontier_ScottsHouse_EventScript_2638A0
@@ -186,12 +186,12 @@ BattleFrontier_ScottsHouse_EventScript_263913:: @ 8263913
 	end
 
 BattleFrontier_ScottsHouse_EventScript_263939:: @ 8263939
-	msgbox BattleFrontier_ScottsHouse_Text_263DB8, 4
+	msgbox BattleFrontier_ScottsHouse_Text_263DB8, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_ScottsHouse_EventScript_263943:: @ 8263943
-	msgbox BattleFrontier_ScottsHouse_Text_263A3F, 4
+	msgbox BattleFrontier_ScottsHouse_Text_263A3F, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	compare VAR_FACING, 2
@@ -202,10 +202,10 @@ BattleFrontier_ScottsHouse_EventScript_263943:: @ 8263943
 	call_if 1, BattleFrontier_ScottsHouse_EventScript_263A29
 	compare VAR_FACING, 3
 	call_if 1, BattleFrontier_ScottsHouse_EventScript_263A34
-	msgbox BattleFrontier_ScottsHouse_Text_263B29, 4
+	msgbox BattleFrontier_ScottsHouse_Text_263B29, MSGBOX_DEFAULT
 	applymovement 1, BattleFrontier_ScottsHouse_Movement_27259E
 	waitmovement 0
-	msgbox BattleFrontier_ScottsHouse_Text_263BD4, 4
+	msgbox BattleFrontier_ScottsHouse_Text_263BD4, MSGBOX_DEFAULT
 	compare VAR_0x40D1, 13
 	goto_eq BattleFrontier_ScottsHouse_EventScript_2639BC
 	compare VAR_0x40D1, 9
@@ -242,7 +242,7 @@ BattleFrontier_ScottsHouse_EventScript_2639E9:: @ 82639E9
 BattleFrontier_ScottsHouse_EventScript_2639F8:: @ 82639F8
 	special sub_813A9D0
 	msgbox BattleFrontier_ScottsHouse_Text_263CB0, 9
-	msgbox BattleFrontier_ScottsHouse_Text_263CD0, 4
+	msgbox BattleFrontier_ScottsHouse_Text_263CD0, MSGBOX_DEFAULT
 	setflag FLAG_0x1D1
 	setflag FLAG_TEMP_2
 	release

--- a/data/maps/BirthIsland_Harbor/scripts.inc
+++ b/data/maps/BirthIsland_Harbor/scripts.inc
@@ -4,10 +4,10 @@ BirthIsland_Harbor_MapScripts:: @ 826805C
 BirthIsland_Harbor_EventScript_26805D:: @ 826805D
 	lock
 	faceplayer
-	msgbox BirthIsland_Harbor_Text_2C6B90, 5
+	msgbox BirthIsland_Harbor_Text_2C6B90, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq BirthIsland_Harbor_EventScript_2680A2
-	msgbox BirthIsland_Harbor_Text_2A6A5D, 4
+	msgbox BirthIsland_Harbor_Text_2A6A5D, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, BirthIsland_Harbor_Movement_2725AA
 	waitmovement 0
@@ -21,7 +21,7 @@ BirthIsland_Harbor_EventScript_26805D:: @ 826805D
 	end
 
 BirthIsland_Harbor_EventScript_2680A2:: @ 82680A2
-	msgbox BirthIsland_Harbor_Text_2A6A82, 4
+	msgbox BirthIsland_Harbor_Text_2A6A82, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/CaveOfOrigin_B1F/scripts.inc
+++ b/data/maps/CaveOfOrigin_B1F/scripts.inc
@@ -4,7 +4,7 @@ CaveOfOrigin_B1F_MapScripts:: @ 82357A8
 CaveOfOrigin_B1F_EventScript_2357A9:: @ 82357A9
 	lock
 	faceplayer
-	msgbox CaveOfOrigin_B1F_Text_23586E, 4
+	msgbox CaveOfOrigin_B1F_Text_23586E, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, CaveOfOrigin_B1F_Movement_2725A6
 	waitmovement 0
@@ -47,7 +47,7 @@ CaveOfOrigin_B1F_EventScript_235842:: @ 8235842
 	goto CaveOfOrigin_B1F_EventScript_2357F0
 
 CaveOfOrigin_B1F_EventScript_23584D:: @ 823584D
-	msgbox CaveOfOrigin_B1F_Text_235CEE, 4
+	msgbox CaveOfOrigin_B1F_Text_235CEE, MSGBOX_DEFAULT
 	closemessage
 	playse SE_KAIDAN
 	fadescreenspeed 1, 4

--- a/data/maps/DesertRuins/scripts.inc
+++ b/data/maps/DesertRuins/scripts.inc
@@ -51,7 +51,7 @@ DesertRuins_EventScript_22D9DB:: @ 822D9DB
 	end
 
 DesertRuins_EventScript_22D9EE:: @ 822D9EE
-	msgbox gUnknown_0827304E, 4
+	msgbox gUnknown_0827304E, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/DewfordTown/scripts.inc
+++ b/data/maps/DewfordTown/scripts.inc
@@ -22,53 +22,53 @@ DewfordTown_EventScript_1E9511:: @ 81E9511
 	end
 
 DewfordTown_EventScript_1E955A:: @ 81E955A
-	msgbox DewfordTown_Text_1E9CE5, 4
+	msgbox DewfordTown_Text_1E9CE5, MSGBOX_DEFAULT
 	closemessage
 	goto DewfordTown_EventScript_1E9660
 	release
 	end
 
 DewfordTown_EventScript_1E956A:: @ 81E956A
-	msgbox DewfordTown_Text_1E9D3A, 4
+	msgbox DewfordTown_Text_1E9D3A, MSGBOX_DEFAULT
 	closemessage
 	goto DewfordTown_EventScript_1E96E7
 	release
 	end
 
 DewfordTown_EventScript_1E957A:: @ 81E957A
-	msgbox DewfordTown_Text_1E9D8F, 4
+	msgbox DewfordTown_Text_1E9D8F, MSGBOX_DEFAULT
 	closemessage
 	release
 	end
 
 DewfordTown_EventScript_1E9585:: @ 81E9585
-	msgbox DewfordTown_Text_1E9B24, 5
+	msgbox DewfordTown_Text_1E9B24, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq DewfordTown_EventScript_1E95A2
-	msgbox DewfordTown_Text_1E9BD9, 4
+	msgbox DewfordTown_Text_1E9BD9, MSGBOX_DEFAULT
 	release
 	end
 
 DewfordTown_EventScript_1E95A2:: @ 81E95A2
-	msgbox DewfordTown_Text_1E9B7F, 4
+	msgbox DewfordTown_Text_1E9B7F, MSGBOX_DEFAULT
 	closemessage
 	goto DewfordTown_EventScript_1E9660
 	end
 
 DewfordTown_EventScript_1E95B1:: @ 81E95B1
-	msgbox DewfordTown_Text_1E99A8, 2
+	msgbox DewfordTown_Text_1E99A8, MSGBOX_NPC
 	end
 
 DewfordTown_EventScript_1E95BA:: @ 81E95BA
-	msgbox DewfordTown_Text_1E9A0F, 3
+	msgbox DewfordTown_Text_1E9A0F, MSGBOX_SIGN
 	end
 
 DewfordTown_EventScript_1E95C3:: @ 81E95C3
-	msgbox DewfordTown_Text_1E9A3D, 3
+	msgbox DewfordTown_Text_1E9A3D, MSGBOX_SIGN
 	end
 
 DewfordTown_EventScript_1E95CC:: @ 81E95CC
-	msgbox DewfordTown_Text_1E9A7F, 3
+	msgbox DewfordTown_Text_1E9A7F, MSGBOX_SIGN
 	end
 
 DewfordTown_EventScript_1E95D5:: @ 81E95D5
@@ -76,7 +76,7 @@ DewfordTown_EventScript_1E95D5:: @ 81E95D5
 	faceplayer
 	checkflag FLAG_0x101
 	goto_eq DewfordTown_EventScript_1E962A
-	msgbox DewfordTown_Text_1E9DD1, 5
+	msgbox DewfordTown_Text_1E9DD1, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq DewfordTown_EventScript_1E95FF
 	compare VAR_RESULT, 0
@@ -84,15 +84,15 @@ DewfordTown_EventScript_1E95D5:: @ 81E95D5
 	end
 
 DewfordTown_EventScript_1E95FF:: @ 81E95FF
-	msgbox DewfordTown_Text_1E9E14, 4
+	msgbox DewfordTown_Text_1E9E14, MSGBOX_DEFAULT
 	giveitem_std ITEM_OLD_ROD
 	setflag FLAG_0x101
-	msgbox DewfordTown_Text_1E9E65, 4
+	msgbox DewfordTown_Text_1E9E65, MSGBOX_DEFAULT
 	release
 	end
 
 DewfordTown_EventScript_1E9620:: @ 81E9620
-	msgbox DewfordTown_Text_1E9F92, 4
+	msgbox DewfordTown_Text_1E9F92, MSGBOX_DEFAULT
 	release
 	end
 
@@ -107,12 +107,12 @@ DewfordTown_EventScript_1E962A:: @ 81E962A
 	end
 
 DewfordTown_EventScript_1E964C:: @ 81E964C
-	msgbox DewfordTown_Text_1E9FD0, 4
+	msgbox DewfordTown_Text_1E9FD0, MSGBOX_DEFAULT
 	release
 	end
 
 DewfordTown_EventScript_1E9656:: @ 81E9656
-	msgbox DewfordTown_Text_1EA004, 4
+	msgbox DewfordTown_Text_1EA004, MSGBOX_DEFAULT
 	release
 	end
 
@@ -189,11 +189,11 @@ DewfordTown_EventScript_1E96E7:: @ 81E96E7
 	end
 
 DewfordTown_EventScript_1E9790:: @ 81E9790
-	msgbox DewfordTown_Text_1EEC1D, 4
+	msgbox DewfordTown_Text_1EEC1D, MSGBOX_DEFAULT
 	return
 
 DewfordTown_EventScript_1E9799:: @ 81E9799
-	msgbox DewfordTown_Text_1EEDA7, 4
+	msgbox DewfordTown_Text_1EEDA7, MSGBOX_DEFAULT
 	return
 
 DewfordTown_Movement_1E97A2: @ 81E97A2
@@ -598,7 +598,7 @@ DewfordTown_EventScript_1E9922:: @ 81E9922
 	lock
 	faceplayer
 	call DewfordTown_EventScript_271E8B
-	msgbox DewfordTown_Text_1EA136, 5
+	msgbox DewfordTown_Text_1EA136, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq DewfordTown_EventScript_1E9948
 	compare VAR_RESULT, 0
@@ -606,12 +606,12 @@ DewfordTown_EventScript_1E9922:: @ 81E9922
 	end
 
 DewfordTown_EventScript_1E9948:: @ 81E9948
-	msgbox DewfordTown_Text_1EA491, 4
+	msgbox DewfordTown_Text_1EA491, MSGBOX_DEFAULT
 	release
 	end
 
 DewfordTown_EventScript_1E9952:: @ 81E9952
-	msgbox DewfordTown_Text_1EA242, 4
+	msgbox DewfordTown_Text_1EA242, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 9
 	call DewfordTown_EventScript_271E7C
 	lock
@@ -626,17 +626,17 @@ DewfordTown_EventScript_1E997D:: @ 81E997D
 	incrementgamestat 2
 	compare VAR_0x8004, 0
 	goto_eq DewfordTown_EventScript_1E999E
-	msgbox DewfordTown_Text_1EA2AA, 4
+	msgbox DewfordTown_Text_1EA2AA, MSGBOX_DEFAULT
 	release
 	end
 
 DewfordTown_EventScript_1E9994:: @ 81E9994
-	msgbox DewfordTown_Text_1EA443, 4
+	msgbox DewfordTown_Text_1EA443, MSGBOX_DEFAULT
 	release
 	end
 
 DewfordTown_EventScript_1E999E:: @ 81E999E
-	msgbox DewfordTown_Text_1EA3FE, 4
+	msgbox DewfordTown_Text_1EA3FE, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/DewfordTown_Gym/scripts.inc
+++ b/data/maps/DewfordTown_Gym/scripts.inc
@@ -162,7 +162,7 @@ DewfordTown_Gym_EventScript_1FC7C2:: @ 81FC7C2
 	goto_eq DewfordTown_Gym_EventScript_1FC89C
 	checkflag FLAG_0x0A6
 	goto_if 0, DewfordTown_Gym_EventScript_1FC878
-	msgbox DewfordTown_Gym_Text_1FD20D, 4
+	msgbox DewfordTown_Gym_Text_1FD20D, MSGBOX_DEFAULT
 	release
 	end
 
@@ -171,7 +171,7 @@ DewfordTown_Gym_EventScript_1FC7F7:: @ 81FC7F7
 	message DewfordTown_Gym_Text_1FD07D
 	waitmessage
 	call DewfordTown_Gym_EventScript_27207E
-	msgbox DewfordTown_Gym_Text_1FD0A8, 4
+	msgbox DewfordTown_Gym_Text_1FD0A8, MSGBOX_DEFAULT
 	setflag FLAG_0x4F1
 	setflag FLAG_BADGE02_GET
 	addvar VAR_0x4085, 1
@@ -183,7 +183,7 @@ DewfordTown_Gym_EventScript_1FC7F7:: @ 81FC7F7
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox DewfordTown_Gym_Text_1FD1E0, 4
+	msgbox DewfordTown_Gym_Text_1FD1E0, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
@@ -197,7 +197,7 @@ DewfordTown_Gym_EventScript_1FC855:: @ 81FC855
 	giveitem_std ITEM_TM08
 	compare VAR_RESULT, 0
 	goto_eq DewfordTown_Gym_EventScript_27205E
-	msgbox DewfordTown_Gym_Text_1FD181, 4
+	msgbox DewfordTown_Gym_Text_1FD181, MSGBOX_DEFAULT
 	setflag FLAG_0x0A6
 	return
 
@@ -205,19 +205,19 @@ DewfordTown_Gym_EventScript_1FC878:: @ 81FC878
 	giveitem_std ITEM_TM08
 	compare VAR_RESULT, 0
 	goto_eq DewfordTown_Gym_EventScript_272054
-	msgbox DewfordTown_Gym_Text_1FD181, 4
+	msgbox DewfordTown_Gym_Text_1FD181, MSGBOX_DEFAULT
 	setflag FLAG_0x0A6
 	release
 	end
 
 DewfordTown_Gym_EventScript_1FC89C:: @ 81FC89C
 	trainerbattle 7, TRAINER_BRAWLY_1, 0, DewfordTown_Gym_Text_1FD2C4, DewfordTown_Gym_Text_1FD367, DewfordTown_Gym_Text_1FD3DE
-	msgbox DewfordTown_Gym_Text_1FD37B, 6
+	msgbox DewfordTown_Gym_Text_1FD37B, MSGBOX_AUTOCLOSE
 	end
 
 DewfordTown_Gym_EventScript_1FC8B7:: @ 81FC8B7
 	trainerbattle 2, TRAINER_TAKAO, 0, DewfordTown_Gym_Text_1FCB9F, DewfordTown_Gym_Text_1FCBB8, DewfordTown_Gym_EventScript_1FC8D2
-	msgbox DewfordTown_Gym_Text_1FCBCA, 6
+	msgbox DewfordTown_Gym_Text_1FCBCA, MSGBOX_AUTOCLOSE
 	end
 
 DewfordTown_Gym_EventScript_1FC8D2:: @ 81FC8D2
@@ -227,7 +227,7 @@ DewfordTown_Gym_EventScript_1FC8D2:: @ 81FC8D2
 
 DewfordTown_Gym_EventScript_1FC8D9:: @ 81FC8D9
 	trainerbattle 2, TRAINER_JOCELYN, 0, DewfordTown_Gym_Text_1FCC0A, DewfordTown_Gym_Text_1FCC45, DewfordTown_Gym_EventScript_1FC8F4
-	msgbox DewfordTown_Gym_Text_1FCC6B, 6
+	msgbox DewfordTown_Gym_Text_1FCC6B, MSGBOX_AUTOCLOSE
 	end
 
 DewfordTown_Gym_EventScript_1FC8F4:: @ 81FC8F4
@@ -237,7 +237,7 @@ DewfordTown_Gym_EventScript_1FC8F4:: @ 81FC8F4
 
 DewfordTown_Gym_EventScript_1FC8FB:: @ 81FC8FB
 	trainerbattle 2, TRAINER_LAURA, 0, DewfordTown_Gym_Text_1FCD01, DewfordTown_Gym_Text_1FCD3C, DewfordTown_Gym_EventScript_1FC916
-	msgbox DewfordTown_Gym_Text_1FCD4F, 6
+	msgbox DewfordTown_Gym_Text_1FCD4F, MSGBOX_AUTOCLOSE
 	end
 
 DewfordTown_Gym_EventScript_1FC916:: @ 81FC916
@@ -247,7 +247,7 @@ DewfordTown_Gym_EventScript_1FC916:: @ 81FC916
 
 DewfordTown_Gym_EventScript_1FC91D:: @ 81FC91D
 	trainerbattle 2, TRAINER_BRENDEN, 0, DewfordTown_Gym_Text_1FCE48, DewfordTown_Gym_Text_1FCE75, DewfordTown_Gym_EventScript_1FC938
-	msgbox DewfordTown_Gym_Text_1FCEAB, 6
+	msgbox DewfordTown_Gym_Text_1FCEAB, MSGBOX_AUTOCLOSE
 	end
 
 DewfordTown_Gym_EventScript_1FC938:: @ 81FC938
@@ -257,7 +257,7 @@ DewfordTown_Gym_EventScript_1FC938:: @ 81FC938
 
 DewfordTown_Gym_EventScript_1FC93F:: @ 81FC93F
 	trainerbattle 2, TRAINER_CRISTIAN, 0, DewfordTown_Gym_Text_1FCEDC, DewfordTown_Gym_Text_1FCF0A, DewfordTown_Gym_EventScript_1FC95A
-	msgbox DewfordTown_Gym_Text_1FCF26, 6
+	msgbox DewfordTown_Gym_Text_1FCF26, MSGBOX_AUTOCLOSE
 	end
 
 DewfordTown_Gym_EventScript_1FC95A:: @ 81FC95A
@@ -267,7 +267,7 @@ DewfordTown_Gym_EventScript_1FC95A:: @ 81FC95A
 
 DewfordTown_Gym_EventScript_1FC961:: @ 81FC961
 	trainerbattle 2, TRAINER_LILITH, 0, DewfordTown_Gym_Text_1FCDB8, DewfordTown_Gym_Text_1FCDE5, DewfordTown_Gym_EventScript_1FC97C
-	msgbox DewfordTown_Gym_Text_1FCE08, 6
+	msgbox DewfordTown_Gym_Text_1FCE08, MSGBOX_AUTOCLOSE
 	end
 
 DewfordTown_Gym_EventScript_1FC97C:: @ 81FC97C
@@ -280,12 +280,12 @@ DewfordTown_Gym_EventScript_1FC983:: @ 81FC983
 	faceplayer
 	checkflag FLAG_0x4F1
 	goto_eq DewfordTown_Gym_EventScript_1FC998
-	msgbox DewfordTown_Gym_Text_1FC9D6, 4
+	msgbox DewfordTown_Gym_Text_1FC9D6, MSGBOX_DEFAULT
 	release
 	end
 
 DewfordTown_Gym_EventScript_1FC998:: @ 81FC998
-	msgbox DewfordTown_Gym_Text_1FCB5C, 4
+	msgbox DewfordTown_Gym_Text_1FCB5C, MSGBOX_DEFAULT
 	release
 	end
 
@@ -304,12 +304,12 @@ DewfordTown_Gym_EventScript_1FC9B2:: @ 81FC9B2
 	end
 
 DewfordTown_Gym_EventScript_1FC9C2:: @ 81FC9C2
-	msgbox DewfordTown_Gym_Text_1FD28B, 4
+	msgbox DewfordTown_Gym_Text_1FD28B, MSGBOX_DEFAULT
 	releaseall
 	end
 
 DewfordTown_Gym_EventScript_1FC9CC:: @ 81FC9CC
-	msgbox DewfordTown_Gym_Text_1FD272, 4
+	msgbox DewfordTown_Gym_Text_1FD272, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/DewfordTown_Hall/scripts.inc
+++ b/data/maps/DewfordTown_Hall/scripts.inc
@@ -8,12 +8,12 @@ DewfordTown_Hall_EventScript_1FD4D0:: @ 81FD4D0
 	special TrendyPhraseIsOld
 	compare VAR_RESULT, 1
 	goto_eq DewfordTown_Hall_EventScript_1FD4EF
-	msgbox DewfordTown_Hall_Text_1FD818, 4
+	msgbox DewfordTown_Hall_Text_1FD818, MSGBOX_DEFAULT
 	release
 	end
 
 DewfordTown_Hall_EventScript_1FD4EF:: @ 81FD4EF
-	msgbox DewfordTown_Hall_Text_1FD877, 4
+	msgbox DewfordTown_Hall_Text_1FD877, MSGBOX_DEFAULT
 	release
 	end
 
@@ -21,7 +21,7 @@ DewfordTown_Hall_EventScript_1FD4F9:: @ 81FD4F9
 	lock
 	faceplayer
 	call DewfordTown_Hall_EventScript_271E8B
-	msgbox DewfordTown_Hall_Text_1FD8ED, 4
+	msgbox DewfordTown_Hall_Text_1FD8ED, MSGBOX_DEFAULT
 	release
 	end
 
@@ -30,7 +30,7 @@ DewfordTown_Hall_EventScript_1FD50A:: @ 81FD50A
 	faceplayer
 	call DewfordTown_Hall_EventScript_271E8B
 	special sub_811EF6C
-	msgbox DewfordTown_Hall_Text_1FD948, 5
+	msgbox DewfordTown_Hall_Text_1FD948, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq DewfordTown_Hall_EventScript_1FD533
 	compare VAR_RESULT, 0
@@ -38,12 +38,12 @@ DewfordTown_Hall_EventScript_1FD50A:: @ 81FD50A
 	end
 
 DewfordTown_Hall_EventScript_1FD533:: @ 81FD533
-	msgbox DewfordTown_Hall_Text_1FD9B3, 4
+	msgbox DewfordTown_Hall_Text_1FD9B3, MSGBOX_DEFAULT
 	release
 	end
 
 DewfordTown_Hall_EventScript_1FD53D:: @ 81FD53D
-	msgbox DewfordTown_Hall_Text_1FDA06, 4
+	msgbox DewfordTown_Hall_Text_1FDA06, MSGBOX_DEFAULT
 	release
 	end
 
@@ -51,7 +51,7 @@ DewfordTown_Hall_EventScript_1FD547:: @ 81FD547
 	lock
 	faceplayer
 	call DewfordTown_Hall_EventScript_271E8B
-	msgbox DewfordTown_Hall_Text_1FDA5C, 4
+	msgbox DewfordTown_Hall_Text_1FDA5C, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, DewfordTown_Hall_Movement_2725A6
 	waitmovement 0
@@ -62,7 +62,7 @@ DewfordTown_Hall_EventScript_1FD563:: @ 81FD563
 	lock
 	faceplayer
 	call DewfordTown_Hall_EventScript_271E8B
-	msgbox DewfordTown_Hall_Text_1FDA99, 4
+	msgbox DewfordTown_Hall_Text_1FDA99, MSGBOX_DEFAULT
 	closemessage
 	applymovement 5, DewfordTown_Hall_Movement_2725A6
 	waitmovement 0
@@ -73,14 +73,14 @@ DewfordTown_Hall_EventScript_1FD57F:: @ 81FD57F
 	lock
 	faceplayer
 	call DewfordTown_Hall_EventScript_271E8B
-	msgbox DewfordTown_Hall_Text_1FDAC4, 4
+	msgbox DewfordTown_Hall_Text_1FDAC4, MSGBOX_DEFAULT
 	release
 	end
 
 DewfordTown_Hall_EventScript_1FD590:: @ 81FD590
 	lockall
 	call DewfordTown_Hall_EventScript_271E8B
-	msgbox DewfordTown_Hall_Text_1FDB89, 4
+	msgbox DewfordTown_Hall_Text_1FDB89, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -100,22 +100,22 @@ DewfordTown_Hall_EventScript_1FD5A0:: @ 81FD5A0
 	end
 
 DewfordTown_Hall_EventScript_1FD607:: @ 81FD607
-	msgbox DewfordTown_Hall_Text_1FDC05, 4
+	msgbox DewfordTown_Hall_Text_1FDC05, MSGBOX_DEFAULT
 	releaseall
 	end
 
 DewfordTown_Hall_EventScript_1FD611:: @ 81FD611
-	msgbox DewfordTown_Hall_Text_1FDC21, 4
+	msgbox DewfordTown_Hall_Text_1FDC21, MSGBOX_DEFAULT
 	releaseall
 	end
 
 DewfordTown_Hall_EventScript_1FD61B:: @ 81FD61B
-	msgbox DewfordTown_Hall_Text_1FDC3C, 4
+	msgbox DewfordTown_Hall_Text_1FDC3C, MSGBOX_DEFAULT
 	releaseall
 	end
 
 DewfordTown_Hall_EventScript_1FD625:: @ 81FD625
-	msgbox DewfordTown_Hall_Text_1FDC57, 4
+	msgbox DewfordTown_Hall_Text_1FDC57, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -147,41 +147,41 @@ DewfordTown_Hall_EventScript_1FD647:: @ 81FD647
 
 DewfordTown_Hall_EventScript_1FD6AD:: @ 81FD6AD
 	call DewfordTown_Hall_EventScript_1FD73A
-	msgbox DewfordTown_Hall_Text_1FDC76, 4
+	msgbox DewfordTown_Hall_Text_1FDC76, MSGBOX_DEFAULT
 	call DewfordTown_Hall_EventScript_1FD772
-	msgbox DewfordTown_Hall_Text_1FDCE2, 4
+	msgbox DewfordTown_Hall_Text_1FDCE2, MSGBOX_DEFAULT
 	releaseall
 	end
 
 DewfordTown_Hall_EventScript_1FD6C9:: @ 81FD6C9
 	call DewfordTown_Hall_EventScript_1FD73A
-	msgbox DewfordTown_Hall_Text_1FDD95, 4
+	msgbox DewfordTown_Hall_Text_1FDD95, MSGBOX_DEFAULT
 	call DewfordTown_Hall_EventScript_1FD772
-	msgbox DewfordTown_Hall_Text_1FDE0E, 4
+	msgbox DewfordTown_Hall_Text_1FDE0E, MSGBOX_DEFAULT
 	releaseall
 	end
 
 DewfordTown_Hall_EventScript_1FD6E5:: @ 81FD6E5
 	call DewfordTown_Hall_EventScript_1FD73A
-	msgbox DewfordTown_Hall_Text_1FDE77, 4
+	msgbox DewfordTown_Hall_Text_1FDE77, MSGBOX_DEFAULT
 	call DewfordTown_Hall_EventScript_1FD772
-	msgbox DewfordTown_Hall_Text_1FDED8, 4
+	msgbox DewfordTown_Hall_Text_1FDED8, MSGBOX_DEFAULT
 	releaseall
 	end
 
 DewfordTown_Hall_EventScript_1FD701:: @ 81FD701
 	call DewfordTown_Hall_EventScript_1FD73A
-	msgbox DewfordTown_Hall_Text_1FDF72, 4
+	msgbox DewfordTown_Hall_Text_1FDF72, MSGBOX_DEFAULT
 	call DewfordTown_Hall_EventScript_1FD772
-	msgbox DewfordTown_Hall_Text_1FDFF1, 4
+	msgbox DewfordTown_Hall_Text_1FDFF1, MSGBOX_DEFAULT
 	releaseall
 	end
 
 DewfordTown_Hall_EventScript_1FD71D:: @ 81FD71D
 	call DewfordTown_Hall_EventScript_1FD73A
-	msgbox DewfordTown_Hall_Text_1FE09A, 4
+	msgbox DewfordTown_Hall_Text_1FE09A, MSGBOX_DEFAULT
 	call DewfordTown_Hall_EventScript_1FD772
-	msgbox DewfordTown_Hall_Text_1FE0F2, 4
+	msgbox DewfordTown_Hall_Text_1FE0F2, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -254,7 +254,7 @@ DewfordTown_Hall_EventScript_1FD7DA:: @ 81FD7DA
 	call DewfordTown_Hall_EventScript_271E8B
 	checkflag FLAG_RECEIVED_TM_36
 	goto_eq DewfordTown_Hall_EventScript_1FD80E
-	msgbox DewfordTown_Hall_Text_1FE142, 4
+	msgbox DewfordTown_Hall_Text_1FE142, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM36
 	compare VAR_RESULT, 0
 	goto_eq DewfordTown_Hall_EventScript_272054
@@ -263,7 +263,7 @@ DewfordTown_Hall_EventScript_1FD7DA:: @ 81FD7DA
 	end
 
 DewfordTown_Hall_EventScript_1FD80E:: @ 81FD80E
-	msgbox DewfordTown_Hall_Text_1FE1ED, 4
+	msgbox DewfordTown_Hall_Text_1FE1ED, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/DewfordTown_House1/scripts.inc
+++ b/data/maps/DewfordTown_House1/scripts.inc
@@ -2,11 +2,11 @@ DewfordTown_House1_MapScripts:: @ 81FC3CD
 	.byte 0
 
 DewfordTown_House1_EventScript_1FC3CE:: @ 81FC3CE
-	msgbox DewfordTown_House1_Text_1FC3F3, 2
+	msgbox DewfordTown_House1_Text_1FC3F3, MSGBOX_NPC
 	end
 
 DewfordTown_House1_EventScript_1FC3D7:: @ 81FC3D7
-	msgbox DewfordTown_House1_Text_1FC45B, 2
+	msgbox DewfordTown_House1_Text_1FC45B, MSGBOX_NPC
 	end
 
 DewfordTown_House1_EventScript_1FC3E0:: @ 81FC3E0
@@ -14,7 +14,7 @@ DewfordTown_House1_EventScript_1FC3E0:: @ 81FC3E0
 	faceplayer
 	waitse
 	playmoncry SPECIES_ZIGZAGOON, 0
-	msgbox DewfordTown_House1_Text_1FC510, 4
+	msgbox DewfordTown_House1_Text_1FC510, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/DewfordTown_House2/scripts.inc
+++ b/data/maps/DewfordTown_House2/scripts.inc
@@ -6,7 +6,7 @@ DewfordTown_House2_EventScript_1FE22E:: @ 81FE22E
 	faceplayer
 	checkflag FLAG_0x121
 	goto_eq DewfordTown_House2_EventScript_1FE267
-	msgbox DewfordTown_House2_Text_1FE27A, 4
+	msgbox DewfordTown_House2_Text_1FE27A, MSGBOX_DEFAULT
 	giveitem_std ITEM_SILK_SCARF
 	compare VAR_RESULT, 0
 	goto_eq DewfordTown_House2_EventScript_1FE25D
@@ -15,17 +15,17 @@ DewfordTown_House2_EventScript_1FE22E:: @ 81FE22E
 	end
 
 DewfordTown_House2_EventScript_1FE25D:: @ 81FE25D
-	msgbox DewfordTown_House2_Text_1FE356, 4
+	msgbox DewfordTown_House2_Text_1FE356, MSGBOX_DEFAULT
 	release
 	end
 
 DewfordTown_House2_EventScript_1FE267:: @ 81FE267
-	msgbox DewfordTown_House2_Text_1FE3D1, 4
+	msgbox DewfordTown_House2_Text_1FE3D1, MSGBOX_DEFAULT
 	release
 	end
 
 DewfordTown_House2_EventScript_1FE271:: @ 81FE271
-	msgbox DewfordTown_House2_Text_1FE444, 2
+	msgbox DewfordTown_House2_Text_1FE444, MSGBOX_NPC
 	end
 
 DewfordTown_House2_Text_1FE27A: @ 81FE27A

--- a/data/maps/DewfordTown_PokemonCenter_1F/scripts.inc
+++ b/data/maps/DewfordTown_PokemonCenter_1F/scripts.inc
@@ -17,11 +17,11 @@ DewfordTown_PokemonCenter_1F_EventScript_1FC537:: @ 81FC537
 	end
 
 DewfordTown_PokemonCenter_1F_EventScript_1FC545:: @ 81FC545
-	msgbox DewfordTown_PokemonCenter_1F_Text_1FC557, 2
+	msgbox DewfordTown_PokemonCenter_1F_Text_1FC557, MSGBOX_NPC
 	end
 
 DewfordTown_PokemonCenter_1F_EventScript_1FC54E:: @ 81FC54E
-	msgbox DewfordTown_PokemonCenter_1F_Text_1FC5AE, 2
+	msgbox DewfordTown_PokemonCenter_1F_Text_1FC5AE, MSGBOX_NPC
 	end
 
 DewfordTown_PokemonCenter_1F_Text_1FC557: @ 81FC557

--- a/data/maps/EverGrandeCity/scripts.inc
+++ b/data/maps/EverGrandeCity/scripts.inc
@@ -8,15 +8,15 @@ EverGrandeCity_MapScript1_1E7D21: @ 81E7D21
 	end
 
 EverGrandeCity_EventScript_1E7D2B:: @ 81E7D2B
-	msgbox EverGrandeCity_Text_1E7D4F, 3
+	msgbox EverGrandeCity_Text_1E7D4F, MSGBOX_SIGN
 	end
 
 EverGrandeCity_EventScript_1E7D34:: @ 81E7D34
-	msgbox EverGrandeCity_Text_1E7D89, 3
+	msgbox EverGrandeCity_Text_1E7D89, MSGBOX_SIGN
 	end
 
 EverGrandeCity_EventScript_1E7D3D:: @ 81E7D3D
-	msgbox EverGrandeCity_Text_1E7D65, 3
+	msgbox EverGrandeCity_Text_1E7D65, MSGBOX_SIGN
 	end
 
 EverGrandeCity_EventScript_1E7D46:: @ 81E7D46

--- a/data/maps/EverGrandeCity_ChampionsRoom/scripts.inc
+++ b/data/maps/EverGrandeCity_ChampionsRoom/scripts.inc
@@ -39,7 +39,7 @@ EverGrandeCity_ChampionsRoom_Movement_228A42: @ 8228A42
 
 EverGrandeCity_ChampionsRoom_EventScript_228A45:: @ 8228A45
 	playbgm MUS_DAIGO, 0
-	msgbox EverGrandeCity_ChampionsRoom_Text_228C4C, 4
+	msgbox EverGrandeCity_ChampionsRoom_Text_228C4C, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_WALLACE, 0, EverGrandeCity_ChampionsRoom_Text_228EAC
 	goto EverGrandeCity_ChampionsRoom_EventScript_228A61
 	end
@@ -49,7 +49,7 @@ EverGrandeCity_ChampionsRoom_EventScript_228A61:: @ 8228A61
 	setmetatile 6, 1, 838, 0
 	setmetatile 6, 2, 839, 0
 	special DrawWholeMapView
-	msgbox EverGrandeCity_ChampionsRoom_Text_228F66, 4
+	msgbox EverGrandeCity_ChampionsRoom_Text_228F66, MSGBOX_DEFAULT
 	closemessage
 	playse SE_DOOR
 	checkplayergender
@@ -75,7 +75,7 @@ EverGrandeCity_ChampionsRoom_EventScript_228AC1:: @ 8228AC1
 	return
 
 EverGrandeCity_ChampionsRoom_EventScript_228AC6:: @ 8228AC6
-	msgbox EverGrandeCity_ChampionsRoom_Text_2290CA, 4
+	msgbox EverGrandeCity_ChampionsRoom_Text_2290CA, MSGBOX_DEFAULT
 	delay 40
 	playse SE_PIN
 	applymovement 2, EverGrandeCity_ChampionsRoom_Movement_272598
@@ -83,12 +83,12 @@ EverGrandeCity_ChampionsRoom_EventScript_228AC6:: @ 8228AC6
 	applymovement 2, EverGrandeCity_ChampionsRoom_Movement_27259A
 	waitmovement 0
 	call EverGrandeCity_ChampionsRoom_EventScript_228C12
-	msgbox EverGrandeCity_ChampionsRoom_Text_22910B, 4
+	msgbox EverGrandeCity_ChampionsRoom_Text_22910B, MSGBOX_DEFAULT
 	goto EverGrandeCity_ChampionsRoom_EventScript_228B30
 	end
 
 EverGrandeCity_ChampionsRoom_EventScript_228AFB:: @ 8228AFB
-	msgbox EverGrandeCity_ChampionsRoom_Text_229152, 4
+	msgbox EverGrandeCity_ChampionsRoom_Text_229152, MSGBOX_DEFAULT
 	delay 40
 	playse SE_PIN
 	applymovement 2, EverGrandeCity_ChampionsRoom_Movement_272598
@@ -96,7 +96,7 @@ EverGrandeCity_ChampionsRoom_EventScript_228AFB:: @ 8228AFB
 	applymovement 2, EverGrandeCity_ChampionsRoom_Movement_27259A
 	waitmovement 0
 	call EverGrandeCity_ChampionsRoom_EventScript_228C12
-	msgbox EverGrandeCity_ChampionsRoom_Text_2291A2, 4
+	msgbox EverGrandeCity_ChampionsRoom_Text_2291A2, MSGBOX_DEFAULT
 	goto EverGrandeCity_ChampionsRoom_EventScript_228B30
 	end
 
@@ -107,15 +107,15 @@ EverGrandeCity_ChampionsRoom_EventScript_228B30:: @ 8228B30
 	waitmovement 0
 	applymovement 255, EverGrandeCity_ChampionsRoom_Movement_2725A8
 	waitmovement 0
-	msgbox EverGrandeCity_ChampionsRoom_Text_2291E6, 4
+	msgbox EverGrandeCity_ChampionsRoom_Text_2291E6, MSGBOX_DEFAULT
 	call EverGrandeCity_ChampionsRoom_EventScript_272184
-	msgbox EverGrandeCity_ChampionsRoom_Text_22934D, 4
+	msgbox EverGrandeCity_ChampionsRoom_Text_22934D, MSGBOX_DEFAULT
 	applymovement 1, EverGrandeCity_ChampionsRoom_Movement_2725A6
 	waitmovement 0
 	delay 20
 	applymovement 1, EverGrandeCity_ChampionsRoom_Movement_2725AA
 	waitmovement 0
-	msgbox EverGrandeCity_ChampionsRoom_Text_229399, 4
+	msgbox EverGrandeCity_ChampionsRoom_Text_229399, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	applymovement 1, EverGrandeCity_ChampionsRoom_Movement_228C3B
@@ -126,7 +126,7 @@ EverGrandeCity_ChampionsRoom_EventScript_228B30:: @ 8228B30
 	delay 20
 	applymovement 255, EverGrandeCity_ChampionsRoom_Movement_2725AA
 	waitmovement 0
-	msgbox EverGrandeCity_ChampionsRoom_Text_2293EB, 4
+	msgbox EverGrandeCity_ChampionsRoom_Text_2293EB, MSGBOX_DEFAULT
 	checkplayergender
 	compare VAR_RESULT, 0
 	call_if 1, EverGrandeCity_ChampionsRoom_EventScript_228BEB
@@ -143,11 +143,11 @@ EverGrandeCity_ChampionsRoom_EventScript_228B30:: @ 8228B30
 	end
 
 EverGrandeCity_ChampionsRoom_EventScript_228BEB:: @ 8228BEB
-	msgbox EverGrandeCity_ChampionsRoom_Text_229479, 4
+	msgbox EverGrandeCity_ChampionsRoom_Text_229479, MSGBOX_DEFAULT
 	return
 
 EverGrandeCity_ChampionsRoom_EventScript_228BF4:: @ 8228BF4
-	msgbox EverGrandeCity_ChampionsRoom_Text_2294F5, 4
+	msgbox EverGrandeCity_ChampionsRoom_Text_2294F5, MSGBOX_DEFAULT
 	return
 
 EverGrandeCity_ChampionsRoom_EventScript_228BFD:: @ 8228BFD

--- a/data/maps/EverGrandeCity_DrakesRoom/scripts.inc
+++ b/data/maps/EverGrandeCity_DrakesRoom/scripts.inc
@@ -44,13 +44,13 @@ EverGrandeCity_DrakesRoom_EventScript_2286F3:: @ 82286F3
 	checkflag FLAG_0x4FE
 	goto_eq EverGrandeCity_DrakesRoom_EventScript_22871A
 	playbgm MUS_SITENNOU, 0
-	msgbox EverGrandeCity_DrakesRoom_Text_22873E, 4
+	msgbox EverGrandeCity_DrakesRoom_Text_22873E, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_DRAKE, 0, EverGrandeCity_DrakesRoom_Text_228895
 	goto EverGrandeCity_DrakesRoom_EventScript_228724
 	end
 
 EverGrandeCity_DrakesRoom_EventScript_22871A:: @ 822871A
-	msgbox EverGrandeCity_DrakesRoom_Text_2288B0, 4
+	msgbox EverGrandeCity_DrakesRoom_Text_2288B0, MSGBOX_DEFAULT
 	release
 	end
 
@@ -59,7 +59,7 @@ EverGrandeCity_DrakesRoom_EventScript_228724:: @ 8228724
 	special sub_813BF7C
 	setflag FLAG_0x4FE
 	call EverGrandeCity_DrakesRoom_EventScript_2723F8
-	msgbox EverGrandeCity_DrakesRoom_Text_2288B0, 4
+	msgbox EverGrandeCity_DrakesRoom_Text_2288B0, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/EverGrandeCity_GlaciasRoom/scripts.inc
+++ b/data/maps/EverGrandeCity_GlaciasRoom/scripts.inc
@@ -44,20 +44,20 @@ EverGrandeCity_GlaciasRoom_EventScript_228469:: @ 8228469
 	checkflag FLAG_0x4FD
 	goto_eq EverGrandeCity_GlaciasRoom_EventScript_228490
 	playbgm MUS_SITENNOU, 0
-	msgbox EverGrandeCity_GlaciasRoom_Text_2284AC, 4
+	msgbox EverGrandeCity_GlaciasRoom_Text_2284AC, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_GLACIA, 0, EverGrandeCity_GlaciasRoom_Text_2285B4
 	goto EverGrandeCity_GlaciasRoom_EventScript_22849A
 	end
 
 EverGrandeCity_GlaciasRoom_EventScript_228490:: @ 8228490
-	msgbox EverGrandeCity_GlaciasRoom_Text_228640, 4
+	msgbox EverGrandeCity_GlaciasRoom_Text_228640, MSGBOX_DEFAULT
 	release
 	end
 
 EverGrandeCity_GlaciasRoom_EventScript_22849A:: @ 822849A
 	setflag FLAG_0x4FD
 	call EverGrandeCity_GlaciasRoom_EventScript_2723F8
-	msgbox EverGrandeCity_GlaciasRoom_Text_228640, 4
+	msgbox EverGrandeCity_GlaciasRoom_Text_228640, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/EverGrandeCity_HallOfFame/scripts.inc
+++ b/data/maps/EverGrandeCity_HallOfFame/scripts.inc
@@ -23,7 +23,7 @@ EverGrandeCity_HallOfFame_EventScript_229850:: @ 8229850
 	applymovement 1, EverGrandeCity_HallOfFame_Movement_2725A8
 	applymovement 255, EverGrandeCity_HallOfFame_Movement_2725A4
 	waitmovement 0
-	msgbox EverGrandeCity_HallOfFame_Text_22990E, 4
+	msgbox EverGrandeCity_HallOfFame_Text_22990E, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, EverGrandeCity_HallOfFame_Movement_229908
 	applymovement 255, EverGrandeCity_HallOfFame_Movement_229908
@@ -32,7 +32,7 @@ EverGrandeCity_HallOfFame_EventScript_229850:: @ 8229850
 	applymovement 1, EverGrandeCity_HallOfFame_Movement_2725A8
 	applymovement 255, EverGrandeCity_HallOfFame_Movement_2725A4
 	waitmovement 0
-	msgbox EverGrandeCity_HallOfFame_Text_2299A3, 4
+	msgbox EverGrandeCity_HallOfFame_Text_2299A3, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, EverGrandeCity_HallOfFame_Movement_2725A6
 	applymovement 255, EverGrandeCity_HallOfFame_Movement_2725A6

--- a/data/maps/EverGrandeCity_PhoebesRoom/scripts.inc
+++ b/data/maps/EverGrandeCity_PhoebesRoom/scripts.inc
@@ -44,20 +44,20 @@ EverGrandeCity_PhoebesRoom_EventScript_2281CB:: @ 82281CB
 	checkflag FLAG_0x4FC
 	goto_eq EverGrandeCity_PhoebesRoom_EventScript_2281F2
 	playbgm MUS_SITENNOU, 0
-	msgbox EverGrandeCity_PhoebesRoom_Text_22820E, 4
+	msgbox EverGrandeCity_PhoebesRoom_Text_22820E, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_PHOEBE, 0, EverGrandeCity_PhoebesRoom_Text_228325
 	goto EverGrandeCity_PhoebesRoom_EventScript_2281FC
 	end
 
 EverGrandeCity_PhoebesRoom_EventScript_2281F2:: @ 82281F2
-	msgbox EverGrandeCity_PhoebesRoom_Text_228343, 4
+	msgbox EverGrandeCity_PhoebesRoom_Text_228343, MSGBOX_DEFAULT
 	release
 	end
 
 EverGrandeCity_PhoebesRoom_EventScript_2281FC:: @ 82281FC
 	setflag FLAG_0x4FC
 	call EverGrandeCity_PhoebesRoom_EventScript_2723F8
-	msgbox EverGrandeCity_PhoebesRoom_Text_228343, 4
+	msgbox EverGrandeCity_PhoebesRoom_Text_228343, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/EverGrandeCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/EverGrandeCity_PokemonCenter_1F/scripts.inc
@@ -24,17 +24,17 @@ EverGrandeCity_PokemonCenter_1F_EventScript_229A59:: @ 8229A59
 	end
 
 EverGrandeCity_PokemonCenter_1F_EventScript_229A67:: @ 8229A67
-	msgbox EverGrandeCity_PokemonCenter_1F_Text_229ADA, 2
+	msgbox EverGrandeCity_PokemonCenter_1F_Text_229ADA, MSGBOX_NPC
 	end
 
 EverGrandeCity_PokemonCenter_1F_EventScript_229A70:: @ 8229A70
-	msgbox EverGrandeCity_PokemonCenter_1F_Text_229B62, 2
+	msgbox EverGrandeCity_PokemonCenter_1F_Text_229B62, MSGBOX_NPC
 	end
 
 EverGrandeCity_PokemonCenter_1F_EventScript_229A79:: @ 8229A79
 	lock
 	faceplayer
-	msgbox EverGrandeCity_PokemonCenter_1F_Text_229BF1, 4
+	msgbox EverGrandeCity_PokemonCenter_1F_Text_229BF1, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_FACING, 2
 	call_if 1, EverGrandeCity_PokemonCenter_1F_EventScript_229AB6

--- a/data/maps/EverGrandeCity_PokemonLeague_1F/scripts.inc
+++ b/data/maps/EverGrandeCity_PokemonLeague_1F/scripts.inc
@@ -29,7 +29,7 @@ EverGrandeCity_PokemonLeague_1F_EventScript_22960A:: @ 822960A
 	message gUnknown_08272A21
 	waitmessage
 	pokemart EverGrandeCity_PokemonLeague_1F_Pokemart_229624
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -88,14 +88,14 @@ EverGrandeCity_PokemonLeague_1F_EventScript_2296A3:: @ 82296A3
 
 EverGrandeCity_PokemonLeague_1F_EventScript_2296AE:: @ 82296AE
 	playse SE_HAZURE
-	msgbox EverGrandeCity_PokemonLeague_1F_Text_229787, 4
+	msgbox EverGrandeCity_PokemonLeague_1F_Text_229787, MSGBOX_DEFAULT
 	releaseall
 	end
 
 EverGrandeCity_PokemonLeague_1F_EventScript_2296BB:: @ 82296BB
 	applymovement VAR_LAST_TALKED, EverGrandeCity_PokemonLeague_1F_Movement_27259E
 	waitmovement 0
-	msgbox EverGrandeCity_PokemonLeague_1F_Text_2297EF, 4
+	msgbox EverGrandeCity_PokemonLeague_1F_Text_2297EF, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, EverGrandeCity_PokemonLeague_1F_Movement_2725A2
 	waitmovement 0

--- a/data/maps/EverGrandeCity_SidneysRoom/scripts.inc
+++ b/data/maps/EverGrandeCity_SidneysRoom/scripts.inc
@@ -51,20 +51,20 @@ EverGrandeCity_SidneysRoom_EventScript_227F64:: @ 8227F64
 	checkflag FLAG_0x4FB
 	goto_eq EverGrandeCity_SidneysRoom_EventScript_227F8B
 	playbgm MUS_SITENNOU, 0
-	msgbox EverGrandeCity_SidneysRoom_Text_227FA7, 4
+	msgbox EverGrandeCity_SidneysRoom_Text_227FA7, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_SIDNEY, 0, EverGrandeCity_SidneysRoom_Text_2280A2
 	goto EverGrandeCity_SidneysRoom_EventScript_227F95
 	end
 
 EverGrandeCity_SidneysRoom_EventScript_227F8B:: @ 8227F8B
-	msgbox EverGrandeCity_SidneysRoom_Text_2280EC, 4
+	msgbox EverGrandeCity_SidneysRoom_Text_2280EC, MSGBOX_DEFAULT
 	release
 	end
 
 EverGrandeCity_SidneysRoom_EventScript_227F95:: @ 8227F95
 	setflag FLAG_0x4FB
 	call EverGrandeCity_SidneysRoom_EventScript_2723F8
-	msgbox EverGrandeCity_SidneysRoom_Text_2280EC, 4
+	msgbox EverGrandeCity_SidneysRoom_Text_2280EC, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/FallarborTown/scripts.inc
+++ b/data/maps/FallarborTown/scripts.inc
@@ -13,21 +13,21 @@ FallarborTown_EventScript_1EB20C:: @ 81EB20C
 	faceplayer
 	checkflag FLAG_0x08B
 	goto_eq FallarborTown_EventScript_1EB221
-	msgbox FallarborTown_Text_1EB26B, 4
+	msgbox FallarborTown_Text_1EB26B, MSGBOX_DEFAULT
 	release
 	end
 
 FallarborTown_EventScript_1EB221:: @ 81EB221
-	msgbox FallarborTown_Text_1EB2DE, 4
+	msgbox FallarborTown_Text_1EB2DE, MSGBOX_DEFAULT
 	release
 	end
 
 FallarborTown_EventScript_1EB22B:: @ 81EB22B
-	msgbox FallarborTown_Text_1EB35F, 2
+	msgbox FallarborTown_Text_1EB35F, MSGBOX_NPC
 	end
 
 FallarborTown_EventScript_1EB234:: @ 81EB234
-	msgbox FallarborTown_Text_1EB3CA, 2
+	msgbox FallarborTown_Text_1EB3CA, MSGBOX_NPC
 	end
 
 FallarborTown_EventScript_1EB23D:: @ 81EB23D
@@ -35,21 +35,21 @@ FallarborTown_EventScript_1EB23D:: @ 81EB23D
 	faceplayer
 	waitse
 	playmoncry SPECIES_AZURILL, 0
-	msgbox FallarborTown_Text_1EB3B5, 4
+	msgbox FallarborTown_Text_1EB3B5, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
 
 FallarborTown_EventScript_1EB250:: @ 81EB250
-	msgbox FallarborTown_Text_1EB4C2, 3
+	msgbox FallarborTown_Text_1EB4C2, MSGBOX_SIGN
 	end
 
 FallarborTown_EventScript_1EB259:: @ 81EB259
-	msgbox FallarborTown_Text_1EB4FE, 3
+	msgbox FallarborTown_Text_1EB4FE, MSGBOX_SIGN
 	end
 
 FallarborTown_EventScript_1EB262:: @ 81EB262
-	msgbox FallarborTown_Text_1EB534, 3
+	msgbox FallarborTown_Text_1EB534, MSGBOX_SIGN
 	end
 
 FallarborTown_Text_1EB26B: @ 81EB26B

--- a/data/maps/FallarborTown_BattleTentBattleRoom/scripts.inc
+++ b/data/maps/FallarborTown_BattleTentBattleRoom/scripts.inc
@@ -51,10 +51,10 @@ FallarborTown_BattleTentBattleRoom_EventScript_20090F:: @ 820090F
 	playse SE_W187
 	waitse
 	waitmovement 0
-	msgbox FallarborTown_BattleTentBattleRoom_Text_257C93, 4
+	msgbox FallarborTown_BattleTentBattleRoom_Text_257C93, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 4
 	special sub_81B99B4
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	waitmessage
 	call FallarborTown_BattleTentBattleRoom_EventScript_257B6C
 	switch VAR_RESULT
@@ -65,7 +65,7 @@ FallarborTown_BattleTentBattleRoom_EventScript_20090F:: @ 820090F
 	waitmovement 0
 	setvar VAR_0x8004, 6
 	special sub_81B9B80
-	msgbox FallarborTown_BattleTentBattleRoom_Text_257CCE, 4
+	msgbox FallarborTown_BattleTentBattleRoom_Text_257CCE, MSGBOX_DEFAULT
 
 FallarborTown_BattleTentBattleRoom_EventScript_20097E:: @ 820097E
 	setvar VAR_0x8004, 2
@@ -81,7 +81,7 @@ FallarborTown_BattleTentBattleRoom_EventScript_20099C:: @ 820099C
 	playse SE_BAN
 	waitse
 	waitmovement 0
-	msgbox FallarborTown_BattleTentBattleRoom_Text_257CB3, 4
+	msgbox FallarborTown_BattleTentBattleRoom_Text_257CB3, MSGBOX_DEFAULT
 	closemessage
 
 FallarborTown_BattleTentBattleRoom_EventScript_2009B3:: @ 82009B3
@@ -102,7 +102,7 @@ FallarborTown_BattleTentBattleRoom_EventScript_2009B3:: @ 82009B3
 	waitmovement 0
 	applymovement 1, FallarborTown_BattleTentBattleRoom_Movement_200B94
 	waitmovement 0
-	msgbox FallarborTown_BattleTentBattleRoom_Text_257CE9, 4
+	msgbox FallarborTown_BattleTentBattleRoom_Text_257CE9, MSGBOX_DEFAULT
 	special LoadPlayerParty
 	special SavePlayerParty
 	setvar VAR_0x8004, 3
@@ -127,7 +127,7 @@ FallarborTown_BattleTentBattleRoom_EventScript_200A2A:: @ 8200A2A
 	case 2, FallarborTown_BattleTentBattleRoom_EventScript_200AA6
 
 FallarborTown_BattleTentBattleRoom_EventScript_200A78:: @ 8200A78
-	msgbox FallarborTown_BattleTentBattleRoom_Text_257E6B, 5
+	msgbox FallarborTown_BattleTentBattleRoom_Text_257E6B, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, FallarborTown_BattleTentBattleRoom_EventScript_200A2A
 	case 1, FallarborTown_BattleTentBattleRoom_EventScript_200B51

--- a/data/maps/FallarborTown_BattleTentLobby/scripts.inc
+++ b/data/maps/FallarborTown_BattleTentLobby/scripts.inc
@@ -27,7 +27,7 @@ FallarborTown_BattleTentLobby_EventScript_1FFEAF:: @ 81FFEAF
 
 FallarborTown_BattleTentLobby_EventScript_1FFEB8:: @ 81FFEB8
 	lockall
-	msgbox FallarborTown_BattleTentLobby_Text_2C4DED, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C4DED, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 0
@@ -43,7 +43,7 @@ FallarborTown_BattleTentLobby_EventScript_1FFEB8:: @ 81FFEB8
 
 FallarborTown_BattleTentLobby_EventScript_1FFEED:: @ 81FFEED
 	lockall
-	msgbox FallarborTown_BattleTentLobby_Text_2C4EC3, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C4EC3, MSGBOX_DEFAULT
 	message FallarborTown_BattleTentLobby_Text_2C4EFF
 	waitmessage
 	setvar VAR_0x8004, 4
@@ -59,7 +59,7 @@ FallarborTown_BattleTentLobby_EventScript_1FFEED:: @ 81FFEED
 	waitse
 
 FallarborTown_BattleTentLobby_EventScript_1FFF27:: @ 81FFF27
-	msgbox FallarborTown_BattleTentLobby_Text_2C4F22, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C4F22, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 5
 	special sub_81B9B80
 	switch VAR_RESULT
@@ -72,14 +72,14 @@ FallarborTown_BattleTentLobby_EventScript_1FFF27:: @ 81FFF27
 	waitmessage
 	playfanfare MUS_FANFA4
 	waitfanfare
-	msgbox FallarborTown_BattleTentLobby_Text_2C501F, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C501F, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
 	end
 
 FallarborTown_BattleTentLobby_EventScript_1FFF73:: @ 81FFF73
-	msgbox FallarborTown_BattleTentLobby_Text_2C4F83, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C4F83, MSGBOX_DEFAULT
 	waitmessage
 	closemessage
 	setvar VAR_TEMP_0, 255
@@ -88,7 +88,7 @@ FallarborTown_BattleTentLobby_EventScript_1FFF73:: @ 81FFF73
 
 FallarborTown_BattleTentLobby_EventScript_1FFF84:: @ 81FFF84
 	lockall
-	msgbox FallarborTown_BattleTentLobby_Text_2C4EC3, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C4EC3, MSGBOX_DEFAULT
 	goto FallarborTown_BattleTentLobby_EventScript_1FFF27
 	end
 
@@ -105,7 +105,7 @@ FallarborTown_BattleTentLobby_EventScript_1FFF93:: @ 81FFF93
 	special sub_81B9B80
 	playse SE_SAVE
 	waitse
-	msgbox FallarborTown_BattleTentLobby_Text_2C501F, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C501F, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
@@ -135,7 +135,7 @@ FallarborTown_BattleTentLobby_EventScript_200001:: @ 8200001
 	compare VAR_RESULT, 0
 	goto_if 5, FallarborTown_BattleTentLobby_EventScript_1FFF84
 	special SavePlayerParty
-	msgbox FallarborTown_BattleTentLobby_Text_2C47EB, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C47EB, MSGBOX_DEFAULT
 
 FallarborTown_BattleTentLobby_EventScript_200021:: @ 8200021
 	message FallarborTown_BattleTentLobby_Text_2C4843
@@ -159,7 +159,7 @@ FallarborTown_BattleTentLobby_EventScript_20005D:: @ 820005D
 	setvar VAR_0x8005, 1
 	setvar VAR_0x8006, 2
 	special CallFrontierUtilFunc
-	msgbox FallarborTown_BattleTentLobby_Text_2C4BC8, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C4BC8, MSGBOX_DEFAULT
 	fadescreen 1
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 3
@@ -167,7 +167,7 @@ FallarborTown_BattleTentLobby_EventScript_20005D:: @ 820005D
 	waitstate
 	compare VAR_RESULT, 0
 	goto_eq FallarborTown_BattleTentLobby_EventScript_2001C2
-	msgbox FallarborTown_BattleTentLobby_Text_2C4B35, 5
+	msgbox FallarborTown_BattleTentLobby_Text_2C4B35, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, FallarborTown_BattleTentLobby_EventScript_2001C2
 	case 1, FallarborTown_BattleTentLobby_EventScript_2000E2
@@ -201,7 +201,7 @@ FallarborTown_BattleTentLobby_EventScript_20013C:: @ 820013C
 	setvar VAR_0x8004, 3
 	setvar VAR_0x8005, 3
 	special CallFrontierUtilFunc
-	msgbox FallarborTown_BattleTentLobby_Text_2C4DC3, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C4DC3, MSGBOX_DEFAULT
 	closemessage
 	call FallarborTown_BattleTentLobby_EventScript_2001CF
 	warp MAP_FALLARBOR_TOWN_BATTLE_TENT_CORRIDOR, 255, 2, 7
@@ -210,7 +210,7 @@ FallarborTown_BattleTentLobby_EventScript_20013C:: @ 820013C
 	end
 
 FallarborTown_BattleTentLobby_EventScript_200169:: @ 8200169
-	msgbox FallarborTown_BattleTentLobby_Text_2C48AC, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C48AC, MSGBOX_DEFAULT
 	goto FallarborTown_BattleTentLobby_EventScript_200021
 
 FallarborTown_BattleTentLobby_EventScript_200176:: @ 8200176
@@ -219,11 +219,11 @@ FallarborTown_BattleTentLobby_EventScript_200176:: @ 8200176
 	case 1, FallarborTown_BattleTentLobby_EventScript_20019E
 
 FallarborTown_BattleTentLobby_EventScript_200191:: @ 8200191
-	msgbox FallarborTown_BattleTentLobby_Text_2C4BFA, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C4BFA, MSGBOX_DEFAULT
 	goto FallarborTown_BattleTentLobby_EventScript_2001CD
 
 FallarborTown_BattleTentLobby_EventScript_20019E:: @ 820019E
-	msgbox FallarborTown_BattleTentLobby_Text_2C4CC0, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C4CC0, MSGBOX_DEFAULT
 	goto FallarborTown_BattleTentLobby_EventScript_2001CD
 
 FallarborTown_BattleTentLobby_EventScript_2001AB:: @ 82001AB
@@ -237,7 +237,7 @@ FallarborTown_BattleTentLobby_EventScript_2001C2:: @ 82001C2
 	special LoadPlayerParty
 
 FallarborTown_BattleTentLobby_EventScript_2001C5:: @ 82001C5
-	msgbox FallarborTown_BattleTentLobby_Text_2C487F, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C487F, MSGBOX_DEFAULT
 
 FallarborTown_BattleTentLobby_EventScript_2001CD:: @ 82001CD
 	release
@@ -280,15 +280,15 @@ FallarborTown_BattleTentLobby_Movement_200209: @ 8200209
 	step_end
 
 FallarborTown_BattleTentLobby_EventScript_20020D:: @ 820020D
-	msgbox FallarborTown_BattleTentLobby_Text_20045A, 2
+	msgbox FallarborTown_BattleTentLobby_Text_20045A, MSGBOX_NPC
 	end
 
 FallarborTown_BattleTentLobby_EventScript_200216:: @ 8200216
-	msgbox FallarborTown_BattleTentLobby_Text_200304, 2
+	msgbox FallarborTown_BattleTentLobby_Text_200304, MSGBOX_NPC
 	end
 
 FallarborTown_BattleTentLobby_EventScript_20021F:: @ 820021F
-	msgbox FallarborTown_BattleTentLobby_Text_200382, 2
+	msgbox FallarborTown_BattleTentLobby_Text_200382, MSGBOX_NPC
 	end
 
 FallarborTown_BattleTentLobby_EventScript_200228:: @ 8200228
@@ -296,20 +296,20 @@ FallarborTown_BattleTentLobby_EventScript_200228:: @ 8200228
 	faceplayer
 	checkflag FLAG_0x1CD
 	goto_eq FallarborTown_BattleTentLobby_EventScript_200245
-	msgbox FallarborTown_BattleTentLobby_Text_200501, 4
+	msgbox FallarborTown_BattleTentLobby_Text_200501, MSGBOX_DEFAULT
 	addvar VAR_0x40D1, 1
 	setflag FLAG_0x1CD
 	release
 	end
 
 FallarborTown_BattleTentLobby_EventScript_200245:: @ 8200245
-	msgbox FallarborTown_BattleTentLobby_Text_200653, 4
+	msgbox FallarborTown_BattleTentLobby_Text_200653, MSGBOX_DEFAULT
 	release
 	end
 
 FallarborTown_BattleTentLobby_EventScript_20024F:: @ 820024F
 	lockall
-	msgbox FallarborTown_BattleTentLobby_Text_256DB8, 4
+	msgbox FallarborTown_BattleTentLobby_Text_256DB8, MSGBOX_DEFAULT
 	goto FallarborTown_BattleTentLobby_EventScript_20025E
 	end
 
@@ -328,27 +328,27 @@ FallarborTown_BattleTentLobby_EventScript_20025E:: @ 820025E
 	end
 
 FallarborTown_BattleTentLobby_EventScript_2002BC:: @ 82002BC
-	msgbox FallarborTown_BattleTentLobby_Text_2C67CD, 4
+	msgbox FallarborTown_BattleTentLobby_Text_2C67CD, MSGBOX_DEFAULT
 	goto FallarborTown_BattleTentLobby_EventScript_20025E
 	end
 
 FallarborTown_BattleTentLobby_EventScript_2002CA:: @ 82002CA
-	msgbox FallarborTown_BattleTentLobby_Text_256E02, 4
+	msgbox FallarborTown_BattleTentLobby_Text_256E02, MSGBOX_DEFAULT
 	goto FallarborTown_BattleTentLobby_EventScript_20025E
 	end
 
 FallarborTown_BattleTentLobby_EventScript_2002D8:: @ 82002D8
-	msgbox FallarborTown_BattleTentLobby_Text_256F43, 4
+	msgbox FallarborTown_BattleTentLobby_Text_256F43, MSGBOX_DEFAULT
 	goto FallarborTown_BattleTentLobby_EventScript_20025E
 	end
 
 FallarborTown_BattleTentLobby_EventScript_2002E6:: @ 82002E6
-	msgbox FallarborTown_BattleTentLobby_Text_256FF2, 4
+	msgbox FallarborTown_BattleTentLobby_Text_256FF2, MSGBOX_DEFAULT
 	goto FallarborTown_BattleTentLobby_EventScript_20025E
 	end
 
 FallarborTown_BattleTentLobby_EventScript_2002F4:: @ 82002F4
-	msgbox FallarborTown_BattleTentLobby_Text_257202, 4
+	msgbox FallarborTown_BattleTentLobby_Text_257202, MSGBOX_DEFAULT
 	goto FallarborTown_BattleTentLobby_EventScript_20025E
 	end
 

--- a/data/maps/FallarborTown_House1/scripts.inc
+++ b/data/maps/FallarborTown_House1/scripts.inc
@@ -9,7 +9,7 @@ FallarborTown_House1_EventScript_200F13:: @ 8200F13
 	checkitem ITEM_METEORITE, 1
 	compare VAR_RESULT, 1
 	goto_eq FallarborTown_House1_EventScript_200F38
-	msgbox FallarborTown_House1_Text_200FEE, 4
+	msgbox FallarborTown_House1_Text_200FEE, MSGBOX_DEFAULT
 	release
 	end
 
@@ -20,34 +20,34 @@ FallarborTown_House1_EventScript_200F38:: @ 8200F38
 	call_if 1, FallarborTown_House1_EventScript_200F9C
 	compare VAR_RESULT, 0
 	goto_eq FallarborTown_House1_EventScript_200FA5
-	msgbox FallarborTown_House1_Text_201159, 4
+	msgbox FallarborTown_House1_Text_201159, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM27
 	compare VAR_RESULT, 0
 	goto_eq FallarborTown_House1_EventScript_272054
 	setvar VAR_0x8004, 280
 	call FallarborTown_House1_EventScript_2723E4
 	setflag FLAG_0x0E5
-	msgbox FallarborTown_House1_Text_2011A5, 4
+	msgbox FallarborTown_House1_Text_2011A5, MSGBOX_DEFAULT
 	release
 	end
 
 FallarborTown_House1_EventScript_200F8B:: @ 8200F8B
-	msgbox FallarborTown_House1_Text_200FEE, 4
-	msgbox FallarborTown_House1_Text_2010A2, 5
+	msgbox FallarborTown_House1_Text_200FEE, MSGBOX_DEFAULT
+	msgbox FallarborTown_House1_Text_2010A2, MSGBOX_YESNO
 	return
 
 FallarborTown_House1_EventScript_200F9C:: @ 8200F9C
-	msgbox FallarborTown_House1_Text_201249, 5
+	msgbox FallarborTown_House1_Text_201249, MSGBOX_YESNO
 	return
 
 FallarborTown_House1_EventScript_200FA5:: @ 8200FA5
 	setflag FLAG_TEMP_2
-	msgbox FallarborTown_House1_Text_201212, 4
+	msgbox FallarborTown_House1_Text_201212, MSGBOX_DEFAULT
 	release
 	end
 
 FallarborTown_House1_EventScript_200FB2:: @ 8200FB2
-	msgbox FallarborTown_House1_Text_2011A5, 4
+	msgbox FallarborTown_House1_Text_2011A5, MSGBOX_DEFAULT
 	release
 	end
 
@@ -58,17 +58,17 @@ FallarborTown_House1_EventScript_200FBC:: @ 8200FBC
 	goto_eq FallarborTown_House1_EventScript_200FE4
 	checkflag FLAG_0x08B
 	goto_eq FallarborTown_House1_EventScript_200FDA
-	msgbox FallarborTown_House1_Text_2012BC, 4
+	msgbox FallarborTown_House1_Text_2012BC, MSGBOX_DEFAULT
 	release
 	end
 
 FallarborTown_House1_EventScript_200FDA:: @ 8200FDA
-	msgbox FallarborTown_House1_Text_201310, 4
+	msgbox FallarborTown_House1_Text_201310, MSGBOX_DEFAULT
 	release
 	end
 
 FallarborTown_House1_EventScript_200FE4:: @ 8200FE4
-	msgbox FallarborTown_House1_Text_20134B, 4
+	msgbox FallarborTown_House1_Text_20134B, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/FallarborTown_House2/scripts.inc
+++ b/data/maps/FallarborTown_House2/scripts.inc
@@ -7,7 +7,7 @@ FallarborTown_House2_EventScript_201383:: @ 8201383
 	waitmovement 0
 	checkflag FLAG_TEMP_1
 	goto_eq FallarborTown_House2_EventScript_2013A8
-	msgbox FallarborTown_House2_Text_20145C, 4
+	msgbox FallarborTown_House2_Text_20145C, MSGBOX_DEFAULT
 	setflag FLAG_TEMP_1
 	goto FallarborTown_House2_EventScript_2013A8
 	end
@@ -16,14 +16,14 @@ FallarborTown_House2_EventScript_2013A8:: @ 82013A8
 	checkitem ITEM_HEART_SCALE, 1
 	compare VAR_RESULT, 0
 	goto_eq FallarborTown_House2_EventScript_201452
-	msgbox FallarborTown_House2_Text_201541, 5
+	msgbox FallarborTown_House2_Text_201541, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, FallarborTown_House2_EventScript_201452
 	goto FallarborTown_House2_EventScript_2013D6
 	end
 
 FallarborTown_House2_EventScript_2013D6:: @ 82013D6
-	msgbox FallarborTown_House2_Text_2015A5, 4
+	msgbox FallarborTown_House2_Text_2015A5, MSGBOX_DEFAULT
 	special sub_81B951C
 	waitstate
 	compare VAR_0x8004, 255
@@ -37,28 +37,28 @@ FallarborTown_House2_EventScript_2013D6:: @ 82013D6
 	end
 
 FallarborTown_House2_EventScript_20140C:: @ 820140C
-	msgbox FallarborTown_House2_Text_2015C3, 4
+	msgbox FallarborTown_House2_Text_2015C3, MSGBOX_DEFAULT
 	special TeachMoveTutorMove
 	waitstate
 	compare VAR_0x8004, 0
 	goto_eq FallarborTown_House2_EventScript_2013D6
-	msgbox FallarborTown_House2_Text_201627, 4
+	msgbox FallarborTown_House2_Text_201627, MSGBOX_DEFAULT
 	takeitem ITEM_HEART_SCALE, 1
 	goto FallarborTown_House2_EventScript_201452
 	end
 
 FallarborTown_House2_EventScript_201436:: @ 8201436
-	msgbox FallarborTown_House2_Text_2015DE, 4
+	msgbox FallarborTown_House2_Text_2015DE, MSGBOX_DEFAULT
 	goto FallarborTown_House2_EventScript_2013D6
 	end
 
 FallarborTown_House2_EventScript_201444:: @ 8201444
-	msgbox FallarborTown_House2_Text_201697, 4
+	msgbox FallarborTown_House2_Text_201697, MSGBOX_DEFAULT
 	goto FallarborTown_House2_EventScript_2013D6
 	end
 
 FallarborTown_House2_EventScript_201452:: @ 8201452
-	msgbox FallarborTown_House2_Text_201653, 4
+	msgbox FallarborTown_House2_Text_201653, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/FallarborTown_Mart/scripts.inc
+++ b/data/maps/FallarborTown_Mart/scripts.inc
@@ -7,7 +7,7 @@ FallarborTown_Mart_EventScript_1FFCBF:: @ 81FFCBF
 	message gUnknown_08272A21
 	waitmessage
 	pokemart FallarborTown_Mart_Pokemart_1FFCD8
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -30,11 +30,11 @@ FallarborTown_Mart_Pokemart_1FFCD8: @ 81FFCD8
 	end
 
 FallarborTown_Mart_EventScript_1FFCF4:: @ 81FFCF4
-	msgbox FallarborTown_Mart_Text_1FFD19, 2
+	msgbox FallarborTown_Mart_Text_1FFD19, MSGBOX_NPC
 	end
 
 FallarborTown_Mart_EventScript_1FFCFD:: @ 81FFCFD
-	msgbox FallarborTown_Mart_Text_1FFE09, 2
+	msgbox FallarborTown_Mart_Text_1FFE09, MSGBOX_NPC
 	end
 
 FallarborTown_Mart_EventScript_1FFD06:: @ 81FFD06
@@ -42,7 +42,7 @@ FallarborTown_Mart_EventScript_1FFD06:: @ 81FFD06
 	faceplayer
 	waitse
 	playmoncry SPECIES_SKITTY, 0
-	msgbox FallarborTown_Mart_Text_1FFDFA, 4
+	msgbox FallarborTown_Mart_Text_1FFDFA, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/FallarborTown_PokemonCenter_1F/scripts.inc
+++ b/data/maps/FallarborTown_PokemonCenter_1F/scripts.inc
@@ -17,17 +17,17 @@ FallarborTown_PokemonCenter_1F_EventScript_200BE1:: @ 8200BE1
 	end
 
 FallarborTown_PokemonCenter_1F_EventScript_200BEF:: @ 8200BEF
-	msgbox FallarborTown_PokemonCenter_1F_Text_200E22, 2
+	msgbox FallarborTown_PokemonCenter_1F_Text_200E22, MSGBOX_NPC
 	end
 
 FallarborTown_PokemonCenter_1F_EventScript_200BF8:: @ 8200BF8
-	msgbox FallarborTown_PokemonCenter_1F_Text_200E8B, 2
+	msgbox FallarborTown_PokemonCenter_1F_Text_200E8B, MSGBOX_NPC
 	end
 
 FallarborTown_PokemonCenter_1F_EventScript_200C01:: @ 8200C01
 	lock
 	faceplayer
-	msgbox FallarborTown_PokemonCenter_1F_Text_200C6B, 4
+	msgbox FallarborTown_PokemonCenter_1F_Text_200C6B, MSGBOX_DEFAULT
 	closemessage
 	switch VAR_FACING
 	case 2, FallarborTown_PokemonCenter_1F_EventScript_200C28

--- a/data/maps/FarawayIsland_Entrance/scripts.inc
+++ b/data/maps/FarawayIsland_Entrance/scripts.inc
@@ -19,10 +19,10 @@ FarawayIsland_Entrance_EventScript_267C9D:: @ 8267C9D
 FarawayIsland_Entrance_EventScript_267CA2:: @ 8267CA2
 	lock
 	faceplayer
-	msgbox FarawayIsland_Entrance_Text_2C6B42, 5
+	msgbox FarawayIsland_Entrance_Text_2C6B42, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq FarawayIsland_Entrance_EventScript_267CE7
-	msgbox FarawayIsland_Entrance_Text_2A6A5D, 4
+	msgbox FarawayIsland_Entrance_Text_2A6A5D, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, FarawayIsland_Entrance_Movement_2725AA
 	waitmovement 0
@@ -36,11 +36,11 @@ FarawayIsland_Entrance_EventScript_267CA2:: @ 8267CA2
 	end
 
 FarawayIsland_Entrance_EventScript_267CE7:: @ 8267CE7
-	msgbox FarawayIsland_Entrance_Text_2A6A82, 4
+	msgbox FarawayIsland_Entrance_Text_2A6A82, MSGBOX_DEFAULT
 	release
 	end
 
 FarawayIsland_Entrance_EventScript_267CF1:: @ 8267CF1
-	msgbox FarawayIsland_Entrance_Text_2C6D5A, 3
+	msgbox FarawayIsland_Entrance_Text_2C6D5A, MSGBOX_SIGN
 	end
 

--- a/data/maps/FarawayIsland_Interior/scripts.inc
+++ b/data/maps/FarawayIsland_Interior/scripts.inc
@@ -198,7 +198,7 @@ FarawayIsland_Interior_EventScript_267EDB:: @ 8267EDB
 	setflag FLAG_HIDE_MEW
 	removeobject 1
 	fadescreenswapbuffers 0
-	msgbox FarawayIsland_Interior_Text_267EF1, 4
+	msgbox FarawayIsland_Interior_Text_267EF1, MSGBOX_DEFAULT
 	closemessage
 	releaseall
 	end

--- a/data/maps/FortreeCity/scripts.inc
+++ b/data/maps/FortreeCity/scripts.inc
@@ -12,7 +12,7 @@ FortreeCity_MapScript1_1E25B3: @ 81E25B3
 	end
 
 FortreeCity_EventScript_1E25B6:: @ 81E25B6
-	msgbox FortreeCity_Text_1E2676, 2
+	msgbox FortreeCity_Text_1E2676, MSGBOX_NPC
 	end
 
 FortreeCity_EventScript_1E25BF:: @ 81E25BF
@@ -20,37 +20,37 @@ FortreeCity_EventScript_1E25BF:: @ 81E25BF
 	faceplayer
 	checkflag FLAG_0x127
 	goto_eq FortreeCity_EventScript_1E25D4
-	msgbox FortreeCity_Text_1E2738, 4
+	msgbox FortreeCity_Text_1E2738, MSGBOX_DEFAULT
 	release
 	end
 
 FortreeCity_EventScript_1E25D4:: @ 81E25D4
-	msgbox FortreeCity_Text_1E27B6, 4
+	msgbox FortreeCity_Text_1E27B6, MSGBOX_DEFAULT
 	release
 	end
 
 FortreeCity_EventScript_1E25DE:: @ 81E25DE
-	msgbox FortreeCity_Text_1E27FE, 2
+	msgbox FortreeCity_Text_1E27FE, MSGBOX_NPC
 	end
 
 FortreeCity_EventScript_1E25E7:: @ 81E25E7
-	msgbox FortreeCity_Text_1E2880, 2
+	msgbox FortreeCity_Text_1E2880, MSGBOX_NPC
 	end
 
 FortreeCity_EventScript_1E25F0:: @ 81E25F0
-	msgbox FortreeCity_Text_1E292E, 2
+	msgbox FortreeCity_Text_1E292E, MSGBOX_NPC
 	end
 
 FortreeCity_EventScript_1E25F9:: @ 81E25F9
-	msgbox FortreeCity_Text_1E299D, 2
+	msgbox FortreeCity_Text_1E299D, MSGBOX_NPC
 	end
 
 FortreeCity_EventScript_1E2602:: @ 81E2602
-	msgbox FortreeCity_Text_1E2AAC, 3
+	msgbox FortreeCity_Text_1E2AAC, MSGBOX_SIGN
 	end
 
 FortreeCity_EventScript_1E260B:: @ 81E260B
-	msgbox FortreeCity_Text_1E2AE6, 3
+	msgbox FortreeCity_Text_1E2AE6, MSGBOX_SIGN
 	end
 
 FortreeCity_EventScript_1E2614:: @ 81E2614
@@ -59,19 +59,19 @@ FortreeCity_EventScript_1E2614:: @ 81E2614
 	checkitem ITEM_DEVON_SCOPE, 1
 	compare VAR_RESULT, 1
 	goto_eq FortreeCity_EventScript_1E2630
-	msgbox FortreeCity_Text_1E29E5, 4
+	msgbox FortreeCity_Text_1E29E5, MSGBOX_DEFAULT
 	release
 	end
 
 FortreeCity_EventScript_1E2630:: @ 81E2630
-	msgbox FortreeCity_Text_1E2A08, 5
+	msgbox FortreeCity_Text_1E2A08, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq FortreeCity_EventScript_1E2645
 	release
 	end
 
 FortreeCity_EventScript_1E2645:: @ 81E2645
-	msgbox FortreeCity_Text_1E2A48, 4
+	msgbox FortreeCity_Text_1E2A48, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, FortreeCity_Movement_2723C7
 	waitmovement 0

--- a/data/maps/FortreeCity_DecorationShop/scripts.inc
+++ b/data/maps/FortreeCity_DecorationShop/scripts.inc
@@ -2,11 +2,11 @@ FortreeCity_DecorationShop_MapScripts:: @ 821800D
 	.byte 0
 
 FortreeCity_DecorationShop_EventScript_21800E:: @ 821800E
-	msgbox FortreeCity_DecorationShop_Text_218078, 2
+	msgbox FortreeCity_DecorationShop_Text_218078, MSGBOX_NPC
 	end
 
 FortreeCity_DecorationShop_EventScript_218017:: @ 8218017
-	msgbox FortreeCity_DecorationShop_Text_2180ED, 2
+	msgbox FortreeCity_DecorationShop_Text_2180ED, MSGBOX_NPC
 	end
 
 FortreeCity_DecorationShop_EventScript_218020:: @ 8218020
@@ -15,7 +15,7 @@ FortreeCity_DecorationShop_EventScript_218020:: @ 8218020
 	message gUnknown_08272A21
 	waitmessage
 	pokemartdecoration FortreeCity_DecorationShop_PokemartDecor_218038
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -39,7 +39,7 @@ FortreeCity_DecorationShop_EventScript_21804C:: @ 821804C
 	message gUnknown_08272A21
 	waitmessage
 	pokemartdecoration FortreeCity_DecorationShop_PokemartDecor_218064
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/FortreeCity_Gym/scripts.inc
+++ b/data/maps/FortreeCity_Gym/scripts.inc
@@ -22,7 +22,7 @@ FortreeCity_Gym_EventScript_2165C8:: @ 82165C8
 	goto_eq FortreeCity_Gym_EventScript_21668D
 	checkflag FLAG_0x0AA
 	goto_if 0, FortreeCity_Gym_EventScript_216646
-	msgbox FortreeCity_Gym_Text_217071, 4
+	msgbox FortreeCity_Gym_Text_217071, MSGBOX_DEFAULT
 	release
 	end
 
@@ -30,7 +30,7 @@ FortreeCity_Gym_EventScript_2165FD:: @ 82165FD
 	message FortreeCity_Gym_Text_216EEC
 	waitmessage
 	call FortreeCity_Gym_EventScript_27207E
-	msgbox FortreeCity_Gym_Text_216F17, 4
+	msgbox FortreeCity_Gym_Text_216F17, MSGBOX_DEFAULT
 	setflag FLAG_0x4F5
 	setflag FLAG_BADGE06_GET
 	setvar VAR_0x8008, 6
@@ -39,7 +39,7 @@ FortreeCity_Gym_EventScript_2165FD:: @ 82165FD
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox FortreeCity_Gym_Text_217044, 4
+	msgbox FortreeCity_Gym_Text_217044, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
@@ -53,7 +53,7 @@ FortreeCity_Gym_EventScript_216646:: @ 8216646
 	giveitem_std ITEM_TM40
 	compare VAR_RESULT, 0
 	goto_eq FortreeCity_Gym_EventScript_272054
-	msgbox FortreeCity_Gym_Text_216FEC, 4
+	msgbox FortreeCity_Gym_Text_216FEC, MSGBOX_DEFAULT
 	setflag FLAG_0x0AA
 	release
 	end
@@ -62,43 +62,43 @@ FortreeCity_Gym_EventScript_21666A:: @ 821666A
 	giveitem_std ITEM_TM40
 	compare VAR_RESULT, 0
 	goto_eq FortreeCity_Gym_EventScript_27205E
-	msgbox FortreeCity_Gym_Text_216FEC, 4
+	msgbox FortreeCity_Gym_Text_216FEC, MSGBOX_DEFAULT
 	setflag FLAG_0x0AA
 	return
 
 FortreeCity_Gym_EventScript_21668D:: @ 821668D
 	trainerbattle 7, TRAINER_WINONA_1, 0, FortreeCity_Gym_Text_217100, FortreeCity_Gym_Text_2171E6, FortreeCity_Gym_Text_217292
-	msgbox FortreeCity_Gym_Text_21720B, 6
+	msgbox FortreeCity_Gym_Text_21720B, MSGBOX_AUTOCLOSE
 	end
 
 FortreeCity_Gym_EventScript_2166A8:: @ 82166A8
 	trainerbattle 0, TRAINER_JARED, 0, FortreeCity_Gym_Text_2168A2, FortreeCity_Gym_Text_2168D3
-	msgbox FortreeCity_Gym_Text_2168E7, 6
+	msgbox FortreeCity_Gym_Text_2168E7, MSGBOX_AUTOCLOSE
 	end
 
 FortreeCity_Gym_EventScript_2166BF:: @ 82166BF
 	trainerbattle 0, TRAINER_EDWARDO, 0, FortreeCity_Gym_Text_21695A, FortreeCity_Gym_Text_2169C7
-	msgbox FortreeCity_Gym_Text_2169F1, 6
+	msgbox FortreeCity_Gym_Text_2169F1, MSGBOX_AUTOCLOSE
 	end
 
 FortreeCity_Gym_EventScript_2166D6:: @ 82166D6
 	trainerbattle 0, TRAINER_FLINT, 0, FortreeCity_Gym_Text_216A66, FortreeCity_Gym_Text_216AC4
-	msgbox FortreeCity_Gym_Text_216AD7, 6
+	msgbox FortreeCity_Gym_Text_216AD7, MSGBOX_AUTOCLOSE
 	end
 
 FortreeCity_Gym_EventScript_2166ED:: @ 82166ED
 	trainerbattle 0, TRAINER_ASHLEY, 0, FortreeCity_Gym_Text_216B1A, FortreeCity_Gym_Text_216B51
-	msgbox FortreeCity_Gym_Text_216B5F, 6
+	msgbox FortreeCity_Gym_Text_216B5F, MSGBOX_AUTOCLOSE
 	end
 
 FortreeCity_Gym_EventScript_216704:: @ 8216704
 	trainerbattle 0, TRAINER_HUMBERTO, 0, FortreeCity_Gym_Text_216B9E, FortreeCity_Gym_Text_216C18
-	msgbox FortreeCity_Gym_Text_216C32, 6
+	msgbox FortreeCity_Gym_Text_216C32, MSGBOX_AUTOCLOSE
 	end
 
 FortreeCity_Gym_EventScript_21671B:: @ 821671B
 	trainerbattle 0, TRAINER_DARIUS, 0, FortreeCity_Gym_Text_216C96, FortreeCity_Gym_Text_216CF2
-	msgbox FortreeCity_Gym_Text_216D0F, 6
+	msgbox FortreeCity_Gym_Text_216D0F, MSGBOX_AUTOCLOSE
 	end
 
 FortreeCity_Gym_EventScript_216732:: @ 8216732
@@ -106,12 +106,12 @@ FortreeCity_Gym_EventScript_216732:: @ 8216732
 	faceplayer
 	checkflag FLAG_0x4F5
 	goto_eq FortreeCity_Gym_EventScript_216747
-	msgbox FortreeCity_Gym_Text_216785, 4
+	msgbox FortreeCity_Gym_Text_216785, MSGBOX_DEFAULT
 	release
 	end
 
 FortreeCity_Gym_EventScript_216747:: @ 8216747
-	msgbox FortreeCity_Gym_Text_21687D, 4
+	msgbox FortreeCity_Gym_Text_21687D, MSGBOX_DEFAULT
 	release
 	end
 
@@ -130,12 +130,12 @@ FortreeCity_Gym_EventScript_216761:: @ 8216761
 	end
 
 FortreeCity_Gym_EventScript_216771:: @ 8216771
-	msgbox FortreeCity_Gym_Text_2170C7, 4
+	msgbox FortreeCity_Gym_Text_2170C7, MSGBOX_DEFAULT
 	releaseall
 	end
 
 FortreeCity_Gym_EventScript_21677B:: @ 821677B
-	msgbox FortreeCity_Gym_Text_2170AE, 4
+	msgbox FortreeCity_Gym_Text_2170AE, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/FortreeCity_House1/scripts.inc
+++ b/data/maps/FortreeCity_House1/scripts.inc
@@ -10,7 +10,7 @@ FortreeCity_House1_EventScript_2162BB:: @ 82162BB
 	copyvar VAR_0x8004, VAR_0x8008
 	specialvar VAR_RESULT, sub_807E73C
 	copyvar VAR_0x8009, VAR_RESULT
-	msgbox FortreeCity_House1_Text_21637B, 5
+	msgbox FortreeCity_House1_Text_21637B, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq FortreeCity_House1_EventScript_21633D
 	special sub_81B94B0
@@ -29,29 +29,29 @@ FortreeCity_House1_EventScript_2162BB:: @ 82162BB
 	special sub_807F0E4
 	waitstate
 	bufferspeciesname 0, VAR_0x8009
-	msgbox FortreeCity_House1_Text_216440, 4
+	msgbox FortreeCity_House1_Text_216440, MSGBOX_DEFAULT
 	setflag FLAG_0x09B
 	release
 	end
 
 FortreeCity_House1_EventScript_21633D:: @ 821633D
-	msgbox FortreeCity_House1_Text_21649F, 4
+	msgbox FortreeCity_House1_Text_21649F, MSGBOX_DEFAULT
 	release
 	end
 
 FortreeCity_House1_EventScript_216347:: @ 8216347
 	bufferspeciesname 0, VAR_0x8009
-	msgbox FortreeCity_House1_Text_216474, 4
+	msgbox FortreeCity_House1_Text_216474, MSGBOX_DEFAULT
 	release
 	end
 
 FortreeCity_House1_EventScript_216355:: @ 8216355
-	msgbox FortreeCity_House1_Text_2164DB, 4
+	msgbox FortreeCity_House1_Text_2164DB, MSGBOX_DEFAULT
 	release
 	end
 
 FortreeCity_House1_EventScript_21635F:: @ 821635F
-	msgbox FortreeCity_House1_Text_21653B, 2
+	msgbox FortreeCity_House1_Text_21653B, MSGBOX_NPC
 	end
 
 FortreeCity_House1_EventScript_216368:: @ 8216368
@@ -59,7 +59,7 @@ FortreeCity_House1_EventScript_216368:: @ 8216368
 	faceplayer
 	waitse
 	playmoncry SPECIES_ZIGZAGOON, 0
-	msgbox FortreeCity_House1_Text_216597, 4
+	msgbox FortreeCity_House1_Text_216597, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/FortreeCity_House2/scripts.inc
+++ b/data/maps/FortreeCity_House2/scripts.inc
@@ -8,39 +8,39 @@ FortreeCity_House2_EventScript_2177CB:: @ 82177CB
 	goto_eq FortreeCity_House2_EventScript_21786E
 	checkflag FLAG_0x076
 	call_if 0, FortreeCity_House2_EventScript_217862
-	msgbox FortreeCity_House2_Text_2178D6, 4
+	msgbox FortreeCity_House2_Text_2178D6, MSGBOX_DEFAULT
 	multichoice 21, 8, 54, 1
 	switch VAR_RESULT
 	case 1, FortreeCity_House2_EventScript_217878
-	msgbox FortreeCity_House2_Text_21796A, 4
+	msgbox FortreeCity_House2_Text_21796A, MSGBOX_DEFAULT
 	multichoice 21, 8, 54, 1
 	switch VAR_RESULT
 	case 1, FortreeCity_House2_EventScript_217878
-	msgbox FortreeCity_House2_Text_2179C9, 4
+	msgbox FortreeCity_House2_Text_2179C9, MSGBOX_DEFAULT
 	multichoice 21, 8, 54, 1
 	switch VAR_RESULT
 	case 0, FortreeCity_House2_EventScript_217878
-	msgbox FortreeCity_House2_Text_217A28, 4
+	msgbox FortreeCity_House2_Text_217A28, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM10
 	compare VAR_RESULT, 0
 	goto_eq FortreeCity_House2_EventScript_272054
 	setflag FLAG_0x108
-	msgbox FortreeCity_House2_Text_217A91, 4
+	msgbox FortreeCity_House2_Text_217A91, MSGBOX_DEFAULT
 	release
 	end
 
 FortreeCity_House2_EventScript_217862:: @ 8217862
-	msgbox FortreeCity_House2_Text_217882, 4
+	msgbox FortreeCity_House2_Text_217882, MSGBOX_DEFAULT
 	setflag FLAG_0x076
 	return
 
 FortreeCity_House2_EventScript_21786E:: @ 821786E
-	msgbox FortreeCity_House2_Text_217A91, 4
+	msgbox FortreeCity_House2_Text_217A91, MSGBOX_DEFAULT
 	release
 	end
 
 FortreeCity_House2_EventScript_217878:: @ 8217878
-	msgbox FortreeCity_House2_Text_217AC7, 4
+	msgbox FortreeCity_House2_Text_217AC7, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/FortreeCity_House3/scripts.inc
+++ b/data/maps/FortreeCity_House3/scripts.inc
@@ -2,11 +2,11 @@ FortreeCity_House3_MapScripts:: @ 8217AE7
 	.byte 0
 
 FortreeCity_House3_EventScript_217AE8:: @ 8217AE8
-	msgbox FortreeCity_House3_Text_217AFA, 2
+	msgbox FortreeCity_House3_Text_217AFA, MSGBOX_NPC
 	end
 
 FortreeCity_House3_EventScript_217AF1:: @ 8217AF1
-	msgbox FortreeCity_House3_Text_217C22, 2
+	msgbox FortreeCity_House3_Text_217C22, MSGBOX_NPC
 	end
 
 FortreeCity_House3_Text_217AFA: @ 8217AFA

--- a/data/maps/FortreeCity_House4/scripts.inc
+++ b/data/maps/FortreeCity_House4/scripts.inc
@@ -2,7 +2,7 @@ FortreeCity_House4_MapScripts:: @ 8217C80
 	.byte 0
 
 FortreeCity_House4_EventScript_217C81:: @ 8217C81
-	msgbox FortreeCity_House4_Text_217D33, 2
+	msgbox FortreeCity_House4_Text_217D33, MSGBOX_NPC
 	end
 
 FortreeCity_House4_EventScript_217C8A:: @ 8217C8A
@@ -13,7 +13,7 @@ FortreeCity_House4_EventScript_217C8A:: @ 8217C8A
 	goto_eq FortreeCity_House4_EventScript_217CD8
 	checkflag FLAG_0x0DE
 	goto_eq FortreeCity_House4_EventScript_217CC4
-	msgbox FortreeCity_House4_Text_217DB9, 4
+	msgbox FortreeCity_House4_Text_217DB9, MSGBOX_DEFAULT
 	closemessage
 	setflag FLAG_0x0DE
 	clearflag FLAG_HIDE_MOSSDEEP_CITY_HOUSE_2_WINGULL
@@ -26,14 +26,14 @@ FortreeCity_House4_EventScript_217C8A:: @ 8217C8A
 FortreeCity_House4_EventScript_217CC4:: @ 8217CC4
 	applymovement VAR_LAST_TALKED, FortreeCity_House4_Movement_27259E
 	waitmovement 0
-	msgbox FortreeCity_House4_Text_217DD2, 4
+	msgbox FortreeCity_House4_Text_217DD2, MSGBOX_DEFAULT
 	releaseall
 	end
 
 FortreeCity_House4_EventScript_217CD8:: @ 8217CD8
 	applymovement VAR_LAST_TALKED, FortreeCity_House4_Movement_27259E
 	waitmovement 0
-	msgbox FortreeCity_House4_Text_217E05, 4
+	msgbox FortreeCity_House4_Text_217E05, MSGBOX_DEFAULT
 	giveitem_std ITEM_MENTAL_HERB
 	compare VAR_RESULT, 0
 	goto_eq FortreeCity_House4_EventScript_272054
@@ -44,7 +44,7 @@ FortreeCity_House4_EventScript_217CD8:: @ 8217CD8
 FortreeCity_House4_EventScript_217D06:: @ 8217D06
 	applymovement VAR_LAST_TALKED, FortreeCity_House4_Movement_27259E
 	waitmovement 0
-	msgbox FortreeCity_House4_Text_217EA8, 4
+	msgbox FortreeCity_House4_Text_217EA8, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -61,7 +61,7 @@ FortreeCity_House4_EventScript_217D20:: @ 8217D20
 	faceplayer
 	waitse
 	playmoncry SPECIES_WINGULL, 0
-	msgbox FortreeCity_House4_Text_217EE0, 4
+	msgbox FortreeCity_House4_Text_217EE0, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/FortreeCity_House5/scripts.inc
+++ b/data/maps/FortreeCity_House5/scripts.inc
@@ -2,11 +2,11 @@ FortreeCity_House5_MapScripts:: @ 8217EF1
 	.byte 0
 
 FortreeCity_House5_EventScript_217EF2:: @ 8217EF2
-	msgbox FortreeCity_House5_Text_217F17, 2
+	msgbox FortreeCity_House5_Text_217F17, MSGBOX_NPC
 	end
 
 FortreeCity_House5_EventScript_217EFB:: @ 8217EFB
-	msgbox FortreeCity_House5_Text_217F80, 2
+	msgbox FortreeCity_House5_Text_217F80, MSGBOX_NPC
 	end
 
 FortreeCity_House5_EventScript_217F04:: @ 8217F04
@@ -14,7 +14,7 @@ FortreeCity_House5_EventScript_217F04:: @ 8217F04
 	faceplayer
 	waitse
 	playmoncry SPECIES_ZIGZAGOON, 0
-	msgbox FortreeCity_House5_Text_217FFB, 4
+	msgbox FortreeCity_House5_Text_217FFB, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/FortreeCity_Mart/scripts.inc
+++ b/data/maps/FortreeCity_Mart/scripts.inc
@@ -7,7 +7,7 @@ FortreeCity_Mart_EventScript_217666:: @ 8217666
 	message gUnknown_08272A21
 	waitmessage
 	pokemart FortreeCity_Mart_Pokemart_217680
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -28,15 +28,15 @@ FortreeCity_Mart_Pokemart_217680: @ 8217680
 	end
 
 FortreeCity_Mart_EventScript_217698:: @ 8217698
-	msgbox FortreeCity_Mart_Text_2176B3, 2
+	msgbox FortreeCity_Mart_Text_2176B3, MSGBOX_NPC
 	end
 
 FortreeCity_Mart_EventScript_2176A1:: @ 82176A1
-	msgbox FortreeCity_Mart_Text_217715, 2
+	msgbox FortreeCity_Mart_Text_217715, MSGBOX_NPC
 	end
 
 FortreeCity_Mart_EventScript_2176AA:: @ 82176AA
-	msgbox FortreeCity_Mart_Text_21778E, 2
+	msgbox FortreeCity_Mart_Text_21778E, MSGBOX_NPC
 	end
 
 FortreeCity_Mart_Text_2176B3: @ 82176B3

--- a/data/maps/FortreeCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/FortreeCity_PokemonCenter_1F/scripts.inc
@@ -16,15 +16,15 @@ FortreeCity_PokemonCenter_1F_EventScript_2173E7:: @ 82173E7
 	end
 
 FortreeCity_PokemonCenter_1F_EventScript_2173F5:: @ 82173F5
-	msgbox FortreeCity_PokemonCenter_1F_Text_217410, 2
+	msgbox FortreeCity_PokemonCenter_1F_Text_217410, MSGBOX_NPC
 	end
 
 FortreeCity_PokemonCenter_1F_EventScript_2173FE:: @ 82173FE
-	msgbox FortreeCity_PokemonCenter_1F_Text_21746D, 2
+	msgbox FortreeCity_PokemonCenter_1F_Text_21746D, MSGBOX_NPC
 	end
 
 FortreeCity_PokemonCenter_1F_EventScript_217407:: @ 8217407
-	msgbox FortreeCity_PokemonCenter_1F_Text_21751F, 2
+	msgbox FortreeCity_PokemonCenter_1F_Text_21751F, MSGBOX_NPC
 	end
 
 FortreeCity_PokemonCenter_1F_Text_217410: @ 8217410

--- a/data/maps/GraniteCave_1F/scripts.inc
+++ b/data/maps/GraniteCave_1F/scripts.inc
@@ -6,15 +6,15 @@ GraniteCave_1F_EventScript_22DA5E:: @ 822DA5E
 	faceplayer
 	checkflag FLAG_0x06D
 	goto_eq GraniteCave_1F_EventScript_22DA8A
-	msgbox GraniteCave_1F_Text_22DA94, 4
+	msgbox GraniteCave_1F_Text_22DA94, MSGBOX_DEFAULT
 	giveitem_std ITEM_HM05
 	setflag FLAG_0x06D
-	msgbox GraniteCave_1F_Text_22DBB7, 4
+	msgbox GraniteCave_1F_Text_22DBB7, MSGBOX_DEFAULT
 	release
 	end
 
 GraniteCave_1F_EventScript_22DA8A:: @ 822DA8A
-	msgbox GraniteCave_1F_Text_22DBB7, 4
+	msgbox GraniteCave_1F_Text_22DBB7, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/GraniteCave_StevensRoom/scripts.inc
+++ b/data/maps/GraniteCave_StevensRoom/scripts.inc
@@ -4,24 +4,24 @@ GraniteCave_StevensRoom_MapScripts:: @ 822DC7A
 GraniteCave_StevensRoom_EventScript_22DC7B:: @ 822DC7B
 	lock
 	faceplayer
-	msgbox GraniteCave_StevensRoom_Text_22DD5A, 4
+	msgbox GraniteCave_StevensRoom_Text_22DD5A, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 274
 	call GraniteCave_StevensRoom_EventScript_2723E4
 	setflag FLAG_0x0BD
-	msgbox GraniteCave_StevensRoom_Text_22DDBD, 4
+	msgbox GraniteCave_StevensRoom_Text_22DDBD, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM47
 	compare VAR_RESULT, 0
 	call_if 1, GraniteCave_StevensRoom_EventScript_22DD3C
-	msgbox GraniteCave_StevensRoom_Text_22DE6B, 4
+	msgbox GraniteCave_StevensRoom_Text_22DE6B, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox GraniteCave_StevensRoom_Text_22DF6A, 4
+	msgbox GraniteCave_StevensRoom_Text_22DF6A, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
 	setflag FLAG_0x131
-	msgbox GraniteCave_StevensRoom_Text_22DF8C, 4
+	msgbox GraniteCave_StevensRoom_Text_22DF8C, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_FACING, 2
 	call_if 1, GraniteCave_StevensRoom_EventScript_22DD0D
@@ -54,7 +54,7 @@ GraniteCave_StevensRoom_EventScript_22DD2A:: @ 822DD2A
 	return
 
 GraniteCave_StevensRoom_EventScript_22DD3C:: @ 822DD3C
-	msgbox GraniteCave_StevensRoom_Text_22DFAA, 4
+	msgbox GraniteCave_StevensRoom_Text_22DFAA, MSGBOX_DEFAULT
 	return
 
 GraniteCave_StevensRoom_Movement_22DD45: @ 822DD45

--- a/data/maps/InsideOfTruck/scripts.inc
+++ b/data/maps/InsideOfTruck/scripts.inc
@@ -50,7 +50,7 @@ InsideOfTruck_EventScript_23BF46:: @ 823BF46
 	end
 
 InsideOfTruck_EventScript_23BF6C:: @ 823BF6C
-	msgbox InsideOfTruck_Text_23BF75, 3
+	msgbox InsideOfTruck_Text_23BF75, MSGBOX_SIGN
 	end
 
 InsideOfTruck_Text_23BF75: @ 823BF75

--- a/data/maps/IslandCave/scripts.inc
+++ b/data/maps/IslandCave/scripts.inc
@@ -66,7 +66,7 @@ IslandCave_EventScript_238EEF:: @ 8238EEF
 	end
 
 IslandCave_EventScript_238F13:: @ 8238F13
-	msgbox gUnknown_0827304E, 4
+	msgbox gUnknown_0827304E, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/JaggedPass/scripts.inc
+++ b/data/maps/JaggedPass/scripts.inc
@@ -114,10 +114,7 @@ JaggedPass_EventScript_23079C:: @ 823079C
 JaggedPass_EventScript_2307C8:: @ 82307C8
 	special sub_80B4808
 	msgbox JaggedPass_Text_230A2C, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 474
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 474
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_DIANA_1
 	release
 	end
 
@@ -138,10 +135,7 @@ JaggedPass_EventScript_2307FB:: @ 82307FB
 JaggedPass_EventScript_230827:: @ 8230827
 	special sub_80B4808
 	msgbox JaggedPass_Text_230BC6, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 216
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 216
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_ETHAN_1
 	release
 	end
 

--- a/data/maps/JaggedPass/scripts.inc
+++ b/data/maps/JaggedPass/scripts.inc
@@ -48,7 +48,7 @@ JaggedPass_EventScript_2306BB:: @ 82306BB
 	setvar VAR_0x8007, 5
 	special sub_8139560
 	waitstate
-	msgbox JaggedPass_Text_230DBA, 4
+	msgbox JaggedPass_Text_230DBA, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 1
 	setvar VAR_0x8005, 1
@@ -78,7 +78,7 @@ JaggedPass_EventScript_230718:: @ 8230718
 	waitmovement 0
 	applymovement 5, JaggedPass_Movement_27259E
 	waitmovement 0
-	msgbox JaggedPass_Text_230CCB, 4
+	msgbox JaggedPass_Text_230CCB, MSGBOX_DEFAULT
 	closemessage
 	trainerbattle 3, TRAINER_GRUNT_30, 0, JaggedPass_Text_230D2D
 	setflag FLAG_0x139
@@ -90,7 +90,7 @@ JaggedPass_EventScript_230718:: @ 8230718
 JaggedPass_EventScript_230766:: @ 8230766
 	applymovement 5, JaggedPass_Movement_27259E
 	waitmovement 0
-	msgbox JaggedPass_Text_230D65, 4
+	msgbox JaggedPass_Text_230D65, MSGBOX_DEFAULT
 	closemessage
 	applymovement 5, JaggedPass_Movement_2725A2
 	waitmovement 0
@@ -99,7 +99,7 @@ JaggedPass_EventScript_230766:: @ 8230766
 
 JaggedPass_EventScript_230785:: @ 8230785
 	trainerbattle 0, TRAINER_ERIC, 0, JaggedPass_Text_230888, JaggedPass_Text_2308FF
-	msgbox JaggedPass_Text_230916, 6
+	msgbox JaggedPass_Text_230916, MSGBOX_AUTOCLOSE
 	end
 
 JaggedPass_EventScript_23079C:: @ 823079C
@@ -107,23 +107,23 @@ JaggedPass_EventScript_23079C:: @ 823079C
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq JaggedPass_EventScript_2307E4
-	msgbox JaggedPass_Text_2309D8, 4
+	msgbox JaggedPass_Text_2309D8, MSGBOX_DEFAULT
 	release
 	end
 
 JaggedPass_EventScript_2307C8:: @ 82307C8
 	special sub_80B4808
-	msgbox JaggedPass_Text_230A2C, 4
+	msgbox JaggedPass_Text_230A2C, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 474
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 474
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 JaggedPass_EventScript_2307E4:: @ 82307E4
 	trainerbattle 5, TRAINER_DIANA_1, 0, JaggedPass_Text_230A76, JaggedPass_Text_230AAA
-	msgbox JaggedPass_Text_230AD7, 6
+	msgbox JaggedPass_Text_230AD7, MSGBOX_AUTOCLOSE
 	end
 
 JaggedPass_EventScript_2307FB:: @ 82307FB
@@ -131,33 +131,33 @@ JaggedPass_EventScript_2307FB:: @ 82307FB
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq JaggedPass_EventScript_230843
-	msgbox JaggedPass_Text_230B93, 4
+	msgbox JaggedPass_Text_230B93, MSGBOX_DEFAULT
 	release
 	end
 
 JaggedPass_EventScript_230827:: @ 8230827
 	special sub_80B4808
-	msgbox JaggedPass_Text_230BC6, 4
+	msgbox JaggedPass_Text_230BC6, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 216
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 216
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 JaggedPass_EventScript_230843:: @ 8230843
 	trainerbattle 5, TRAINER_ETHAN_1, 0, JaggedPass_Text_230C28, JaggedPass_Text_230C60
-	msgbox JaggedPass_Text_230C94, 6
+	msgbox JaggedPass_Text_230C94, MSGBOX_AUTOCLOSE
 	end
 
 JaggedPass_EventScript_23085A:: @ 823085A
 	trainerbattle 0, TRAINER_JULIO, 0, JaggedPass_Text_230DF7, JaggedPass_Text_230E38
-	msgbox JaggedPass_Text_230E57, 6
+	msgbox JaggedPass_Text_230E57, MSGBOX_AUTOCLOSE
 	end
 
 JaggedPass_EventScript_230871:: @ 8230871
 	trainerbattle 0, TRAINER_AUTUMN, 0, JaggedPass_Text_230E8E, JaggedPass_Text_230ECD
-	msgbox JaggedPass_Text_230EE3, 6
+	msgbox JaggedPass_Text_230EE3, MSGBOX_AUTOCLOSE
 	end
 
 JaggedPass_Text_230888: @ 8230888

--- a/data/maps/LavaridgeTown/scripts.inc
+++ b/data/maps/LavaridgeTown/scripts.inc
@@ -71,18 +71,18 @@ LavaridgeTown_EventScript_1EA551:: @ 81EA551
 	end
 
 LavaridgeTown_EventScript_1EA5B5:: @ 81EA5B5
-	msgbox LavaridgeTown_Text_1EA7C0, 4
+	msgbox LavaridgeTown_Text_1EA7C0, MSGBOX_DEFAULT
 	giveitem_std ITEM_GO_GOGGLES
 	setflag FLAG_0x0DD
-	msgbox LavaridgeTown_Text_1EA897, 4
+	msgbox LavaridgeTown_Text_1EA897, MSGBOX_DEFAULT
 	goto LavaridgeTown_EventScript_1EA5FF
 	end
 
 LavaridgeTown_EventScript_1EA5DA:: @ 81EA5DA
-	msgbox LavaridgeTown_Text_1EA9A2, 4
+	msgbox LavaridgeTown_Text_1EA9A2, MSGBOX_DEFAULT
 	giveitem_std ITEM_GO_GOGGLES
 	setflag FLAG_0x0DD
-	msgbox LavaridgeTown_Text_1EAA2E, 4
+	msgbox LavaridgeTown_Text_1EAA2E, MSGBOX_DEFAULT
 	goto LavaridgeTown_EventScript_1EA5FF
 	end
 
@@ -222,27 +222,27 @@ LavaridgeTown_EventScript_1EA70B:: @ 81EA70B
 	end
 
 LavaridgeTown_EventScript_1EA70E:: @ 81EA70E
-	msgbox LavaridgeTown_Text_1EAE03, 2
+	msgbox LavaridgeTown_Text_1EAE03, MSGBOX_NPC
 	end
 
 LavaridgeTown_EventScript_1EA717:: @ 81EA717
-	msgbox LavaridgeTown_Text_1EAEE1, 3
+	msgbox LavaridgeTown_Text_1EAEE1, MSGBOX_SIGN
 	end
 
 LavaridgeTown_EventScript_1EA720:: @ 81EA720
-	msgbox LavaridgeTown_Text_1EAF9B, 2
+	msgbox LavaridgeTown_Text_1EAF9B, MSGBOX_NPC
 	end
 
 LavaridgeTown_EventScript_1EA729:: @ 81EA729
-	msgbox LavaridgeTown_Text_1EB003, 2
+	msgbox LavaridgeTown_Text_1EB003, MSGBOX_NPC
 	end
 
 LavaridgeTown_EventScript_1EA732:: @ 81EA732
-	msgbox LavaridgeTown_Text_1EB092, 2
+	msgbox LavaridgeTown_Text_1EB092, MSGBOX_NPC
 	end
 
 LavaridgeTown_EventScript_1EA73B:: @ 81EA73B
-	msgbox LavaridgeTown_Text_1EAF4E, 2
+	msgbox LavaridgeTown_Text_1EAF4E, MSGBOX_NPC
 	end
 
 LavaridgeTown_EventScript_1EA744:: @ 81EA744
@@ -250,13 +250,13 @@ LavaridgeTown_EventScript_1EA744:: @ 81EA744
 	faceplayer
 	checkflag FLAG_0x10A
 	goto_eq LavaridgeTown_EventScript_1EA787
-	msgbox LavaridgeTown_Text_1EAB80, 5
+	msgbox LavaridgeTown_Text_1EAB80, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LavaridgeTown_EventScript_1EA79B
 	getpartysize
 	compare VAR_RESULT, 6
 	goto_eq LavaridgeTown_EventScript_1EA791
-	msgbox LavaridgeTown_Text_1EACC0, 4
+	msgbox LavaridgeTown_Text_1EACC0, MSGBOX_DEFAULT
 	setflag FLAG_0x10A
 	playfanfare MUS_FANFA4
 	message LavaridgeTown_Text_1EACF4
@@ -266,30 +266,30 @@ LavaridgeTown_EventScript_1EA744:: @ 81EA744
 	end
 
 LavaridgeTown_EventScript_1EA787:: @ 81EA787
-	msgbox LavaridgeTown_Text_1EAD9E, 4
+	msgbox LavaridgeTown_Text_1EAD9E, MSGBOX_DEFAULT
 	release
 	end
 
 LavaridgeTown_EventScript_1EA791:: @ 81EA791
-	msgbox LavaridgeTown_Text_1EAD09, 4
+	msgbox LavaridgeTown_Text_1EAD09, MSGBOX_DEFAULT
 	release
 	end
 
 LavaridgeTown_EventScript_1EA79B:: @ 81EA79B
-	msgbox LavaridgeTown_Text_1EAD44, 4
+	msgbox LavaridgeTown_Text_1EAD44, MSGBOX_DEFAULT
 	release
 	end
 
 LavaridgeTown_EventScript_1EA7A5:: @ 81EA7A5
-	msgbox LavaridgeTown_Text_1EB12B, 3
+	msgbox LavaridgeTown_Text_1EB12B, MSGBOX_SIGN
 	end
 
 LavaridgeTown_EventScript_1EA7AE:: @ 81EA7AE
-	msgbox LavaridgeTown_Text_1EB178, 3
+	msgbox LavaridgeTown_Text_1EB178, MSGBOX_SIGN
 	end
 
 LavaridgeTown_EventScript_1EA7B7:: @ 81EA7B7
-	msgbox LavaridgeTown_Text_1EB1CB, 3
+	msgbox LavaridgeTown_Text_1EB1CB, MSGBOX_SIGN
 	end
 
 LavaridgeTown_Text_1EA7C0: @ 81EA7C0

--- a/data/maps/LavaridgeTown_Gym_1F/scripts.inc
+++ b/data/maps/LavaridgeTown_Gym_1F/scripts.inc
@@ -65,7 +65,7 @@ LavaridgeTown_Gym_1F_EventScript_1FE78C:: @ 81FE78C
 	goto_eq LavaridgeTown_Gym_1F_EventScript_1FE864
 	checkflag FLAG_0x0A8
 	goto_if 0, LavaridgeTown_Gym_1F_EventScript_1FE81D
-	msgbox LavaridgeTown_Gym_1F_Text_1FF546, 4
+	msgbox LavaridgeTown_Gym_1F_Text_1FF546, MSGBOX_DEFAULT
 	release
 	end
 
@@ -73,7 +73,7 @@ LavaridgeTown_Gym_1F_EventScript_1FE7C1:: @ 81FE7C1
 	message LavaridgeTown_Gym_1F_Text_1FF32F
 	waitmessage
 	call LavaridgeTown_Gym_1F_EventScript_27207E
-	msgbox LavaridgeTown_Gym_1F_Text_1FF359, 4
+	msgbox LavaridgeTown_Gym_1F_Text_1FF359, MSGBOX_DEFAULT
 	setflag FLAG_0x06C
 	setflag FLAG_0x4F3
 	setflag FLAG_BADGE04_GET
@@ -88,7 +88,7 @@ LavaridgeTown_Gym_1F_EventScript_1FE7C1:: @ 81FE7C1
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox LavaridgeTown_Gym_1F_Text_1FF517, 4
+	msgbox LavaridgeTown_Gym_1F_Text_1FF517, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
@@ -100,7 +100,7 @@ LavaridgeTown_Gym_1F_EventScript_1FE81D:: @ 81FE81D
 	giveitem_std ITEM_TM50
 	compare VAR_RESULT, 0
 	goto_eq LavaridgeTown_Gym_1F_EventScript_272054
-	msgbox LavaridgeTown_Gym_1F_Text_1FF45C, 4
+	msgbox LavaridgeTown_Gym_1F_Text_1FF45C, MSGBOX_DEFAULT
 	setflag FLAG_0x0A8
 	release
 	end
@@ -109,18 +109,18 @@ LavaridgeTown_Gym_1F_EventScript_1FE841:: @ 81FE841
 	giveitem_std ITEM_TM50
 	compare VAR_RESULT, 0
 	goto_eq LavaridgeTown_Gym_1F_EventScript_27205E
-	msgbox LavaridgeTown_Gym_1F_Text_1FF45C, 4
+	msgbox LavaridgeTown_Gym_1F_Text_1FF45C, MSGBOX_DEFAULT
 	setflag FLAG_0x0A8
 	return
 
 LavaridgeTown_Gym_1F_EventScript_1FE864:: @ 81FE864
 	trainerbattle 7, TRAINER_FLANNERY_1, 0, LavaridgeTown_Gym_1F_Text_1FF601, LavaridgeTown_Gym_1F_Text_1FF69F, LavaridgeTown_Gym_1F_Text_1FF75E
-	msgbox LavaridgeTown_Gym_1F_Text_1FF6BF, 6
+	msgbox LavaridgeTown_Gym_1F_Text_1FF6BF, MSGBOX_AUTOCLOSE
 	end
 
 LavaridgeTown_Gym_1F_EventScript_1FE87F:: @ 81FE87F
 	trainerbattle 2, TRAINER_COLE, 2, LavaridgeTown_Gym_1F_Text_1FEADE, LavaridgeTown_Gym_1F_Text_1FEAFB, LavaridgeTown_Gym_1F_EventScript_1FE89A
-	msgbox LavaridgeTown_Gym_1F_Text_1FEB1C, 6
+	msgbox LavaridgeTown_Gym_1F_Text_1FEB1C, MSGBOX_AUTOCLOSE
 	end
 
 LavaridgeTown_Gym_1F_EventScript_1FE89A:: @ 81FE89A
@@ -134,37 +134,37 @@ LavaridgeTown_Gym_B1F_EventScript_1FE89A:: @ 81FE89A
 
 LavaridgeTown_Gym_1F_EventScript_1FE8AF:: @ 81FE8AF
 	trainerbattle 2, TRAINER_AXLE, 4, LavaridgeTown_Gym_1F_Text_1FEB7B, LavaridgeTown_Gym_1F_Text_1FEBC0, LavaridgeTown_Gym_1F_EventScript_1FE89A
-	msgbox LavaridgeTown_Gym_1F_Text_1FEBE1, 6
+	msgbox LavaridgeTown_Gym_1F_Text_1FEBE1, MSGBOX_AUTOCLOSE
 	end
 
 LavaridgeTown_Gym_B1F_EventScript_1FE8CA:: @ 81FE8CA
 	trainerbattle 2, TRAINER_KEEGAN, 2, LavaridgeTown_Gym_B1F_Text_1FEC31, LavaridgeTown_Gym_B1F_Text_1FECE3, LavaridgeTown_Gym_B1F_EventScript_1FE89A
-	msgbox LavaridgeTown_Gym_B1F_Text_1FED02, 6
+	msgbox LavaridgeTown_Gym_B1F_Text_1FED02, MSGBOX_AUTOCLOSE
 	end
 
 LavaridgeTown_Gym_1F_EventScript_1FE8E5:: @ 81FE8E5
 	trainerbattle 2, TRAINER_DANIELLE, 5, LavaridgeTown_Gym_1F_Text_1FEE22, LavaridgeTown_Gym_1F_Text_1FEE42, LavaridgeTown_Gym_1F_EventScript_1FE89A
-	msgbox LavaridgeTown_Gym_1F_Text_1FEE5D, 6
+	msgbox LavaridgeTown_Gym_1F_Text_1FEE5D, MSGBOX_AUTOCLOSE
 	end
 
 LavaridgeTown_Gym_1F_EventScript_1FE900:: @ 81FE900
 	trainerbattle 2, TRAINER_GERALD, 3, LavaridgeTown_Gym_1F_Text_1FED72, LavaridgeTown_Gym_1F_Text_1FED9E, LavaridgeTown_Gym_1F_EventScript_1FE89A
-	msgbox LavaridgeTown_Gym_1F_Text_1FEDBB, 6
+	msgbox LavaridgeTown_Gym_1F_Text_1FEDBB, MSGBOX_AUTOCLOSE
 	end
 
 LavaridgeTown_Gym_B1F_EventScript_1FE91B:: @ 81FE91B
 	trainerbattle 2, TRAINER_JACE, 1, LavaridgeTown_Gym_B1F_Text_1FEE9D, LavaridgeTown_Gym_B1F_Text_1FEED5, LavaridgeTown_Gym_B1F_EventScript_1FE89A
-	msgbox LavaridgeTown_Gym_B1F_Text_1FEF07, 6
+	msgbox LavaridgeTown_Gym_B1F_Text_1FEF07, MSGBOX_AUTOCLOSE
 	end
 
 LavaridgeTown_Gym_B1F_EventScript_1FE936:: @ 81FE936
 	trainerbattle 2, TRAINER_JEFF, 3, LavaridgeTown_Gym_B1F_Text_1FEF60, LavaridgeTown_Gym_B1F_Text_1FEFA7, LavaridgeTown_Gym_B1F_EventScript_1FE89A
-	msgbox LavaridgeTown_Gym_B1F_Text_1FEFC2, 6
+	msgbox LavaridgeTown_Gym_B1F_Text_1FEFC2, MSGBOX_AUTOCLOSE
 	end
 
 LavaridgeTown_Gym_B1F_EventScript_1FE951:: @ 81FE951
 	trainerbattle 2, TRAINER_ELI, 4, LavaridgeTown_Gym_B1F_Text_1FF025, LavaridgeTown_Gym_B1F_Text_1FF05F, LavaridgeTown_Gym_B1F_EventScript_1FE89A
-	msgbox LavaridgeTown_Gym_B1F_Text_1FF09A, 6
+	msgbox LavaridgeTown_Gym_B1F_Text_1FF09A, MSGBOX_AUTOCLOSE
 	end
 
 LavaridgeTown_Gym_1F_EventScript_1FE96C:: @ 81FE96C
@@ -172,12 +172,12 @@ LavaridgeTown_Gym_1F_EventScript_1FE96C:: @ 81FE96C
 	faceplayer
 	checkflag FLAG_0x4F3
 	goto_eq LavaridgeTown_Gym_1F_EventScript_1FE981
-	msgbox LavaridgeTown_Gym_1F_Text_1FE9BF, 4
+	msgbox LavaridgeTown_Gym_1F_Text_1FE9BF, MSGBOX_DEFAULT
 	release
 	end
 
 LavaridgeTown_Gym_1F_EventScript_1FE981:: @ 81FE981
-	msgbox LavaridgeTown_Gym_1F_Text_1FEAB8, 4
+	msgbox LavaridgeTown_Gym_1F_Text_1FEAB8, MSGBOX_DEFAULT
 	release
 	end
 
@@ -196,12 +196,12 @@ LavaridgeTown_Gym_1F_EventScript_1FE99B:: @ 81FE99B
 	end
 
 LavaridgeTown_Gym_1F_EventScript_1FE9AB:: @ 81FE9AB
-	msgbox LavaridgeTown_Gym_1F_Text_1FF5C4, 4
+	msgbox LavaridgeTown_Gym_1F_Text_1FF5C4, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LavaridgeTown_Gym_1F_EventScript_1FE9B5:: @ 81FE9B5
-	msgbox LavaridgeTown_Gym_1F_Text_1FF5A9, 4
+	msgbox LavaridgeTown_Gym_1F_Text_1FF5A9, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/LavaridgeTown_HerbShop/scripts.inc
+++ b/data/maps/LavaridgeTown_HerbShop/scripts.inc
@@ -7,7 +7,7 @@ LavaridgeTown_HerbShop_EventScript_1FE4D7:: @ 81FE4D7
 	message LavaridgeTown_HerbShop_Text_1FE53E
 	waitmessage
 	pokemart LavaridgeTown_HerbShop_Pokemart_1FE4F0
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -22,7 +22,7 @@ LavaridgeTown_HerbShop_Pokemart_1FE4F0: @ 81FE4F0
 	end
 
 LavaridgeTown_HerbShop_EventScript_1FE4FC:: @ 81FE4FC
-	msgbox LavaridgeTown_HerbShop_Text_1FE685, 2
+	msgbox LavaridgeTown_HerbShop_Text_1FE685, MSGBOX_NPC
 	end
 
 LavaridgeTown_HerbShop_EventScript_1FE505:: @ 81FE505
@@ -30,7 +30,7 @@ LavaridgeTown_HerbShop_EventScript_1FE505:: @ 81FE505
 	faceplayer
 	checkflag FLAG_0x0FE
 	goto_eq LavaridgeTown_HerbShop_EventScript_1FE534
-	msgbox LavaridgeTown_HerbShop_Text_1FE584, 4
+	msgbox LavaridgeTown_HerbShop_Text_1FE584, MSGBOX_DEFAULT
 	giveitem_std ITEM_CHARCOAL
 	compare VAR_RESULT, 0
 	goto_eq LavaridgeTown_HerbShop_EventScript_272054
@@ -39,7 +39,7 @@ LavaridgeTown_HerbShop_EventScript_1FE505:: @ 81FE505
 	end
 
 LavaridgeTown_HerbShop_EventScript_1FE534:: @ 81FE534
-	msgbox LavaridgeTown_HerbShop_Text_1FE5EB, 4
+	msgbox LavaridgeTown_HerbShop_Text_1FE5EB, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/LavaridgeTown_House/scripts.inc
+++ b/data/maps/LavaridgeTown_House/scripts.inc
@@ -2,7 +2,7 @@ LavaridgeTown_House_MapScripts:: @ 81FF911
 	.byte 0
 
 LavaridgeTown_House_EventScript_1FF912:: @ 81FF912
-	msgbox LavaridgeTown_House_Text_1FF92E, 2
+	msgbox LavaridgeTown_House_Text_1FF92E, MSGBOX_NPC
 	end
 
 LavaridgeTown_House_EventScript_1FF91B:: @ 81FF91B
@@ -10,7 +10,7 @@ LavaridgeTown_House_EventScript_1FF91B:: @ 81FF91B
 	faceplayer
 	waitse
 	playmoncry SPECIES_ZIGZAGOON, 0
-	msgbox LavaridgeTown_House_Text_1FF9BB, 4
+	msgbox LavaridgeTown_House_Text_1FF9BB, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/LavaridgeTown_Mart/scripts.inc
+++ b/data/maps/LavaridgeTown_Mart/scripts.inc
@@ -7,7 +7,7 @@ LavaridgeTown_Mart_EventScript_1FF9CE:: @ 81FF9CE
 	message gUnknown_08272A21
 	waitmessage
 	pokemart LavaridgeTown_Mart_Pokemart_1FF9E8
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -27,11 +27,11 @@ LavaridgeTown_Mart_Pokemart_1FF9E8: @ 81FF9E8
 	end
 
 LavaridgeTown_Mart_EventScript_1FF9FE:: @ 81FF9FE
-	msgbox LavaridgeTown_Mart_Text_1FFA10, 2
+	msgbox LavaridgeTown_Mart_Text_1FFA10, MSGBOX_NPC
 	end
 
 LavaridgeTown_Mart_EventScript_1FFA07:: @ 81FFA07
-	msgbox LavaridgeTown_Mart_Text_1FFA83, 2
+	msgbox LavaridgeTown_Mart_Text_1FFA83, MSGBOX_NPC
 	end
 
 LavaridgeTown_Mart_Text_1FFA10: @ 81FFA10

--- a/data/maps/LavaridgeTown_PokemonCenter_1F/scripts.inc
+++ b/data/maps/LavaridgeTown_PokemonCenter_1F/scripts.inc
@@ -17,15 +17,15 @@ LavaridgeTown_PokemonCenter_1F_EventScript_1FFB0E:: @ 81FFB0E
 	end
 
 LavaridgeTown_PokemonCenter_1F_EventScript_1FFB1C:: @ 81FFB1C
-	msgbox LavaridgeTown_PokemonCenter_1F_Text_1FFBAD, 2
+	msgbox LavaridgeTown_PokemonCenter_1F_Text_1FFBAD, MSGBOX_NPC
 	end
 
 LavaridgeTown_PokemonCenter_1F_EventScript_1FFB25:: @ 81FFB25
-	msgbox LavaridgeTown_PokemonCenter_1F_Text_1FFB37, 2
+	msgbox LavaridgeTown_PokemonCenter_1F_Text_1FFB37, MSGBOX_NPC
 	end
 
 LavaridgeTown_PokemonCenter_1F_EventScript_1FFB2E:: @ 81FFB2E
-	msgbox LavaridgeTown_PokemonCenter_1F_Text_1FFC21, 2
+	msgbox LavaridgeTown_PokemonCenter_1F_Text_1FFC21, MSGBOX_NPC
 	end
 
 LavaridgeTown_PokemonCenter_1F_Text_1FFB37: @ 81FFB37

--- a/data/maps/LilycoveCity/scripts.inc
+++ b/data/maps/LilycoveCity/scripts.inc
@@ -38,24 +38,24 @@ LilycoveCity_EventScript_1E2BD8:: @ 81E2BD8
 	dodailyevents
 	checkflag FLAG_0x92F
 	goto_eq LilycoveCity_EventScript_1E2C18
-	msgbox LilycoveCity_Text_2A7244, 4
+	msgbox LilycoveCity_Text_2A7244, MSGBOX_DEFAULT
 	random 10
 	addvar VAR_RESULT, 133
 	giveitem_std VAR_RESULT
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_EventScript_272054
 	setflag FLAG_0x92F
-	msgbox LilycoveCity_Text_2A72E3, 4
+	msgbox LilycoveCity_Text_2A72E3, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_EventScript_1E2C18:: @ 81E2C18
-	msgbox LilycoveCity_Text_2A7321, 4
+	msgbox LilycoveCity_Text_2A7321, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_EventScript_1E2C22:: @ 81E2C22
-	msgbox LilycoveCity_Text_1E3D9E, 2
+	msgbox LilycoveCity_Text_1E3D9E, MSGBOX_NPC
 	end
 
 LilycoveCity_EventScript_1E2C2B:: @ 81E2C2B
@@ -63,17 +63,17 @@ LilycoveCity_EventScript_1E2C2B:: @ 81E2C2B
 	faceplayer
 	checkflag FLAG_BADGE07_GET
 	goto_eq LilycoveCity_EventScript_1E2C40
-	msgbox LilycoveCity_Text_1E3E3C, 4
+	msgbox LilycoveCity_Text_1E3E3C, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_EventScript_1E2C40:: @ 81E2C40
-	msgbox LilycoveCity_Text_1E3E7D, 4
+	msgbox LilycoveCity_Text_1E3E7D, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_EventScript_1E2C4A:: @ 81E2C4A
-	msgbox LilycoveCity_Text_1E3F05, 2
+	msgbox LilycoveCity_Text_1E3F05, MSGBOX_NPC
 	end
 
 LilycoveCity_EventScript_1E2C53:: @ 81E2C53
@@ -81,12 +81,12 @@ LilycoveCity_EventScript_1E2C53:: @ 81E2C53
 	faceplayer
 	checkflag FLAG_0x070
 	goto_eq LilycoveCity_EventScript_1E2C68
-	msgbox LilycoveCity_Text_1E3FAB, 4
+	msgbox LilycoveCity_Text_1E3FAB, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_EventScript_1E2C68:: @ 81E2C68
-	msgbox LilycoveCity_Text_1E4020, 4
+	msgbox LilycoveCity_Text_1E4020, MSGBOX_DEFAULT
 	release
 	end
 
@@ -95,25 +95,25 @@ LilycoveCity_EventScript_1E2C72:: @ 81E2C72
 	faceplayer
 	checkflag FLAG_0x070
 	goto_eq LilycoveCity_EventScript_1E2C87
-	msgbox LilycoveCity_Text_1E40AD, 4
+	msgbox LilycoveCity_Text_1E40AD, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_EventScript_1E2C87:: @ 81E2C87
-	msgbox LilycoveCity_Text_1E4145, 4
+	msgbox LilycoveCity_Text_1E4145, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_EventScript_1E2C91:: @ 81E2C91
-	msgbox LilycoveCity_Text_1E417B, 2
+	msgbox LilycoveCity_Text_1E417B, MSGBOX_NPC
 	end
 
 LilycoveCity_EventScript_1E2C9A:: @ 81E2C9A
-	msgbox LilycoveCity_Text_1E420B, 3
+	msgbox LilycoveCity_Text_1E420B, MSGBOX_SIGN
 	end
 
 LilycoveCity_EventScript_1E2CA3:: @ 81E2CA3
-	msgbox LilycoveCity_Text_1E4283, 3
+	msgbox LilycoveCity_Text_1E4283, MSGBOX_SIGN
 	end
 
 LilycoveCity_EventScript_1E2CAC:: @ 81E2CAC
@@ -121,45 +121,45 @@ LilycoveCity_EventScript_1E2CAC:: @ 81E2CAC
 	faceplayer
 	checkflag FLAG_BADGE07_GET
 	goto_eq LilycoveCity_EventScript_1E2CC1
-	msgbox LilycoveCity_Text_1E42FC, 4
+	msgbox LilycoveCity_Text_1E42FC, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_EventScript_1E2CC1:: @ 81E2CC1
-	msgbox LilycoveCity_Text_1E43FF, 4
+	msgbox LilycoveCity_Text_1E43FF, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_EventScript_1E2CCB:: @ 81E2CCB
-	msgbox LilycoveCity_Text_1E48A5, 2
+	msgbox LilycoveCity_Text_1E48A5, MSGBOX_NPC
 	end
 
 LilycoveCity_EventScript_1E2CD4:: @ 81E2CD4
-	msgbox LilycoveCity_Text_1E4902, 2
+	msgbox LilycoveCity_Text_1E4902, MSGBOX_NPC
 	end
 
 LilycoveCity_EventScript_1E2CDD:: @ 81E2CDD
 	lockall
-	msgbox LilycoveCity_Text_1E494D, 2
+	msgbox LilycoveCity_Text_1E494D, MSGBOX_NPC
 	applymovement 20, LilycoveCity_Movement_2725A2
 	end
 
 LilycoveCity_EventScript_1E2CEE:: @ 81E2CEE
 	lockall
-	msgbox LilycoveCity_Text_1E49F4, 2
+	msgbox LilycoveCity_Text_1E49F4, MSGBOX_NPC
 	applymovement 19, LilycoveCity_Movement_2725A2
 	end
 
 LilycoveCity_EventScript_1E2CFF:: @ 81E2CFF
-	msgbox LilycoveCity_Text_1E448B, 3
+	msgbox LilycoveCity_Text_1E448B, MSGBOX_SIGN
 	end
 
 LilycoveCity_EventScript_1E2D08:: @ 81E2D08
-	msgbox LilycoveCity_Text_1E44C3, 3
+	msgbox LilycoveCity_Text_1E44C3, MSGBOX_SIGN
 	end
 
 LilycoveCity_EventScript_1E2D11:: @ 81E2D11
-	msgbox LilycoveCity_Text_1E44FC, 3
+	msgbox LilycoveCity_Text_1E44FC, MSGBOX_SIGN
 	end
 
 LilycoveCity_EventScript_1E2D1A:: @ 81E2D1A
@@ -167,12 +167,12 @@ LilycoveCity_EventScript_1E2D1A:: @ 81E2D1A
 	specialvar VAR_0x8004, sub_80F8940
 	switch VAR_0x8004
 	case 0, LilycoveCity_EventScript_1E2D3A
-	msgbox LilycoveCity_Text_1E4571, 4
+	msgbox LilycoveCity_Text_1E4571, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_EventScript_1E2D3A:: @ 81E2D3A
-	msgbox LilycoveCity_Text_1E4534, 4
+	msgbox LilycoveCity_Text_1E4534, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -180,35 +180,35 @@ LilycoveCity_EventScript_1E2D44:: @ 81E2D44
 	lockall
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_eq LilycoveCity_EventScript_1E2D58
-	msgbox LilycoveCity_Text_1E45A7, 4
+	msgbox LilycoveCity_Text_1E45A7, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_EventScript_1E2D58:: @ 81E2D58
-	msgbox LilycoveCity_Text_1E4624, 4
+	msgbox LilycoveCity_Text_1E4624, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_EventScript_1E2D62:: @ 81E2D62
-	msgbox LilycoveCity_Text_1E466E, 3
+	msgbox LilycoveCity_Text_1E466E, MSGBOX_SIGN
 	end
 
 LilycoveCity_EventScript_1E2D6B:: @ 81E2D6B
-	msgbox LilycoveCity_Text_1E46BE, 3
+	msgbox LilycoveCity_Text_1E46BE, MSGBOX_SIGN
 	end
 
 LilycoveCity_EventScript_1E2D74:: @ 81E2D74
-	msgbox LilycoveCity_Text_1E473D, 3
+	msgbox LilycoveCity_Text_1E473D, MSGBOX_SIGN
 	end
 
 LilycoveCity_EventScript_1E2D7D:: @ 81E2D7D
 	lockall
 	checkflag FLAG_0x0DA
 	goto_eq LilycoveCity_EventScript_1E2DB0
-	msgbox LilycoveCity_Text_1E3D1F, 4
+	msgbox LilycoveCity_Text_1E3D1F, MSGBOX_DEFAULT
 	applymovement VAR_LAST_TALKED, LilycoveCity_Movement_27259E
 	waitmovement 0
-	msgbox LilycoveCity_Text_1E3D4A, 4
+	msgbox LilycoveCity_Text_1E3D4A, MSGBOX_DEFAULT
 	applymovement VAR_LAST_TALKED, LilycoveCity_Movement_2725A2
 	waitmovement 0
 	setflag FLAG_0x0DA
@@ -216,24 +216,24 @@ LilycoveCity_EventScript_1E2D7D:: @ 81E2D7D
 	end
 
 LilycoveCity_EventScript_1E2DB0:: @ 81E2DB0
-	msgbox LilycoveCity_Text_1E3D1F, 4
+	msgbox LilycoveCity_Text_1E3D1F, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_EventScript_1E2DBA:: @ 81E2DBA
-	msgbox LilycoveCity_Text_1E3B2C, 2
+	msgbox LilycoveCity_Text_1E3B2C, MSGBOX_NPC
 	end
 
 LilycoveCity_EventScript_1E2DC3:: @ 81E2DC3
-	msgbox LilycoveCity_Text_1E3B95, 2
+	msgbox LilycoveCity_Text_1E3B95, MSGBOX_NPC
 	end
 
 LilycoveCity_EventScript_1E2DCC:: @ 81E2DCC
-	msgbox LilycoveCity_Text_1E3C46, 2
+	msgbox LilycoveCity_Text_1E3C46, MSGBOX_NPC
 	end
 
 LilycoveCity_EventScript_1E2DD5:: @ 81E2DD5
-	msgbox LilycoveCity_Text_1E3CBE, 2
+	msgbox LilycoveCity_Text_1E3CBE, MSGBOX_NPC
 	end
 
 LilycoveCity_EventScript_1E2DDE:: @ 81E2DDE
@@ -254,7 +254,7 @@ LilycoveCity_EventScript_1E2DF8:: @ 81E2DF8
 	call_if 0, LilycoveCity_EventScript_1E2E51
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_EventScript_1E2E5A
-	msgbox LilycoveCity_Text_1E3234, 4
+	msgbox LilycoveCity_Text_1E3234, MSGBOX_DEFAULT
 	switch VAR_STARTER_MON
 	case 0, LilycoveCity_EventScript_1E2EDE
 	case 1, LilycoveCity_EventScript_1E2EEE
@@ -262,16 +262,16 @@ LilycoveCity_EventScript_1E2DF8:: @ 81E2DF8
 	end
 
 LilycoveCity_EventScript_1E2E48:: @ 81E2E48
-	msgbox LilycoveCity_Text_1E31F5, 5
+	msgbox LilycoveCity_Text_1E31F5, MSGBOX_YESNO
 	return
 
 LilycoveCity_EventScript_1E2E51:: @ 81E2E51
-	msgbox LilycoveCity_Text_1E3061, 5
+	msgbox LilycoveCity_Text_1E3061, MSGBOX_YESNO
 	return
 
 LilycoveCity_EventScript_1E2E5A:: @ 81E2E5A
 	setflag FLAG_0x11E
-	msgbox LilycoveCity_Text_1E318D, 4
+	msgbox LilycoveCity_Text_1E318D, MSGBOX_DEFAULT
 	savebgm MUS_DUMMY
 	fadedefaultbgm
 	release
@@ -285,7 +285,7 @@ LilycoveCity_EventScript_1E2E6B:: @ 81E2E6B
 	call_if 0, LilycoveCity_EventScript_1E2EC4
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_EventScript_1E2ECD
-	msgbox LilycoveCity_Text_1E373C, 4
+	msgbox LilycoveCity_Text_1E373C, MSGBOX_DEFAULT
 	switch VAR_STARTER_MON
 	case 0, LilycoveCity_EventScript_1E2F0E
 	case 1, LilycoveCity_EventScript_1E2F1E
@@ -293,16 +293,16 @@ LilycoveCity_EventScript_1E2E6B:: @ 81E2E6B
 	end
 
 LilycoveCity_EventScript_1E2EBB:: @ 81E2EBB
-	msgbox LilycoveCity_Text_1E36FA, 5
+	msgbox LilycoveCity_Text_1E36FA, MSGBOX_YESNO
 	return
 
 LilycoveCity_EventScript_1E2EC4:: @ 81E2EC4
-	msgbox LilycoveCity_Text_1E3608, 5
+	msgbox LilycoveCity_Text_1E3608, MSGBOX_YESNO
 	return
 
 LilycoveCity_EventScript_1E2ECD:: @ 81E2ECD
 	setflag FLAG_0x11E
-	msgbox LilycoveCity_Text_1E36BF, 4
+	msgbox LilycoveCity_Text_1E36BF, MSGBOX_DEFAULT
 	savebgm MUS_DUMMY
 	fadedefaultbgm
 	release
@@ -339,7 +339,7 @@ LilycoveCity_EventScript_1E2F2E:: @ 81E2F2E
 	end
 
 LilycoveCity_EventScript_1E2F3E:: @ 81E2F3E
-	msgbox LilycoveCity_Text_1E32FB, 4
+	msgbox LilycoveCity_Text_1E32FB, MSGBOX_DEFAULT
 	setvar VAR_RESULT, 0
 	checkflag FLAG_BADGE06_GET
 	call_if 1, LilycoveCity_EventScript_1E2F76
@@ -362,21 +362,21 @@ LilycoveCity_EventScript_1E2F80:: @ 81E2F80
 	return
 
 LilycoveCity_EventScript_1E2F86:: @ 81E2F86
-	msgbox LilycoveCity_Text_1E3398, 4
+	msgbox LilycoveCity_Text_1E3398, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_EventScript_1E2F8F:: @ 81E2F8F
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_eq LilycoveCity_EventScript_1E2FA1
-	msgbox LilycoveCity_Text_1E346D, 4
+	msgbox LilycoveCity_Text_1E346D, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_EventScript_1E2FA1:: @ 81E2FA1
-	msgbox LilycoveCity_Text_1E353A, 4
+	msgbox LilycoveCity_Text_1E353A, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_EventScript_1E2FAA:: @ 81E2FAA
-	msgbox LilycoveCity_Text_1E37D7, 4
+	msgbox LilycoveCity_Text_1E37D7, MSGBOX_DEFAULT
 	setvar VAR_RESULT, 0
 	checkflag FLAG_BADGE06_GET
 	call_if 1, LilycoveCity_EventScript_1E2F76
@@ -390,17 +390,17 @@ LilycoveCity_EventScript_1E2FAA:: @ 81E2FAA
 	end
 
 LilycoveCity_EventScript_1E2FE2:: @ 81E2FE2
-	msgbox LilycoveCity_Text_1E3876, 4
+	msgbox LilycoveCity_Text_1E3876, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_EventScript_1E2FEB:: @ 81E2FEB
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_eq LilycoveCity_EventScript_1E2FFD
-	msgbox LilycoveCity_Text_1E390C, 4
+	msgbox LilycoveCity_Text_1E390C, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_EventScript_1E2FFD:: @ 81E2FFD
-	msgbox LilycoveCity_Text_1E39E3, 4
+	msgbox LilycoveCity_Text_1E39E3, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_EventScript_1E3006:: @ 81E3006
@@ -422,7 +422,7 @@ LilycoveCity_EventScript_1E3006:: @ 81E3006
 LilycoveCity_EventScript_1E302D:: @ 81E302D
 	lock
 	faceplayer
-	msgbox LilycoveCity_Text_1E4774, 5
+	msgbox LilycoveCity_Text_1E4774, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	call_if 1, LilycoveCity_EventScript_1E304F
 	compare VAR_RESULT, 0
@@ -431,11 +431,11 @@ LilycoveCity_EventScript_1E302D:: @ 81E302D
 	end
 
 LilycoveCity_EventScript_1E304F:: @ 81E304F
-	msgbox LilycoveCity_Text_1E47A1, 4
+	msgbox LilycoveCity_Text_1E47A1, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_EventScript_1E3058:: @ 81E3058
-	msgbox LilycoveCity_Text_1E4824, 4
+	msgbox LilycoveCity_Text_1E4824, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_Text_1E3061: @ 81E3061

--- a/data/maps/LilycoveCity_ContestHall/scripts.inc
+++ b/data/maps/LilycoveCity_ContestHall/scripts.inc
@@ -2,25 +2,25 @@ LilycoveCity_ContestHall_MapScripts:: @ 821B484
 	.byte 0
 
 LilycoveCity_ContestHall_EventScript_21B485:: @ 821B485
-	msgbox LilycoveCity_ContestHall_Text_21B74E, 2
+	msgbox LilycoveCity_ContestHall_Text_21B74E, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestHall_EventScript_21B48E:: @ 821B48E
-	msgbox LilycoveCity_ContestHall_Text_21B7D7, 2
+	msgbox LilycoveCity_ContestHall_Text_21B7D7, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestHall_EventScript_21B497:: @ 821B497
-	msgbox LilycoveCity_ContestHall_Text_21B899, 2
+	msgbox LilycoveCity_ContestHall_Text_21B899, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestHall_EventScript_21B4A0:: @ 821B4A0
-	msgbox LilycoveCity_ContestHall_Text_21B911, 2
+	msgbox LilycoveCity_ContestHall_Text_21B911, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestHall_EventScript_21B4A9:: @ 821B4A9
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21B977, 4
+	msgbox LilycoveCity_ContestHall_Text_21B977, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -30,7 +30,7 @@ LilycoveCity_ContestHall_EventScript_21B4A9:: @ 821B4A9
 LilycoveCity_ContestHall_EventScript_21B4C0:: @ 821B4C0
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21B9DC, 4
+	msgbox LilycoveCity_ContestHall_Text_21B9DC, MSGBOX_DEFAULT
 	closemessage
 	applymovement 5, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -40,7 +40,7 @@ LilycoveCity_ContestHall_EventScript_21B4C0:: @ 821B4C0
 LilycoveCity_ContestHall_EventScript_21B4D7:: @ 821B4D7
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21BA44, 4
+	msgbox LilycoveCity_ContestHall_Text_21BA44, MSGBOX_DEFAULT
 	closemessage
 	applymovement 6, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -50,7 +50,7 @@ LilycoveCity_ContestHall_EventScript_21B4D7:: @ 821B4D7
 LilycoveCity_ContestHall_EventScript_21B4EE:: @ 821B4EE
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21BAD5, 4
+	msgbox LilycoveCity_ContestHall_Text_21BAD5, MSGBOX_DEFAULT
 	closemessage
 	applymovement 7, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -60,7 +60,7 @@ LilycoveCity_ContestHall_EventScript_21B4EE:: @ 821B4EE
 LilycoveCity_ContestHall_EventScript_21B505:: @ 821B505
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21BB84, 4
+	msgbox LilycoveCity_ContestHall_Text_21BB84, MSGBOX_DEFAULT
 	closemessage
 	applymovement 8, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -70,7 +70,7 @@ LilycoveCity_ContestHall_EventScript_21B505:: @ 821B505
 LilycoveCity_ContestHall_EventScript_21B51C:: @ 821B51C
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21BBDD, 4
+	msgbox LilycoveCity_ContestHall_Text_21BBDD, MSGBOX_DEFAULT
 	closemessage
 	applymovement 9, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -78,13 +78,13 @@ LilycoveCity_ContestHall_EventScript_21B51C:: @ 821B51C
 	end
 
 LilycoveCity_ContestHall_EventScript_21B533:: @ 821B533
-	msgbox LilycoveCity_ContestHall_Text_21BC65, 3
+	msgbox LilycoveCity_ContestHall_Text_21BC65, MSGBOX_SIGN
 	end
 
 LilycoveCity_ContestHall_EventScript_21B53C:: @ 821B53C
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21BC89, 4
+	msgbox LilycoveCity_ContestHall_Text_21BC89, MSGBOX_DEFAULT
 	closemessage
 	applymovement 12, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -94,7 +94,7 @@ LilycoveCity_ContestHall_EventScript_21B53C:: @ 821B53C
 LilycoveCity_ContestHall_EventScript_21B553:: @ 821B553
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21BD30, 4
+	msgbox LilycoveCity_ContestHall_Text_21BD30, MSGBOX_DEFAULT
 	closemessage
 	applymovement 22, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -104,7 +104,7 @@ LilycoveCity_ContestHall_EventScript_21B553:: @ 821B553
 LilycoveCity_ContestHall_EventScript_21B56A:: @ 821B56A
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21BD70, 4
+	msgbox LilycoveCity_ContestHall_Text_21BD70, MSGBOX_DEFAULT
 	closemessage
 	applymovement 11, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -114,7 +114,7 @@ LilycoveCity_ContestHall_EventScript_21B56A:: @ 821B56A
 LilycoveCity_ContestHall_EventScript_21B581:: @ 821B581
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21BDDD, 4
+	msgbox LilycoveCity_ContestHall_Text_21BDDD, MSGBOX_DEFAULT
 	closemessage
 	applymovement 13, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -124,7 +124,7 @@ LilycoveCity_ContestHall_EventScript_21B581:: @ 821B581
 LilycoveCity_ContestHall_EventScript_21B598:: @ 821B598
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21BE16, 4
+	msgbox LilycoveCity_ContestHall_Text_21BE16, MSGBOX_DEFAULT
 	closemessage
 	applymovement 14, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -134,7 +134,7 @@ LilycoveCity_ContestHall_EventScript_21B598:: @ 821B598
 LilycoveCity_ContestHall_EventScript_21B5AF:: @ 821B5AF
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21BE77, 4
+	msgbox LilycoveCity_ContestHall_Text_21BE77, MSGBOX_DEFAULT
 	closemessage
 	applymovement 15, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -144,7 +144,7 @@ LilycoveCity_ContestHall_EventScript_21B5AF:: @ 821B5AF
 LilycoveCity_ContestHall_EventScript_21B5C6:: @ 821B5C6
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21BEDE, 4
+	msgbox LilycoveCity_ContestHall_Text_21BEDE, MSGBOX_DEFAULT
 	closemessage
 	applymovement 16, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -154,7 +154,7 @@ LilycoveCity_ContestHall_EventScript_21B5C6:: @ 821B5C6
 LilycoveCity_ContestHall_EventScript_21B5DD:: @ 821B5DD
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21BF6E, 4
+	msgbox LilycoveCity_ContestHall_Text_21BF6E, MSGBOX_DEFAULT
 	closemessage
 	applymovement 17, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -164,7 +164,7 @@ LilycoveCity_ContestHall_EventScript_21B5DD:: @ 821B5DD
 LilycoveCity_ContestHall_EventScript_21B5F4:: @ 821B5F4
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21BFE3, 4
+	msgbox LilycoveCity_ContestHall_Text_21BFE3, MSGBOX_DEFAULT
 	closemessage
 	applymovement 18, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -174,7 +174,7 @@ LilycoveCity_ContestHall_EventScript_21B5F4:: @ 821B5F4
 LilycoveCity_ContestHall_EventScript_21B60B:: @ 821B60B
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21C07F, 4
+	msgbox LilycoveCity_ContestHall_Text_21C07F, MSGBOX_DEFAULT
 	closemessage
 	applymovement 19, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -184,7 +184,7 @@ LilycoveCity_ContestHall_EventScript_21B60B:: @ 821B60B
 LilycoveCity_ContestHall_EventScript_21B622:: @ 821B622
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21C0D8, 4
+	msgbox LilycoveCity_ContestHall_Text_21C0D8, MSGBOX_DEFAULT
 	closemessage
 	applymovement 21, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -194,7 +194,7 @@ LilycoveCity_ContestHall_EventScript_21B622:: @ 821B622
 LilycoveCity_ContestHall_EventScript_21B639:: @ 821B639
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21C137, 4
+	msgbox LilycoveCity_ContestHall_Text_21C137, MSGBOX_DEFAULT
 	closemessage
 	applymovement 20, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -204,7 +204,7 @@ LilycoveCity_ContestHall_EventScript_21B639:: @ 821B639
 LilycoveCity_ContestHall_EventScript_21B650:: @ 821B650
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21C1A4, 4
+	msgbox LilycoveCity_ContestHall_Text_21C1A4, MSGBOX_DEFAULT
 	closemessage
 	applymovement 23, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -214,7 +214,7 @@ LilycoveCity_ContestHall_EventScript_21B650:: @ 821B650
 LilycoveCity_ContestHall_EventScript_21B667:: @ 821B667
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21C215, 4
+	msgbox LilycoveCity_ContestHall_Text_21C215, MSGBOX_DEFAULT
 	closemessage
 	applymovement 24, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -224,7 +224,7 @@ LilycoveCity_ContestHall_EventScript_21B667:: @ 821B667
 LilycoveCity_ContestHall_EventScript_21B67E:: @ 821B67E
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21C27F, 4
+	msgbox LilycoveCity_ContestHall_Text_21C27F, MSGBOX_DEFAULT
 	closemessage
 	applymovement 25, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -234,7 +234,7 @@ LilycoveCity_ContestHall_EventScript_21B67E:: @ 821B67E
 LilycoveCity_ContestHall_EventScript_21B695:: @ 821B695
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21C2BB, 4
+	msgbox LilycoveCity_ContestHall_Text_21C2BB, MSGBOX_DEFAULT
 	closemessage
 	applymovement 26, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -244,7 +244,7 @@ LilycoveCity_ContestHall_EventScript_21B695:: @ 821B695
 LilycoveCity_ContestHall_EventScript_21B6AC:: @ 821B6AC
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21C307, 4
+	msgbox LilycoveCity_ContestHall_Text_21C307, MSGBOX_DEFAULT
 	closemessage
 	applymovement 27, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -254,7 +254,7 @@ LilycoveCity_ContestHall_EventScript_21B6AC:: @ 821B6AC
 LilycoveCity_ContestHall_EventScript_21B6C3:: @ 821B6C3
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21C365, 4
+	msgbox LilycoveCity_ContestHall_Text_21C365, MSGBOX_DEFAULT
 	closemessage
 	applymovement 28, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -265,19 +265,19 @@ LilycoveCity_ContestHall_EventScript_21B6DA:: @ 821B6DA
 	lockall
 	applymovement 29, LilycoveCity_ContestHall_Movement_27259E
 	waitmovement 0
-	msgbox LilycoveCity_ContestHall_Text_21C3F4, 4
+	msgbox LilycoveCity_ContestHall_Text_21C3F4, MSGBOX_DEFAULT
 	closemessage
 	applymovement 29, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
 	delay 25
-	msgbox LilycoveCity_ContestHall_Text_21C411, 4
+	msgbox LilycoveCity_ContestHall_Text_21C411, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_ContestHall_EventScript_21B705:: @ 821B705
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21C4B1, 4
+	msgbox LilycoveCity_ContestHall_Text_21C4B1, MSGBOX_DEFAULT
 	closemessage
 	applymovement 31, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -287,7 +287,7 @@ LilycoveCity_ContestHall_EventScript_21B705:: @ 821B705
 LilycoveCity_ContestHall_EventScript_21B71C:: @ 821B71C
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestHall_Text_21C445, 4
+	msgbox LilycoveCity_ContestHall_Text_21C445, MSGBOX_DEFAULT
 	closemessage
 	applymovement 30, LilycoveCity_ContestHall_Movement_2725A2
 	waitmovement 0
@@ -295,15 +295,15 @@ LilycoveCity_ContestHall_EventScript_21B71C:: @ 821B71C
 	end
 
 LilycoveCity_ContestHall_EventScript_21B733:: @ 821B733
-	msgbox LilycoveCity_ContestHall_Text_21C512, 3
+	msgbox LilycoveCity_ContestHall_Text_21C512, MSGBOX_SIGN
 	end
 
 LilycoveCity_ContestHall_EventScript_21B73C:: @ 821B73C
-	msgbox LilycoveCity_ContestHall_Text_21C548, 3
+	msgbox LilycoveCity_ContestHall_Text_21C548, MSGBOX_SIGN
 	end
 
 LilycoveCity_ContestHall_EventScript_21B745:: @ 821B745
-	msgbox LilycoveCity_ContestHall_Text_21C57B, 3
+	msgbox LilycoveCity_ContestHall_Text_21C57B, MSGBOX_SIGN
 	end
 
 LilycoveCity_ContestHall_Text_21B74E: @ 821B74E

--- a/data/maps/LilycoveCity_ContestLobby/scripts.inc
+++ b/data/maps/LilycoveCity_ContestLobby/scripts.inc
@@ -39,12 +39,12 @@ LilycoveCity_ContestLobby_EventScript_21A264:: @ 821A264
 	waitmovement 4
 	applymovement 255, LilycoveCity_ContestLobby_Movement_21A418
 	waitmovement 0
-	msgbox LilycoveCity_ContestLobby_Text_21ADB9, 4
+	msgbox LilycoveCity_ContestLobby_Text_21ADB9, MSGBOX_DEFAULT
 	lockall
 	fadescreen 1
 	drawcontestwinner 0
 	lockall
-	msgbox LilycoveCity_ContestLobby_Text_21AE78, 5
+	msgbox LilycoveCity_ContestLobby_Text_21AE78, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_ContestLobby_EventScript_21A2AA
 	compare VAR_RESULT, 0
@@ -53,7 +53,7 @@ LilycoveCity_ContestLobby_EventScript_21A264:: @ 821A264
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A2AA:: @ 821A2AA
-	msgbox LilycoveCity_ContestLobby_Text_21AF63, 4
+	msgbox LilycoveCity_ContestLobby_Text_21AF63, MSGBOX_DEFAULT
 	closemessage
 	special sub_80F88DC
 	setvar VAR_0x4099, 0
@@ -69,10 +69,10 @@ LilycoveCity_ContestLobby_EventScript_21A2AA:: @ 821A2AA
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A2E4:: @ 821A2E4
-	msgbox LilycoveCity_ContestLobby_Text_21B0BC, 5
+	msgbox LilycoveCity_ContestLobby_Text_21B0BC, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_ContestLobby_EventScript_21A2AA
-	msgbox LilycoveCity_ContestLobby_Text_21B132, 4
+	msgbox LilycoveCity_ContestLobby_Text_21B132, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, LilycoveCity_ContestLobby_Movement_21A40F
 	waitmovement 0
@@ -91,12 +91,12 @@ LilycoveCity_ContestLobby_EventScript_21A314:: @ 821A314
 	waitmovement 0
 	applymovement 4, LilycoveCity_ContestLobby_Movement_21A41E
 	waitmovement 0
-	msgbox LilycoveCity_ContestLobby_Text_21B030, 4
+	msgbox LilycoveCity_ContestLobby_Text_21B030, MSGBOX_DEFAULT
 	playfanfare MUS_FANFA4
-	msgbox LilycoveCity_ContestLobby_Text_21B07E, 4
+	msgbox LilycoveCity_ContestLobby_Text_21B07E, MSGBOX_DEFAULT
 	waitfanfare
-	msgbox LilycoveCity_ContestLobby_Text_21B094, 4
-	msgbox LilycoveCity_ContestLobby_Text_21B0AD, 4
+	msgbox LilycoveCity_ContestLobby_Text_21B094, MSGBOX_DEFAULT
+	msgbox LilycoveCity_ContestLobby_Text_21B0AD, MSGBOX_DEFAULT
 	closemessage
 	return
 
@@ -214,11 +214,11 @@ LilycoveCity_ContestLobby_EventScript_21A436:: @ 821A436
 	waitmovement 11
 	applymovement 255, LilycoveCity_ContestLobby_Movement_21A545
 	waitmovement 0
-	msgbox LilycoveCity_ContestLobby_Text_21ADB9, 4
+	msgbox LilycoveCity_ContestLobby_Text_21ADB9, MSGBOX_DEFAULT
 	lockall
 	fadescreen 1
 	drawcontestwinner 0
-	msgbox LilycoveCity_ContestLobby_Text_21AE78, 5
+	msgbox LilycoveCity_ContestLobby_Text_21AE78, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_ContestLobby_EventScript_21A47A
 	compare VAR_RESULT, 0
@@ -226,7 +226,7 @@ LilycoveCity_ContestLobby_EventScript_21A436:: @ 821A436
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A47A:: @ 821A47A
-	msgbox LilycoveCity_ContestLobby_Text_21AF63, 4
+	msgbox LilycoveCity_ContestLobby_Text_21AF63, MSGBOX_DEFAULT
 	closemessage
 	special sub_80F88DC
 	setvar VAR_0x4099, 0
@@ -242,10 +242,10 @@ LilycoveCity_ContestLobby_EventScript_21A47A:: @ 821A47A
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A4B4:: @ 821A4B4
-	msgbox LilycoveCity_ContestLobby_Text_21B0BC, 5
+	msgbox LilycoveCity_ContestLobby_Text_21B0BC, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_ContestLobby_EventScript_21A47A
-	msgbox LilycoveCity_ContestLobby_Text_21B132, 4
+	msgbox LilycoveCity_ContestLobby_Text_21B132, MSGBOX_DEFAULT
 	closemessage
 	applymovement 11, LilycoveCity_ContestLobby_Movement_21A53C
 	waitmovement 0
@@ -265,12 +265,12 @@ LilycoveCity_ContestLobby_EventScript_21A4E4:: @ 821A4E4
 	waitmovement 0
 	applymovement 11, LilycoveCity_ContestLobby_Movement_21A54B
 	waitmovement 0
-	msgbox LilycoveCity_ContestLobby_Text_21B030, 4
+	msgbox LilycoveCity_ContestLobby_Text_21B030, MSGBOX_DEFAULT
 	playfanfare MUS_FANFA4
-	msgbox LilycoveCity_ContestLobby_Text_21B07E, 4
+	msgbox LilycoveCity_ContestLobby_Text_21B07E, MSGBOX_DEFAULT
 	waitfanfare
-	msgbox LilycoveCity_ContestLobby_Text_21B094, 4
-	msgbox LilycoveCity_ContestLobby_Text_21B0AD, 4
+	msgbox LilycoveCity_ContestLobby_Text_21B094, MSGBOX_DEFAULT
+	msgbox LilycoveCity_ContestLobby_Text_21B0AD, MSGBOX_DEFAULT
 	closemessage
 	return
 
@@ -424,7 +424,7 @@ LilycoveCity_ContestLobby_EventScript_21A670:: @ 821A670
 	waitmovement 0
 	applymovement 255, LilycoveCity_ContestLobby_Movement_21A6F2
 	waitmovement 0
-	msgbox LilycoveCity_ContestLobby_Text_27B653, 4
+	msgbox LilycoveCity_ContestLobby_Text_27B653, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, LilycoveCity_ContestLobby_Movement_21A6FD
 	applymovement 255, LilycoveCity_ContestLobby_Movement_21A6E8
@@ -477,27 +477,27 @@ LilycoveCity_ContestLobby_Movement_21A706: @ 821A706
 	step_end
 
 LilycoveCity_ContestLobby_EventScript_21A708:: @ 821A708
-	msgbox LilycoveCity_ContestLobby_Text_21B1B1, 2
+	msgbox LilycoveCity_ContestLobby_Text_21B1B1, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A711:: @ 821A711
-	msgbox LilycoveCity_ContestLobby_Text_21B24D, 2
+	msgbox LilycoveCity_ContestLobby_Text_21B24D, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A71A:: @ 821A71A
-	msgbox LilycoveCity_ContestLobby_Text_21B2BA, 2
+	msgbox LilycoveCity_ContestLobby_Text_21B2BA, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A723:: @ 821A723
-	msgbox LilycoveCity_ContestLobby_Text_21B334, 2
+	msgbox LilycoveCity_ContestLobby_Text_21B334, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A72C:: @ 821A72C
-	msgbox LilycoveCity_ContestLobby_Text_21B392, 2
+	msgbox LilycoveCity_ContestLobby_Text_21B392, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A735:: @ 821A735
-	msgbox LilycoveCity_ContestLobby_Text_21B3FC, 2
+	msgbox LilycoveCity_ContestLobby_Text_21B3FC, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A73E:: @ 821A73E
@@ -543,11 +543,11 @@ LilycoveCity_ContestLobby_EventScript_21A761:: @ 821A761
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A768:: @ 821A768
-	msgbox LilycoveCity_ContestLobby_Text_2931AA, 2
+	msgbox LilycoveCity_ContestLobby_Text_2931AA, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A771:: @ 821A771
-	msgbox LilycoveCity_ContestLobby_Text_2931C6, 2
+	msgbox LilycoveCity_ContestLobby_Text_2931C6, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A77A:: @ 821A77A
@@ -571,46 +571,46 @@ LilycoveCity_ContestLobby_EventScript_21A784:: @ 821A784
 LilycoveCity_ContestLobby_EventScript_21A798:: @ 821A798
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestLobby_Text_2C427C, 4
+	msgbox LilycoveCity_ContestLobby_Text_2C427C, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A7F9
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A7A8:: @ 821A7A8
 	lock
-	msgbox LilycoveCity_ContestLobby_Text_2C464B, 4
+	msgbox LilycoveCity_ContestLobby_Text_2C464B, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A7B3:: @ 821A7B3
 	lock
-	msgbox LilycoveCity_ContestLobby_Text_2C465A, 4
+	msgbox LilycoveCity_ContestLobby_Text_2C465A, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A7BE:: @ 821A7BE
 	lock
-	msgbox LilycoveCity_ContestLobby_Text_2C4669, 4
+	msgbox LilycoveCity_ContestLobby_Text_2C4669, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A7C9:: @ 821A7C9
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestLobby_Text_2C4679, 4
+	msgbox LilycoveCity_ContestLobby_Text_2C4679, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A7F9
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A7D9:: @ 821A7D9
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestLobby_Text_2C46B1, 4
+	msgbox LilycoveCity_ContestLobby_Text_2C46B1, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A7F9
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A7E9:: @ 821A7E9
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestLobby_Text_2C4763, 4
+	msgbox LilycoveCity_ContestLobby_Text_2C4763, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A7F9
 	end
 
@@ -625,7 +625,7 @@ LilycoveCity_ContestLobby_EventScript_21A806:: @ 821A806
 	special sub_80F9154
 	lock
 	faceplayer
-	msgbox LilycoveCity_ContestLobby_Text_27C063, 4
+	msgbox LilycoveCity_ContestLobby_Text_27C063, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A819
 	end
 
@@ -641,7 +641,7 @@ LilycoveCity_ContestLobby_EventScript_21A819:: @ 821A819
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A856:: @ 821A856
-	msgbox LilycoveCity_ContestLobby_Text_27BD17, 5
+	msgbox LilycoveCity_ContestLobby_Text_27BD17, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_ContestLobby_EventScript_21A97F
 	call LilycoveCity_ContestLobby_EventScript_27134F
@@ -694,28 +694,28 @@ LilycoveCity_ContestLobby_EventScript_21A90D:: @ 821A90D
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A955:: @ 821A955
-	msgbox LilycoveCity_ContestLobby_Text_27C340, 4
+	msgbox LilycoveCity_ContestLobby_Text_27C340, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A90D
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A963:: @ 821A963
-	msgbox LilycoveCity_ContestLobby_Text_27C5B1, 4
+	msgbox LilycoveCity_ContestLobby_Text_27C5B1, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A90D
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A971:: @ 821A971
-	msgbox LilycoveCity_ContestLobby_Text_27C742, 4
+	msgbox LilycoveCity_ContestLobby_Text_27C742, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A90D
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A97F:: @ 821A97F
 	special CloseLink
-	msgbox LilycoveCity_ContestLobby_Text_27BD4F, 4
+	msgbox LilycoveCity_ContestLobby_Text_27BD4F, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A98C:: @ 821A98C
-	msgbox LilycoveCity_ContestLobby_Text_27C1C3, 4
+	msgbox LilycoveCity_ContestLobby_Text_27C1C3, MSGBOX_DEFAULT
 	setvar VAR_CONTEST_RANK, 0
 	choosecontestmon
 	compare VAR_0x8004, 255
@@ -734,17 +734,17 @@ LilycoveCity_ContestLobby_EventScript_21A98C:: @ 821A98C
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A9E0:: @ 821A9E0
-	msgbox LilycoveCity_ContestLobby_Text_27B471, 4
+	msgbox LilycoveCity_ContestLobby_Text_27B471, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A98C
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A9EE:: @ 821A9EE
-	msgbox LilycoveCity_ContestLobby_Text_27C186, 4
+	msgbox LilycoveCity_ContestLobby_Text_27C186, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A98C
 	end
 
 LilycoveCity_ContestLobby_EventScript_21A9FC:: @ 821A9FC
-	msgbox LilycoveCity_ContestLobby_Text_27C140, 4
+	msgbox LilycoveCity_ContestLobby_Text_27C140, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A98C
 	end
 
@@ -796,34 +796,34 @@ LilycoveCity_ContestLobby_EventScript_21AAC0:: @ 821AAC0
 	return
 
 LilycoveCity_ContestLobby_EventScript_21AAC5:: @ 821AAC5
-	msgbox LilycoveCity_ContestLobby_Text_27BF0E, 4
+	msgbox LilycoveCity_ContestLobby_Text_27BF0E, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A97F
 	end
 
 LilycoveCity_ContestLobby_EventScript_21AAD3:: @ 821AAD3
-	msgbox LilycoveCity_ContestLobby_Text_27BF4B, 4
+	msgbox LilycoveCity_ContestLobby_Text_27BF4B, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A97F
 	end
 
 LilycoveCity_ContestLobby_EventScript_21AAE1:: @ 821AAE1
-	msgbox LilycoveCity_ContestLobby_Text_27C254, 4
+	msgbox LilycoveCity_ContestLobby_Text_27C254, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A97F
 	end
 
 LilycoveCity_ContestLobby_EventScript_21AAEF:: @ 821AAEF
 	special CloseLink
-	msgbox LilycoveCity_ContestLobby_Text_27821C, 4
+	msgbox LilycoveCity_ContestLobby_Text_27821C, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_21AAFC:: @ 821AAFC
 	special CloseLink
-	msgbox LilycoveCity_ContestLobby_Text_27C879, 4
+	msgbox LilycoveCity_ContestLobby_Text_27C879, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_21AB09:: @ 821AB09
-	msgbox LilycoveCity_ContestLobby_Text_27BEFA, 4
+	msgbox LilycoveCity_ContestLobby_Text_27BEFA, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_21A97F
 	end
 
@@ -1008,12 +1008,12 @@ LilycoveCity_ContestLobby_EventScript_21ACF1:: @ 821ACF1
 	faceplayer
 	checkflag FLAG_0x05F
 	goto_eq LilycoveCity_ContestLobby_EventScript_21AD06
-	msgbox LilycoveCity_ContestLobby_Text_21AD10, 4
+	msgbox LilycoveCity_ContestLobby_Text_21AD10, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_21AD06:: @ 821AD06
-	msgbox LilycoveCity_ContestLobby_Text_21AD55, 4
+	msgbox LilycoveCity_ContestLobby_Text_21AD55, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/LilycoveCity_CoveLilyMotel_1F/scripts.inc
+++ b/data/maps/LilycoveCity_CoveLilyMotel_1F/scripts.inc
@@ -7,10 +7,10 @@ LilycoveCity_CoveLilyMotel_1F_EventScript_218189:: @ 8218189
 	goto_eq LilycoveCity_CoveLilyMotel_1F_EventScript_2181EA
 	checkflag FLAG_BADGE07_GET
 	goto_eq LilycoveCity_CoveLilyMotel_1F_EventScript_2181C3
-	msgbox LilycoveCity_CoveLilyMotel_1F_Text_218264, 4
+	msgbox LilycoveCity_CoveLilyMotel_1F_Text_218264, MSGBOX_DEFAULT
 	applymovement 1, LilycoveCity_CoveLilyMotel_1F_Movement_27259E
 	waitmovement 0
-	msgbox LilycoveCity_CoveLilyMotel_1F_Text_21831E, 4
+	msgbox LilycoveCity_CoveLilyMotel_1F_Text_21831E, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, LilycoveCity_CoveLilyMotel_1F_Movement_2725A2
 	waitmovement 0
@@ -18,10 +18,10 @@ LilycoveCity_CoveLilyMotel_1F_EventScript_218189:: @ 8218189
 	end
 
 LilycoveCity_CoveLilyMotel_1F_EventScript_2181C3:: @ 82181C3
-	msgbox LilycoveCity_CoveLilyMotel_1F_Text_2183C3, 4
+	msgbox LilycoveCity_CoveLilyMotel_1F_Text_2183C3, MSGBOX_DEFAULT
 	applymovement 1, LilycoveCity_CoveLilyMotel_1F_Movement_27259E
 	waitmovement 0
-	msgbox LilycoveCity_CoveLilyMotel_1F_Text_218470, 4
+	msgbox LilycoveCity_CoveLilyMotel_1F_Text_218470, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, LilycoveCity_CoveLilyMotel_1F_Movement_2725A2
 	waitmovement 0
@@ -29,10 +29,10 @@ LilycoveCity_CoveLilyMotel_1F_EventScript_2181C3:: @ 82181C3
 	end
 
 LilycoveCity_CoveLilyMotel_1F_EventScript_2181EA:: @ 82181EA
-	msgbox LilycoveCity_CoveLilyMotel_1F_Text_218544, 4
+	msgbox LilycoveCity_CoveLilyMotel_1F_Text_218544, MSGBOX_DEFAULT
 	applymovement 1, LilycoveCity_CoveLilyMotel_1F_Movement_27259E
 	waitmovement 0
-	msgbox LilycoveCity_CoveLilyMotel_1F_Text_2185F4, 4
+	msgbox LilycoveCity_CoveLilyMotel_1F_Text_2185F4, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, LilycoveCity_CoveLilyMotel_1F_Movement_2725A2
 	waitmovement 0
@@ -48,7 +48,7 @@ LilycoveCity_CoveLilyMotel_1F_EventScript_218211:: @ 8218211
 	waitmovement 0
 	applymovement 255, LilycoveCity_CoveLilyMotel_1F_Movement_2725AA
 	waitmovement 0
-	msgbox LilycoveCity_CoveLilyMotel_1F_Text_21839B, 4
+	msgbox LilycoveCity_CoveLilyMotel_1F_Text_21839B, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, LilycoveCity_CoveLilyMotel_1F_Movement_218259
 	applymovement 1, LilycoveCity_CoveLilyMotel_1F_Movement_21825E

--- a/data/maps/LilycoveCity_CoveLilyMotel_2F/scripts.inc
+++ b/data/maps/LilycoveCity_CoveLilyMotel_2F/scripts.inc
@@ -15,7 +15,7 @@ LilycoveCity_CoveLilyMotel_2F_EventScript_2186D3:: @ 82186D3
 	end
 
 LilycoveCity_CoveLilyMotel_2F_EventScript_2186F9:: @ 82186F9
-	msgbox LilycoveCity_CoveLilyMotel_2F_Text_218774, 4
+	msgbox LilycoveCity_CoveLilyMotel_2F_Text_218774, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_CoveLilyMotel_2F_EventScript_218702:: @ 8218702
@@ -35,23 +35,23 @@ LilycoveCity_CoveLilyMotel_2F_EventScript_21870F:: @ 821870F
 	end
 
 LilycoveCity_CoveLilyMotel_2F_EventScript_218720:: @ 8218720
-	msgbox LilycoveCity_CoveLilyMotel_2F_Text_2188D6, 2
+	msgbox LilycoveCity_CoveLilyMotel_2F_Text_2188D6, MSGBOX_NPC
 	end
 
 LilycoveCity_CoveLilyMotel_2F_EventScript_218729:: @ 8218729
-	msgbox LilycoveCity_CoveLilyMotel_2F_Text_21892B, 2
+	msgbox LilycoveCity_CoveLilyMotel_2F_Text_21892B, MSGBOX_NPC
 	end
 
 LilycoveCity_CoveLilyMotel_2F_EventScript_218732:: @ 8218732
-	msgbox LilycoveCity_CoveLilyMotel_2F_Text_21896C, 2
+	msgbox LilycoveCity_CoveLilyMotel_2F_Text_21896C, MSGBOX_NPC
 	end
 
 LilycoveCity_CoveLilyMotel_2F_EventScript_21873B:: @ 821873B
-	msgbox LilycoveCity_CoveLilyMotel_2F_Text_218A21, 2
+	msgbox LilycoveCity_CoveLilyMotel_2F_Text_218A21, MSGBOX_NPC
 	end
 
 LilycoveCity_CoveLilyMotel_2F_EventScript_218744:: @ 8218744
-	msgbox LilycoveCity_CoveLilyMotel_2F_Text_218A5B, 2
+	msgbox LilycoveCity_CoveLilyMotel_2F_Text_218A5B, MSGBOX_NPC
 	end
 
 LilycoveCity_CoveLilyMotel_2F_EventScript_21874D:: @ 821874D
@@ -59,14 +59,14 @@ LilycoveCity_CoveLilyMotel_2F_EventScript_21874D:: @ 821874D
 	faceplayer
 	checkflag FLAG_0x1CE
 	goto_eq LilycoveCity_CoveLilyMotel_2F_EventScript_21876A
-	msgbox LilycoveCity_CoveLilyMotel_2F_Text_218ACF, 4
+	msgbox LilycoveCity_CoveLilyMotel_2F_Text_218ACF, MSGBOX_DEFAULT
 	addvar VAR_0x40D1, 1
 	setflag FLAG_0x1CE
 	release
 	end
 
 LilycoveCity_CoveLilyMotel_2F_EventScript_21876A:: @ 821876A
-	msgbox LilycoveCity_CoveLilyMotel_2F_Text_218C33, 4
+	msgbox LilycoveCity_CoveLilyMotel_2F_Text_218C33, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/LilycoveCity_DepartmentStoreRooftop/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStoreRooftop/scripts.inc
@@ -24,7 +24,7 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_22022F:: @ 822022F
 	message gUnknown_08272A21
 	waitmessage
 	pokemartdecoration LilycoveCity_DepartmentStoreRooftop_PokemartDecor_220248
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -54,17 +54,17 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_220268:: @ 8220268
 	getpricereduction 3
 	compare VAR_RESULT, 1
 	call_if 1, LilycoveCity_DepartmentStoreRooftop_EventScript_220282
-	msgbox LilycoveCity_DepartmentStoreRooftop_Text_220463, 4
+	msgbox LilycoveCity_DepartmentStoreRooftop_Text_220463, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_DepartmentStoreRooftop_EventScript_220282:: @ 8220282
-	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2204C9, 4
+	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2204C9, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_DepartmentStoreRooftop_EventScript_22028C:: @ 822028C
-	msgbox LilycoveCity_DepartmentStoreRooftop_Text_220552, 2
+	msgbox LilycoveCity_DepartmentStoreRooftop_Text_220552, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStoreRooftop_EventScript_220295:: @ 8220295
@@ -82,7 +82,7 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_2202A6:: @ 82202A6
 	case 0, LilycoveCity_DepartmentStoreRooftop_EventScript_2202E4
 	case 1, LilycoveCity_DepartmentStoreRooftop_EventScript_2202EF
 	case 2, LilycoveCity_DepartmentStoreRooftop_EventScript_2202FA
-	msgbox LilycoveCity_DepartmentStoreRooftop_Text_220603, 4
+	msgbox LilycoveCity_DepartmentStoreRooftop_Text_220603, MSGBOX_DEFAULT
 	goto LilycoveCity_DepartmentStoreRooftop_EventScript_22045E
 	end
 
@@ -147,11 +147,11 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_22032F:: @ 822032F
 	nop
 	bufferitemname 0, VAR_TEMP_0
 	playse SE_JIHANKI
-	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2205A1, 4
+	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2205A1, MSGBOX_DEFAULT
 	giveitem VAR_TEMP_0, 1
 	bufferitemname 1, VAR_TEMP_0
 	bufferstdstring 2, 14
-	msgbox gUnknown_08272A9A, 4
+	msgbox gUnknown_08272A9A, MSGBOX_DEFAULT
 	random 64
 	compare VAR_RESULT, 0
 	goto_if 5, LilycoveCity_DepartmentStoreRooftop_EventScript_220436
@@ -159,11 +159,11 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_22032F:: @ 822032F
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_DepartmentStoreRooftop_EventScript_220450
 	playse SE_JIHANKI
-	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2205C2, 4
+	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2205C2, MSGBOX_DEFAULT
 	giveitem VAR_TEMP_0, 1
 	bufferitemname 1, VAR_TEMP_0
 	bufferstdstring 2, 14
-	msgbox gUnknown_08272A9A, 4
+	msgbox gUnknown_08272A9A, MSGBOX_DEFAULT
 	random 64
 	compare VAR_RESULT, 0
 	goto_if 5, LilycoveCity_DepartmentStoreRooftop_EventScript_220436
@@ -171,11 +171,11 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_22032F:: @ 822032F
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_DepartmentStoreRooftop_EventScript_220450
 	playse SE_JIHANKI
-	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2205C2, 4
+	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2205C2, MSGBOX_DEFAULT
 	giveitem VAR_TEMP_0, 1
 	bufferitemname 1, VAR_TEMP_0
 	bufferstdstring 2, 14
-	msgbox gUnknown_08272A9A, 4
+	msgbox gUnknown_08272A9A, MSGBOX_DEFAULT
 	goto LilycoveCity_DepartmentStoreRooftop_EventScript_220436
 	end
 
@@ -186,12 +186,12 @@ LilycoveCity_DepartmentStoreRooftop_EventScript_220436:: @ 8220436
 	end
 
 LilycoveCity_DepartmentStoreRooftop_EventScript_220442:: @ 8220442
-	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2205F1, 4
+	msgbox LilycoveCity_DepartmentStoreRooftop_Text_2205F1, MSGBOX_DEFAULT
 	goto LilycoveCity_DepartmentStoreRooftop_EventScript_22045E
 	end
 
 LilycoveCity_DepartmentStoreRooftop_EventScript_220450:: @ 8220450
-	msgbox gUnknown_08272A89, 4
+	msgbox gUnknown_08272A89, MSGBOX_DEFAULT
 	goto LilycoveCity_DepartmentStoreRooftop_EventScript_22045E
 	end
 

--- a/data/maps/LilycoveCity_DepartmentStore_1F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_1F/scripts.inc
@@ -2,7 +2,7 @@ LilycoveCity_DepartmentStore_1F_MapScripts:: @ 821F692
 	.byte 0
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F693:: @ 821F693
-	msgbox LilycoveCity_DepartmentStore_1F_Text_21F866, 2
+	msgbox LilycoveCity_DepartmentStore_1F_Text_21F866, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F69C:: @ 821F69C
@@ -13,7 +13,7 @@ LilycoveCity_DepartmentStore_1F_EventScript_21F69C:: @ 821F69C
 	goto_if 5, LilycoveCity_DepartmentStore_1F_EventScript_21F7F7
 	checkflag FLAG_0x92A
 	goto_eq LilycoveCity_DepartmentStore_1F_EventScript_21F78D
-	msgbox LilycoveCity_DepartmentStore_1F_Text_2A6390, 5
+	msgbox LilycoveCity_DepartmentStore_1F_Text_2A6390, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_DepartmentStore_1F_EventScript_21F797
 	setflag FLAG_0x92A
@@ -22,7 +22,7 @@ LilycoveCity_DepartmentStore_1F_EventScript_21F69C:: @ 821F69C
 	special RetrieveLotteryNumber
 	copyvar VAR_0x8008, VAR_RESULT
 	special BufferLottoTicketNumber
-	msgbox LilycoveCity_DepartmentStore_1F_Text_2A650B, 4
+	msgbox LilycoveCity_DepartmentStore_1F_Text_2A650B, MSGBOX_DEFAULT
 	applymovement 2, LilycoveCity_DepartmentStore_1F_Movement_2725A8
 	waitmovement 0
 	playse SE_PC_ON
@@ -57,47 +57,47 @@ LilycoveCity_DepartmentStore_1F_EventScript_21F69C:: @ 821F69C
 	end
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F77B:: @ 821F77B
-	msgbox LilycoveCity_DepartmentStore_1F_Text_2A6592, 4
+	msgbox LilycoveCity_DepartmentStore_1F_Text_2A6592, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F784:: @ 821F784
-	msgbox LilycoveCity_DepartmentStore_1F_Text_2A65E6, 4
+	msgbox LilycoveCity_DepartmentStore_1F_Text_2A65E6, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F78D:: @ 821F78D
-	msgbox LilycoveCity_DepartmentStore_1F_Text_2A6496, 4
+	msgbox LilycoveCity_DepartmentStore_1F_Text_2A6496, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F797:: @ 821F797
-	msgbox LilycoveCity_DepartmentStore_1F_Text_2A64B1, 4
+	msgbox LilycoveCity_DepartmentStore_1F_Text_2A64B1, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F7A1:: @ 821F7A1
-	msgbox LilycoveCity_DepartmentStore_1F_Text_2A663C, 4
+	msgbox LilycoveCity_DepartmentStore_1F_Text_2A663C, MSGBOX_DEFAULT
 	goto LilycoveCity_DepartmentStore_1F_EventScript_21F7AF
 	end
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F7AF:: @ 821F7AF
-	msgbox LilycoveCity_DepartmentStore_1F_Text_2A6831, 4
+	msgbox LilycoveCity_DepartmentStore_1F_Text_2A6831, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F7B9:: @ 821F7B9
-	msgbox LilycoveCity_DepartmentStore_1F_Text_2A6664, 4
+	msgbox LilycoveCity_DepartmentStore_1F_Text_2A6664, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F7C2:: @ 821F7C2
-	msgbox LilycoveCity_DepartmentStore_1F_Text_2A66A7, 4
+	msgbox LilycoveCity_DepartmentStore_1F_Text_2A66A7, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F7CB:: @ 821F7CB
-	msgbox LilycoveCity_DepartmentStore_1F_Text_2A66ED, 4
+	msgbox LilycoveCity_DepartmentStore_1F_Text_2A66ED, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F7D4:: @ 821F7D4
-	msgbox LilycoveCity_DepartmentStore_1F_Text_2A6731, 4
+	msgbox LilycoveCity_DepartmentStore_1F_Text_2A6731, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F7DD:: @ 821F7DD
@@ -107,12 +107,12 @@ LilycoveCity_DepartmentStore_1F_EventScript_21F7DD:: @ 821F7DD
 	end
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F7ED:: @ 821F7ED
-	msgbox LilycoveCity_DepartmentStore_1F_Text_2A678C, 4
+	msgbox LilycoveCity_DepartmentStore_1F_Text_2A678C, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F7F7:: @ 821F7F7
-	msgbox LilycoveCity_DepartmentStore_1F_Text_2A67E1, 4
+	msgbox LilycoveCity_DepartmentStore_1F_Text_2A67E1, MSGBOX_DEFAULT
 	giveitem_std VAR_POKELOT_PRIZE
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_DepartmentStore_1F_EventScript_21F7ED
@@ -125,15 +125,15 @@ LilycoveCity_DepartmentStore_1F_EventScript_21F7F7:: @ 821F7F7
 	end
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F82F:: @ 821F82F
-	msgbox LilycoveCity_DepartmentStore_1F_Text_21F88C, 2
+	msgbox LilycoveCity_DepartmentStore_1F_Text_21F88C, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F838:: @ 821F838
-	msgbox LilycoveCity_DepartmentStore_1F_Text_21F8F5, 2
+	msgbox LilycoveCity_DepartmentStore_1F_Text_21F8F5, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F841:: @ 821F841
-	msgbox LilycoveCity_DepartmentStore_1F_Text_21F92B, 2
+	msgbox LilycoveCity_DepartmentStore_1F_Text_21F92B, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F84A:: @ 821F84A
@@ -141,13 +141,13 @@ LilycoveCity_DepartmentStore_1F_EventScript_21F84A:: @ 821F84A
 	faceplayer
 	waitse
 	playmoncry SPECIES_AZUMARILL, 0
-	msgbox LilycoveCity_DepartmentStore_1F_Text_21F974, 4
+	msgbox LilycoveCity_DepartmentStore_1F_Text_21F974, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
 
 LilycoveCity_DepartmentStore_1F_EventScript_21F85D:: @ 821F85D
-	msgbox LilycoveCity_DepartmentStore_1F_Text_21F98A, 3
+	msgbox LilycoveCity_DepartmentStore_1F_Text_21F98A, MSGBOX_SIGN
 	end
 
 LilycoveCity_DepartmentStore_1F_Text_21F866: @ 821F866

--- a/data/maps/LilycoveCity_DepartmentStore_2F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_2F/scripts.inc
@@ -2,15 +2,15 @@ LilycoveCity_DepartmentStore_2F_MapScripts:: @ 821FB2C
 	.byte 0
 
 LilycoveCity_DepartmentStore_2F_EventScript_21FB2D:: @ 821FB2D
-	msgbox LilycoveCity_DepartmentStore_2F_Text_21FBAC, 2
+	msgbox LilycoveCity_DepartmentStore_2F_Text_21FBAC, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_2F_EventScript_21FB36:: @ 821FB36
-	msgbox LilycoveCity_DepartmentStore_2F_Text_21FBDF, 2
+	msgbox LilycoveCity_DepartmentStore_2F_Text_21FBDF, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_2F_EventScript_21FB3F:: @ 821FB3F
-	msgbox LilycoveCity_DepartmentStore_2F_Text_21FC23, 2
+	msgbox LilycoveCity_DepartmentStore_2F_Text_21FC23, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_2F_EventScript_21FB48:: @ 821FB48
@@ -19,7 +19,7 @@ LilycoveCity_DepartmentStore_2F_EventScript_21FB48:: @ 821FB48
 	message gUnknown_08272A21
 	waitmessage
 	pokemart LilycoveCity_DepartmentStore_2F_Pokemart_21FB60
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -46,7 +46,7 @@ LilycoveCity_DepartmentStore_2F_EventScript_21FB7A:: @ 821FB7A
 	message gUnknown_08272A21
 	waitmessage
 	pokemart LilycoveCity_DepartmentStore_2F_Pokemart_21FB94
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/LilycoveCity_DepartmentStore_3F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_3F/scripts.inc
@@ -7,7 +7,7 @@ LilycoveCity_DepartmentStore_3F_EventScript_21FC65:: @ 821FC65
 	message gUnknown_08272A21
 	waitmessage
 	pokemart LilycoveCity_DepartmentStore_3F_Pokemart_21FC7C
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -28,7 +28,7 @@ LilycoveCity_DepartmentStore_3F_EventScript_21FC8C:: @ 821FC8C
 	message gUnknown_08272A21
 	waitmessage
 	pokemart LilycoveCity_DepartmentStore_3F_Pokemart_21FCA4
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -46,15 +46,15 @@ LilycoveCity_DepartmentStore_3F_Pokemart_21FCA4: @ 821FCA4
 	end
 
 LilycoveCity_DepartmentStore_3F_EventScript_21FCB6:: @ 821FCB6
-	msgbox LilycoveCity_DepartmentStore_3F_Text_21FCD1, 2
+	msgbox LilycoveCity_DepartmentStore_3F_Text_21FCD1, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_3F_EventScript_21FCBF:: @ 821FCBF
-	msgbox LilycoveCity_DepartmentStore_3F_Text_21FD3B, 2
+	msgbox LilycoveCity_DepartmentStore_3F_Text_21FD3B, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_3F_EventScript_21FCC8:: @ 821FCC8
-	msgbox LilycoveCity_DepartmentStore_3F_Text_21FDB4, 2
+	msgbox LilycoveCity_DepartmentStore_3F_Text_21FDB4, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_3F_Text_21FCD1: @ 821FCD1

--- a/data/maps/LilycoveCity_DepartmentStore_4F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_4F/scripts.inc
@@ -2,15 +2,15 @@ LilycoveCity_DepartmentStore_4F_MapScripts:: @ 821FDEA
 	.byte 0
 
 LilycoveCity_DepartmentStore_4F_EventScript_21FDEB:: @ 821FDEB
-	msgbox LilycoveCity_DepartmentStore_4F_Text_21FE50, 2
+	msgbox LilycoveCity_DepartmentStore_4F_Text_21FE50, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_4F_EventScript_21FDF4:: @ 821FDF4
-	msgbox LilycoveCity_DepartmentStore_4F_Text_21FEC7, 2
+	msgbox LilycoveCity_DepartmentStore_4F_Text_21FEC7, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_4F_EventScript_21FDFD:: @ 821FDFD
-	msgbox LilycoveCity_DepartmentStore_4F_Text_21FF2D, 2
+	msgbox LilycoveCity_DepartmentStore_4F_Text_21FF2D, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_4F_EventScript_21FE06:: @ 821FE06
@@ -19,7 +19,7 @@ LilycoveCity_DepartmentStore_4F_EventScript_21FE06:: @ 821FE06
 	message gUnknown_08272A21
 	waitmessage
 	pokemart LilycoveCity_DepartmentStore_4F_Pokemart_21FE20
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -39,7 +39,7 @@ LilycoveCity_DepartmentStore_4F_EventScript_21FE2C:: @ 821FE2C
 	message gUnknown_08272A21
 	waitmessage
 	pokemart LilycoveCity_DepartmentStore_4F_Pokemart_21FE44
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/LilycoveCity_DepartmentStore_5F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_5F/scripts.inc
@@ -19,7 +19,7 @@ LilycoveCity_DepartmentStore_5F_EventScript_21FFA6:: @ 821FFA6
 	message gUnknown_08272A21
 	waitmessage
 	pokemartdecoration2 LilycoveCity_DepartmentStore_5F_Pokemart_21FFC0
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -47,7 +47,7 @@ LilycoveCity_DepartmentStore_5F_EventScript_21FFDC:: @ 821FFDC
 	message gUnknown_08272A21
 	waitmessage
 	pokemartdecoration2 LilycoveCity_DepartmentStore_5F_Pokemart_21FFF4
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -72,7 +72,7 @@ LilycoveCity_DepartmentStore_5F_EventScript_22000A:: @ 822000A
 	message gUnknown_08272A21
 	waitmessage
 	pokemartdecoration2 LilycoveCity_DepartmentStore_5F_Pokemart_220024
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -97,7 +97,7 @@ LilycoveCity_DepartmentStore_5F_EventScript_22003A:: @ 822003A
 	message gUnknown_08272A21
 	waitmessage
 	pokemartdecoration2 LilycoveCity_DepartmentStore_5F_Pokemart_220054
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -118,7 +118,7 @@ LilycoveCity_DepartmentStore_5F_Pokemart_220054: @ 8220054
 	end
 
 LilycoveCity_DepartmentStore_5F_EventScript_22006C:: @ 822006C
-	msgbox LilycoveCity_DepartmentStore_5F_Text_2200C5, 2
+	msgbox LilycoveCity_DepartmentStore_5F_Text_2200C5, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_5F_EventScript_220075:: @ 8220075
@@ -133,13 +133,13 @@ LilycoveCity_DepartmentStore_5F_EventScript_220075:: @ 8220075
 	end
 
 LilycoveCity_DepartmentStore_5F_EventScript_22009C:: @ 822009C
-	msgbox LilycoveCity_DepartmentStore_5F_Text_22016B, 4
+	msgbox LilycoveCity_DepartmentStore_5F_Text_22016B, MSGBOX_DEFAULT
 	closemessage
 	releaseall
 	end
 
 LilycoveCity_DepartmentStore_5F_EventScript_2200A7:: @ 82200A7
-	msgbox LilycoveCity_DepartmentStore_5F_Text_2201C4, 4
+	msgbox LilycoveCity_DepartmentStore_5F_Text_2201C4, MSGBOX_DEFAULT
 	closemessage
 	applymovement 7, LilycoveCity_DepartmentStore_5F_Movement_2725A6
 	waitmovement 0
@@ -147,7 +147,7 @@ LilycoveCity_DepartmentStore_5F_EventScript_2200A7:: @ 82200A7
 	end
 
 LilycoveCity_DepartmentStore_5F_EventScript_2200BC:: @ 82200BC
-	msgbox LilycoveCity_DepartmentStore_5F_Text_220122, 2
+	msgbox LilycoveCity_DepartmentStore_5F_Text_220122, MSGBOX_NPC
 	end
 
 LilycoveCity_DepartmentStore_5F_Text_2200C5: @ 82200C5

--- a/data/maps/LilycoveCity_Harbor/scripts.inc
+++ b/data/maps/LilycoveCity_Harbor/scripts.inc
@@ -35,7 +35,7 @@ LilycoveCity_Harbor_EventScript_21E00F:: @ 821E00F
 LilycoveCity_Harbor_EventScript_21E080:: @ 821E080
 	compare VAR_TEMP_A, 0
 	goto_eq LilycoveCity_Harbor_EventScript_21E557
-	msgbox LilycoveCity_Harbor_Text_21E758, 4
+	msgbox LilycoveCity_Harbor_Text_21E758, MSGBOX_DEFAULT
 	message LilycoveCity_Harbor_Text_21E7ED
 	waitmessage
 	goto LilycoveCity_Harbor_EventScript_21E09F
@@ -86,7 +86,7 @@ LilycoveCity_Harbor_EventScript_21E139:: @ 821E139
 	end
 
 LilycoveCity_Harbor_EventScript_21E149:: @ 821E149
-	msgbox LilycoveCity_Harbor_Text_21E864, 5
+	msgbox LilycoveCity_Harbor_Text_21E864, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_Harbor_EventScript_21E5C0
 	setvar VAR_PORTHOLE_STATE, 5
@@ -97,7 +97,7 @@ LilycoveCity_Harbor_EventScript_21E149:: @ 821E149
 	end
 
 LilycoveCity_Harbor_EventScript_21E171:: @ 821E171
-	msgbox LilycoveCity_Harbor_Text_21E880, 5
+	msgbox LilycoveCity_Harbor_Text_21E880, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_Harbor_EventScript_21E5C0
 	call LilycoveCity_Harbor_EventScript_21E5CC
@@ -216,10 +216,10 @@ LilycoveCity_Harbor_EventScript_21E2EA:: @ 821E2EA
 
 LilycoveCity_Harbor_EventScript_21E2F0:: @ 821E2F0
 	setflag FLAG_0x1AE
-	msgbox LilycoveCity_Harbor_Text_2A68D2, 4
+	msgbox LilycoveCity_Harbor_Text_2A68D2, MSGBOX_DEFAULT
 	closemessage
 	call LilycoveCity_Harbor_EventScript_21E4EE
-	msgbox LilycoveCity_Harbor_Text_2A68FC, 4
+	msgbox LilycoveCity_Harbor_Text_2A68FC, MSGBOX_DEFAULT
 	goto LilycoveCity_Harbor_EventScript_21E30F
 	end
 
@@ -233,10 +233,10 @@ LilycoveCity_Harbor_EventScript_21E30F:: @ 821E30F
 
 LilycoveCity_Harbor_EventScript_21E320:: @ 821E320
 	setflag FLAG_0x1AF
-	msgbox LilycoveCity_Harbor_Text_2A68D2, 4
+	msgbox LilycoveCity_Harbor_Text_2A68D2, MSGBOX_DEFAULT
 	closemessage
 	call LilycoveCity_Harbor_EventScript_21E4EE
-	msgbox LilycoveCity_Harbor_Text_2C6A71, 4
+	msgbox LilycoveCity_Harbor_Text_2C6A71, MSGBOX_DEFAULT
 	goto LilycoveCity_Harbor_EventScript_21E33F
 	end
 
@@ -250,10 +250,10 @@ LilycoveCity_Harbor_EventScript_21E33F:: @ 821E33F
 
 LilycoveCity_Harbor_EventScript_21E350:: @ 821E350
 	setflag FLAG_0x1B0
-	msgbox LilycoveCity_Harbor_Text_2A6848, 4
+	msgbox LilycoveCity_Harbor_Text_2A6848, MSGBOX_DEFAULT
 	closemessage
 	call LilycoveCity_Harbor_EventScript_21E4EE
-	msgbox LilycoveCity_Harbor_Text_2C68A5, 4
+	msgbox LilycoveCity_Harbor_Text_2C68A5, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, LilycoveCity_Harbor_Movement_2725A6
 	waitmovement 0
@@ -271,12 +271,12 @@ LilycoveCity_Harbor_EventScript_21E350:: @ 821E350
 	call_if 1, LilycoveCity_Harbor_EventScript_21E675
 	compare VAR_FACING, 4
 	call_if 1, LilycoveCity_Harbor_EventScript_21E680
-	msgbox LilycoveCity_Harbor_Text_2C6951, 4
+	msgbox LilycoveCity_Harbor_Text_2C6951, MSGBOX_DEFAULT
 	compare VAR_FACING, 2
 	call_if 1, LilycoveCity_Harbor_EventScript_21E68B
 	compare VAR_FACING, 4
 	call_if 1, LilycoveCity_Harbor_EventScript_21E696
-	msgbox LilycoveCity_Harbor_Text_2C69AA, 4
+	msgbox LilycoveCity_Harbor_Text_2C69AA, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_FACING, 2
 	call_if 1, LilycoveCity_Harbor_EventScript_21E6A1
@@ -299,10 +299,10 @@ LilycoveCity_Harbor_EventScript_21E40C:: @ 821E40C
 
 LilycoveCity_Harbor_EventScript_21E41D:: @ 821E41D
 	setflag FLAG_0x1DB
-	msgbox LilycoveCity_Harbor_Text_2A68D2, 4
+	msgbox LilycoveCity_Harbor_Text_2A68D2, MSGBOX_DEFAULT
 	closemessage
 	call LilycoveCity_Harbor_EventScript_21E4EE
-	msgbox LilycoveCity_Harbor_Text_2C6A71, 4
+	msgbox LilycoveCity_Harbor_Text_2C6A71, MSGBOX_DEFAULT
 	goto LilycoveCity_Harbor_EventScript_21E43C
 	end
 
@@ -315,7 +315,7 @@ LilycoveCity_Harbor_EventScript_21E43C:: @ 821E43C
 	end
 
 LilycoveCity_Harbor_EventScript_21E44D:: @ 821E44D
-	msgbox LilycoveCity_Harbor_Text_2A68D2, 4
+	msgbox LilycoveCity_Harbor_Text_2A68D2, MSGBOX_DEFAULT
 	closemessage
 	call LilycoveCity_Harbor_EventScript_21E4EE
 	message LilycoveCity_Harbor_Text_2C6BD4
@@ -335,7 +335,7 @@ LilycoveCity_Harbor_EventScript_21E44D:: @ 821E44D
 	end
 
 LilycoveCity_Harbor_EventScript_21E4B6:: @ 821E4B6
-	msgbox LilycoveCity_Harbor_Text_2A6A82, 4
+	msgbox LilycoveCity_Harbor_Text_2A6A82, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, LilycoveCity_Harbor_Movement_2725A6
 	waitmovement 0
@@ -346,7 +346,7 @@ LilycoveCity_Harbor_EventScript_21E4B6:: @ 821E4B6
 	waitmovement 0
 	showobjectat 1, MAP_LILYCOVE_CITY_HARBOR
 	delay 30
-	msgbox LilycoveCity_Harbor_Text_21E842, 4
+	msgbox LilycoveCity_Harbor_Text_21E842, MSGBOX_DEFAULT
 	release
 	end
 
@@ -378,24 +378,24 @@ LilycoveCity_Harbor_EventScript_21E514:: @ 821E514
 	return
 
 LilycoveCity_Harbor_EventScript_21E54D:: @ 821E54D
-	msgbox LilycoveCity_Harbor_Text_21E6F1, 4
+	msgbox LilycoveCity_Harbor_Text_21E6F1, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_Harbor_EventScript_21E557:: @ 821E557
-	msgbox LilycoveCity_Harbor_Text_21E758, 4
+	msgbox LilycoveCity_Harbor_Text_21E758, MSGBOX_DEFAULT
 	message LilycoveCity_Harbor_Text_21E7ED
 	waitmessage
 	goto LilycoveCity_Harbor_EventScript_21E09F
 	end
 
 LilycoveCity_Harbor_EventScript_21E56B:: @ 821E56B
-	msgbox LilycoveCity_Harbor_Text_21E792, 4
+	msgbox LilycoveCity_Harbor_Text_21E792, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_Harbor_EventScript_21E575:: @ 821E575
-	msgbox LilycoveCity_Harbor_Text_21E864, 5
+	msgbox LilycoveCity_Harbor_Text_21E864, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_Harbor_EventScript_21E5C0
 	setvar VAR_PORTHOLE_STATE, 5
@@ -406,7 +406,7 @@ LilycoveCity_Harbor_EventScript_21E575:: @ 821E575
 	end
 
 LilycoveCity_Harbor_EventScript_21E59D:: @ 821E59D
-	msgbox LilycoveCity_Harbor_Text_21E880, 5
+	msgbox LilycoveCity_Harbor_Text_21E880, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_Harbor_EventScript_21E5C0
 	call LilycoveCity_Harbor_EventScript_21E5CC
@@ -422,7 +422,7 @@ LilycoveCity_Harbor_EventScript_21E5C0:: @ 821E5C0
 	end
 
 LilycoveCity_Harbor_EventScript_21E5CC:: @ 821E5CC
-	msgbox LilycoveCity_Harbor_Text_21E89D, 4
+	msgbox LilycoveCity_Harbor_Text_21E89D, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, LilycoveCity_Harbor_Movement_2725A6
 	waitmovement 0
@@ -449,7 +449,7 @@ LilycoveCity_Harbor_EventScript_21E61B:: @ 821E61B
 	return
 
 LilycoveCity_Harbor_EventScript_21E626:: @ 821E626
-	msgbox LilycoveCity_Harbor_Text_21E842, 4
+	msgbox LilycoveCity_Harbor_Text_21E842, MSGBOX_DEFAULT
 	release
 	end
 
@@ -471,12 +471,12 @@ LilycoveCity_Harbor_EventScript_21E637:: @ 821E637
 	faceplayer
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_eq LilycoveCity_Harbor_EventScript_21E64C
-	msgbox LilycoveCity_Harbor_Text_21E8EE, 4
+	msgbox LilycoveCity_Harbor_Text_21E8EE, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_Harbor_EventScript_21E64C:: @ 821E64C
-	msgbox LilycoveCity_Harbor_Text_21E976, 4
+	msgbox LilycoveCity_Harbor_Text_21E976, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/LilycoveCity_House1/scripts.inc
+++ b/data/maps/LilycoveCity_House1/scripts.inc
@@ -2,7 +2,7 @@ LilycoveCity_House1_MapScripts:: @ 821ECCD
 	.byte 0
 
 LilycoveCity_House1_EventScript_21ECCE:: @ 821ECCE
-	msgbox LilycoveCity_House1_Text_21ECEA, 2
+	msgbox LilycoveCity_House1_Text_21ECEA, MSGBOX_NPC
 	end
 
 LilycoveCity_House1_EventScript_21ECD7:: @ 821ECD7
@@ -10,7 +10,7 @@ LilycoveCity_House1_EventScript_21ECD7:: @ 821ECD7
 	faceplayer
 	waitse
 	playmoncry SPECIES_KECLEON, 0
-	msgbox LilycoveCity_House1_Text_21ED63, 4
+	msgbox LilycoveCity_House1_Text_21ED63, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/LilycoveCity_House2/scripts.inc
+++ b/data/maps/LilycoveCity_House2/scripts.inc
@@ -6,17 +6,17 @@ LilycoveCity_House2_EventScript_21ED75:: @ 821ED75
 	faceplayer
 	checkflag FLAG_0x0EA
 	goto_eq LilycoveCity_House2_EventScript_21EDAC
-	msgbox LilycoveCity_House2_Text_21EDB6, 4
+	msgbox LilycoveCity_House2_Text_21EDB6, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM44
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_House2_EventScript_272054
 	setflag FLAG_0x0EA
-	msgbox LilycoveCity_House2_Text_21EDF9, 4
+	msgbox LilycoveCity_House2_Text_21EDF9, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_House2_EventScript_21EDAC:: @ 821EDAC
-	msgbox LilycoveCity_House2_Text_21EDF9, 4
+	msgbox LilycoveCity_House2_Text_21EDF9, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/LilycoveCity_House3/scripts.inc
+++ b/data/maps/LilycoveCity_House3/scripts.inc
@@ -10,10 +10,10 @@ LilycoveCity_House3_MapScript1_21EE42: @ 821EE42
 LilycoveCity_House3_EventScript_21EE4B:: @ 821EE4B
 	lock
 	faceplayer
-	msgbox LilycoveCity_House3_Text_21EF99, 5
+	msgbox LilycoveCity_House3_Text_21EF99, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_House3_EventScript_21EE75
-	msgbox LilycoveCity_House3_Text_21F0F8, 4
+	msgbox LilycoveCity_House3_Text_21F0F8, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, LilycoveCity_House3_Movement_2725A2
 	waitmovement 0
@@ -21,7 +21,7 @@ LilycoveCity_House3_EventScript_21EE4B:: @ 821EE4B
 	end
 
 LilycoveCity_House3_EventScript_21EE75:: @ 821EE75
-	msgbox LilycoveCity_House3_Text_21F0A9, 4
+	msgbox LilycoveCity_House3_Text_21F0A9, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, LilycoveCity_House3_Movement_2725A2
 	waitmovement 0
@@ -31,7 +31,7 @@ LilycoveCity_House3_EventScript_21EE75:: @ 821EE75
 LilycoveCity_House3_EventScript_21EE8A:: @ 821EE8A
 	lock
 	faceplayer
-	msgbox LilycoveCity_House3_Text_21F430, 4
+	msgbox LilycoveCity_House3_Text_21F430, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, LilycoveCity_House3_Movement_2725A2
 	waitmovement 0
@@ -79,22 +79,22 @@ LilycoveCity_House3_EventScript_21EF3D:: @ 821EF3D
 	end
 
 LilycoveCity_House3_EventScript_21EF71:: @ 821EF71
-	msgbox LilycoveCity_House3_Text_21F4A7, 4
+	msgbox LilycoveCity_House3_Text_21F4A7, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_House3_EventScript_21EF7B:: @ 821EF7B
-	msgbox LilycoveCity_House3_Text_21F4E0, 4
+	msgbox LilycoveCity_House3_Text_21F4E0, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_House3_EventScript_21EF85:: @ 821EF85
-	msgbox LilycoveCity_House3_Text_21F523, 4
+	msgbox LilycoveCity_House3_Text_21F523, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_House3_EventScript_21EF8F:: @ 821EF8F
-	msgbox LilycoveCity_House3_Text_21F55A, 4
+	msgbox LilycoveCity_House3_Text_21F55A, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/LilycoveCity_House4/scripts.inc
+++ b/data/maps/LilycoveCity_House4/scripts.inc
@@ -2,11 +2,11 @@ LilycoveCity_House4_MapScripts:: @ 821F5B4
 	.byte 0
 
 LilycoveCity_House4_EventScript_21F5B5:: @ 821F5B5
-	msgbox LilycoveCity_House4_Text_21F5C7, 2
+	msgbox LilycoveCity_House4_Text_21F5C7, MSGBOX_NPC
 	end
 
 LilycoveCity_House4_EventScript_21F5BE:: @ 821F5BE
-	msgbox LilycoveCity_House4_Text_21F62B, 2
+	msgbox LilycoveCity_House4_Text_21F62B, MSGBOX_NPC
 	end
 
 LilycoveCity_House4_Text_21F5C7: @ 821F5C7

--- a/data/maps/LilycoveCity_LilycoveMuseum_1F/scripts.inc
+++ b/data/maps/LilycoveCity_LilycoveMuseum_1F/scripts.inc
@@ -2,7 +2,7 @@ LilycoveCity_LilycoveMuseum_1F_MapScripts:: @ 8218CB8
 	.byte 0
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218CB9:: @ 8218CB9
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_218E4B, 3
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_218E4B, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218CC2:: @ 8218CC2
@@ -18,11 +18,11 @@ LilycoveCity_LilycoveMuseum_1F_EventScript_218CC2:: @ 8218CC2
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218CEC:: @ 8218CEC
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_218F5C, 2
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_218F5C, MSGBOX_NPC
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218CF5:: @ 8218CF5
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_218F98, 5
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_218F98, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_LilycoveMuseum_1F_EventScript_218D14
 	compare VAR_RESULT, 1
@@ -30,12 +30,12 @@ LilycoveCity_LilycoveMuseum_1F_EventScript_218CF5:: @ 8218CF5
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218D14:: @ 8218D14
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_218FF8, 3
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_218FF8, MSGBOX_SIGN
 	releaseall
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218D1E:: @ 8218D1E
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_219035, 3
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_219035, MSGBOX_SIGN
 	applymovement 2, LilycoveCity_LilycoveMuseum_1F_Movement_218D99
 	waitmovement 0
 	removeobject 2
@@ -89,70 +89,70 @@ LilycoveCity_LilycoveMuseum_1F_Movement_218DA1: @ 8218DA1
 	step_end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218DA4:: @ 8218DA4
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_219080, 3
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_219080, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218DAD:: @ 8218DAD
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2190BF, 3
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2190BF, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218DB6:: @ 8218DB6
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2190F9, 3
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2190F9, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218DBF:: @ 8218DBF
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_219142, 3
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_219142, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218DC8:: @ 8218DC8
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2191A2, 3
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2191A2, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218DD1:: @ 8218DD1
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_21920D, 3
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_21920D, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218DDA:: @ 8218DDA
 LilycoveCity_LilycoveMuseum_2F_EventScript_218DDA:: @ 8218DDA
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_219260, 3
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_219260, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218DE3:: @ 8218DE3
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2192AA, 3
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2192AA, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218DEC:: @ 8218DEC
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_219311, 3
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_219311, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218DF5:: @ 8218DF5
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2193B4, 2
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2193B4, MSGBOX_NPC
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218DFE:: @ 8218DFE
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_21941A, 2
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_21941A, MSGBOX_NPC
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218E07:: @ 8218E07
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2194BA, 3
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2194BA, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218E10:: @ 8218E10
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2194E1, 3
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2194E1, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218E19:: @ 8218E19
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_219515, 2
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_219515, MSGBOX_NPC
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218E22:: @ 8218E22
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_21959B, 2
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_21959B, MSGBOX_NPC
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218E2B:: @ 8218E2B
 	lock
 	faceplayer
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2195FF, 4
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_2195FF, MSGBOX_DEFAULT
 	closemessage
 	applymovement 8, LilycoveCity_LilycoveMuseum_1F_Movement_2725A2
 	waitmovement 0
@@ -160,7 +160,7 @@ LilycoveCity_LilycoveMuseum_1F_EventScript_218E2B:: @ 8218E2B
 	end
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_218E42:: @ 8218E42
-	msgbox LilycoveCity_LilycoveMuseum_1F_Text_21967A, 2
+	msgbox LilycoveCity_LilycoveMuseum_1F_Text_21967A, MSGBOX_NPC
 	end
 
 LilycoveCity_LilycoveMuseum_1F_Text_218E4B: @ 8218E4B

--- a/data/maps/LilycoveCity_LilycoveMuseum_2F/scripts.inc
+++ b/data/maps/LilycoveCity_LilycoveMuseum_2F/scripts.inc
@@ -70,17 +70,17 @@ LilycoveCity_LilycoveMuseum_2F_EventScript_219808:: @ 8219808
 	applymovement 1, LilycoveCity_LilycoveMuseum_2F_Movement_27259E
 	applymovement 255, LilycoveCity_LilycoveMuseum_2F_Movement_219861
 	waitmovement 0
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_2199EB, 3
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_2199EB, MSGBOX_SIGN
 	applymovement 1, LilycoveCity_LilycoveMuseum_2F_Movement_219863
 	waitmovement 0
 	applymovement 255, LilycoveCity_LilycoveMuseum_2F_Movement_219863
 	waitmovement 0
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219A0D, 3
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219A0D, MSGBOX_SIGN
 	applymovement 1, LilycoveCity_LilycoveMuseum_2F_Movement_27259E
 	waitmovement 0
 	applymovement 255, LilycoveCity_LilycoveMuseum_2F_Movement_219861
 	waitmovement 0
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219BC4, 3
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219BC4, MSGBOX_SIGN
 	copyvar VAR_0x4094, 0x1
 	releaseall
 	end
@@ -105,25 +105,25 @@ LilycoveCity_LilycoveMuseum_2F_EventScript_219866:: @ 8219866
 	case 3, LilycoveCity_LilycoveMuseum_2F_EventScript_2198BA
 	case 4, LilycoveCity_LilycoveMuseum_2F_EventScript_2198BA
 	case 5, LilycoveCity_LilycoveMuseum_2F_EventScript_2198C3
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219CF3, 2
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219CF3, MSGBOX_NPC
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_2198BA:: @ 82198BA
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219D42, 2
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219D42, MSGBOX_NPC
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_2198C3:: @ 82198C3
 	applymovement 1, LilycoveCity_LilycoveMuseum_2F_Movement_27259E
 	waitmovement 0
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219DD4, 4
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219DD4, MSGBOX_DEFAULT
 	applymovement 1, LilycoveCity_LilycoveMuseum_2F_Movement_219863
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219DE6, 4
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219DE6, MSGBOX_DEFAULT
 	goto LilycoveCity_LilycoveMuseum_2F_EventScript_2198EA
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_2198EA:: @ 82198EA
 	applymovement 1, LilycoveCity_LilycoveMuseum_2F_Movement_27259E
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219EC5, 4
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219EC5, MSGBOX_DEFAULT
 	givedecoration_std 44
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_LilycoveMuseum_2F_EventScript_219911
@@ -134,13 +134,13 @@ LilycoveCity_LilycoveMuseum_2F_EventScript_2198EA:: @ 82198EA
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_219911:: @ 8219911
 	call LilycoveCity_LilycoveMuseum_2F_EventScript_272071
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219EED, 4
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219EED, MSGBOX_DEFAULT
 	closemessage
 	releaseall
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_219921:: @ 8219921
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219F1B, 2
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219F1B, MSGBOX_NPC
 	releaseall
 	end
 
@@ -148,79 +148,79 @@ LilycoveCity_LilycoveMuseum_2F_EventScript_21992B:: @ 821992B
 	lockall
 	checkflag FLAG_0x0A2
 	goto_eq LilycoveCity_LilycoveMuseum_2F_EventScript_2199C1
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219FA0, 3
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219FA0, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_21993E:: @ 821993E
 	lockall
 	checkflag FLAG_0x0A4
 	goto_eq LilycoveCity_LilycoveMuseum_2F_EventScript_2199DD
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219FD3, 3
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_219FD3, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_219951:: @ 8219951
 	lockall
 	checkflag FLAG_0x0A0
 	goto_eq LilycoveCity_LilycoveMuseum_2F_EventScript_2199A5
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A03B, 3
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A03B, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_219964:: @ 8219964
 	lockall
 	checkflag FLAG_0x0A1
 	goto_eq LilycoveCity_LilycoveMuseum_2F_EventScript_2199B3
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A008, 3
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A008, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_219977:: @ 8219977
 	lockall
 	checkflag FLAG_0x0A3
 	goto_eq LilycoveCity_LilycoveMuseum_2F_EventScript_2199CF
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A06D, 3
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A06D, MSGBOX_SIGN
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_21998A:: @ 821998A
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A0BD, 2
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A0BD, MSGBOX_NPC
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_219993:: @ 8219993
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A132, 2
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A132, MSGBOX_NPC
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_21999C:: @ 821999C
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A1A8, 2
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A1A8, MSGBOX_NPC
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_2199A5:: @ 82199A5
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A0A1, 3
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A0A1, MSGBOX_SIGN
 	fadescreen 1
 	drawcontestwinner 9
 	releaseall
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_2199B3:: @ 82199B3
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A0A1, 3
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A0A1, MSGBOX_SIGN
 	fadescreen 1
 	drawcontestwinner 10
 	releaseall
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_2199C1:: @ 82199C1
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A0A1, 3
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A0A1, MSGBOX_SIGN
 	fadescreen 1
 	drawcontestwinner 11
 	releaseall
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_2199CF:: @ 82199CF
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A0A1, 3
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A0A1, MSGBOX_SIGN
 	fadescreen 1
 	drawcontestwinner 12
 	releaseall
 	end
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_2199DD:: @ 82199DD
-	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A0A1, 3
+	msgbox LilycoveCity_LilycoveMuseum_2F_Text_21A0A1, MSGBOX_SIGN
 	fadescreen 1
 	drawcontestwinner 13
 	releaseall

--- a/data/maps/LilycoveCity_MoveDeletersHouse/scripts.inc
+++ b/data/maps/LilycoveCity_MoveDeletersHouse/scripts.inc
@@ -5,7 +5,7 @@ LilycoveCity_MoveDeletersHouse_EventScript_21EA0B:: @ 821EA0B
 	lockall
 	applymovement 1, LilycoveCity_MoveDeletersHouse_Movement_27259E
 	waitmovement 0
-	msgbox LilycoveCity_MoveDeletersHouse_Text_21EAFD, 5
+	msgbox LilycoveCity_MoveDeletersHouse_Text_21EAFD, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 1, LilycoveCity_MoveDeletersHouse_EventScript_21EA3B
 	case 0, LilycoveCity_MoveDeletersHouse_EventScript_21EAE6
@@ -13,7 +13,7 @@ LilycoveCity_MoveDeletersHouse_EventScript_21EA0B:: @ 821EA0B
 	end
 
 LilycoveCity_MoveDeletersHouse_EventScript_21EA3B:: @ 821EA3B
-	msgbox LilycoveCity_MoveDeletersHouse_Text_21EB65, 4
+	msgbox LilycoveCity_MoveDeletersHouse_Text_21EB65, MSGBOX_DEFAULT
 	special sub_81B94B0
 	waitstate
 	compare VAR_0x8004, 255
@@ -24,14 +24,14 @@ LilycoveCity_MoveDeletersHouse_EventScript_21EA3B:: @ 821EA3B
 	special sub_81B96D0
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_MoveDeletersHouse_EventScript_21EACF
-	msgbox LilycoveCity_MoveDeletersHouse_Text_21EB89, 4
+	msgbox LilycoveCity_MoveDeletersHouse_Text_21EB89, MSGBOX_DEFAULT
 	fadescreen 1
 	special sub_81B968C
 	fadescreen 0
 	compare VAR_0x8005, 4
 	goto_eq LilycoveCity_MoveDeletersHouse_EventScript_21EA3B
 	special sub_81B9718
-	msgbox LilycoveCity_MoveDeletersHouse_Text_21EBDA, 5
+	msgbox LilycoveCity_MoveDeletersHouse_Text_21EBDA, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 1, LilycoveCity_MoveDeletersHouse_EventScript_21EAB0
 	case 0, LilycoveCity_MoveDeletersHouse_EventScript_21EAE6
@@ -45,29 +45,29 @@ LilycoveCity_MoveDeletersHouse_EventScript_21EAB0:: @ 821EAB0
 	special sub_81B9770
 	playfanfare MUS_ME_WASURE
 	waitfanfare
-	msgbox LilycoveCity_MoveDeletersHouse_Text_21EC06, 4
+	msgbox LilycoveCity_MoveDeletersHouse_Text_21EC06, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_MoveDeletersHouse_EventScript_21EACF:: @ 821EACF
 	special sub_81B9718
-	msgbox LilycoveCity_MoveDeletersHouse_Text_21EBA9, 4
+	msgbox LilycoveCity_MoveDeletersHouse_Text_21EBA9, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_MoveDeletersHouse_EventScript_21EADC:: @ 821EADC
-	msgbox LilycoveCity_MoveDeletersHouse_Text_21EC78, 4
+	msgbox LilycoveCity_MoveDeletersHouse_Text_21EC78, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_MoveDeletersHouse_EventScript_21EAE6:: @ 821EAE6
-	msgbox LilycoveCity_MoveDeletersHouse_Text_21EC3F, 4
+	msgbox LilycoveCity_MoveDeletersHouse_Text_21EC3F, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_MoveDeletersHouse_EventScript_21EAF0:: @ 821EAF0
 	special sub_81B9718
-	msgbox LilycoveCity_MoveDeletersHouse_Text_21EC9C, 4
+	msgbox LilycoveCity_MoveDeletersHouse_Text_21EC9C, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/LilycoveCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/LilycoveCity_PokemonCenter_1F/scripts.inc
@@ -33,7 +33,7 @@ LilycoveCity_PokemonCenter_1F_EventScript_21C5E8:: @ 821C5E8
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_21C5F6:: @ 821C5F6
-	msgbox LilycoveCity_PokemonCenter_1F_Text_21C61E, 2
+	msgbox LilycoveCity_PokemonCenter_1F_Text_21C61E, MSGBOX_NPC
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_21C5FF:: @ 821C5FF
@@ -41,12 +41,12 @@ LilycoveCity_PokemonCenter_1F_EventScript_21C5FF:: @ 821C5FF
 	faceplayer
 	checkflag FLAG_BADGE07_GET
 	goto_eq LilycoveCity_PokemonCenter_1F_EventScript_21C614
-	msgbox LilycoveCity_PokemonCenter_1F_Text_21C69D, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_21C69D, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_21C614:: @ 821C614
-	msgbox LilycoveCity_PokemonCenter_1F_Text_21C6F6, 4
+	msgbox LilycoveCity_PokemonCenter_1F_Text_21C6F6, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/LilycoveCity_PokemonTrainerFanClub/scripts.inc
+++ b/data/maps/LilycoveCity_PokemonTrainerFanClub/scripts.inc
@@ -11,13 +11,13 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21C79A:: @ 821C79A
 	lockall
 	applymovement 1, LilycoveCity_PokemonTrainerFanClub_Movement_2725AA
 	waitmovement 0
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21CF00, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21CF00, MSGBOX_DEFAULT
 	applymovement 4, LilycoveCity_PokemonTrainerFanClub_Movement_21C7FD
 	applymovement 2, LilycoveCity_PokemonTrainerFanClub_Movement_21C7F5
 	waitmovement 0
 	applymovement 255, LilycoveCity_PokemonTrainerFanClub_Movement_2725A8
 	waitmovement 0
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21CF12, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21CF12, MSGBOX_DEFAULT
 	applymovement 4, LilycoveCity_PokemonTrainerFanClub_Movement_21C804
 	waitmovement 0
 	applymovement 255, LilycoveCity_PokemonTrainerFanClub_Movement_2725A4
@@ -217,7 +217,7 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CA17:: @ 821CA17
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 7
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CA7A
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D12A, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D12A, MSGBOX_DEFAULT
 	release
 	end
 
@@ -225,22 +225,22 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CA56:: @ 821CA56
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CA70
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D094, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D094, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CA70:: @ 821CA70
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D0BB, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D0BB, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CA7A:: @ 821CA7A
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D1B5, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D1B5, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CA84:: @ 821CA84
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D20C, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D20C, MSGBOX_DEFAULT
 	release
 	end
 
@@ -257,7 +257,7 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CA8E:: @ 821CA8E
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 7
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CAF1
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D347, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D347, MSGBOX_DEFAULT
 	release
 	end
 
@@ -265,22 +265,22 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CACD:: @ 821CACD
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CAE7
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D2A6, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D2A6, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CAE7:: @ 821CAE7
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D2CE, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D2CE, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CAF1:: @ 821CAF1
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D377, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D377, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CAFB:: @ 821CAFB
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D3EE, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D3EE, MSGBOX_DEFAULT
 	release
 	end
 
@@ -297,7 +297,7 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CB05:: @ 821CB05
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 7
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CB68
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D52E, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D52E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -305,22 +305,22 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CB44:: @ 821CB44
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CB5E
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D438, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D438, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CB5E:: @ 821CB5E
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D4A3, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D4A3, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CB68:: @ 821CB68
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D5DC, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D5DC, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CB72:: @ 821CB72
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D69C, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D69C, MSGBOX_DEFAULT
 	release
 	end
 
@@ -337,7 +337,7 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CB7C:: @ 821CB7C
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 7
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CBDF
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D822, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D822, MSGBOX_DEFAULT
 	release
 	end
 
@@ -345,22 +345,22 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CBBB:: @ 821CBBB
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CBD5
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D751, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D751, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CBD5:: @ 821CBD5
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D79B, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D79B, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CBDF:: @ 821CBDF
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D857, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D857, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CBE9:: @ 821CBE9
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D8C4, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D8C4, MSGBOX_DEFAULT
 	release
 	end
 
@@ -375,7 +375,7 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CBF3:: @ 821CBF3
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 7
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CC4B
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D9D1, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D9D1, MSGBOX_DEFAULT
 	release
 	end
 
@@ -383,17 +383,17 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CC27:: @ 821CC27
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CC41
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D921, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D921, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CC41:: @ 821CC41
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D96A, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21D96A, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CC4B:: @ 821CC4B
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DA0D, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DA0D, MSGBOX_DEFAULT
 	release
 	end
 
@@ -408,7 +408,7 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CC55:: @ 821CC55
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 7
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CCAD
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DB69, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DB69, MSGBOX_DEFAULT
 	release
 	end
 
@@ -416,17 +416,17 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CC89:: @ 821CC89
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CCA3
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DA73, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DA73, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CCA3:: @ 821CCA3
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DAF5, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DAF5, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CCAD:: @ 821CCAD
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DBFB, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DBFB, MSGBOX_DEFAULT
 	release
 	end
 
@@ -441,7 +441,7 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CCB7:: @ 821CCB7
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 7
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CD0F
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DD36, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DD36, MSGBOX_DEFAULT
 	release
 	end
 
@@ -449,17 +449,17 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CCEB:: @ 821CCEB
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CD05
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DC68, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DC68, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CD05:: @ 821CD05
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DCD6, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DCD6, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CD0F:: @ 821CD0F
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DDCE, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DDCE, MSGBOX_DEFAULT
 	release
 	end
 
@@ -474,7 +474,7 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CD19:: @ 821CD19
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 7
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CD71
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DEFF, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DEFF, MSGBOX_DEFAULT
 	release
 	end
 
@@ -482,17 +482,17 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CD4D:: @ 821CD4D
 	specialvar VAR_RESULT, GetNumMovedLilycoveFanClubMembers
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CD67
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DE72, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DE72, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CD67:: @ 821CD67
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DE83, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DE83, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CD71:: @ 821CD71
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DF51, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_21DF51, MSGBOX_DEFAULT
 	release
 	end
 
@@ -513,7 +513,7 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CD90:: @ 821CD90
 	copyvar VAR_0x800A, VAR_0x8006
 	setvar VAR_0x8004, 8
 	special BufferStreakTrainerText
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281BCB, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281BCB, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 14
 	copyvar VAR_0x8005, VAR_0x800A
 	call LilycoveCity_PokemonTrainerFanClub_EventScript_271E7C
@@ -526,14 +526,14 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CD90:: @ 821CD90
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CDE0:: @ 821CDE0
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281C06, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281C06, MSGBOX_DEFAULT
 	goto LilycoveCity_PokemonTrainerFanClub_EventScript_21CE4D
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CDEE:: @ 821CDEE
 	setvar VAR_0x8004, 8
 	special BufferStreakTrainerText
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281C3D, 5
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281C3D, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CEC6
 	compare VAR_RESULT, 0
@@ -543,7 +543,7 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CDEE:: @ 821CDEE
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CE15:: @ 821CE15
 	setvar VAR_0x8004, 8
 	special BufferStreakTrainerText
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281C65, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281C65, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 14
 	copyvar VAR_0x8005, VAR_0x800A
 	call LilycoveCity_PokemonTrainerFanClub_EventScript_271E7C
@@ -578,7 +578,7 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CE4D:: @ 821CE4D
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CE9F:: @ 821CE9F
 	setvar VAR_0x8004, 8
 	special BufferStreakTrainerText
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281CCD, 5
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281CCD, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_PokemonTrainerFanClub_EventScript_21CEC6
 	compare VAR_RESULT, 0
@@ -588,14 +588,14 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CE9F:: @ 821CE9F
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CEC6:: @ 821CEC6
 	setvar VAR_0x8004, 8
 	special BufferStreakTrainerText
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281CF5, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281CF5, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CED8:: @ 821CED8
 	setvar VAR_0x8004, 8
 	special BufferStreakTrainerText
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281D40, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281D40, MSGBOX_DEFAULT
 	setflag FLAG_0x0D2
 	release
 	end
@@ -603,7 +603,7 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_21CED8:: @ 821CED8
 LilycoveCity_PokemonTrainerFanClub_EventScript_21CEED:: @ 821CEED
 	setvar VAR_0x8004, 8
 	special BufferStreakTrainerText
-	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281DB4, 4
+	msgbox LilycoveCity_PokemonTrainerFanClub_Text_281DB4, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/LittlerootTown/scripts.inc
+++ b/data/maps/LittlerootTown/scripts.inc
@@ -126,7 +126,7 @@ LittlerootTown_EventScript_1E7F17:: @ 81E7F17
 	delay 10
 	applymovement 4, LittlerootTown_Movement_1E7F9A
 	waitmovement 0
-	msgbox LittlerootTown_Text_1E86BC, 4
+	msgbox LittlerootTown_Text_1E86BC, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, LittlerootTown_Movement_1E7F9D
 	applymovement 255, LittlerootTown_Movement_1E7FA4
@@ -190,7 +190,7 @@ LittlerootTown_EventScript_1E7FB1:: @ 81E7FB1
 	applymovement 8, LittlerootTown_Movement_272598
 	waitmovement 0
 	delay 80
-	msgbox LittlerootTown_Text_1E8DA2, 4
+	msgbox LittlerootTown_Text_1E8DA2, MSGBOX_DEFAULT
 	closemessage
 	clearflag FLAG_HIDE_LITTLEROOT_TOWN_RIVAL
 	clearflag FLAG_HIDE_LITTLEROOT_TOWN_BIRCH
@@ -225,11 +225,11 @@ LittlerootTown_EventScript_1E8013:: @ 81E8013
 	end
 
 LittlerootTown_EventScript_1E8022:: @ 81E8022
-	msgbox LittlerootTown_Text_1E8ACF, 2
+	msgbox LittlerootTown_Text_1E8ACF, MSGBOX_NPC
 	end
 
 LittlerootTown_EventScript_1E802B:: @ 81E802B
-	msgbox LittlerootTown_Text_1E8B25, 2
+	msgbox LittlerootTown_Text_1E8B25, MSGBOX_NPC
 	end
 
 LittlerootTown_EventScript_1E8034:: @ 81E8034
@@ -241,13 +241,13 @@ LittlerootTown_EventScript_1E8034:: @ 81E8034
 	goto_eq LittlerootTown_EventScript_1E807A
 	compare VAR_0x4050, 0
 	goto_if 5, LittlerootTown_EventScript_1E805D
-	msgbox LittlerootTown_Text_1E8BB8, 4
+	msgbox LittlerootTown_Text_1E8BB8, MSGBOX_DEFAULT
 	release
 	end
 
 LittlerootTown_EventScript_1E805D:: @ 81E805D
 	special GetPlayerBigGuyGirlString
-	msgbox LittlerootTown_Text_1E8C3A, 4
+	msgbox LittlerootTown_Text_1E8C3A, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, LittlerootTown_Movement_2725A2
 	waitmovement 0
@@ -257,12 +257,12 @@ LittlerootTown_EventScript_1E805D:: @ 81E805D
 
 LittlerootTown_EventScript_1E807A:: @ 81E807A
 	special GetPlayerBigGuyGirlString
-	msgbox LittlerootTown_Text_1E8CE3, 4
+	msgbox LittlerootTown_Text_1E8CE3, MSGBOX_DEFAULT
 	release
 	end
 
 LittlerootTown_EventScript_1E8087:: @ 81E8087
-	msgbox LittlerootTown_Text_1E8D07, 4
+	msgbox LittlerootTown_Text_1E8D07, MSGBOX_DEFAULT
 	release
 	end
 
@@ -277,12 +277,12 @@ LittlerootTown_EventScript_1E8091:: @ 81E8091
 	end
 
 LittlerootTown_EventScript_1E80AD:: @ 81E80AD
-	msgbox LittlerootTown_Text_1E8BB8, 4
+	msgbox LittlerootTown_Text_1E8BB8, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, LittlerootTown_Movement_1E80DF
 	applymovement 255, LittlerootTown_Movement_1E80EB
 	waitmovement 0
-	msgbox LittlerootTown_Text_1E8C07, 4
+	msgbox LittlerootTown_Text_1E8C07, MSGBOX_DEFAULT
 	closemessage
 	return
 
@@ -365,7 +365,7 @@ LittlerootTown_EventScript_1E811F:: @ 81E811F
 	applymovement 255, LittlerootTown_Movement_2725A4
 	waitmovement 0
 	special GetPlayerBigGuyGirlString
-	msgbox LittlerootTown_Text_1E8C3A, 4
+	msgbox LittlerootTown_Text_1E8C3A, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, LittlerootTown_Movement_2725A2
 	waitmovement 0
@@ -374,11 +374,11 @@ LittlerootTown_EventScript_1E811F:: @ 81E811F
 	end
 
 LittlerootTown_EventScript_1E8151:: @ 81E8151
-	msgbox LittlerootTown_Text_1E8D32, 3
+	msgbox LittlerootTown_Text_1E8D32, MSGBOX_SIGN
 	end
 
 LittlerootTown_EventScript_1E815A:: @ 81E815A
-	msgbox LittlerootTown_Text_1E8D69, 3
+	msgbox LittlerootTown_Text_1E8D69, MSGBOX_SIGN
 	end
 
 LittlerootTown_EventScript_1E8163:: @ 81E8163
@@ -392,11 +392,11 @@ LittlerootTown_EventScript_1E8163:: @ 81E8163
 	end
 
 LittlerootTown_EventScript_1E817D:: @ 81E817D
-	msgbox LittlerootTown_Text_1E8D83, 4
+	msgbox LittlerootTown_Text_1E8D83, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_EventScript_1E8186:: @ 81E8186
-	msgbox LittlerootTown_Text_1E8D8E, 4
+	msgbox LittlerootTown_Text_1E8D8E, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_EventScript_1E818F:: @ 81E818F
@@ -410,11 +410,11 @@ LittlerootTown_EventScript_1E818F:: @ 81E818F
 	end
 
 LittlerootTown_EventScript_1E81A9:: @ 81E81A9
-	msgbox LittlerootTown_Text_1E8D8E, 4
+	msgbox LittlerootTown_Text_1E8D8E, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_EventScript_1E81B2:: @ 81E81B2
-	msgbox LittlerootTown_Text_1E8D83, 4
+	msgbox LittlerootTown_Text_1E8D83, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_EventScript_1E81BB:: @ 81E81BB
@@ -466,7 +466,7 @@ LittlerootTown_EventScript_1E8211:: @ 81E8211
 	call_if 1, LittlerootTown_EventScript_1E8281
 	compare VAR_RESULT, 1
 	call_if 1, LittlerootTown_EventScript_1E828C
-	msgbox LittlerootTown_Text_1E87E1, 4
+	msgbox LittlerootTown_Text_1E87E1, MSGBOX_DEFAULT
 	closemessage
 	checkplayergender
 	compare VAR_RESULT, 0
@@ -917,13 +917,13 @@ LittlerootTown_EventScript_1E8686:: @ 81E8686
 	end
 
 LittlerootTown_EventScript_1E8693:: @ 81E8693
-	msgbox LittlerootTown_Text_1E87F0, 4
+	msgbox LittlerootTown_Text_1E87F0, MSGBOX_DEFAULT
 	playfanfare MUS_FANFA4
 	message LittlerootTown_Text_1E8925
 	waitfanfare
 	setflag FLAG_0x112
-	msgbox LittlerootTown_Text_1E894F, 4
-	msgbox LittlerootTown_Text_1E8A03, 4
+	msgbox LittlerootTown_Text_1E894F, MSGBOX_DEFAULT
+	msgbox LittlerootTown_Text_1E8A03, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	return

--- a/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
@@ -60,7 +60,7 @@ LittlerootTown_BrendansHouse_1F_MapScript2_1F77EA: @ 81F77EA
 
 LittlerootTown_BrendansHouse_1F_EventScript_1F7814:: @ 81F7814
 	lockall
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7B67, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7B67, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, LittlerootTown_BrendansHouse_1F_Movement_1F783A
 	applymovement 1, LittlerootTown_BrendansHouse_1F_Movement_1F783A
@@ -99,7 +99,7 @@ LittlerootTown_BrendansHouse_1F_EventScript_1F785E:: @ 81F785E
 	applymovement 4, LittlerootTown_BrendansHouse_1F_Movement_1F789C
 	waitmovement 0
 	special GetRivalSonDaughterString
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F8BC5, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F8BC5, MSGBOX_DEFAULT
 	setflag FLAG_0x057
 	setvar VAR_0x4082, 2
 	releaseall
@@ -160,7 +160,7 @@ LittlerootTown_BrendansHouse_1F_EventScript_1F78E2:: @ 81F78E2
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_1F7997
 	compare VAR_0x8008, 2
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_1F79A2
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F90B4, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F90B4, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_0x8008, 0
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_1F79C1

--- a/data/maps/LittlerootTown_BrendansHouse_2F/scripts.inc
+++ b/data/maps/LittlerootTown_BrendansHouse_2F/scripts.inc
@@ -58,7 +58,7 @@ LittlerootTown_BrendansHouse_2F_EventScript_1F8481:: @ 81F8481
 	lockall
 	compare VAR_0x408D, 2
 	goto_eq LittlerootTown_BrendansHouse_2F_EventScript_1F8497
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F9991, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F9991, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -96,7 +96,7 @@ LittlerootTown_BrendansHouse_2F_EventScript_1F8507:: @ 81F8507
 	waitmovement 0
 	applymovement 255, LittlerootTown_BrendansHouse_2F_Movement_2725A8
 	waitmovement 0
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F97B4, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F97B4, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, LittlerootTown_BrendansHouse_2F_Movement_1F85CF
 	applymovement 1, LittlerootTown_BrendansHouse_2F_Movement_1F85C6
@@ -108,7 +108,7 @@ LittlerootTown_BrendansHouse_2F_EventScript_1F8536:: @ 81F8536
 	waitmovement 0
 	applymovement 255, LittlerootTown_BrendansHouse_2F_Movement_2725A8
 	waitmovement 0
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F97B4, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F97B4, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, LittlerootTown_BrendansHouse_2F_Movement_1F85E2
 	applymovement 1, LittlerootTown_BrendansHouse_2F_Movement_1F85DB
@@ -120,7 +120,7 @@ LittlerootTown_BrendansHouse_2F_EventScript_1F8565:: @ 81F8565
 	waitmovement 0
 	applymovement 255, LittlerootTown_BrendansHouse_2F_Movement_2725A8
 	waitmovement 0
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F97B4, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F97B4, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, LittlerootTown_BrendansHouse_2F_Movement_1F85F6
 	applymovement 1, LittlerootTown_BrendansHouse_2F_Movement_1F85ED
@@ -132,7 +132,7 @@ LittlerootTown_BrendansHouse_2F_EventScript_1F8594:: @ 81F8594
 	waitmovement 0
 	applymovement 255, LittlerootTown_BrendansHouse_2F_Movement_2725A6
 	waitmovement 0
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F97B4, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F97B4, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, LittlerootTown_BrendansHouse_2F_Movement_1F8604
 	waitmovement 0
@@ -258,7 +258,7 @@ LittlerootTown_BrendansHouse_2F_EventScript_1F8626:: @ 81F8626
 	setvar VAR_0x8004, 1
 	special DoPCTurnOnEffect
 	playse SE_PC_ON
-	msgbox gUnknown_08272D87, 4
+	msgbox gUnknown_08272D87, MSGBOX_DEFAULT
 	special BedroomPC
 	waitstate
 	releaseall
@@ -272,18 +272,18 @@ LittlerootTown_BrendansHouse_2F_EventScript_1F863F:: @ 81F863F
 	end
 
 LittlerootTown_BrendansHouse_2F_EventScript_1F864C:: @ 81F864C
-	msgbox gUnknown_08272CD5, 4
+	msgbox gUnknown_08272CD5, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LittlerootTown_BrendansHouse_2F_EventScript_1F8656:: @ 81F8656
 LittlerootTown_MaysHouse_2F_EventScript_1F8656:: @ 81F8656
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F877F, 3
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F877F, MSGBOX_SIGN
 	end
 
 LittlerootTown_BrendansHouse_2F_EventScript_1F865F:: @ 81F865F
 LittlerootTown_MaysHouse_2F_EventScript_1F865F:: @ 81F865F
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F884F, 3
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F884F, MSGBOX_SIGN
 	end
 
 LittlerootTown_BrendansHouse_2F_Text_1F8668: @ 81F8668

--- a/data/maps/LittlerootTown_MaysHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_MaysHouse_1F/scripts.inc
@@ -60,7 +60,7 @@ LittlerootTown_MaysHouse_1F_MapScript2_1F893A: @ 81F893A
 
 LittlerootTown_MaysHouse_1F_EventScript_1F8964:: @ 81F8964
 	lockall
-	msgbox LittlerootTown_MaysHouse_1F_Text_1F7B67, 4
+	msgbox LittlerootTown_MaysHouse_1F_Text_1F7B67, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, LittlerootTown_MaysHouse_1F_Movement_1F898A
 	applymovement 1, LittlerootTown_MaysHouse_1F_Movement_1F898A
@@ -99,7 +99,7 @@ LittlerootTown_MaysHouse_1F_EventScript_1F89AE:: @ 81F89AE
 	applymovement 4, LittlerootTown_MaysHouse_1F_Movement_1F89EC
 	waitmovement 0
 	special GetRivalSonDaughterString
-	msgbox LittlerootTown_MaysHouse_1F_Text_1F8BC5, 4
+	msgbox LittlerootTown_MaysHouse_1F_Text_1F8BC5, MSGBOX_DEFAULT
 	setflag FLAG_0x057
 	setvar VAR_0x408C, 2
 	releaseall
@@ -125,22 +125,22 @@ LittlerootTown_MaysHouse_1F_EventScript_1F89F3:: @ 81F89F3
 	compare VAR_0x408D, 3
 	goto_eq LittlerootTown_BrendansHouse_1F_EventScript_1F8A1F
 	special GetRivalSonDaughterString
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F8CA5, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F8CA5, MSGBOX_DEFAULT
 	release
 	end
 
 LittlerootTown_BrendansHouse_1F_EventScript_1F8A1F:: @ 81F8A1F
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F8D37, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F8D37, MSGBOX_DEFAULT
 	release
 	end
 
 LittlerootTown_BrendansHouse_1F_EventScript_1F8A29:: @ 81F8A29
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F8D93, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F8D93, MSGBOX_DEFAULT
 	release
 	end
 
 LittlerootTown_BrendansHouse_1F_EventScript_1F8A33:: @ 81F8A33
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F8E01, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F8E01, MSGBOX_DEFAULT
 	release
 	end
 
@@ -149,7 +149,7 @@ LittlerootTown_MaysHouse_1F_EventScript_1F8A3D:: @ 81F8A3D
 	lock
 	faceplayer
 	special GetPlayerBigGuyGirlString
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F9262, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F9262, MSGBOX_DEFAULT
 	release
 	end
 
@@ -199,7 +199,7 @@ LittlerootTown_MaysHouse_1F_EventScript_1F8A8B:: @ 81F8A8B
 	call_if 1, LittlerootTown_MaysHouse_1F_EventScript_1F8B40
 	compare VAR_0x8008, 2
 	call_if 1, LittlerootTown_MaysHouse_1F_EventScript_1F8B4B
-	msgbox LittlerootTown_MaysHouse_1F_Text_1F8EC6, 4
+	msgbox LittlerootTown_MaysHouse_1F_Text_1F8EC6, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_0x8008, 0
 	call_if 1, LittlerootTown_MaysHouse_1F_EventScript_1F8B6A

--- a/data/maps/LittlerootTown_MaysHouse_2F/scripts.inc
+++ b/data/maps/LittlerootTown_MaysHouse_2F/scripts.inc
@@ -59,7 +59,7 @@ LittlerootTown_MaysHouse_2F_EventScript_1F9334:: @ 81F9334
 	lockall
 	compare VAR_0x408D, 2
 	goto_eq LittlerootTown_MaysHouse_2F_EventScript_1F934A
-	msgbox LittlerootTown_MaysHouse_2F_Text_1F9991, 4
+	msgbox LittlerootTown_MaysHouse_2F_Text_1F9991, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -97,7 +97,7 @@ LittlerootTown_MaysHouse_2F_EventScript_1F93BA:: @ 81F93BA
 	waitmovement 0
 	applymovement 255, LittlerootTown_MaysHouse_2F_Movement_2725A4
 	waitmovement 0
-	msgbox LittlerootTown_MaysHouse_2F_Text_1F959C, 4
+	msgbox LittlerootTown_MaysHouse_2F_Text_1F959C, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, LittlerootTown_MaysHouse_2F_Movement_1F9483
 	applymovement 1, LittlerootTown_MaysHouse_2F_Movement_1F9479
@@ -109,7 +109,7 @@ LittlerootTown_MaysHouse_2F_EventScript_1F93E9:: @ 81F93E9
 	waitmovement 0
 	applymovement 255, LittlerootTown_MaysHouse_2F_Movement_2725A4
 	waitmovement 0
-	msgbox LittlerootTown_MaysHouse_2F_Text_1F959C, 4
+	msgbox LittlerootTown_MaysHouse_2F_Text_1F959C, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, LittlerootTown_MaysHouse_2F_Movement_1F9497
 	applymovement 1, LittlerootTown_MaysHouse_2F_Movement_1F948F
@@ -121,7 +121,7 @@ LittlerootTown_MaysHouse_2F_EventScript_1F9418:: @ 81F9418
 	waitmovement 0
 	applymovement 255, LittlerootTown_MaysHouse_2F_Movement_2725A6
 	waitmovement 0
-	msgbox LittlerootTown_MaysHouse_2F_Text_1F959C, 4
+	msgbox LittlerootTown_MaysHouse_2F_Text_1F959C, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, LittlerootTown_MaysHouse_2F_Movement_1F94A4
 	waitmovement 0
@@ -132,7 +132,7 @@ LittlerootTown_MaysHouse_2F_EventScript_1F9440:: @ 81F9440
 	waitmovement 0
 	applymovement 255, LittlerootTown_MaysHouse_2F_Movement_2725A4
 	waitmovement 0
-	msgbox LittlerootTown_MaysHouse_2F_Text_1F959C, 4
+	msgbox LittlerootTown_MaysHouse_2F_Text_1F959C, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, LittlerootTown_MaysHouse_2F_Movement_1F94BB
 	applymovement 1, LittlerootTown_MaysHouse_2F_Movement_1F94B2
@@ -260,12 +260,12 @@ LittlerootTown_MaysHouse_2F_EventScript_1F94C1:: @ 81F94C1
 	end
 
 LittlerootTown_BrendansHouse_2F_EventScript_1F94E3:: @ 81F94E3
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F978A, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F978A, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LittlerootTown_BrendansHouse_2F_EventScript_1F94ED:: @ 81F94ED
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F9962, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F9962, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -284,21 +284,21 @@ LittlerootTown_BrendansHouse_2F_EventScript_1F94F7:: @ 81F94F7
 LittlerootTown_BrendansHouse_2F_EventScript_1F951D:: @ 81F951D
 	checkflag FLAG_0x125
 	goto_eq LittlerootTown_BrendansHouse_2F_EventScript_1F9541
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F99C9, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F99C9, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_BrendansHouse_2F_EventScript_1F952F:: @ 81F952F
 	checkflag FLAG_0x125
 	goto_eq LittlerootTown_BrendansHouse_2F_EventScript_1F954A
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F9B0D, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F9B0D, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_BrendansHouse_2F_EventScript_1F9541:: @ 81F9541
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F9A9E, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F9A9E, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_BrendansHouse_2F_EventScript_1F954A:: @ 81F954A
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F9BE7, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F9BE7, MSGBOX_DEFAULT
 	return
 
 EventScript_PlayerPCFemale:: @ 81F9553
@@ -311,7 +311,7 @@ EventScript_PlayerPCFemale:: @ 81F9553
 	end
 
 LittlerootTown_MaysHouse_2F_EventScript_1F956C:: @ 81F956C
-	msgbox gUnknown_08272CD5, 4
+	msgbox gUnknown_08272CD5, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -319,7 +319,7 @@ LittlerootTown_MaysHouse_2F_EventScript_1F9576:: @ 81F9576
 	setvar VAR_0x8004, 2
 	special DoPCTurnOnEffect
 	playse SE_PC_ON
-	msgbox gUnknown_08272D87, 4
+	msgbox gUnknown_08272D87, MSGBOX_DEFAULT
 	special BedroomPC
 	waitstate
 	releaseall

--- a/data/maps/LittlerootTown_ProfessorBirchsLab/scripts.inc
+++ b/data/maps/LittlerootTown_ProfessorBirchsLab/scripts.inc
@@ -98,7 +98,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1F9DDB:: @ 81F9DDB
 	waitmessage
 	playfanfare MUS_FANFA4
 	waitfanfare
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FA8B1, 5
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FA8B1, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_1F9E07
 	compare VAR_RESULT, 0
@@ -112,7 +112,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1F9E07:: @ 81F9E07
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1F9E17:: @ 81F9E17
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FA8F6, 5
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FA8F6, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_1F9E36
 	compare VAR_RESULT, 0
@@ -120,14 +120,14 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1F9E17:: @ 81F9E17
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1F9E36:: @ 81F9E36
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FA9D5, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FA9D5, MSGBOX_DEFAULT
 	clearflag FLAG_HIDE_ROUTE_101_BOY
 	setvar VAR_0x4084, 3
 	releaseall
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1F9E48:: @ 81F9E48
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAA35, 5
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAA35, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_1F9E36
 	compare VAR_RESULT, 0
@@ -154,7 +154,7 @@ LittlerootTown_ProfessorBirchsLab_Movement_1F9E78: @ 81F9E78
 LittlerootTown_ProfessorBirchsLab_EventScript_1F9E80:: @ 81F9E80
 	lockall
 	delay 30
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB16D, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB16D, MSGBOX_DEFAULT
 	closemessage
 	applymovement 2, LittlerootTown_ProfessorBirchsLab_Movement_1F9F46
 	waitmovement 0
@@ -183,14 +183,14 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1F9E80:: @ 81F9E80
 	applymovement 3, LittlerootTown_ProfessorBirchsLab_Movement_2725A6
 	applymovement 255, LittlerootTown_ProfessorBirchsLab_Movement_2725A6
 	waitmovement 0
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB419, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB419, MSGBOX_DEFAULT
 	playfanfare MUS_FANFA4
 	message LittlerootTown_ProfessorBirchsLab_Text_1FB436
 	waitmessage
 	waitfanfare
 	setflag FLAG_SYS_NATIONAL_DEX
 	special EnableNationalPokedex
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB466, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB466, MSGBOX_DEFAULT
 	closemessage
 	setflag FLAG_HIDE_LITTLEROOT_TOWN_BIRCH
 	setflag FLAG_HIDE_LITTLEROOT_TOWN_RIVAL
@@ -201,12 +201,12 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1F9E80:: @ 81F9E80
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1F9F32:: @ 81F9F32
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB30F, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB30F, MSGBOX_DEFAULT
 	closemessage
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1F9F3C:: @ 81F9F3C
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB38E, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB38E, MSGBOX_DEFAULT
 	closemessage
 	return
 
@@ -246,7 +246,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1F9F62:: @ 81F9F62
 	lockall
 	applymovement 255, LittlerootTown_ProfessorBirchsLab_Movement_1F9F7C
 	waitmovement 0
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB5F9, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB5F9, MSGBOX_DEFAULT
 	setvar VAR_0x40D3, 5
 	releaseall
 	end
@@ -268,18 +268,18 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1F9F84:: @ 81F9F84
 	goto_if 4, LittlerootTown_ProfessorBirchsLab_EventScript_1F9FB1
 	checkflag FLAG_0x058
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_1F9FA7
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FA4E2, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FA4E2, MSGBOX_DEFAULT
 	setflag FLAG_0x058
 	release
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1F9FA7:: @ 81F9FA7
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FA641, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FA641, MSGBOX_DEFAULT
 	release
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1F9FB1:: @ 81F9FB1
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FA6CE, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FA6CE, MSGBOX_DEFAULT
 	release
 	end
 
@@ -290,7 +290,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1F9FBB:: @ 81F9FBB
 	applymovement 2, LittlerootTown_ProfessorBirchsLab_Movement_2725A8
 	waitmovement 0
 	drawmonpic SPECIES_CYNDAQUIL, 10, 3
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB7F6, 5
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB7F6, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_1FA061
 	goto LittlerootTown_ProfessorBirchsLab_EventScript_1FA06C
@@ -303,7 +303,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1F9FEF:: @ 81F9FEF
 	applymovement 2, LittlerootTown_ProfessorBirchsLab_Movement_2725A8
 	waitmovement 0
 	drawmonpic SPECIES_TOTODILE, 10, 3
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB869, 5
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB869, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_1FA061
 	goto LittlerootTown_ProfessorBirchsLab_EventScript_1FA10D
@@ -316,20 +316,20 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA023:: @ 81FA023
 	applymovement 2, LittlerootTown_ProfessorBirchsLab_Movement_2725A8
 	waitmovement 0
 	drawmonpic SPECIES_CHIKORITA, 10, 3
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB8E0, 5
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB8E0, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_1FA061
 	goto LittlerootTown_ProfessorBirchsLab_EventScript_1FA1AE
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA057:: @ 81FA057
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBAF8, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBAF8, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA061:: @ 81FA061
 	erasemonpic
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB959, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB959, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -348,7 +348,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA06C:: @ 81FA06C
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA0A1:: @ 81FA0A1
 	call LittlerootTown_ProfessorBirchsLab_EventScript_1FA24F
 	removeobject 4
-	msgbox gUnknown_08273374, 5
+	msgbox gUnknown_08273374, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_1FA0FD
 	call LittlerootTown_ProfessorBirchsLab_EventScript_27378B
@@ -359,7 +359,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA0A1:: @ 81FA0A1
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA0CC:: @ 81FA0CC
 	call LittlerootTown_ProfessorBirchsLab_EventScript_1FA24F
 	removeobject 4
-	msgbox gUnknown_08273374, 5
+	msgbox gUnknown_08273374, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_1FA0F2
 	call LittlerootTown_ProfessorBirchsLab_EventScript_273797
@@ -373,7 +373,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA0F2:: @ 81FA0F2
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA0FD:: @ 81FA0FD
 	erasemonpic
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBA2C, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBA2C, MSGBOX_DEFAULT
 	setvar VAR_0x40D3, 6
 	releaseall
 	end
@@ -393,7 +393,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA10D:: @ 81FA10D
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA142:: @ 81FA142
 	call LittlerootTown_ProfessorBirchsLab_EventScript_1FA24F
 	removeobject 5
-	msgbox gUnknown_08273374, 5
+	msgbox gUnknown_08273374, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_1FA19E
 	call LittlerootTown_ProfessorBirchsLab_EventScript_27378B
@@ -404,7 +404,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA142:: @ 81FA142
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA16D:: @ 81FA16D
 	call LittlerootTown_ProfessorBirchsLab_EventScript_1FA24F
 	removeobject 5
-	msgbox gUnknown_08273374, 5
+	msgbox gUnknown_08273374, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_1FA193
 	call LittlerootTown_ProfessorBirchsLab_EventScript_273797
@@ -418,7 +418,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA193:: @ 81FA193
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA19E:: @ 81FA19E
 	erasemonpic
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBA2C, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBA2C, MSGBOX_DEFAULT
 	setvar VAR_0x40D3, 6
 	releaseall
 	end
@@ -438,7 +438,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA1AE:: @ 81FA1AE
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA1E3:: @ 81FA1E3
 	call LittlerootTown_ProfessorBirchsLab_EventScript_1FA24F
 	removeobject 6
-	msgbox gUnknown_08273374, 5
+	msgbox gUnknown_08273374, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_1FA23F
 	call LittlerootTown_ProfessorBirchsLab_EventScript_27378B
@@ -449,7 +449,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA1E3:: @ 81FA1E3
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA20E:: @ 81FA20E
 	call LittlerootTown_ProfessorBirchsLab_EventScript_1FA24F
 	removeobject 6
-	msgbox gUnknown_08273374, 5
+	msgbox gUnknown_08273374, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_1FA234
 	call LittlerootTown_ProfessorBirchsLab_EventScript_273797
@@ -463,7 +463,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA234:: @ 81FA234
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA23F:: @ 81FA23F
 	erasemonpic
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBA2C, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBA2C, MSGBOX_DEFAULT
 	setvar VAR_0x40D3, 6
 	releaseall
 	end
@@ -490,12 +490,12 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA25A:: @ 81FA25A
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA28A:: @ 81FA28A
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB787, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB787, MSGBOX_DEFAULT
 	release
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA294:: @ 81FA294
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB466, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB466, MSGBOX_DEFAULT
 	release
 	end
 
@@ -508,17 +508,17 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA29E:: @ 81FA29E
 	goto_if 4, LittlerootTown_ProfessorBirchsLab_EventScript_272141
 	compare VAR_0x4084, 5
 	goto_eq LittlerootTown_ProfessorBirchsLab_EventScript_1FA3C4
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAA74, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAA74, MSGBOX_DEFAULT
 	release
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA2D2:: @ 81FA2D2
 Route101_EventScript_1FA2D2:: @ 81FA2D2
-	msgbox Route101_Text_2B5F52, 4
+	msgbox Route101_Text_2B5F52, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox Route101_Text_2B603A, 4
+	msgbox Route101_Text_2B603A, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
@@ -528,9 +528,9 @@ Route101_EventScript_1FA2D2:: @ 81FA2D2
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA2F8:: @ 81FA2F8
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAB22, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAB22, MSGBOX_DEFAULT
 	call LittlerootTown_ProfessorBirchsLab_EventScript_1FA3AC
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAC4B, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAC4B, MSGBOX_DEFAULT
 	closemessage
 	applymovement 3, LittlerootTown_ProfessorBirchsLab_Movement_1FA3E0
 	waitmovement 0
@@ -550,20 +550,20 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA2F8:: @ 81FA2F8
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA352:: @ 81FA352
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FADD7, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FADD7, MSGBOX_DEFAULT
 	giveitem_std ITEM_POKE_BALL, 5
 	compare VAR_RESULT, 0
 	call_if 1, LittlerootTown_ProfessorBirchsLab_EventScript_1FA3CE
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAE40, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAE40, MSGBOX_DEFAULT
 	setvar VAR_RESULT, 0
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA37F:: @ 81FA37F
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAF3F, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAF3F, MSGBOX_DEFAULT
 	giveitem_std ITEM_POKE_BALL, 5
 	compare VAR_RESULT, 0
 	call_if 1, LittlerootTown_ProfessorBirchsLab_EventScript_1FA3D7
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAF8E, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAF8E, MSGBOX_DEFAULT
 	setvar VAR_RESULT, 1
 	return
 
@@ -578,16 +578,16 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA3AC:: @ 81FA3AC
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA3C4:: @ 81FA3C4
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAD6F, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAD6F, MSGBOX_DEFAULT
 	release
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA3CE:: @ 81FA3CE
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAEF3, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAEF3, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA3D7:: @ 81FA3D7
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB05D, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB05D, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_ProfessorBirchsLab_Movement_1FA3E0: @ 81FA3E0
@@ -596,7 +596,7 @@ LittlerootTown_ProfessorBirchsLab_Movement_1FA3E0: @ 81FA3E0
 	step_end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA3E3:: @ 81FA3E3
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB0A2, 3
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB0A2, MSGBOX_SIGN
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA3EC:: @ 81FA3EC
@@ -617,11 +617,11 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA3EC:: @ 81FA3EC
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA428:: @ 81FA428
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAF08, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FAF08, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA431:: @ 81FA431
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB073, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB073, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA43A:: @ 81FA43A
@@ -634,11 +634,11 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA43A:: @ 81FA43A
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA453:: @ 81FA453
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBB68, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBB68, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA45C:: @ 81FA45C
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBC2D, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBC2D, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA465:: @ 81FA465
@@ -651,11 +651,11 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA465:: @ 81FA465
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA47E:: @ 81FA47E
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBC8D, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBC8D, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA487:: @ 81FA487
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBCD2, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FBCD2, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA490:: @ 81FA490
@@ -668,23 +668,23 @@ LittlerootTown_ProfessorBirchsLab_EventScript_1FA490:: @ 81FA490
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA4A9:: @ 81FA4A9
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB528, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB528, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA4B2:: @ 81FA4B2
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB58A, 4
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB58A, MSGBOX_DEFAULT
 	return
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA4BB:: @ 81FA4BB
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB0E7, 3
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB0E7, MSGBOX_SIGN
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA4C4:: @ 81FA4C4
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB124, 3
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB124, MSGBOX_SIGN
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA4CD:: @ 81FA4CD
-	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB148, 3
+	msgbox LittlerootTown_ProfessorBirchsLab_Text_1FB148, MSGBOX_SIGN
 	end
 
 LittlerootTown_ProfessorBirchsLab_EventScript_1FA4D6:: @ 81FA4D6

--- a/data/maps/MagmaHideout_1F/scripts.inc
+++ b/data/maps/MagmaHideout_1F/scripts.inc
@@ -8,12 +8,12 @@ MagmaHideout_1F_MapScript1_239886: @ 8239886
 
 MagmaHideout_1F_EventScript_23988C:: @ 823988C
 	trainerbattle 0, TRAINER_GRUNT_38, 0, MagmaHideout_1F_Text_2398BA, MagmaHideout_1F_Text_239964
-	msgbox MagmaHideout_1F_Text_2399B1, 6
+	msgbox MagmaHideout_1F_Text_2399B1, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_1F_EventScript_2398A3:: @ 82398A3
 	trainerbattle 0, TRAINER_GRUNT_39, 0, MagmaHideout_1F_Text_2399F5, MagmaHideout_1F_Text_239ABA
-	msgbox MagmaHideout_1F_Text_239ACD, 6
+	msgbox MagmaHideout_1F_Text_239ACD, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_1F_Text_2398BA: @ 82398BA

--- a/data/maps/MagmaHideout_2F_1R/scripts.inc
+++ b/data/maps/MagmaHideout_2F_1R/scripts.inc
@@ -3,22 +3,22 @@ MagmaHideout_2F_1R_MapScripts:: @ 8239B50
 
 MagmaHideout_2F_1R_EventScript_239B51:: @ 8239B51
 	trainerbattle 0, TRAINER_GRUNT_51, 0, MagmaHideout_2F_1R_Text_239BAD, MagmaHideout_2F_1R_Text_239C4B
-	msgbox MagmaHideout_2F_1R_Text_239C74, 6
+	msgbox MagmaHideout_2F_1R_Text_239C74, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_2F_1R_EventScript_239B68:: @ 8239B68
 	trainerbattle 0, TRAINER_GRUNT_40, 0, MagmaHideout_2F_1R_Text_239CAB, MagmaHideout_2F_1R_Text_239D09
-	msgbox MagmaHideout_2F_1R_Text_239D1D, 6
+	msgbox MagmaHideout_2F_1R_Text_239D1D, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_2F_1R_EventScript_239B7F:: @ 8239B7F
 	trainerbattle 0, TRAINER_GRUNT_41, 0, MagmaHideout_2F_1R_Text_239D62, MagmaHideout_2F_1R_Text_239D75
-	msgbox MagmaHideout_2F_1R_Text_239D7D, 6
+	msgbox MagmaHideout_2F_1R_Text_239D7D, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_2F_1R_EventScript_239B96:: @ 8239B96
 	trainerbattle 0, TRAINER_GRUNT_42, 0, MagmaHideout_2F_1R_Text_239DC5, MagmaHideout_2F_1R_Text_239DDA
-	msgbox MagmaHideout_2F_1R_Text_239DE2, 6
+	msgbox MagmaHideout_2F_1R_Text_239DE2, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_2F_1R_Text_239BAD: @ 8239BAD

--- a/data/maps/MagmaHideout_2F_2R/scripts.inc
+++ b/data/maps/MagmaHideout_2F_2R/scripts.inc
@@ -3,22 +3,22 @@ MagmaHideout_2F_2R_MapScripts:: @ 8239E07
 
 MagmaHideout_2F_2R_EventScript_239E08:: @ 8239E08
 	trainerbattle 0, TRAINER_GRUNT_52, 0, MagmaHideout_2F_2R_Text_239E64, MagmaHideout_2F_2R_Text_239EA5
-	msgbox MagmaHideout_2F_2R_Text_239EBB, 6
+	msgbox MagmaHideout_2F_2R_Text_239EBB, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_2F_2R_EventScript_239E1F:: @ 8239E1F
 	trainerbattle 0, TRAINER_GRUNT_43, 0, MagmaHideout_2F_2R_Text_239F31, MagmaHideout_2F_2R_Text_239F71
-	msgbox MagmaHideout_2F_2R_Text_239FA1, 6
+	msgbox MagmaHideout_2F_2R_Text_239FA1, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_2F_2R_EventScript_239E36:: @ 8239E36
 	trainerbattle 0, TRAINER_GRUNT_44, 0, MagmaHideout_2F_2R_Text_239FDE, MagmaHideout_2F_2R_Text_23A050
-	msgbox MagmaHideout_2F_2R_Text_23A07D, 6
+	msgbox MagmaHideout_2F_2R_Text_23A07D, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_2F_2R_EventScript_239E4D:: @ 8239E4D
 	trainerbattle 0, TRAINER_GRUNT_45, 0, MagmaHideout_2F_2R_Text_23A0E4, MagmaHideout_2F_2R_Text_23A14C
-	msgbox MagmaHideout_2F_2R_Text_23A16F, 6
+	msgbox MagmaHideout_2F_2R_Text_23A16F, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_2F_2R_Text_239E64: @ 8239E64

--- a/data/maps/MagmaHideout_3F_1R/scripts.inc
+++ b/data/maps/MagmaHideout_3F_1R/scripts.inc
@@ -3,12 +3,12 @@ MagmaHideout_3F_1R_MapScripts:: @ 823A1B2
 
 MagmaHideout_3F_1R_EventScript_23A1B3:: @ 823A1B3
 	trainerbattle 0, TRAINER_GRUNT_46, 0, MagmaHideout_3F_1R_Text_23A1E1, MagmaHideout_3F_1R_Text_23A229
-	msgbox MagmaHideout_3F_1R_Text_23A246, 6
+	msgbox MagmaHideout_3F_1R_Text_23A246, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_3F_1R_EventScript_23A1CA:: @ 823A1CA
 	trainerbattle 0, TRAINER_GRUNT_53, 0, MagmaHideout_3F_1R_Text_23A293, MagmaHideout_3F_1R_Text_23A353
-	msgbox MagmaHideout_3F_1R_Text_23A37C, 6
+	msgbox MagmaHideout_3F_1R_Text_23A37C, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_3F_1R_Text_23A1E1: @ 823A1E1

--- a/data/maps/MagmaHideout_3F_2R/scripts.inc
+++ b/data/maps/MagmaHideout_3F_2R/scripts.inc
@@ -3,7 +3,7 @@ MagmaHideout_3F_2R_MapScripts:: @ 823A3D4
 
 MagmaHideout_3F_2R_EventScript_23A3D5:: @ 823A3D5
 	trainerbattle 0, TRAINER_GRUNT_47, 0, MagmaHideout_3F_2R_Text_23A3EC, MagmaHideout_3F_2R_Text_23A4BB
-	msgbox MagmaHideout_3F_2R_Text_23A4EF, 6
+	msgbox MagmaHideout_3F_2R_Text_23A4EF, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_3F_2R_Text_23A3EC: @ 823A3EC

--- a/data/maps/MagmaHideout_4F/scripts.inc
+++ b/data/maps/MagmaHideout_4F/scripts.inc
@@ -4,7 +4,7 @@ MagmaHideout_4F_MapScripts:: @ 823A55F
 MagmaHideout_4F_EventScript_23A560:: @ 823A560
 	lockall
 	playbgm MUS_MGM0, 0
-	msgbox MagmaHideout_4F_Text_23A9F4, 4
+	msgbox MagmaHideout_4F_Text_23A9F4, MSGBOX_DEFAULT
 	closemessage
 	delay 20
 	setvar VAR_RESULT, 1
@@ -48,17 +48,17 @@ MagmaHideout_4F_EventScript_23A560:: @ 823A560
 	delay 30
 	applymovement 6, MagmaHideout_4F_Movement_23A680
 	waitmovement 0
-	msgbox MagmaHideout_4F_Text_23AADA, 4
+	msgbox MagmaHideout_4F_Text_23AADA, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, MagmaHideout_4F_Movement_2725A8
 	waitmovement 0
 	delay 30
 	applymovement 6, MagmaHideout_4F_Movement_27259E
 	waitmovement 0
-	msgbox MagmaHideout_4F_Text_23AB33, 4
+	msgbox MagmaHideout_4F_Text_23AB33, MSGBOX_DEFAULT
 	closemessage
 	trainerbattle 3, TRAINER_MAXIE_1, 0, MagmaHideout_4F_Text_23ABB5
-	msgbox MagmaHideout_4F_Text_23ABE2, 4
+	msgbox MagmaHideout_4F_Text_23ABE2, MSGBOX_DEFAULT
 	closemessage
 	clearflag FLAG_HIDE_SLATEPORT_CITY_CAPTAIN_STERN
 	clearflag FLAG_HIDE_SLATEPORT_CITY_GABBY_AND_TY
@@ -110,22 +110,22 @@ MagmaHideout_4F_Movement_23A680: @ 823A680
 
 MagmaHideout_4F_EventScript_23A68C:: @ 823A68C
 	trainerbattle 0, TRAINER_GRUNT_48, 0, MagmaHideout_4F_Text_23A6E8, MagmaHideout_4F_Text_23A775
-	msgbox MagmaHideout_4F_Text_23A7B5, 6
+	msgbox MagmaHideout_4F_Text_23A7B5, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_4F_EventScript_23A6A3:: @ 823A6A3
 	trainerbattle 0, TRAINER_GRUNT_49, 0, MagmaHideout_4F_Text_23A7DA, MagmaHideout_4F_Text_23A81B
-	msgbox MagmaHideout_4F_Text_23A841, 6
+	msgbox MagmaHideout_4F_Text_23A841, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_4F_EventScript_23A6BA:: @ 823A6BA
 	trainerbattle 0, TRAINER_GRUNT_50, 0, MagmaHideout_4F_Text_23A86D, MagmaHideout_4F_Text_23A8A7
-	msgbox MagmaHideout_4F_Text_23A8C6, 6
+	msgbox MagmaHideout_4F_Text_23A8C6, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_4F_EventScript_23A6D1:: @ 823A6D1
 	trainerbattle 0, TRAINER_TABITHA_3, 0, MagmaHideout_4F_Text_23A8E1, MagmaHideout_4F_Text_23A994
-	msgbox MagmaHideout_4F_Text_23A9AC, 6
+	msgbox MagmaHideout_4F_Text_23A9AC, MSGBOX_AUTOCLOSE
 	end
 
 MagmaHideout_4F_Text_23A6E8: @ 823A6E8

--- a/data/maps/MauvilleCity/scripts.inc
+++ b/data/maps/MauvilleCity/scripts.inc
@@ -20,35 +20,35 @@ MauvilleCity_EventScript_1DF3A9:: @ 81DF3A9
 	return
 
 MauvilleCity_EventScript_1DF3B3:: @ 81DF3B3
-	msgbox MauvilleCity_Text_1E0301, 2
+	msgbox MauvilleCity_Text_1E0301, MSGBOX_NPC
 	end
 
 MauvilleCity_EventScript_1DF3BC:: @ 81DF3BC
-	msgbox MauvilleCity_Text_1E037C, 2
+	msgbox MauvilleCity_Text_1E037C, MSGBOX_NPC
 	end
 
 MauvilleCity_EventScript_1DF3C5:: @ 81DF3C5
-	msgbox MauvilleCity_Text_1E03FB, 2
+	msgbox MauvilleCity_Text_1E03FB, MSGBOX_NPC
 	end
 
 MauvilleCity_EventScript_1DF3CE:: @ 81DF3CE
-	msgbox MauvilleCity_Text_1E044A, 2
+	msgbox MauvilleCity_Text_1E044A, MSGBOX_NPC
 	end
 
 MauvilleCity_EventScript_1DF3D7:: @ 81DF3D7
-	msgbox MauvilleCity_Text_1E0485, 3
+	msgbox MauvilleCity_Text_1E0485, MSGBOX_SIGN
 	end
 
 MauvilleCity_EventScript_1DF3E0:: @ 81DF3E0
-	msgbox MauvilleCity_Text_1E04B7, 3
+	msgbox MauvilleCity_Text_1E04B7, MSGBOX_SIGN
 	end
 
 MauvilleCity_EventScript_1DF3E9:: @ 81DF3E9
-	msgbox MauvilleCity_Text_1E0504, 3
+	msgbox MauvilleCity_Text_1E0504, MSGBOX_SIGN
 	end
 
 MauvilleCity_EventScript_1DF3F2:: @ 81DF3F2
-	msgbox MauvilleCity_Text_1E053C, 3
+	msgbox MauvilleCity_Text_1E053C, MSGBOX_SIGN
 	end
 
 MauvilleCity_EventScript_1DF3FB:: @ 81DF3FB
@@ -56,13 +56,13 @@ MauvilleCity_EventScript_1DF3FB:: @ 81DF3FB
 	faceplayer
 	checkflag FLAG_0x062
 	goto_eq MauvilleCity_EventScript_1DF413
-	msgbox MauvilleCity_Text_1E056A, 4
+	msgbox MauvilleCity_Text_1E056A, MSGBOX_DEFAULT
 	setflag FLAG_0x062
 	release
 	end
 
 MauvilleCity_EventScript_1DF413:: @ 81DF413
-	msgbox MauvilleCity_Text_1E0699, 4
+	msgbox MauvilleCity_Text_1E0699, MSGBOX_DEFAULT
 	release
 	end
 
@@ -71,7 +71,7 @@ MauvilleCity_EventScript_1DF41D:: @ 81DF41D
 	faceplayer
 	checkflag FLAG_0x11C
 	goto_eq MauvilleCity_EventScript_1DF43D
-	msgbox MauvilleCity_Text_1DF7DC, 4
+	msgbox MauvilleCity_Text_1DF7DC, MSGBOX_DEFAULT
 	closemessage
 	applymovement 7, MauvilleCity_Movement_2725A2
 	waitmovement 0
@@ -79,7 +79,7 @@ MauvilleCity_EventScript_1DF41D:: @ 81DF41D
 	end
 
 MauvilleCity_EventScript_1DF43D:: @ 81DF43D
-	msgbox MauvilleCity_Text_1DFAA5, 4
+	msgbox MauvilleCity_Text_1DFAA5, MSGBOX_DEFAULT
 	closemessage
 	applymovement 7, MauvilleCity_Movement_2725A2
 	waitmovement 0
@@ -92,9 +92,9 @@ MauvilleCity_EventScript_1DF452:: @ 81DF452
 	goto_eq MauvilleCity_EventScript_1DF690
 	applymovement 6, MauvilleCity_Movement_2725A8
 	waitmovement 0
-	msgbox MauvilleCity_Text_1DF845, 4
-	msgbox MauvilleCity_Text_1DF8B9, 4
-	msgbox MauvilleCity_Text_1DF963, 4
+	msgbox MauvilleCity_Text_1DF845, MSGBOX_DEFAULT
+	msgbox MauvilleCity_Text_1DF8B9, MSGBOX_DEFAULT
+	msgbox MauvilleCity_Text_1DF963, MSGBOX_DEFAULT
 	applymovement 6, MauvilleCity_Movement_27259E
 	waitmovement 0
 	playse SE_PIN
@@ -102,7 +102,7 @@ MauvilleCity_EventScript_1DF452:: @ 81DF452
 	waitmovement 0
 	applymovement 6, MauvilleCity_Movement_27259A
 	waitmovement 0
-	msgbox MauvilleCity_Text_1DF9B2, 5
+	msgbox MauvilleCity_Text_1DF9B2, MSGBOX_YESNO
 	goto MauvilleCity_EventScript_1DF4AD
 	end
 
@@ -128,7 +128,7 @@ MauvilleCity_EventScript_1DF4E0:: @ 81DF4E0
 	applymovement 255, MauvilleCity_Movement_1DF6EE
 	applymovement 7, MauvilleCity_Movement_1DF6F3
 	waitmovement 0
-	msgbox MauvilleCity_Text_1DFD34, 4
+	msgbox MauvilleCity_Text_1DFD34, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, MauvilleCity_Movement_1DF6CC
 	applymovement 7, MauvilleCity_Movement_1DF6FA
@@ -147,7 +147,7 @@ MauvilleCity_EventScript_1DF53D:: @ 81DF53D
 	delay 30
 	applymovement 7, MauvilleCity_Movement_1DF6F7
 	waitmovement 0
-	msgbox MauvilleCity_Text_1DFD34, 4
+	msgbox MauvilleCity_Text_1DFD34, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, MauvilleCity_Movement_1DF6D0
 	applymovement 7, MauvilleCity_Movement_1DF703
@@ -170,7 +170,7 @@ MauvilleCity_EventScript_1DF593:: @ 81DF593
 	call_if 1, MauvilleCity_EventScript_1DF601
 	applymovement 255, MauvilleCity_Movement_2725AA
 	waitmovement 0
-	msgbox MauvilleCity_Text_1DFED5, 4
+	msgbox MauvilleCity_Text_1DFED5, MSGBOX_DEFAULT
 	closemessage
 	addvar VAR_0x40D1, 1
 	compare VAR_FACING, 2
@@ -207,29 +207,29 @@ MauvilleCity_EventScript_1DF628:: @ 81DF628
 	return
 
 MauvilleCity_EventScript_1DF63A:: @ 81DF63A
-	msgbox MauvilleCity_Text_1DFB6D, 4
+	msgbox MauvilleCity_Text_1DFB6D, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_WALLY_2, 0, MauvilleCity_Text_1DFB96
 	applymovement 6, MauvilleCity_Movement_2725A8
 	waitmovement 0
-	msgbox MauvilleCity_Text_1DFBC3, 4
+	msgbox MauvilleCity_Text_1DFBC3, MSGBOX_DEFAULT
 	applymovement 6, MauvilleCity_Movement_27259E
 	waitmovement 0
-	msgbox MauvilleCity_Text_1DFBED, 4
+	msgbox MauvilleCity_Text_1DFBED, MSGBOX_DEFAULT
 	applymovement 6, MauvilleCity_Movement_2725A8
 	waitmovement 0
-	msgbox MauvilleCity_Text_1DFC8A, 4
+	msgbox MauvilleCity_Text_1DFC8A, MSGBOX_DEFAULT
 	return
 
 MauvilleCity_EventScript_1DF683:: @ 81DF683
 	setflag FLAG_0x11C
-	msgbox MauvilleCity_Text_1DFA4A, 4
+	msgbox MauvilleCity_Text_1DFA4A, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_EventScript_1DF690:: @ 81DF690
 	applymovement 6, MauvilleCity_Movement_27259E
 	waitmovement 0
-	msgbox MauvilleCity_Text_1DFB42, 5
+	msgbox MauvilleCity_Text_1DFB42, MSGBOX_YESNO
 	goto MauvilleCity_EventScript_1DF4AD
 	end
 
@@ -430,30 +430,30 @@ MauvilleCity_EventScript_1DF73A:: @ 81DF73A
 	goto_eq MauvilleCity_EventScript_1DF784
 	checkflag FLAG_GOT_BASEMENT_KEY_FROM_WATTSON
 	goto_eq MauvilleCity_EventScript_1DF77A
-	msgbox MauvilleCity_Text_1DFFE4, 4
+	msgbox MauvilleCity_Text_1DFFE4, MSGBOX_DEFAULT
 	giveitem_std ITEM_BASEMENT_KEY
 	setflag FLAG_GOT_BASEMENT_KEY_FROM_WATTSON
-	msgbox MauvilleCity_Text_1E0154, 4
+	msgbox MauvilleCity_Text_1E0154, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_EventScript_1DF77A:: @ 81DF77A
-	msgbox MauvilleCity_Text_1E0154, 4
+	msgbox MauvilleCity_Text_1E0154, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_EventScript_1DF784:: @ 81DF784
-	msgbox MauvilleCity_Text_1E020E, 4
+	msgbox MauvilleCity_Text_1E020E, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM24
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_EventScript_272054
 	setflag FLAG_GOT_TM24_FROM_WATTSON
-	msgbox MauvilleCity_Text_1E02AA, 4
+	msgbox MauvilleCity_Text_1E02AA, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_EventScript_1DF7B0:: @ 81DF7B0
-	msgbox MauvilleCity_Text_1E02AA, 4
+	msgbox MauvilleCity_Text_1E02AA, MSGBOX_DEFAULT
 	release
 	end
 
@@ -463,7 +463,7 @@ MauvilleCity_EventScript_1DF7BA:: @ 81DF7BA
 	waitmessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox MauvilleCity_Text_1DFEB4, 4
+	msgbox MauvilleCity_Text_1DFEB4, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30

--- a/data/maps/MauvilleCity_BikeShop/scripts.inc
+++ b/data/maps/MauvilleCity_BikeShop/scripts.inc
@@ -8,8 +8,8 @@ MauvilleCity_BikeShop_EventScript_20EBBC:: @ 820EBBC
 	goto_eq MauvilleCity_BikeShop_EventScript_20EC94
 	checkflag FLAG_0x059
 	goto_eq MauvilleCity_BikeShop_EventScript_20EBF7
-	msgbox MauvilleCity_BikeShop_Text_20EE22, 4
-	msgbox MauvilleCity_BikeShop_Text_20EE99, 5
+	msgbox MauvilleCity_BikeShop_Text_20EE22, MSGBOX_DEFAULT
+	msgbox MauvilleCity_BikeShop_Text_20EE99, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_BikeShop_EventScript_20EC4A
 	compare VAR_RESULT, 0
@@ -17,7 +17,7 @@ MauvilleCity_BikeShop_EventScript_20EBBC:: @ 820EBBC
 	end
 
 MauvilleCity_BikeShop_EventScript_20EBF7:: @ 820EBF7
-	msgbox MauvilleCity_BikeShop_Text_20EE99, 5
+	msgbox MauvilleCity_BikeShop_Text_20EE99, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_BikeShop_EventScript_20EC4A
 	compare VAR_RESULT, 0
@@ -35,7 +35,7 @@ MauvilleCity_BikeShop_EventScript_20EC16:: @ 820EC16
 
 MauvilleCity_BikeShop_EventScript_20EC3D:: @ 820EC3D
 	setflag FLAG_0x059
-	msgbox MauvilleCity_BikeShop_Text_20EEE8, 4
+	msgbox MauvilleCity_BikeShop_Text_20EEE8, MSGBOX_DEFAULT
 	release
 	end
 
@@ -45,25 +45,25 @@ MauvilleCity_BikeShop_EventScript_20EC4A:: @ 820EC4A
 	end
 
 MauvilleCity_BikeShop_EventScript_20EC53:: @ 820EC53
-	msgbox MauvilleCity_BikeShop_Text_20F18D, 4
+	msgbox MauvilleCity_BikeShop_Text_20F18D, MSGBOX_DEFAULT
 	giveitem_std ITEM_MACH_BIKE
 	goto MauvilleCity_BikeShop_EventScript_20EC87
 	end
 
 MauvilleCity_BikeShop_EventScript_20EC6D:: @ 820EC6D
-	msgbox MauvilleCity_BikeShop_Text_20F1A5, 4
+	msgbox MauvilleCity_BikeShop_Text_20F1A5, MSGBOX_DEFAULT
 	giveitem_std ITEM_ACRO_BIKE
 	goto MauvilleCity_BikeShop_EventScript_20EC87
 	end
 
 MauvilleCity_BikeShop_EventScript_20EC87:: @ 820EC87
-	msgbox MauvilleCity_BikeShop_Text_20F1BD, 4
+	msgbox MauvilleCity_BikeShop_Text_20F1BD, MSGBOX_DEFAULT
 	special SwapRegisteredBike
 	release
 	end
 
 MauvilleCity_BikeShop_EventScript_20EC94:: @ 820EC94
-	msgbox MauvilleCity_BikeShop_Text_20F1FB, 5
+	msgbox MauvilleCity_BikeShop_Text_20F1FB, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_BikeShop_EventScript_20ECB3
 	compare VAR_RESULT, 0
@@ -71,25 +71,25 @@ MauvilleCity_BikeShop_EventScript_20EC94:: @ 820EC94
 	end
 
 MauvilleCity_BikeShop_EventScript_20ECB3:: @ 820ECB3
-	msgbox MauvilleCity_BikeShop_Text_20F22F, 4
+	msgbox MauvilleCity_BikeShop_Text_20F22F, MSGBOX_DEFAULT
 	checkitem ITEM_ACRO_BIKE, 1
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_BikeShop_EventScript_20ECEF
 	checkitem ITEM_MACH_BIKE, 1
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_BikeShop_EventScript_20ED10
-	msgbox MauvilleCity_BikeShop_Text_20F2F3, 4
+	msgbox MauvilleCity_BikeShop_Text_20F2F3, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_BikeShop_EventScript_20ECE5:: @ 820ECE5
-	msgbox MauvilleCity_BikeShop_Text_20F2C4, 4
+	msgbox MauvilleCity_BikeShop_Text_20F2C4, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_BikeShop_EventScript_20ECEF:: @ 820ECEF
 	incrementgamestat 4
-	msgbox MauvilleCity_BikeShop_Text_20F294, 4
+	msgbox MauvilleCity_BikeShop_Text_20F294, MSGBOX_DEFAULT
 	takeitem ITEM_ACRO_BIKE, 1
 	giveitem_std ITEM_MACH_BIKE
 	goto MauvilleCity_BikeShop_EventScript_20EC87
@@ -97,14 +97,14 @@ MauvilleCity_BikeShop_EventScript_20ECEF:: @ 820ECEF
 
 MauvilleCity_BikeShop_EventScript_20ED10:: @ 820ED10
 	incrementgamestat 4
-	msgbox MauvilleCity_BikeShop_Text_20F263, 4
+	msgbox MauvilleCity_BikeShop_Text_20F263, MSGBOX_DEFAULT
 	takeitem ITEM_MACH_BIKE, 1
 	giveitem_std ITEM_ACRO_BIKE
 	goto MauvilleCity_BikeShop_EventScript_20EC87
 	end
 
 MauvilleCity_BikeShop_EventScript_20ED31:: @ 820ED31
-	msgbox MauvilleCity_BikeShop_Text_20F3C3, 2
+	msgbox MauvilleCity_BikeShop_Text_20F3C3, MSGBOX_NPC
 	end
 
 MauvilleCity_BikeShop_EventScript_20ED3A:: @ 820ED3A

--- a/data/maps/MauvilleCity_GameCorner/scripts.inc
+++ b/data/maps/MauvilleCity_GameCorner/scripts.inc
@@ -4,7 +4,7 @@ MauvilleCity_GameCorner_MapScripts:: @ 820FBB8
 MauvilleCity_GameCorner_EventScript_20FBB9:: @ 820FBB9
 	lock
 	faceplayer
-	msgbox MauvilleCity_GameCorner_Text_210460, 4
+	msgbox MauvilleCity_GameCorner_Text_210460, MSGBOX_DEFAULT
 	checkitem ITEM_COIN_CASE, 1
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_GameCorner_EventScript_20FCB7
@@ -43,7 +43,7 @@ MauvilleCity_GameCorner_EventScript_20FC33:: @ 820FC33
 	nop
 	updatecoinsbox 1, 6
 	playse SE_REGI
-	msgbox MauvilleCity_GameCorner_Text_210529, 4
+	msgbox MauvilleCity_GameCorner_Text_210529, MSGBOX_DEFAULT
 	hidemoneybox
 	nop
 	nop
@@ -64,7 +64,7 @@ MauvilleCity_GameCorner_EventScript_20FC75:: @ 820FC75
 	nop
 	updatecoinsbox 1, 6
 	playse SE_REGI
-	msgbox MauvilleCity_GameCorner_Text_210529, 4
+	msgbox MauvilleCity_GameCorner_Text_210529, MSGBOX_DEFAULT
 	hidemoneybox
 	nop
 	nop
@@ -73,12 +73,12 @@ MauvilleCity_GameCorner_EventScript_20FC75:: @ 820FC75
 	end
 
 MauvilleCity_GameCorner_EventScript_20FCB7:: @ 820FCB7
-	msgbox MauvilleCity_GameCorner_Text_21047E, 4
+	msgbox MauvilleCity_GameCorner_Text_21047E, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_GameCorner_EventScript_20FCC1:: @ 820FCC1
-	msgbox MauvilleCity_GameCorner_Text_210553, 4
+	msgbox MauvilleCity_GameCorner_Text_210553, MSGBOX_DEFAULT
 	hidemoneybox
 	nop
 	nop
@@ -87,7 +87,7 @@ MauvilleCity_GameCorner_EventScript_20FCC1:: @ 820FCC1
 	end
 
 MauvilleCity_GameCorner_EventScript_20FCD1:: @ 820FCD1
-	msgbox MauvilleCity_GameCorner_Text_21059A, 4
+	msgbox MauvilleCity_GameCorner_Text_21059A, MSGBOX_DEFAULT
 	hidemoneybox
 	nop
 	nop
@@ -96,7 +96,7 @@ MauvilleCity_GameCorner_EventScript_20FCD1:: @ 820FCD1
 	end
 
 MauvilleCity_GameCorner_EventScript_20FCE1:: @ 820FCE1
-	msgbox MauvilleCity_GameCorner_Text_21057E, 4
+	msgbox MauvilleCity_GameCorner_Text_21057E, MSGBOX_DEFAULT
 	hidemoneybox
 	nop
 	nop
@@ -107,7 +107,7 @@ MauvilleCity_GameCorner_EventScript_20FCE1:: @ 820FCE1
 MauvilleCity_GameCorner_EventScript_20FCF1:: @ 820FCF1
 	lock
 	faceplayer
-	msgbox MauvilleCity_GameCorner_Text_2105D7, 4
+	msgbox MauvilleCity_GameCorner_Text_2105D7, MSGBOX_DEFAULT
 	checkitem ITEM_COIN_CASE, 1
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_GameCorner_EventScript_20FD0D
@@ -152,7 +152,7 @@ MauvilleCity_GameCorner_EventScript_20FD83:: @ 820FD83
 	goto MauvilleCity_GameCorner_EventScript_20FD91
 
 MauvilleCity_GameCorner_EventScript_20FD91:: @ 820FD91
-	msgbox MauvilleCity_GameCorner_Text_210705, 5
+	msgbox MauvilleCity_GameCorner_Text_210705, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_GameCorner_EventScript_20FE92
 	switch VAR_TEMP_1
@@ -173,7 +173,7 @@ MauvilleCity_GameCorner_EventScript_20FDCB:: @ 820FDCB
 	givedecoration 88
 	updatecoinsbox 1, 1
 	playse SE_REGI
-	msgbox MauvilleCity_GameCorner_Text_210646, 4
+	msgbox MauvilleCity_GameCorner_Text_210646, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_20FD20
 	end
 
@@ -189,7 +189,7 @@ MauvilleCity_GameCorner_EventScript_20FE05:: @ 820FE05
 	givedecoration 89
 	updatecoinsbox 1, 1
 	playse SE_REGI
-	msgbox MauvilleCity_GameCorner_Text_210646, 4
+	msgbox MauvilleCity_GameCorner_Text_210646, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_20FD20
 	end
 
@@ -205,12 +205,12 @@ MauvilleCity_GameCorner_EventScript_20FE3F:: @ 820FE3F
 	givedecoration 90
 	updatecoinsbox 1, 1
 	playse SE_REGI
-	msgbox MauvilleCity_GameCorner_Text_210646, 4
+	msgbox MauvilleCity_GameCorner_Text_210646, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_20FD20
 	end
 
 MauvilleCity_GameCorner_EventScript_20FE79:: @ 820FE79
-	msgbox MauvilleCity_GameCorner_Text_210673, 4
+	msgbox MauvilleCity_GameCorner_Text_210673, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_20FD20
 	end
 
@@ -220,7 +220,7 @@ MauvilleCity_GameCorner_EventScript_20FE87:: @ 820FE87
 	end
 
 MauvilleCity_GameCorner_EventScript_20FE92:: @ 820FE92
-	msgbox MauvilleCity_GameCorner_Text_2106BF, 4
+	msgbox MauvilleCity_GameCorner_Text_2106BF, MSGBOX_DEFAULT
 	hidecoinsbox 0, 0
 	release
 	end
@@ -228,7 +228,7 @@ MauvilleCity_GameCorner_EventScript_20FE92:: @ 820FE92
 MauvilleCity_GameCorner_EventScript_20FE9F:: @ 820FE9F
 	lock
 	faceplayer
-	msgbox MauvilleCity_GameCorner_Text_2105D7, 4
+	msgbox MauvilleCity_GameCorner_Text_2105D7, MSGBOX_DEFAULT
 	checkitem ITEM_COIN_CASE, 1
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_GameCorner_EventScript_20FEBB
@@ -291,7 +291,7 @@ MauvilleCity_GameCorner_EventScript_20FF77:: @ 820FF77
 
 MauvilleCity_GameCorner_EventScript_20FF8A:: @ 820FF8A
 	special sub_81398C0
-	msgbox MauvilleCity_GameCorner_Text_210629, 5
+	msgbox MauvilleCity_GameCorner_Text_210629, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_GameCorner_EventScript_210118
 	switch VAR_TEMP_1
@@ -313,7 +313,7 @@ MauvilleCity_GameCorner_EventScript_20FFDD:: @ 820FFDD
 	giveitem ITEM_TM32, 1
 	updatecoinsbox 1, 1
 	playse SE_REGI
-	msgbox MauvilleCity_GameCorner_Text_21071B, 4
+	msgbox MauvilleCity_GameCorner_Text_21071B, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_20FECE
 	end
 
@@ -328,7 +328,7 @@ MauvilleCity_GameCorner_EventScript_210017:: @ 8210017
 	giveitem ITEM_TM29, 1
 	updatecoinsbox 1, 1
 	playse SE_REGI
-	msgbox MauvilleCity_GameCorner_Text_21071B, 4
+	msgbox MauvilleCity_GameCorner_Text_21071B, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_20FECE
 	end
 
@@ -343,7 +343,7 @@ MauvilleCity_GameCorner_EventScript_210051:: @ 8210051
 	giveitem ITEM_TM35, 1
 	updatecoinsbox 1, 1
 	playse SE_REGI
-	msgbox MauvilleCity_GameCorner_Text_21071B, 4
+	msgbox MauvilleCity_GameCorner_Text_21071B, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_20FECE
 	end
 
@@ -358,7 +358,7 @@ MauvilleCity_GameCorner_EventScript_21008B:: @ 821008B
 	giveitem ITEM_TM24, 1
 	updatecoinsbox 1, 1
 	playse SE_REGI
-	msgbox MauvilleCity_GameCorner_Text_21071B, 4
+	msgbox MauvilleCity_GameCorner_Text_21071B, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_20FECE
 	end
 
@@ -373,12 +373,12 @@ MauvilleCity_GameCorner_EventScript_2100C5:: @ 82100C5
 	giveitem ITEM_TM13, 1
 	updatecoinsbox 1, 1
 	playse SE_REGI
-	msgbox MauvilleCity_GameCorner_Text_21071B, 4
+	msgbox MauvilleCity_GameCorner_Text_21071B, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_20FECE
 	end
 
 MauvilleCity_GameCorner_EventScript_2100FF:: @ 82100FF
-	msgbox MauvilleCity_GameCorner_Text_210673, 4
+	msgbox MauvilleCity_GameCorner_Text_210673, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_20FECE
 	end
 
@@ -388,17 +388,17 @@ MauvilleCity_GameCorner_EventScript_21010D:: @ 821010D
 	end
 
 MauvilleCity_GameCorner_EventScript_210118:: @ 8210118
-	msgbox MauvilleCity_GameCorner_Text_2106BF, 4
+	msgbox MauvilleCity_GameCorner_Text_2106BF, MSGBOX_DEFAULT
 	hidecoinsbox 0, 0
 	release
 	end
 
 MauvilleCity_GameCorner_EventScript_210125:: @ 8210125
-	msgbox MauvilleCity_GameCorner_Text_2109D3, 2
+	msgbox MauvilleCity_GameCorner_Text_2109D3, MSGBOX_NPC
 	end
 
 MauvilleCity_GameCorner_EventScript_21012E:: @ 821012E
-	msgbox MauvilleCity_GameCorner_Text_210A05, 2
+	msgbox MauvilleCity_GameCorner_Text_210A05, MSGBOX_NPC
 	end
 
 MauvilleCity_GameCorner_EventScript_210137:: @ 8210137
@@ -406,7 +406,7 @@ MauvilleCity_GameCorner_EventScript_210137:: @ 8210137
 	faceplayer
 	checkflag FLAG_0x0E2
 	goto_eq MauvilleCity_GameCorner_EventScript_210213
-	msgbox MauvilleCity_GameCorner_Text_210750, 5
+	msgbox MauvilleCity_GameCorner_Text_210750, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_GameCorner_EventScript_210209
 	switch VAR_STARTER_MON
@@ -420,7 +420,7 @@ MauvilleCity_GameCorner_EventScript_21017C:: @ 821017C
 	checkdecorspace 88
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_GameCorner_EventScript_2101FA
-	msgbox MauvilleCity_GameCorner_Text_21079C, 4
+	msgbox MauvilleCity_GameCorner_Text_21079C, MSGBOX_DEFAULT
 	givedecoration_std 88
 	setflag FLAG_0x0E2
 	goto MauvilleCity_GameCorner_EventScript_210213
@@ -431,7 +431,7 @@ MauvilleCity_GameCorner_EventScript_2101A6:: @ 82101A6
 	checkdecorspace 89
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_GameCorner_EventScript_2101FA
-	msgbox MauvilleCity_GameCorner_Text_21079C, 4
+	msgbox MauvilleCity_GameCorner_Text_21079C, MSGBOX_DEFAULT
 	givedecoration_std 89
 	setflag FLAG_0x0E2
 	goto MauvilleCity_GameCorner_EventScript_210213
@@ -442,7 +442,7 @@ MauvilleCity_GameCorner_EventScript_2101D0:: @ 82101D0
 	checkdecorspace 90
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_GameCorner_EventScript_2101FA
-	msgbox MauvilleCity_GameCorner_Text_21079C, 4
+	msgbox MauvilleCity_GameCorner_Text_21079C, MSGBOX_DEFAULT
 	givedecoration_std 90
 	setflag FLAG_0x0E2
 	goto MauvilleCity_GameCorner_EventScript_210213
@@ -450,17 +450,17 @@ MauvilleCity_GameCorner_EventScript_2101D0:: @ 82101D0
 
 MauvilleCity_GameCorner_EventScript_2101FA:: @ 82101FA
 	call MauvilleCity_GameCorner_EventScript_272071
-	msgbox MauvilleCity_GameCorner_Text_2107A9, 4
+	msgbox MauvilleCity_GameCorner_Text_2107A9, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_GameCorner_EventScript_210209:: @ 8210209
-	msgbox MauvilleCity_GameCorner_Text_2107CE, 4
+	msgbox MauvilleCity_GameCorner_Text_2107CE, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_GameCorner_EventScript_210213:: @ 8210213
-	msgbox MauvilleCity_GameCorner_Text_2107FB, 4
+	msgbox MauvilleCity_GameCorner_Text_2107FB, MSGBOX_DEFAULT
 	release
 	end
 
@@ -470,7 +470,7 @@ MauvilleCity_GameCorner_EventScript_21021D:: @ 821021D
 	checkitem ITEM_COIN_CASE, 1
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_GameCorner_EventScript_21023D
-	msgbox MauvilleCity_GameCorner_Text_210830, 4
+	msgbox MauvilleCity_GameCorner_Text_210830, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_2102A9
 	end
 
@@ -482,34 +482,34 @@ MauvilleCity_GameCorner_EventScript_21023D:: @ 821023D
 	goto_if 4, MauvilleCity_GameCorner_EventScript_21026B
 	setflag FLAG_0x0E1
 	givecoins 20
-	msgbox MauvilleCity_GameCorner_Text_2108A0, 4
+	msgbox MauvilleCity_GameCorner_Text_2108A0, MSGBOX_DEFAULT
 	playse SE_REGI
 	goto MauvilleCity_GameCorner_EventScript_21026B
 	end
 
 MauvilleCity_GameCorner_EventScript_21026B:: @ 821026B
-	msgbox MauvilleCity_GameCorner_Text_2108EF, 4
+	msgbox MauvilleCity_GameCorner_Text_2108EF, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_2102A9
 	end
 
 MauvilleCity_GameCorner_EventScript_210279:: @ 8210279
 	lock
 	faceplayer
-	msgbox MauvilleCity_GameCorner_Text_210932, 4
+	msgbox MauvilleCity_GameCorner_Text_210932, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_2102A9
 	end
 
 MauvilleCity_GameCorner_EventScript_210289:: @ 8210289
 	lock
 	faceplayer
-	msgbox MauvilleCity_GameCorner_Text_21098E, 4
+	msgbox MauvilleCity_GameCorner_Text_21098E, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_2102A9
 	end
 
 MauvilleCity_GameCorner_EventScript_210299:: @ 8210299
 	lock
 	faceplayer
-	msgbox MauvilleCity_GameCorner_Text_210A51, 4
+	msgbox MauvilleCity_GameCorner_Text_210A51, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_2102A9
 	end
 
@@ -523,14 +523,14 @@ MauvilleCity_GameCorner_EventScript_2102A9:: @ 82102A9
 MauvilleCity_GameCorner_EventScript_2102B6:: @ 82102B6
 	lock
 	faceplayer
-	msgbox MauvilleCity_GameCorner_Text_210A82, 4
+	msgbox MauvilleCity_GameCorner_Text_210A82, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_2102A9
 	end
 
 MauvilleCity_GameCorner_EventScript_2102C6:: @ 82102C6
 	lock
 	faceplayer
-	msgbox MauvilleCity_GameCorner_Text_210B04, 4
+	msgbox MauvilleCity_GameCorner_Text_210B04, MSGBOX_DEFAULT
 	goto MauvilleCity_GameCorner_EventScript_2102A9
 	end
 
@@ -667,7 +667,7 @@ MauvilleCity_GameCorner_EventScript_210436:: @ 8210436
 	end
 
 MauvilleCity_GameCorner_EventScript_210456:: @ 8210456
-	msgbox MauvilleCity_GameCorner_Text_210C2E, 4
+	msgbox MauvilleCity_GameCorner_Text_210C2E, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/MauvilleCity_Gym/scripts.inc
+++ b/data/maps/MauvilleCity_Gym/scripts.inc
@@ -84,7 +84,7 @@ MauvilleCity_Gym_EventScript_20DEEB:: @ 820DEEB
 	goto_if 0, MauvilleCity_Gym_EventScript_20DF8D
 	compare VAR_0x40BA, 2
 	goto_eq MauvilleCity_Gym_EventScript_20DFD4
-	msgbox MauvilleCity_Gym_Text_20E8E3, 4
+	msgbox MauvilleCity_Gym_Text_20E8E3, MSGBOX_DEFAULT
 	release
 	end
 
@@ -92,7 +92,7 @@ MauvilleCity_Gym_EventScript_20DF2B:: @ 820DF2B
 	message MauvilleCity_Gym_Text_20E77F
 	waitmessage
 	call MauvilleCity_Gym_EventScript_27207E
-	msgbox MauvilleCity_Gym_Text_20E7AA, 4
+	msgbox MauvilleCity_Gym_Text_20E7AA, MSGBOX_DEFAULT
 	setvar VAR_0x40D2, 3
 	clearflag FLAG_HIDE_VERDANTURF_TOWN_SCOTT
 	setflag FLAG_0x4F2
@@ -109,7 +109,7 @@ MauvilleCity_Gym_EventScript_20DF2B:: @ 820DF2B
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox MauvilleCity_Gym_Text_20E8B5, 4
+	msgbox MauvilleCity_Gym_Text_20E8B5, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
@@ -121,7 +121,7 @@ MauvilleCity_Gym_EventScript_20DF8D:: @ 820DF8D
 	giveitem_std ITEM_TM34
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_Gym_EventScript_272054
-	msgbox MauvilleCity_Gym_Text_20E844, 4
+	msgbox MauvilleCity_Gym_Text_20E844, MSGBOX_DEFAULT
 	setflag FLAG_0x0A7
 	release
 	end
@@ -130,18 +130,18 @@ MauvilleCity_Gym_EventScript_20DFB1:: @ 820DFB1
 	giveitem_std ITEM_TM34
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_Gym_EventScript_27205E
-	msgbox MauvilleCity_Gym_Text_20E844, 4
+	msgbox MauvilleCity_Gym_Text_20E844, MSGBOX_DEFAULT
 	setflag FLAG_0x0A7
 	return
 
 MauvilleCity_Gym_EventScript_20DFD4:: @ 820DFD4
-	msgbox MauvilleCity_Gym_Text_20E925, 4
+	msgbox MauvilleCity_Gym_Text_20E925, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_Gym_EventScript_20DFDE:: @ 820DFDE
 	trainerbattle 7, TRAINER_WATTSON_1, 0, MauvilleCity_Gym_Text_20E9A7, MauvilleCity_Gym_Text_20EA42, MauvilleCity_Gym_Text_20EAFD
-	msgbox MauvilleCity_Gym_Text_20EA5E, 6
+	msgbox MauvilleCity_Gym_Text_20EA5E, MSGBOX_AUTOCLOSE
 	end
 
 MauvilleCity_Gym_EventScript_20DFF9:: @ 820DFF9
@@ -216,27 +216,27 @@ MauvilleCity_Gym_EventScript_20E0B4:: @ 820E0B4
 
 MauvilleCity_Gym_EventScript_20E0B9:: @ 820E0B9
 	trainerbattle 0, TRAINER_KIRK, 0, MauvilleCity_Gym_Text_20E2BC, MauvilleCity_Gym_Text_20E2FC
-	msgbox MauvilleCity_Gym_Text_20E336, 6
+	msgbox MauvilleCity_Gym_Text_20E336, MSGBOX_AUTOCLOSE
 	end
 
 MauvilleCity_Gym_EventScript_20E0D0:: @ 820E0D0
 	trainerbattle 0, TRAINER_SHAWN, 0, MauvilleCity_Gym_Text_20E369, MauvilleCity_Gym_Text_20E3A7
-	msgbox MauvilleCity_Gym_Text_20E3C1, 6
+	msgbox MauvilleCity_Gym_Text_20E3C1, MSGBOX_AUTOCLOSE
 	end
 
 MauvilleCity_Gym_EventScript_20E0E7:: @ 820E0E7
 	trainerbattle 0, TRAINER_BEN, 0, MauvilleCity_Gym_Text_20E443, MauvilleCity_Gym_Text_20E469
-	msgbox MauvilleCity_Gym_Text_20E47E, 6
+	msgbox MauvilleCity_Gym_Text_20E47E, MSGBOX_AUTOCLOSE
 	end
 
 MauvilleCity_Gym_EventScript_20E0FE:: @ 820E0FE
 	trainerbattle 0, TRAINER_VIVIAN, 0, MauvilleCity_Gym_Text_20E4BB, MauvilleCity_Gym_Text_20E4F4
-	msgbox MauvilleCity_Gym_Text_20E50F, 6
+	msgbox MauvilleCity_Gym_Text_20E50F, MSGBOX_AUTOCLOSE
 	end
 
 MauvilleCity_Gym_EventScript_20E115:: @ 820E115
 	trainerbattle 0, TRAINER_ANGELO, 0, MauvilleCity_Gym_Text_20E593, MauvilleCity_Gym_Text_20E5A8
-	msgbox MauvilleCity_Gym_Text_20E5C2, 6
+	msgbox MauvilleCity_Gym_Text_20E5C2, MSGBOX_AUTOCLOSE
 	end
 
 MauvilleCity_Gym_EventScript_20E12C:: @ 820E12C
@@ -244,12 +244,12 @@ MauvilleCity_Gym_EventScript_20E12C:: @ 820E12C
 	faceplayer
 	checkflag FLAG_0x4F2
 	goto_eq MauvilleCity_Gym_EventScript_20E141
-	msgbox MauvilleCity_Gym_Text_20E17F, 4
+	msgbox MauvilleCity_Gym_Text_20E17F, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_Gym_EventScript_20E141:: @ 820E141
-	msgbox MauvilleCity_Gym_Text_20E283, 4
+	msgbox MauvilleCity_Gym_Text_20E283, MSGBOX_DEFAULT
 	release
 	end
 
@@ -268,12 +268,12 @@ MauvilleCity_Gym_EventScript_20E15B:: @ 820E15B
 	end
 
 MauvilleCity_Gym_EventScript_20E16B:: @ 820E16B
-	msgbox MauvilleCity_Gym_Text_20E96C, 4
+	msgbox MauvilleCity_Gym_Text_20E96C, MSGBOX_DEFAULT
 	releaseall
 	end
 
 MauvilleCity_Gym_EventScript_20E175:: @ 820E175
-	msgbox MauvilleCity_Gym_Text_20E952, 4
+	msgbox MauvilleCity_Gym_Text_20E952, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/MauvilleCity_House1/scripts.inc
+++ b/data/maps/MauvilleCity_House1/scripts.inc
@@ -6,16 +6,16 @@ MauvilleCity_House1_EventScript_20F976:: @ 820F976
 	faceplayer
 	checkflag FLAG_0x06B
 	goto_eq MauvilleCity_House1_EventScript_20F9A5
-	msgbox MauvilleCity_House1_Text_20F9AF, 4
+	msgbox MauvilleCity_House1_Text_20F9AF, MSGBOX_DEFAULT
 	giveitem_std ITEM_HM06
 	setflag FLAG_0x06B
 	setflag FLAG_HIDE_ROUTE_111_ROCK_SMASH_TIP_GUY
-	msgbox MauvilleCity_House1_Text_20FAA9, 4
+	msgbox MauvilleCity_House1_Text_20FAA9, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_House1_EventScript_20F9A5:: @ 820F9A5
-	msgbox MauvilleCity_House1_Text_20FB67, 4
+	msgbox MauvilleCity_House1_Text_20FB67, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/MauvilleCity_House2/scripts.inc
+++ b/data/maps/MauvilleCity_House2/scripts.inc
@@ -6,7 +6,7 @@ MauvilleCity_House2_EventScript_210C5D:: @ 8210C5D
 	faceplayer
 	checkflag FLAG_0x102
 	goto_eq MauvilleCity_House2_EventScript_210CDA
-	msgbox MauvilleCity_House2_Text_210CEE, 4
+	msgbox MauvilleCity_House2_Text_210CEE, MSGBOX_DEFAULT
 	checkitem ITEM_HARBOR_MAIL, 1
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_House2_EventScript_210C82
@@ -19,7 +19,7 @@ MauvilleCity_House2_EventScript_210C82:: @ 8210C82
 	waitmovement 0
 	applymovement VAR_LAST_TALKED, MauvilleCity_House2_Movement_27259A
 	waitmovement 0
-	msgbox MauvilleCity_House2_Text_210D76, 5
+	msgbox MauvilleCity_House2_Text_210D76, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_House2_EventScript_210CB8
 	compare VAR_RESULT, 0
@@ -27,7 +27,7 @@ MauvilleCity_House2_EventScript_210C82:: @ 8210C82
 	end
 
 MauvilleCity_House2_EventScript_210CB8:: @ 8210CB8
-	msgbox MauvilleCity_House2_Text_210DB3, 4
+	msgbox MauvilleCity_House2_Text_210DB3, MSGBOX_DEFAULT
 	takeitem ITEM_HARBOR_MAIL, 1
 	giveitem_std ITEM_COIN_CASE
 	setflag FLAG_0x102
@@ -35,12 +35,12 @@ MauvilleCity_House2_EventScript_210CB8:: @ 8210CB8
 	end
 
 MauvilleCity_House2_EventScript_210CDA:: @ 8210CDA
-	msgbox MauvilleCity_House2_Text_210DE7, 4
+	msgbox MauvilleCity_House2_Text_210DE7, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_House2_EventScript_210CE4:: @ 8210CE4
-	msgbox MauvilleCity_House2_Text_210E16, 4
+	msgbox MauvilleCity_House2_Text_210E16, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/MauvilleCity_Mart/scripts.inc
+++ b/data/maps/MauvilleCity_Mart/scripts.inc
@@ -7,7 +7,7 @@ MauvilleCity_Mart_EventScript_2110E6:: @ 82110E6
 	message gUnknown_08272A21
 	waitmessage
 	pokemart MauvilleCity_Mart_Pokemart_211100
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -30,11 +30,11 @@ MauvilleCity_Mart_Pokemart_211100: @ 8211100
 	end
 
 MauvilleCity_Mart_EventScript_21111C:: @ 821111C
-	msgbox MauvilleCity_Mart_Text_21112E, 2
+	msgbox MauvilleCity_Mart_Text_21112E, MSGBOX_NPC
 	end
 
 MauvilleCity_Mart_EventScript_211125:: @ 8211125
-	msgbox MauvilleCity_Mart_Text_2111D8, 2
+	msgbox MauvilleCity_Mart_Text_2111D8, MSGBOX_NPC
 	end
 
 MauvilleCity_Mart_Text_21112E: @ 821112E

--- a/data/maps/MauvilleCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/MauvilleCity_PokemonCenter_1F/scripts.inc
@@ -22,15 +22,15 @@ MauvilleCity_PokemonCenter_1F_EventScript_210E78:: @ 8210E78
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_210E86:: @ 8210E86
-	msgbox MauvilleCity_PokemonCenter_1F_Text_210EA1, 2
+	msgbox MauvilleCity_PokemonCenter_1F_Text_210EA1, MSGBOX_NPC
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_210E8F:: @ 8210E8F
-	msgbox MauvilleCity_PokemonCenter_1F_Text_210F06, 2
+	msgbox MauvilleCity_PokemonCenter_1F_Text_210F06, MSGBOX_NPC
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_210E98:: @ 8210E98
-	msgbox MauvilleCity_PokemonCenter_1F_Text_210F8A, 2
+	msgbox MauvilleCity_PokemonCenter_1F_Text_210F8A, MSGBOX_NPC
 	end
 
 MauvilleCity_PokemonCenter_1F_Text_210EA1: @ 8210EA1

--- a/data/maps/MauvilleCity_PokemonCenter_2F/scripts.inc
+++ b/data/maps/MauvilleCity_PokemonCenter_2F/scripts.inc
@@ -18,7 +18,7 @@ MauvilleCity_PokemonCenter_2F_EventScript_211029:: @ 8211029
 	end
 
 MauvilleCity_PokemonCenter_2F_EventScript_21102F:: @ 821102F
-	msgbox MauvilleCity_PokemonCenter_2F_Text_211038, 2
+	msgbox MauvilleCity_PokemonCenter_2F_Text_211038, MSGBOX_NPC
 	end
 
 MauvilleCity_PokemonCenter_2F_Text_211038: @ 8211038

--- a/data/maps/MeteorFalls_1F_1R/scripts.inc
+++ b/data/maps/MeteorFalls_1F_1R/scripts.inc
@@ -22,7 +22,7 @@ MeteorFalls_1F_1R_EventScript_22BD5F:: @ 822BD5F
 	delay 30
 	applymovement 5, MeteorFalls_1F_1R_Movement_2725B4
 	waitmovement 0
-	msgbox MeteorFalls_1F_1R_Text_22BF47, 4
+	msgbox MeteorFalls_1F_1R_Text_22BF47, MSGBOX_DEFAULT
 	closemessage
 	applymovement 5, MeteorFalls_1F_1R_Movement_2725A6
 	applymovement 6, MeteorFalls_1F_1R_Movement_2725A6
@@ -32,11 +32,11 @@ MeteorFalls_1F_1R_EventScript_22BD5F:: @ 822BD5F
 	waitmovement 0
 	applymovement 5, MeteorFalls_1F_1R_Movement_27259A
 	waitmovement 0
-	msgbox MeteorFalls_1F_1R_Text_22BF84, 4
+	msgbox MeteorFalls_1F_1R_Text_22BF84, MSGBOX_DEFAULT
 	closemessage
 	applymovement 5, MeteorFalls_1F_1R_Movement_22BEC0
 	waitmovement 0
-	msgbox MeteorFalls_1F_1R_Text_22BFE4, 4
+	msgbox MeteorFalls_1F_1R_Text_22BFE4, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, MeteorFalls_1F_1R_Movement_2725A4
 	applymovement 5, MeteorFalls_1F_1R_Movement_2725A4
@@ -53,7 +53,7 @@ MeteorFalls_1F_1R_EventScript_22BD5F:: @ 822BD5F
 	applymovement 5, MeteorFalls_1F_1R_Movement_2725A4
 	applymovement 6, MeteorFalls_1F_1R_Movement_2725A4
 	waitmovement 0
-	msgbox MeteorFalls_1F_1R_Text_22C04E, 4
+	msgbox MeteorFalls_1F_1R_Text_22C04E, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, MeteorFalls_1F_1R_Movement_22BF1D
 	applymovement 5, MeteorFalls_1F_1R_Movement_22BEC4
@@ -63,18 +63,18 @@ MeteorFalls_1F_1R_EventScript_22BD5F:: @ 822BD5F
 	removeobject 6
 	applymovement 7, MeteorFalls_1F_1R_Movement_22BEF8
 	waitmovement 0
-	msgbox MeteorFalls_1F_1R_Text_22C11C, 4
+	msgbox MeteorFalls_1F_1R_Text_22C11C, MSGBOX_DEFAULT
 	closemessage
 	applymovement 8, MeteorFalls_1F_1R_Movement_22BF08
 	applymovement 9, MeteorFalls_1F_1R_Movement_22BF18
 	waitmovement 0
-	msgbox MeteorFalls_1F_1R_Text_22C268, 4
+	msgbox MeteorFalls_1F_1R_Text_22C268, MSGBOX_DEFAULT
 	applymovement 7, MeteorFalls_1F_1R_Movement_2725AA
 	waitmovement 0
-	msgbox MeteorFalls_1F_1R_Text_22C292, 4
+	msgbox MeteorFalls_1F_1R_Text_22C292, MSGBOX_DEFAULT
 	applymovement 7, MeteorFalls_1F_1R_Movement_2725A4
 	waitmovement 0
-	msgbox MeteorFalls_1F_1R_Text_22C2FC, 4
+	msgbox MeteorFalls_1F_1R_Text_22C2FC, MSGBOX_DEFAULT
 	closemessage
 	applymovement 7, MeteorFalls_1F_1R_Movement_22BEF0
 	applymovement 8, MeteorFalls_1F_1R_Movement_22BEFE
@@ -224,12 +224,12 @@ MeteorFalls_1F_1R_EventScript_22BF25:: @ 822BF25
 	checkflag FLAG_0x0F4
 	goto_eq MeteorFalls_1F_1R_EventScript_22BF3D
 	setflag FLAG_0x0F4
-	msgbox MeteorFalls_1F_1R_Text_22C342, 4
+	msgbox MeteorFalls_1F_1R_Text_22C342, MSGBOX_DEFAULT
 	release
 	end
 
 MeteorFalls_1F_1R_EventScript_22BF3D:: @ 822BF3D
-	msgbox MeteorFalls_1F_1R_Text_22C47D, 4
+	msgbox MeteorFalls_1F_1R_Text_22C47D, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/MeteorFalls_1F_2R/scripts.inc
+++ b/data/maps/MeteorFalls_1F_2R/scripts.inc
@@ -14,10 +14,7 @@ MeteorFalls_1F_2R_EventScript_22C50A:: @ 822C50A
 	special sub_80B4808
 	waitmovement 0
 	msgbox MeteorFalls_1F_2R_Text_22C6F6, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 392
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 392
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_NICOLAS_1
 	release
 	end
 
@@ -37,10 +34,7 @@ MeteorFalls_1F_2R_EventScript_22C540:: @ 822C540
 
 MeteorFalls_1F_2R_EventScript_22C570:: @ 822C570
 	msgbox MeteorFalls_1F_2R_Text_22C99C, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 681
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 681
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_JOHN_AND_JAY_1
 	release
 	end
 
@@ -60,10 +54,7 @@ MeteorFalls_1F_2R_EventScript_22C5A4:: @ 822C5A4
 
 MeteorFalls_1F_2R_EventScript_22C5D4:: @ 822C5D4
 	msgbox MeteorFalls_1F_2R_Text_22C99C, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 681
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 681
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_JOHN_AND_JAY_1
 	release
 	end
 

--- a/data/maps/MeteorFalls_1F_2R/scripts.inc
+++ b/data/maps/MeteorFalls_1F_2R/scripts.inc
@@ -6,24 +6,24 @@ MeteorFalls_1F_2R_EventScript_22C4DE:: @ 822C4DE
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq MeteorFalls_1F_2R_EventScript_22C529
-	msgbox MeteorFalls_1F_2R_Text_22C6A3, 4
+	msgbox MeteorFalls_1F_2R_Text_22C6A3, MSGBOX_DEFAULT
 	release
 	end
 
 MeteorFalls_1F_2R_EventScript_22C50A:: @ 822C50A
 	special sub_80B4808
 	waitmovement 0
-	msgbox MeteorFalls_1F_2R_Text_22C6F6, 4
+	msgbox MeteorFalls_1F_2R_Text_22C6F6, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 392
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 392
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 MeteorFalls_1F_2R_EventScript_22C529:: @ 822C529
 	trainerbattle 5, TRAINER_NICOLAS_1, 0, MeteorFalls_1F_2R_Text_22C73F, MeteorFalls_1F_2R_Text_22C7AD
-	msgbox MeteorFalls_1F_2R_Text_22C7D8, 6
+	msgbox MeteorFalls_1F_2R_Text_22C7D8, MSGBOX_AUTOCLOSE
 	end
 
 MeteorFalls_1F_2R_EventScript_22C540:: @ 822C540
@@ -31,22 +31,22 @@ MeteorFalls_1F_2R_EventScript_22C540:: @ 822C540
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq MeteorFalls_1F_2R_EventScript_22C589
-	msgbox MeteorFalls_1F_2R_Text_22C8C1, 4
+	msgbox MeteorFalls_1F_2R_Text_22C8C1, MSGBOX_DEFAULT
 	release
 	end
 
 MeteorFalls_1F_2R_EventScript_22C570:: @ 822C570
-	msgbox MeteorFalls_1F_2R_Text_22C99C, 4
+	msgbox MeteorFalls_1F_2R_Text_22C99C, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 681
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 681
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 MeteorFalls_1F_2R_EventScript_22C589:: @ 822C589
 	trainerbattle 7, TRAINER_JOHN_AND_JAY_1, 0, MeteorFalls_1F_2R_Text_22CB47, MeteorFalls_1F_2R_Text_22CBA0, MeteorFalls_1F_2R_Text_22CC27
-	msgbox MeteorFalls_1F_2R_Text_22CBC5, 6
+	msgbox MeteorFalls_1F_2R_Text_22CBC5, MSGBOX_AUTOCLOSE
 	end
 
 MeteorFalls_1F_2R_EventScript_22C5A4:: @ 822C5A4
@@ -54,22 +54,22 @@ MeteorFalls_1F_2R_EventScript_22C5A4:: @ 822C5A4
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq MeteorFalls_1F_2R_EventScript_22C5ED
-	msgbox MeteorFalls_1F_2R_Text_22CA70, 4
+	msgbox MeteorFalls_1F_2R_Text_22CA70, MSGBOX_DEFAULT
 	release
 	end
 
 MeteorFalls_1F_2R_EventScript_22C5D4:: @ 822C5D4
-	msgbox MeteorFalls_1F_2R_Text_22C99C, 4
+	msgbox MeteorFalls_1F_2R_Text_22C99C, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 681
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 681
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 MeteorFalls_1F_2R_EventScript_22C5ED:: @ 822C5ED
 	trainerbattle 7, TRAINER_JOHN_AND_JAY_1, 0, MeteorFalls_1F_2R_Text_22CC98, MeteorFalls_1F_2R_Text_22CD08, MeteorFalls_1F_2R_Text_22CDAB
-	msgbox MeteorFalls_1F_2R_Text_22CD34, 6
+	msgbox MeteorFalls_1F_2R_Text_22CD34, MSGBOX_AUTOCLOSE
 	end
 
 MeteorFalls_1F_2R_Text_22C608: @ 822C608

--- a/data/maps/MeteorFalls_StevensCave/scripts.inc
+++ b/data/maps/MeteorFalls_StevensCave/scripts.inc
@@ -13,9 +13,9 @@ MeteorFalls_StevensCave_EventScript_23B182:: @ 823B182
 	waitmovement 0
 	applymovement 1, MeteorFalls_StevensCave_Movement_27259E
 	waitmovement 0
-	msgbox MeteorFalls_StevensCave_Text_23B1E1, 4
+	msgbox MeteorFalls_StevensCave_Text_23B1E1, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_STEVEN, 0, MeteorFalls_StevensCave_Text_23B32D
-	msgbox MeteorFalls_StevensCave_Text_23B358, 4
+	msgbox MeteorFalls_StevensCave_Text_23B358, MSGBOX_DEFAULT
 	setflag FLAG_0x4F8
 	release
 	end
@@ -23,7 +23,7 @@ MeteorFalls_StevensCave_EventScript_23B182:: @ 823B182
 MeteorFalls_StevensCave_EventScript_23B1CD:: @ 823B1CD
 	applymovement 1, MeteorFalls_StevensCave_Movement_27259E
 	waitmovement 0
-	msgbox MeteorFalls_StevensCave_Text_23B358, 4
+	msgbox MeteorFalls_StevensCave_Text_23B358, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/MirageTower_4F/scripts.inc
+++ b/data/maps/MirageTower_4F/scripts.inc
@@ -4,7 +4,7 @@ MirageTower_4F_MapScripts:: @ 823AD47
 MirageTower_4F_EventScript_23AD48:: @ 823AD48
 	lock
 	faceplayer
-	msgbox MirageTower_4F_Text_23ADF9, 5
+	msgbox MirageTower_4F_Text_23ADF9, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MirageTower_4F_EventScript_23AD7F
 	giveitem_std ITEM_ROOT_FOSSIL
@@ -18,14 +18,14 @@ MirageTower_4F_EventScript_23AD48:: @ 823AD48
 	end
 
 MirageTower_4F_EventScript_23AD7F:: @ 823AD7F
-	msgbox MirageTower_4F_Text_23AE79, 4
+	msgbox MirageTower_4F_Text_23AE79, MSGBOX_DEFAULT
 	release
 	end
 
 MirageTower_4F_EventScript_23AD89:: @ 823AD89
 	lock
 	faceplayer
-	msgbox MirageTower_4F_Text_23AE98, 5
+	msgbox MirageTower_4F_Text_23AE98, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MirageTower_4F_EventScript_23ADC0
 	giveitem_std ITEM_CLAW_FOSSIL
@@ -39,7 +39,7 @@ MirageTower_4F_EventScript_23AD89:: @ 823AD89
 	end
 
 MirageTower_4F_EventScript_23ADC0:: @ 823ADC0
-	msgbox MirageTower_4F_Text_23AF18, 4
+	msgbox MirageTower_4F_Text_23AF18, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/MossdeepCity/scripts.inc
+++ b/data/maps/MossdeepCity/scripts.inc
@@ -16,12 +16,12 @@ MossdeepCity_EventScript_1E4AB2:: @ 81E4AB2
 	faceplayer
 	checkflag FLAG_0x07B
 	goto_eq MossdeepCity_EventScript_1E4AC7
-	msgbox MossdeepCity_Text_1E4E90, 4
+	msgbox MossdeepCity_Text_1E4E90, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_EventScript_1E4AC7:: @ 81E4AC7
-	msgbox MossdeepCity_Text_1E4F15, 4
+	msgbox MossdeepCity_Text_1E4F15, MSGBOX_DEFAULT
 	release
 	end
 
@@ -30,45 +30,45 @@ MossdeepCity_EventScript_1E4AD1:: @ 81E4AD1
 	faceplayer
 	checkflag FLAG_0x07B
 	goto_eq MossdeepCity_EventScript_1E4AE6
-	msgbox MossdeepCity_Text_1E4F50, 4
+	msgbox MossdeepCity_Text_1E4F50, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_EventScript_1E4AE6:: @ 81E4AE6
-	msgbox MossdeepCity_Text_1E5051, 4
+	msgbox MossdeepCity_Text_1E5051, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_EventScript_1E4AF0:: @ 81E4AF0
-	msgbox MossdeepCity_Text_1E4E22, 2
+	msgbox MossdeepCity_Text_1E4E22, MSGBOX_NPC
 	end
 
 MossdeepCity_EventScript_1E4AF9:: @ 81E4AF9
-	msgbox MossdeepCity_Text_1E5135, 2
+	msgbox MossdeepCity_Text_1E5135, MSGBOX_NPC
 	end
 
 MossdeepCity_EventScript_1E4B02:: @ 81E4B02
-	msgbox MossdeepCity_Text_1E50D9, 2
+	msgbox MossdeepCity_Text_1E50D9, MSGBOX_NPC
 	end
 
 MossdeepCity_EventScript_1E4B0B:: @ 81E4B0B
-	msgbox MossdeepCity_Text_1E529D, 2
+	msgbox MossdeepCity_Text_1E529D, MSGBOX_NPC
 	end
 
 MossdeepCity_EventScript_1E4B14:: @ 81E4B14
-	msgbox MossdeepCity_Text_1E5396, 3
+	msgbox MossdeepCity_Text_1E5396, MSGBOX_SIGN
 	end
 
 MossdeepCity_EventScript_1E4B1D:: @ 81E4B1D
-	msgbox MossdeepCity_Text_1E53A9, 3
+	msgbox MossdeepCity_Text_1E53A9, MSGBOX_SIGN
 	end
 
 MossdeepCity_EventScript_1E4B26:: @ 81E4B26
-	msgbox MossdeepCity_Text_1E53F2, 3
+	msgbox MossdeepCity_Text_1E53F2, MSGBOX_SIGN
 	end
 
 MossdeepCity_EventScript_1E4B2F:: @ 81E4B2F
-	msgbox MossdeepCity_Text_1E541F, 3
+	msgbox MossdeepCity_Text_1E541F, MSGBOX_SIGN
 	end
 
 MossdeepCity_EventScript_1E4B38:: @ 81E4B38
@@ -218,7 +218,7 @@ MossdeepCity_Movement_1E4C00: @ 81E4C00
 MossdeepCity_EventScript_1E4C10:: @ 81E4C10
 	lock
 	faceplayer
-	msgbox MossdeepCity_Text_1E5213, 4
+	msgbox MossdeepCity_Text_1E5213, MSGBOX_DEFAULT
 	applymovement VAR_LAST_TALKED, MossdeepCity_Movement_2725A2
 	waitmovement 0
 	release
@@ -229,10 +229,10 @@ MossdeepCity_EventScript_1E4C26:: @ 81E4C26
 	faceplayer
 	checkflag FLAG_0x114
 	goto_eq MossdeepCity_EventScript_1E4C68
-	msgbox MossdeepCity_Text_1E4CED, 5
+	msgbox MossdeepCity_Text_1E4CED, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_EventScript_1E4C72
-	msgbox MossdeepCity_Text_1E4D5B, 4
+	msgbox MossdeepCity_Text_1E4D5B, MSGBOX_DEFAULT
 	giveitem_std ITEM_KINGS_ROCK
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_EventScript_272054
@@ -241,23 +241,23 @@ MossdeepCity_EventScript_1E4C26:: @ 81E4C26
 	end
 
 MossdeepCity_EventScript_1E4C68:: @ 81E4C68
-	msgbox MossdeepCity_Text_1E4DB3, 4
+	msgbox MossdeepCity_Text_1E4DB3, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_EventScript_1E4C72:: @ 81E4C72
-	msgbox MossdeepCity_Text_1E4DD7, 4
+	msgbox MossdeepCity_Text_1E4DD7, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_EventScript_1E4C7C:: @ 81E4C7C
-	msgbox MossdeepCity_Text_1E5581, 2
+	msgbox MossdeepCity_Text_1E5581, MSGBOX_NPC
 	end
 
 MossdeepCity_EventScript_1E4C85:: @ 81E4C85
 	lock
 	faceplayer
-	msgbox MossdeepCity_Text_1E5453, 4
+	msgbox MossdeepCity_Text_1E5453, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_FACING, 2
 	call_if 1, MossdeepCity_EventScript_1E4CB0

--- a/data/maps/MossdeepCity_GameCorner_1F/scripts.inc
+++ b/data/maps/MossdeepCity_GameCorner_1F/scripts.inc
@@ -27,7 +27,7 @@ MossdeepCity_GameCorner_1F_EventScript_224B54:: @ 8224B54
 	end
 
 MossdeepCity_GameCorner_1F_EventScript_224B5D:: @ 8224B5D
-	msgbox MossdeepCity_GameCorner_1F_Text_224BFD, 3
+	msgbox MossdeepCity_GameCorner_1F_Text_224BFD, MSGBOX_SIGN
 	end
 
 MossdeepCity_GameCorner_1F_Text_224B66: @ 8224B66

--- a/data/maps/MossdeepCity_Gym/scripts.inc
+++ b/data/maps/MossdeepCity_Gym/scripts.inc
@@ -55,7 +55,7 @@ MossdeepCity_Gym_EventScript_220898:: @ 8220898
 	goto_eq MossdeepCity_Gym_EventScript_22097E
 	checkflag FLAG_0x0AB
 	goto_if 0, MossdeepCity_Gym_EventScript_220937
-	msgbox MossdeepCity_Gym_Text_221B1D, 4
+	msgbox MossdeepCity_Gym_Text_221B1D, MSGBOX_DEFAULT
 	release
 	end
 
@@ -63,7 +63,7 @@ MossdeepCity_Gym_EventScript_2208D1:: @ 82208D1
 	message MossdeepCity_Gym_Text_22196A
 	waitmessage
 	call MossdeepCity_Gym_EventScript_27207E
-	msgbox MossdeepCity_Gym_Text_221999, 4
+	msgbox MossdeepCity_Gym_Text_221999, MSGBOX_DEFAULT
 	setflag FLAG_0x4F6
 	setflag FLAG_BADGE07_GET
 	setflag FLAG_HIDE_AQUA_HIDEOUT_GRUNTS
@@ -83,7 +83,7 @@ MossdeepCity_Gym_EventScript_2208D1:: @ 82208D1
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox MossdeepCity_Gym_Text_221AEA, 4
+	msgbox MossdeepCity_Gym_Text_221AEA, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
@@ -95,7 +95,7 @@ MossdeepCity_Gym_EventScript_220937:: @ 8220937
 	giveitem_std ITEM_TM04
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_Gym_EventScript_272054
-	msgbox MossdeepCity_Gym_Text_221A40, 4
+	msgbox MossdeepCity_Gym_Text_221A40, MSGBOX_DEFAULT
 	setflag FLAG_0x0AB
 	release
 	end
@@ -104,13 +104,13 @@ MossdeepCity_Gym_EventScript_22095B:: @ 822095B
 	giveitem_std ITEM_TM04
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_Gym_EventScript_27205E
-	msgbox MossdeepCity_Gym_Text_221A40, 4
+	msgbox MossdeepCity_Gym_Text_221A40, MSGBOX_DEFAULT
 	setflag FLAG_0x0AB
 	return
 
 MossdeepCity_Gym_EventScript_22097E:: @ 822097E
 	trainerbattle 7, TRAINER_TATE_AND_LIZA_1, 0, MossdeepCity_Gym_Text_221D0B, MossdeepCity_Gym_Text_221E05, MossdeepCity_Gym_Text_221EB8
-	msgbox MossdeepCity_Gym_Text_221E45, 6
+	msgbox MossdeepCity_Gym_Text_221E45, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_Gym_EventScript_220999:: @ 8220999
@@ -212,62 +212,62 @@ MossdeepCity_Gym_EventScript_220AF1:: @ 8220AF1
 
 MossdeepCity_Gym_EventScript_220AFD:: @ 8220AFD
 	trainerbattle 0, TRAINER_PRESTON, 0, MossdeepCity_Gym_Text_220E5C, MossdeepCity_Gym_Text_220EAC
-	msgbox MossdeepCity_Gym_Text_220ED3, 6
+	msgbox MossdeepCity_Gym_Text_220ED3, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_Gym_EventScript_220B14:: @ 8220B14
 	trainerbattle 0, TRAINER_VIRGIL, 0, MossdeepCity_Gym_Text_220F02, MossdeepCity_Gym_Text_220F1A
-	msgbox MossdeepCity_Gym_Text_220F3A, 6
+	msgbox MossdeepCity_Gym_Text_220F3A, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_Gym_EventScript_220B2B:: @ 8220B2B
 	trainerbattle 0, TRAINER_BLAKE, 0, MossdeepCity_Gym_Text_220FB0, MossdeepCity_Gym_Text_221024
-	msgbox MossdeepCity_Gym_Text_221055, 6
+	msgbox MossdeepCity_Gym_Text_221055, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_Gym_EventScript_220B42:: @ 8220B42
 	trainerbattle 0, TRAINER_HANNAH, 0, MossdeepCity_Gym_Text_2210EE, MossdeepCity_Gym_Text_221152
-	msgbox MossdeepCity_Gym_Text_22116A, 6
+	msgbox MossdeepCity_Gym_Text_22116A, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_Gym_EventScript_220B59:: @ 8220B59
 	trainerbattle 0, TRAINER_SAMANTHA, 0, MossdeepCity_Gym_Text_2211E2, MossdeepCity_Gym_Text_221230
-	msgbox MossdeepCity_Gym_Text_22123D, 6
+	msgbox MossdeepCity_Gym_Text_22123D, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_Gym_EventScript_220B70:: @ 8220B70
 	trainerbattle 0, TRAINER_MAURA, 0, MossdeepCity_Gym_Text_2212A6, MossdeepCity_Gym_Text_221309
-	msgbox MossdeepCity_Gym_Text_22132E, 6
+	msgbox MossdeepCity_Gym_Text_22132E, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_Gym_EventScript_220B87:: @ 8220B87
 	trainerbattle 0, TRAINER_SYLVIA, 0, MossdeepCity_Gym_Text_2213C2, MossdeepCity_Gym_Text_2213F4
-	msgbox MossdeepCity_Gym_Text_221412, 6
+	msgbox MossdeepCity_Gym_Text_221412, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_Gym_EventScript_220B9E:: @ 8220B9E
 	trainerbattle 0, TRAINER_NATE, 0, MossdeepCity_Gym_Text_221460, MossdeepCity_Gym_Text_2214A7
-	msgbox MossdeepCity_Gym_Text_2214D3, 6
+	msgbox MossdeepCity_Gym_Text_2214D3, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_Gym_EventScript_220BB5:: @ 8220BB5
 	trainerbattle 0, TRAINER_MACEY, 0, MossdeepCity_Gym_Text_22161B, MossdeepCity_Gym_Text_221658
-	msgbox MossdeepCity_Gym_Text_221680, 6
+	msgbox MossdeepCity_Gym_Text_221680, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_Gym_EventScript_220BCC:: @ 8220BCC
 	trainerbattle 0, TRAINER_CLIFFORD, 0, MossdeepCity_Gym_Text_22157C, MossdeepCity_Gym_Text_2215B8
-	msgbox MossdeepCity_Gym_Text_2215E2, 6
+	msgbox MossdeepCity_Gym_Text_2215E2, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_Gym_EventScript_220BE3:: @ 8220BE3
 	trainerbattle 0, TRAINER_NICHOLAS, 0, MossdeepCity_Gym_Text_2216EE, MossdeepCity_Gym_Text_22172D
-	msgbox MossdeepCity_Gym_Text_22173A, 6
+	msgbox MossdeepCity_Gym_Text_22173A, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_Gym_EventScript_220BFA:: @ 8220BFA
 	trainerbattle 0, TRAINER_KATHLEEN, 0, MossdeepCity_Gym_Text_221507, MossdeepCity_Gym_Text_22153B
-	msgbox MossdeepCity_Gym_Text_221545, 6
+	msgbox MossdeepCity_Gym_Text_221545, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_Gym_EventScript_220C11:: @ 8220C11
@@ -275,12 +275,12 @@ MossdeepCity_Gym_EventScript_220C11:: @ 8220C11
 	faceplayer
 	checkflag FLAG_0x4F6
 	goto_eq MossdeepCity_Gym_EventScript_220C26
-	msgbox MossdeepCity_Gym_Text_220CD5, 4
+	msgbox MossdeepCity_Gym_Text_220CD5, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_Gym_EventScript_220C26:: @ 8220C26
-	msgbox MossdeepCity_Gym_Text_220E2A, 4
+	msgbox MossdeepCity_Gym_Text_220E2A, MSGBOX_DEFAULT
 	release
 	end
 
@@ -304,12 +304,12 @@ MossdeepCity_Gym_EventScript_220C43:: @ 8220C43
 	end
 
 MossdeepCity_Gym_EventScript_220C53:: @ 8220C53
-	msgbox MossdeepCity_Gym_Text_221CCA, 4
+	msgbox MossdeepCity_Gym_Text_221CCA, MSGBOX_DEFAULT
 	releaseall
 	end
 
 MossdeepCity_Gym_EventScript_220C5D:: @ 8220C5D
-	msgbox MossdeepCity_Gym_Text_221CB0, 4
+	msgbox MossdeepCity_Gym_Text_221CB0, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/MossdeepCity_House1/scripts.inc
+++ b/data/maps/MossdeepCity_House1/scripts.inc
@@ -5,21 +5,21 @@ MossdeepCity_House1_EventScript_221FD6:: @ 8221FD6
 	lock
 	faceplayer
 	bufferleadmonspeciesname 0
-	msgbox MossdeepCity_House1_Text_22200F, 4
+	msgbox MossdeepCity_House1_Text_22200F, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, GetPokeblockNameByMonNature
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_House1_EventScript_221FFC
-	msgbox MossdeepCity_House1_Text_22201D, 4
+	msgbox MossdeepCity_House1_Text_22201D, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_House1_EventScript_221FFC:: @ 8221FFC
-	msgbox MossdeepCity_House1_Text_222068, 4
+	msgbox MossdeepCity_House1_Text_222068, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_House1_EventScript_222006:: @ 8222006
-	msgbox MossdeepCity_House1_Text_222099, 2
+	msgbox MossdeepCity_House1_Text_222099, MSGBOX_NPC
 	end
 
 MossdeepCity_House1_Text_22200F: @ 822200F

--- a/data/maps/MossdeepCity_House2/scripts.inc
+++ b/data/maps/MossdeepCity_House2/scripts.inc
@@ -2,11 +2,11 @@ MossdeepCity_House2_MapScripts:: @ 82220DE
 	.byte 0
 
 MossdeepCity_House2_EventScript_2220DF:: @ 82220DF
-	msgbox MossdeepCity_House2_Text_222146, 2
+	msgbox MossdeepCity_House2_Text_222146, MSGBOX_NPC
 	end
 
 MossdeepCity_House2_EventScript_2220E8:: @ 82220E8
-	msgbox MossdeepCity_House2_Text_2221A6, 2
+	msgbox MossdeepCity_House2_Text_2221A6, MSGBOX_NPC
 	end
 
 MossdeepCity_House2_EventScript_2220F1:: @ 82220F1
@@ -14,7 +14,7 @@ MossdeepCity_House2_EventScript_2220F1:: @ 82220F1
 	faceplayer
 	waitse
 	playmoncry SPECIES_WINGULL, 0
-	msgbox MossdeepCity_House2_Text_22222E, 4
+	msgbox MossdeepCity_House2_Text_22222E, MSGBOX_DEFAULT
 	waitmoncry
 	closemessage
 	setflag FLAG_0x0E0

--- a/data/maps/MossdeepCity_House3/scripts.inc
+++ b/data/maps/MossdeepCity_House3/scripts.inc
@@ -6,23 +6,23 @@ MossdeepCity_House3_EventScript_2225C3:: @ 82225C3
 	faceplayer
 	checkflag FLAG_0x098
 	goto_eq MossdeepCity_House3_EventScript_222602
-	msgbox MossdeepCity_House3_Text_222616, 5
+	msgbox MossdeepCity_House3_Text_222616, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_House3_EventScript_22260C
-	msgbox MossdeepCity_House3_Text_2226B6, 4
+	msgbox MossdeepCity_House3_Text_2226B6, MSGBOX_DEFAULT
 	giveitem_std ITEM_SUPER_ROD
 	setflag FLAG_0x098
-	msgbox MossdeepCity_House3_Text_2226F0, 4
+	msgbox MossdeepCity_House3_Text_2226F0, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_House3_EventScript_222602:: @ 8222602
-	msgbox MossdeepCity_House3_Text_222751, 4
+	msgbox MossdeepCity_House3_Text_222751, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_House3_EventScript_22260C:: @ 822260C
-	msgbox MossdeepCity_House3_Text_222733, 4
+	msgbox MossdeepCity_House3_Text_222733, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/MossdeepCity_House4/scripts.inc
+++ b/data/maps/MossdeepCity_House4/scripts.inc
@@ -6,12 +6,12 @@ MossdeepCity_House4_EventScript_222DD8:: @ 8222DD8
 	faceplayer
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_eq MossdeepCity_House4_EventScript_222DED
-	msgbox MossdeepCity_House4_Text_222E31, 4
+	msgbox MossdeepCity_House4_Text_222E31, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_House4_EventScript_222DED:: @ 8222DED
-	msgbox MossdeepCity_House4_Text_222E73, 4
+	msgbox MossdeepCity_House4_Text_222E73, MSGBOX_DEFAULT
 	release
 	end
 
@@ -22,12 +22,12 @@ MossdeepCity_House4_EventScript_222DF7:: @ 8222DF7
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_House4_EventScript_222E14
 	special GetSecretBaseNearbyMapName
-	msgbox MossdeepCity_House4_Text_222ECC, 4
+	msgbox MossdeepCity_House4_Text_222ECC, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_House4_EventScript_222E14:: @ 8222E14
-	msgbox MossdeepCity_House4_Text_222EF7, 4
+	msgbox MossdeepCity_House4_Text_222EF7, MSGBOX_DEFAULT
 	release
 	end
 
@@ -36,7 +36,7 @@ MossdeepCity_House4_EventScript_222E1E:: @ 8222E1E
 	faceplayer
 	waitse
 	playmoncry SPECIES_SKITTY, 0
-	msgbox MossdeepCity_House4_Text_222F31, 4
+	msgbox MossdeepCity_House4_Text_222F31, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/MossdeepCity_Mart/scripts.inc
+++ b/data/maps/MossdeepCity_Mart/scripts.inc
@@ -7,7 +7,7 @@ MossdeepCity_Mart_EventScript_2223C8:: @ 82223C8
 	message gUnknown_08272A21
 	waitmessage
 	pokemart MossdeepCity_Mart_Pokemart_2223E0
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -27,15 +27,15 @@ MossdeepCity_Mart_Pokemart_2223E0: @ 82223E0
 	end
 
 MossdeepCity_Mart_EventScript_2223F6:: @ 82223F6
-	msgbox MossdeepCity_Mart_Text_222411, 2
+	msgbox MossdeepCity_Mart_Text_222411, MSGBOX_NPC
 	end
 
 MossdeepCity_Mart_EventScript_2223FF:: @ 82223FF
-	msgbox MossdeepCity_Mart_Text_2224A0, 2
+	msgbox MossdeepCity_Mart_Text_2224A0, MSGBOX_NPC
 	end
 
 MossdeepCity_Mart_EventScript_222408:: @ 8222408
-	msgbox MossdeepCity_Mart_Text_2224FA, 2
+	msgbox MossdeepCity_Mart_Text_2224FA, MSGBOX_NPC
 	end
 
 MossdeepCity_Mart_Text_222411: @ 8222411

--- a/data/maps/MossdeepCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/MossdeepCity_PokemonCenter_1F/scripts.inc
@@ -16,11 +16,11 @@ MossdeepCity_PokemonCenter_1F_EventScript_22224E:: @ 822224E
 	end
 
 MossdeepCity_PokemonCenter_1F_EventScript_22225C:: @ 822225C
-	msgbox MossdeepCity_PokemonCenter_1F_Text_22226E, 2
+	msgbox MossdeepCity_PokemonCenter_1F_Text_22226E, MSGBOX_NPC
 	end
 
 MossdeepCity_PokemonCenter_1F_EventScript_222265:: @ 8222265
-	msgbox MossdeepCity_PokemonCenter_1F_Text_2222D9, 2
+	msgbox MossdeepCity_PokemonCenter_1F_Text_2222D9, MSGBOX_NPC
 	end
 
 MossdeepCity_PokemonCenter_1F_Text_22226E: @ 822226E

--- a/data/maps/MossdeepCity_PokemonCenter_2F/scripts.inc
+++ b/data/maps/MossdeepCity_PokemonCenter_2F/scripts.inc
@@ -18,7 +18,7 @@ MossdeepCity_PokemonCenter_2F_EventScript_222355:: @ 8222355
 	end
 
 MossdeepCity_PokemonCenter_2F_EventScript_22235B:: @ 822235B
-	msgbox MossdeepCity_PokemonCenter_2F_Text_222364, 2
+	msgbox MossdeepCity_PokemonCenter_2F_Text_222364, MSGBOX_NPC
 	end
 
 MossdeepCity_PokemonCenter_2F_Text_222364: @ 8222364

--- a/data/maps/MossdeepCity_SpaceCenter_1F/scripts.inc
+++ b/data/maps/MossdeepCity_SpaceCenter_1F/scripts.inc
@@ -66,11 +66,11 @@ MossdeepCity_SpaceCenter_1F_EventScript_222FD8:: @ 8222FD8
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_223012:: @ 8223012
-	msgbox MossdeepCity_SpaceCenter_1F_Text_2232A7, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_2232A7, MSGBOX_DEFAULT
 	return
 
 MossdeepCity_SpaceCenter_1F_EventScript_22301B:: @ 822301B
-	msgbox MossdeepCity_SpaceCenter_1F_Text_2232C8, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_2232C8, MSGBOX_DEFAULT
 	return
 
 MossdeepCity_SpaceCenter_1F_EventScript_223024:: @ 8223024
@@ -88,11 +88,11 @@ MossdeepCity_SpaceCenter_1F_EventScript_223024:: @ 8223024
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_223051:: @ 8223051
-	msgbox MossdeepCity_SpaceCenter_1F_Text_223305, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_223305, MSGBOX_DEFAULT
 	return
 
 MossdeepCity_SpaceCenter_1F_EventScript_22305A:: @ 822305A
-	msgbox MossdeepCity_SpaceCenter_1F_Text_22335E, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_22335E, MSGBOX_DEFAULT
 	return
 
 MossdeepCity_SpaceCenter_1F_EventScript_223063:: @ 8223063
@@ -100,12 +100,12 @@ MossdeepCity_SpaceCenter_1F_EventScript_223063:: @ 8223063
 	faceplayer
 	compare VAR_0x405D, 2
 	goto_eq MossdeepCity_SpaceCenter_1F_EventScript_22307A
-	msgbox MossdeepCity_SpaceCenter_1F_Text_2233D3, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_2233D3, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_22307A:: @ 822307A
-	msgbox MossdeepCity_SpaceCenter_1F_Text_2234B7, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_2234B7, MSGBOX_DEFAULT
 	applymovement VAR_LAST_TALKED, MossdeepCity_SpaceCenter_1F_Movement_2725A8
 	waitmovement 0
 	release
@@ -118,36 +118,36 @@ MossdeepCity_SpaceCenter_1F_EventScript_22308E:: @ 822308E
 	goto_eq MossdeepCity_SpaceCenter_1F_EventScript_2230DA
 	checkflag FLAG_0x0C0
 	goto_eq MossdeepCity_SpaceCenter_1F_EventScript_2230D0
-	msgbox MossdeepCity_SpaceCenter_1F_Text_223540, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_223540, MSGBOX_DEFAULT
 	giveitem_std ITEM_SUN_STONE
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_SpaceCenter_1F_EventScript_272054
 	setflag FLAG_0x0C0
-	msgbox MossdeepCity_SpaceCenter_1F_Text_2235A6, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_2235A6, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_2230D0:: @ 82230D0
-	msgbox MossdeepCity_SpaceCenter_1F_Text_2235A6, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_2235A6, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_2230DA:: @ 82230DA
 	checkflag FLAG_0x0C0
 	goto_eq MossdeepCity_SpaceCenter_1F_EventScript_223119
-	msgbox MossdeepCity_SpaceCenter_1F_Text_2235F0, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_2235F0, MSGBOX_DEFAULT
 	giveitem_std ITEM_SUN_STONE
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_SpaceCenter_1F_EventScript_272054
 	setflag FLAG_0x0C0
-	msgbox MossdeepCity_SpaceCenter_1F_Text_223664, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_223664, MSGBOX_DEFAULT
 	applymovement VAR_LAST_TALKED, MossdeepCity_SpaceCenter_1F_Movement_2725A8
 	waitmovement 0
 	release
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_223119:: @ 8223119
-	msgbox MossdeepCity_SpaceCenter_1F_Text_223664, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_223664, MSGBOX_DEFAULT
 	applymovement VAR_LAST_TALKED, MossdeepCity_SpaceCenter_1F_Movement_2725A8
 	waitmovement 0
 	release
@@ -166,12 +166,12 @@ MossdeepCity_SpaceCenter_1F_EventScript_22312D:: @ 822312D
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_223154:: @ 8223154
-	msgbox MossdeepCity_SpaceCenter_1F_Text_2236A6, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_2236A6, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_22315E:: @ 822315E
-	msgbox MossdeepCity_SpaceCenter_1F_Text_2236E8, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_2236E8, MSGBOX_DEFAULT
 	release
 	end
 
@@ -188,7 +188,7 @@ MossdeepCity_SpaceCenter_1F_EventScript_223168:: @ 8223168
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_22318F:: @ 822318F
-	msgbox MossdeepCity_SpaceCenter_1F_Text_22375B, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_22375B, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, MossdeepCity_SpaceCenter_1F_Movement_2725A2
 	waitmovement 0
@@ -196,7 +196,7 @@ MossdeepCity_SpaceCenter_1F_EventScript_22318F:: @ 822318F
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_2231A4:: @ 82231A4
-	msgbox MossdeepCity_SpaceCenter_1F_Text_2237B5, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_2237B5, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, MossdeepCity_SpaceCenter_1F_Movement_2725A2
 	waitmovement 0
@@ -206,7 +206,7 @@ MossdeepCity_SpaceCenter_1F_EventScript_2231A4:: @ 82231A4
 MossdeepCity_SpaceCenter_1F_EventScript_2231B9:: @ 82231B9
 	lock
 	faceplayer
-	msgbox MossdeepCity_SpaceCenter_1F_Text_223849, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_223849, MSGBOX_DEFAULT
 	applymovement VAR_LAST_TALKED, MossdeepCity_SpaceCenter_1F_Movement_2725A2
 	waitmovement 0
 	release
@@ -214,23 +214,23 @@ MossdeepCity_SpaceCenter_1F_EventScript_2231B9:: @ 82231B9
 
 MossdeepCity_SpaceCenter_1F_EventScript_2231CF:: @ 82231CF
 	lockall
-	msgbox MossdeepCity_SpaceCenter_1F_Text_223C2C, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_223C2C, MSGBOX_DEFAULT
 	releaseall
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_2231DA:: @ 82231DA
 	trainerbattle 0, TRAINER_GRUNT_32, 0, MossdeepCity_SpaceCenter_1F_Text_22396C, MossdeepCity_SpaceCenter_1F_Text_223999
-	msgbox MossdeepCity_SpaceCenter_1F_Text_2239AA, 6
+	msgbox MossdeepCity_SpaceCenter_1F_Text_2239AA, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_2231F1:: @ 82231F1
 	trainerbattle 0, TRAINER_GRUNT_16, 0, MossdeepCity_SpaceCenter_1F_Text_2239E6, MossdeepCity_SpaceCenter_1F_Text_223A21
-	msgbox MossdeepCity_SpaceCenter_1F_Text_223A4B, 6
+	msgbox MossdeepCity_SpaceCenter_1F_Text_223A4B, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_223208:: @ 8223208
 	trainerbattle 0, TRAINER_GRUNT_33, 0, MossdeepCity_SpaceCenter_1F_Text_223A8A, MossdeepCity_SpaceCenter_1F_Text_223AFA
-	msgbox MossdeepCity_SpaceCenter_1F_Text_223B37, 6
+	msgbox MossdeepCity_SpaceCenter_1F_Text_223B37, MSGBOX_AUTOCLOSE
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_22321F:: @ 822321F
@@ -238,7 +238,7 @@ MossdeepCity_SpaceCenter_1F_EventScript_22321F:: @ 822321F
 	faceplayer
 	checkflag FLAG_0x0BF
 	goto_eq MossdeepCity_SpaceCenter_1F_EventScript_22326E
-	msgbox MossdeepCity_SpaceCenter_1F_Text_223B90, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_223B90, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_GRUNT_23, 0, MossdeepCity_SpaceCenter_1F_Text_223BC2
 	setflag FLAG_0x0BF
 	moveobjectoffscreen 9
@@ -252,7 +252,7 @@ MossdeepCity_SpaceCenter_1F_EventScript_22321F:: @ 822321F
 	end
 
 MossdeepCity_SpaceCenter_1F_EventScript_22326E:: @ 822326E
-	msgbox MossdeepCity_SpaceCenter_1F_Text_223BD3, 4
+	msgbox MossdeepCity_SpaceCenter_1F_Text_223BD3, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/MossdeepCity_SpaceCenter_2F/scripts.inc
+++ b/data/maps/MossdeepCity_SpaceCenter_2F/scripts.inc
@@ -36,10 +36,10 @@ MossdeepCity_SpaceCenter_2F_EventScript_223DBF:: @ 8223DBF
 	waitmovement 0
 	applymovement 255, MossdeepCity_SpaceCenter_2F_Movement_27259A
 	waitmovement 0
-	msgbox MossdeepCity_SpaceCenter_2F_Text_2243A4, 5
+	msgbox MossdeepCity_SpaceCenter_2F_Text_2243A4, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq MossdeepCity_SpaceCenter_2F_EventScript_223E09
-	msgbox MossdeepCity_SpaceCenter_2F_Text_2243FE, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_2243FE, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, MossdeepCity_SpaceCenter_2F_Movement_223E07
 	waitmovement 0
@@ -53,19 +53,19 @@ MossdeepCity_SpaceCenter_2F_Movement_223E07: @ 8223E07
 	step_end
 
 MossdeepCity_SpaceCenter_2F_EventScript_223E09:: @ 8223E09
-	msgbox MossdeepCity_SpaceCenter_2F_Text_22442D, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_22442D, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_GRUNT_34, 0, MossdeepCity_SpaceCenter_2F_Text_224461
 	applymovement 6, MossdeepCity_SpaceCenter_2F_Movement_223E85
 	waitmovement 0
 	applymovement 255, MossdeepCity_SpaceCenter_2F_Movement_2725A4
 	waitmovement 0
-	msgbox MossdeepCity_SpaceCenter_2F_Text_22446E, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_22446E, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_GRUNT_35, 0, MossdeepCity_SpaceCenter_2F_Text_224499
 	applymovement 5, MossdeepCity_SpaceCenter_2F_Movement_223E81
 	waitmovement 0
 	applymovement 255, MossdeepCity_SpaceCenter_2F_Movement_2725A8
 	waitmovement 0
-	msgbox MossdeepCity_SpaceCenter_2F_Text_2244AB, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_2244AB, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_GRUNT_36, 0, MossdeepCity_SpaceCenter_2F_Text_2244F1
 	applymovement 7, MossdeepCity_SpaceCenter_2F_Movement_223E89
 	waitmovement 0
@@ -107,12 +107,12 @@ MossdeepCity_SpaceCenter_2F_EventScript_223E8D:: @ 8223E8D
 	end
 
 MossdeepCity_SpaceCenter_2F_EventScript_223EB4:: @ 8223EB4
-	msgbox MossdeepCity_SpaceCenter_2F_Text_2241A1, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_2241A1, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_SpaceCenter_2F_EventScript_223EBE:: @ 8223EBE
-	msgbox MossdeepCity_SpaceCenter_2F_Text_22420C, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_22420C, MSGBOX_DEFAULT
 	release
 	end
 
@@ -129,12 +129,12 @@ MossdeepCity_SpaceCenter_2F_EventScript_223EC8:: @ 8223EC8
 	end
 
 MossdeepCity_SpaceCenter_2F_EventScript_223EEF:: @ 8223EEF
-	msgbox MossdeepCity_SpaceCenter_2F_Text_224253, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_224253, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_SpaceCenter_2F_EventScript_223EF9:: @ 8223EF9
-	msgbox MossdeepCity_SpaceCenter_2F_Text_2242C5, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_2242C5, MSGBOX_DEFAULT
 	release
 	end
 
@@ -151,31 +151,31 @@ MossdeepCity_SpaceCenter_2F_EventScript_223F03:: @ 8223F03
 	end
 
 MossdeepCity_SpaceCenter_2F_EventScript_223F2A:: @ 8223F2A
-	msgbox MossdeepCity_SpaceCenter_2F_Text_224342, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_224342, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_SpaceCenter_2F_EventScript_223F34:: @ 8223F34
-	msgbox MossdeepCity_SpaceCenter_2F_Text_224376, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_224376, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_SpaceCenter_2F_EventScript_223F3E:: @ 8223F3E
-	msgbox MossdeepCity_SpaceCenter_2F_Text_22452C, 2
+	msgbox MossdeepCity_SpaceCenter_2F_Text_22452C, MSGBOX_NPC
 	end
 
 MossdeepCity_SpaceCenter_2F_EventScript_223F47:: @ 8223F47
-	msgbox MossdeepCity_SpaceCenter_2F_Text_224570, 2
+	msgbox MossdeepCity_SpaceCenter_2F_Text_224570, MSGBOX_NPC
 	end
 
 MossdeepCity_SpaceCenter_2F_EventScript_223F50:: @ 8223F50
-	msgbox MossdeepCity_SpaceCenter_2F_Text_2245AF, 2
+	msgbox MossdeepCity_SpaceCenter_2F_Text_2245AF, MSGBOX_NPC
 	end
 
 MossdeepCity_SpaceCenter_2F_EventScript_223F59:: @ 8223F59
 	lock
 	faceplayer
-	msgbox MossdeepCity_SpaceCenter_2F_Text_2245D9, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_2245D9, MSGBOX_DEFAULT
 	applymovement VAR_LAST_TALKED, MossdeepCity_SpaceCenter_2F_Movement_2725A2
 	waitmovement 0
 	release
@@ -183,7 +183,7 @@ MossdeepCity_SpaceCenter_2F_EventScript_223F59:: @ 8223F59
 
 MossdeepCity_SpaceCenter_2F_EventScript_223F6F:: @ 8223F6F
 	lockall
-	msgbox MossdeepCity_SpaceCenter_2F_Text_22467B, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_22467B, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -192,8 +192,8 @@ MossdeepCity_SpaceCenter_2F_EventScript_223F7A:: @ 8223F7A
 	checkflag FLAG_0x0CD
 	goto_eq MossdeepCity_SpaceCenter_2F_EventScript_223FDA
 	setflag FLAG_0x0CD
-	msgbox MossdeepCity_SpaceCenter_2F_Text_2246B2, 4
-	msgbox MossdeepCity_SpaceCenter_2F_Text_2246F0, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_2246B2, MSGBOX_DEFAULT
+	msgbox MossdeepCity_SpaceCenter_2F_Text_2246F0, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	playse SE_KOUKA_L
@@ -237,10 +237,10 @@ MossdeepCity_SpaceCenter_2F_Movement_223FCF: @ 8223FCF
 MossdeepCity_SpaceCenter_2F_EventScript_223FDA:: @ 8223FDA
 	applymovement VAR_LAST_TALKED, MossdeepCity_SpaceCenter_2F_Movement_27259E
 	waitmovement 0
-	msgbox MossdeepCity_SpaceCenter_2F_Text_2247FF, 5
+	msgbox MossdeepCity_SpaceCenter_2F_Text_2247FF, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq MossdeepCity_SpaceCenter_2F_EventScript_22400C
-	msgbox MossdeepCity_SpaceCenter_2F_Text_224854, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_224854, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, MossdeepCity_SpaceCenter_2F_Movement_2725AA
 	waitmovement 0
@@ -278,7 +278,7 @@ MossdeepCity_SpaceCenter_2F_EventScript_224032:: @ 8224032
 	waitstate
 
 MossdeepCity_SpaceCenter_2F_EventScript_224071:: @ 8224071
-	msgbox MossdeepCity_SpaceCenter_2F_Text_2248C2, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_2248C2, MSGBOX_DEFAULT
 	closemessage
 	delay 20
 	applymovement 9, MossdeepCity_SpaceCenter_2F_Movement_2725A4
@@ -289,7 +289,7 @@ MossdeepCity_SpaceCenter_2F_EventScript_224071:: @ 8224071
 	applymovement 8, MossdeepCity_SpaceCenter_2F_Movement_2725A8
 	waitmovement 0
 	delay 20
-	msgbox MossdeepCity_SpaceCenter_2F_Text_2249DC, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_2249DC, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x405D, 3
 	fadedefaultbgm
@@ -311,7 +311,7 @@ MossdeepCity_SpaceCenter_2F_EventScript_224071:: @ 8224071
 	turnobject 1, 2
 	call MossdeepCity_SpaceCenter_2F_EventScript_224131
 	fadescreen 0
-	msgbox MossdeepCity_SpaceCenter_2F_Text_224A4A, 4
+	msgbox MossdeepCity_SpaceCenter_2F_Text_224A4A, MSGBOX_DEFAULT
 	closemessage
 	fadescreen 1
 	setflag FLAG_0x075

--- a/data/maps/MossdeepCity_StevensHouse/scripts.inc
+++ b/data/maps/MossdeepCity_StevensHouse/scripts.inc
@@ -38,11 +38,11 @@ MossdeepCity_StevensHouse_EventScript_2227CA:: @ 82227CA
 	waitmovement 0
 	applymovement 1, MossdeepCity_StevensHouse_Movement_222833
 	waitmovement 0
-	msgbox MossdeepCity_StevensHouse_Text_222936, 4
+	msgbox MossdeepCity_StevensHouse_Text_222936, MSGBOX_DEFAULT
 	giveitem_std ITEM_HM08
 	setflag FLAG_0x07B
 	setflag FLAG_0x12E
-	msgbox MossdeepCity_StevensHouse_Text_222A0E, 4
+	msgbox MossdeepCity_StevensHouse_Text_222A0E, MSGBOX_DEFAULT
 	closemessage
 	delay 20
 	applymovement 1, MossdeepCity_StevensHouse_Movement_22283B
@@ -73,14 +73,14 @@ MossdeepCity_StevensHouse_Movement_22283B: @ 822283B
 
 MossdeepCity_StevensHouse_EventScript_222841:: @ 8222841
 	lockall
-	msgbox MossdeepCity_StevensHouse_Text_222B9E, 5
+	msgbox MossdeepCity_StevensHouse_Text_222B9E, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_StevensHouse_EventScript_22285B
 	goto MossdeepCity_StevensHouse_EventScript_222865
 	end
 
 MossdeepCity_StevensHouse_EventScript_22285B:: @ 822285B
-	msgbox MossdeepCity_StevensHouse_Text_222C2A, 4
+	msgbox MossdeepCity_StevensHouse_Text_222C2A, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -96,7 +96,7 @@ MossdeepCity_StevensHouse_EventScript_222865:: @ 8222865
 
 MossdeepCity_StevensHouse_EventScript_222895:: @ 8222895
 	call MossdeepCity_StevensHouse_EventScript_2228EB
-	msgbox gUnknown_08273374, 5
+	msgbox gUnknown_08273374, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_StevensHouse_EventScript_222901
 	call MossdeepCity_StevensHouse_EventScript_27378B
@@ -106,7 +106,7 @@ MossdeepCity_StevensHouse_EventScript_222895:: @ 8222895
 
 MossdeepCity_StevensHouse_EventScript_2228BD:: @ 82228BD
 	call MossdeepCity_StevensHouse_EventScript_2228EB
-	msgbox gUnknown_08273374, 5
+	msgbox gUnknown_08273374, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_StevensHouse_EventScript_2228E0
 	call MossdeepCity_StevensHouse_EventScript_273797
@@ -135,16 +135,16 @@ MossdeepCity_StevensHouse_EventScript_222901:: @ 8222901
 	end
 
 MossdeepCity_StevensHouse_EventScript_222909:: @ 8222909
-	msgbox MossdeepCity_StevensHouse_Text_222D97, 3
+	msgbox MossdeepCity_StevensHouse_Text_222D97, MSGBOX_SIGN
 	end
 
 MossdeepCity_StevensHouse_EventScript_222912:: @ 8222912
-	msgbox MossdeepCity_StevensHouse_Text_222B11, 2
+	msgbox MossdeepCity_StevensHouse_Text_222B11, MSGBOX_NPC
 	end
 
 MossdeepCity_StevensHouse_EventScript_22291B:: @ 822291B
 	lockall
-	msgbox MossdeepCity_StevensHouse_Text_222C4E, 4
+	msgbox MossdeepCity_StevensHouse_Text_222C4E, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/MtChimney/scripts.inc
+++ b/data/maps/MtChimney/scripts.inc
@@ -499,10 +499,7 @@ MtChimney_EventScript_22F176:: @ 822F176
 	special sub_80B4808
 	waitmovement 0
 	msgbox MtChimney_Text_2300E3, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 313
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 313
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_SHELBY_1
 	release
 	end
 
@@ -544,10 +541,7 @@ MtChimney_EventScript_22F234:: @ 822F234
 	special sub_80B4808
 	waitmovement 0
 	msgbox MtChimney_Text_230557, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 1
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 1
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_SAWYER_1
 	release
 	end
 

--- a/data/maps/MtChimney/scripts.inc
+++ b/data/maps/MtChimney/scripts.inc
@@ -26,17 +26,17 @@ MtChimney_EventScript_22EDD5:: @ 822EDD5
 	end
 
 MtChimney_EventScript_22EDF9:: @ 822EDF9
-	msgbox MtChimney_Text_22FAD2, 4
+	msgbox MtChimney_Text_22FAD2, MSGBOX_DEFAULT
 	return
 
 MtChimney_EventScript_22EE02:: @ 822EE02
-	msgbox MtChimney_Text_22FBC7, 4
+	msgbox MtChimney_Text_22FBC7, MSGBOX_DEFAULT
 	return
 
 MtChimney_EventScript_22EE0B:: @ 822EE0B
 	lockall
 	playbgm MUS_MGM0, 0
-	msgbox MtChimney_Text_22F26A, 4
+	msgbox MtChimney_Text_22F26A, MSGBOX_DEFAULT
 	applymovement 2, MtChimney_Movement_27259E
 	waitmovement 0
 	playse SE_PIN
@@ -44,9 +44,9 @@ MtChimney_EventScript_22EE0B:: @ 822EE0B
 	waitmovement 0
 	applymovement 2, MtChimney_Movement_27259A
 	waitmovement 0
-	msgbox MtChimney_Text_22F32E, 4
+	msgbox MtChimney_Text_22F32E, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_MAXIE_2, 0, MtChimney_Text_22F5CF
-	msgbox MtChimney_Text_22F5F7, 4
+	msgbox MtChimney_Text_22F5F7, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	fadescreen 1
@@ -64,7 +64,7 @@ MtChimney_EventScript_22EE0B:: @ 822EE0B
 	call_if 1, MtChimney_EventScript_22EED2
 	applymovement 255, MtChimney_Movement_2725A4
 	waitmovement 0
-	msgbox MtChimney_Text_22FC3D, 4
+	msgbox MtChimney_Text_22FC3D, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_FACING, 4
 	call_if 1, MtChimney_EventScript_22EEDD
@@ -103,13 +103,13 @@ MtChimney_EventScript_22EEF3:: @ 822EEF3
 	lock
 	faceplayer
 	showmoneybox 0, 0, 0
-	msgbox MtChimney_Text_22FE04, 5
+	msgbox MtChimney_Text_22FE04, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MtChimney_EventScript_22EF69
 	checkmoney 0xc8, 0
 	compare VAR_RESULT, 0
 	goto_eq MtChimney_EventScript_22EF76
-	msgbox MtChimney_Text_22FE4D, 4
+	msgbox MtChimney_Text_22FE4D, MSGBOX_DEFAULT
 	checkitemspace ITEM_LAVA_COOKIE, 1
 	compare VAR_RESULT, 1
 	call_if 1, MtChimney_EventScript_22EF5E
@@ -123,7 +123,7 @@ MtChimney_EventScript_22EEF3:: @ 822EEF3
 	end
 
 MtChimney_EventScript_22EF51:: @ 822EF51
-	msgbox gUnknown_08272AD0, 4
+	msgbox gUnknown_08272AD0, MSGBOX_DEFAULT
 	hidemoneybox
 	nop
 	nop
@@ -137,7 +137,7 @@ MtChimney_EventScript_22EF5E:: @ 822EF5E
 	return
 
 MtChimney_EventScript_22EF69:: @ 822EF69
-	msgbox MtChimney_Text_22FE9B, 4
+	msgbox MtChimney_Text_22FE9B, MSGBOX_DEFAULT
 	hidemoneybox
 	nop
 	nop
@@ -145,7 +145,7 @@ MtChimney_EventScript_22EF69:: @ 822EF69
 	end
 
 MtChimney_EventScript_22EF76:: @ 822EF76
-	msgbox MtChimney_Text_22FE5E, 4
+	msgbox MtChimney_Text_22FE5E, MSGBOX_DEFAULT
 	hidemoneybox
 	nop
 	nop
@@ -399,57 +399,57 @@ MtChimney_Movement_22F04F: @ 822F04F
 	step_end
 
 MtChimney_EventScript_22F053:: @ 822F053
-	msgbox MtChimney_Text_22FD1F, 3
+	msgbox MtChimney_Text_22FD1F, MSGBOX_SIGN
 	end
 
 MtChimney_EventScript_22F05C:: @ 822F05C
-	msgbox MtChimney_Text_22FD5B, 3
+	msgbox MtChimney_Text_22FD5B, MSGBOX_SIGN
 	end
 
 MtChimney_EventScript_22F065:: @ 822F065
-	msgbox MtChimney_Text_22FDA1, 3
+	msgbox MtChimney_Text_22FDA1, MSGBOX_SIGN
 	end
 
 MtChimney_EventScript_22F06E:: @ 822F06E
 	trainerbattle 0, TRAINER_TABITHA_2, 0, MtChimney_Text_22F6AA, MtChimney_Text_22F72C
-	msgbox MtChimney_Text_22F76D, 6
+	msgbox MtChimney_Text_22F76D, MSGBOX_AUTOCLOSE
 	end
 
 MtChimney_EventScript_22F085:: @ 822F085
 	trainerbattle 0, TRAINER_GRUNT_31, 0, MtChimney_Text_22F7A2, MtChimney_Text_22F83A
-	msgbox MtChimney_Text_22F859, 6
+	msgbox MtChimney_Text_22F859, MSGBOX_AUTOCLOSE
 	end
 
 MtChimney_EventScript_22F09C:: @ 822F09C
-	msgbox MtChimney_Text_22F978, 3
+	msgbox MtChimney_Text_22F978, MSGBOX_SIGN
 	end
 
 MtChimney_EventScript_22F0A5:: @ 822F0A5
-	msgbox MtChimney_Text_22F9B2, 3
+	msgbox MtChimney_Text_22F9B2, MSGBOX_SIGN
 	end
 
 MtChimney_EventScript_22F0AE:: @ 822F0AE
-	msgbox MtChimney_Text_22F9D1, 3
+	msgbox MtChimney_Text_22F9D1, MSGBOX_SIGN
 	end
 
 MtChimney_EventScript_22F0B7:: @ 822F0B7
-	msgbox MtChimney_Text_22FA2F, 3
+	msgbox MtChimney_Text_22FA2F, MSGBOX_SIGN
 	end
 
 MtChimney_EventScript_22F0C0:: @ 822F0C0
-	msgbox MtChimney_Text_22FA8B, 3
+	msgbox MtChimney_Text_22FA8B, MSGBOX_SIGN
 	end
 
 MtChimney_EventScript_22F0C9:: @ 822F0C9
-	msgbox MtChimney_Text_22FAA5, 3
+	msgbox MtChimney_Text_22FAA5, MSGBOX_SIGN
 	end
 
 MtChimney_EventScript_22F0D2:: @ 822F0D2
-	msgbox MtChimney_Text_22FACB, 3
+	msgbox MtChimney_Text_22FACB, MSGBOX_SIGN
 	end
 
 MtChimney_EventScript_22F0DB:: @ 822F0DB
-	msgbox MtChimney_Text_22FDFC, 3
+	msgbox MtChimney_Text_22FDFC, MSGBOX_SIGN
 	end
 
 MtChimney_EventScript_22F0E4:: @ 822F0E4
@@ -458,32 +458,32 @@ MtChimney_EventScript_22F0E4:: @ 822F0E4
 	goto_if 0, MtChimney_EventScript_22F137
 	checkflag FLAG_0x073
 	goto_eq MtChimney_EventScript_22F12D
-	msgbox MtChimney_Text_22FF12, 5
+	msgbox MtChimney_Text_22FF12, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MtChimney_EventScript_22F123
-	msgbox MtChimney_Text_22FF66, 4
+	msgbox MtChimney_Text_22FF66, MSGBOX_DEFAULT
 	giveitem_std ITEM_METEORITE
 	setflag FLAG_0x073
 	releaseall
 	end
 
 MtChimney_EventScript_22F123:: @ 822F123
-	msgbox MtChimney_Text_22FF9C, 4
+	msgbox MtChimney_Text_22FF9C, MSGBOX_DEFAULT
 	releaseall
 	end
 
 MtChimney_EventScript_22F12D:: @ 822F12D
-	msgbox MtChimney_Text_22FFC0, 4
+	msgbox MtChimney_Text_22FFC0, MSGBOX_DEFAULT
 	releaseall
 	end
 
 MtChimney_EventScript_22F137:: @ 822F137
-	msgbox MtChimney_Text_22FEAA, 4
+	msgbox MtChimney_Text_22FEAA, MSGBOX_DEFAULT
 	releaseall
 	end
 
 MtChimney_EventScript_22F141:: @ 822F141
-	msgbox MtChimney_Text_22FFFA, 3
+	msgbox MtChimney_Text_22FFFA, MSGBOX_SIGN
 	end
 
 MtChimney_EventScript_22F14A:: @ 822F14A
@@ -491,44 +491,44 @@ MtChimney_EventScript_22F14A:: @ 822F14A
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq MtChimney_EventScript_22F195
-	msgbox MtChimney_Text_2300A2, 4
+	msgbox MtChimney_Text_2300A2, MSGBOX_DEFAULT
 	release
 	end
 
 MtChimney_EventScript_22F176:: @ 822F176
 	special sub_80B4808
 	waitmovement 0
-	msgbox MtChimney_Text_2300E3, 4
+	msgbox MtChimney_Text_2300E3, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 313
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 313
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 MtChimney_EventScript_22F195:: @ 822F195
 	trainerbattle 5, TRAINER_SHELBY_1, 0, MtChimney_Text_230153, MtChimney_Text_2301BB
-	msgbox MtChimney_Text_2301E7, 6
+	msgbox MtChimney_Text_2301E7, MSGBOX_AUTOCLOSE
 	end
 
 MtChimney_EventScript_22F1AC:: @ 822F1AC
 	trainerbattle 0, TRAINER_MELISSA, 0, MtChimney_Text_23022A, MtChimney_Text_23026D
-	msgbox MtChimney_Text_230292, 6
+	msgbox MtChimney_Text_230292, MSGBOX_AUTOCLOSE
 	end
 
 MtChimney_EventScript_22F1C3:: @ 822F1C3
 	trainerbattle 0, TRAINER_SHEILA, 0, MtChimney_Text_2302BD, MtChimney_Text_230304
-	msgbox MtChimney_Text_23033A, 6
+	msgbox MtChimney_Text_23033A, MSGBOX_AUTOCLOSE
 	end
 
 MtChimney_EventScript_22F1DA:: @ 822F1DA
 	trainerbattle 0, TRAINER_SHIRLEY, 0, MtChimney_Text_2303DF, MtChimney_Text_230436
-	msgbox MtChimney_Text_230463, 6
+	msgbox MtChimney_Text_230463, MSGBOX_AUTOCLOSE
 	end
 
 MtChimney_EventScript_22F1F1:: @ 822F1F1
 	trainerbattle 0, TRAINER_GRUNT_24, 0, MtChimney_Text_22F8B6, MtChimney_Text_22F921
-	msgbox MtChimney_Text_22F93A, 6
+	msgbox MtChimney_Text_22F93A, MSGBOX_AUTOCLOSE
 	end
 
 MtChimney_EventScript_22F208:: @ 822F208
@@ -536,24 +536,24 @@ MtChimney_EventScript_22F208:: @ 822F208
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq MtChimney_EventScript_22F253
-	msgbox MtChimney_Text_230519, 4
+	msgbox MtChimney_Text_230519, MSGBOX_DEFAULT
 	release
 	end
 
 MtChimney_EventScript_22F234:: @ 822F234
 	special sub_80B4808
 	waitmovement 0
-	msgbox MtChimney_Text_230557, 4
+	msgbox MtChimney_Text_230557, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 1
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 1
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 MtChimney_EventScript_22F253:: @ 822F253
 	trainerbattle 5, TRAINER_SAWYER_1, 0, MtChimney_Text_23059C, MtChimney_Text_2305E3
-	msgbox MtChimney_Text_230614, 6
+	msgbox MtChimney_Text_230614, MSGBOX_AUTOCLOSE
 	end
 
 MtChimney_Text_22F26A: @ 822F26A

--- a/data/maps/MtChimney_CableCarStation/scripts.inc
+++ b/data/maps/MtChimney_CableCarStation/scripts.inc
@@ -31,7 +31,7 @@ MtChimney_CableCarStation_EventScript_22AC27:: @ 822AC27
 MtChimney_CableCarStation_EventScript_22AC4B:: @ 822AC4B
 	lock
 	faceplayer
-	msgbox MtChimney_CableCarStation_Text_22ACB9, 5
+	msgbox MtChimney_CableCarStation_Text_22ACB9, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq MtChimney_CableCarStation_EventScript_22AC6C
 	compare VAR_RESULT, 0
@@ -39,7 +39,7 @@ MtChimney_CableCarStation_EventScript_22AC4B:: @ 822AC4B
 	end
 
 MtChimney_CableCarStation_EventScript_22AC6C:: @ 822AC6C
-	msgbox MtChimney_CableCarStation_Text_22ACF8, 4
+	msgbox MtChimney_CableCarStation_Text_22ACF8, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, MtChimney_CableCarStation_Movement_22ACA5
 	applymovement 255, MtChimney_CableCarStation_Movement_22ACAF
@@ -54,7 +54,7 @@ MtChimney_CableCarStation_EventScript_22AC6C:: @ 822AC6C
 	end
 
 MtChimney_CableCarStation_EventScript_22AC9B:: @ 822AC9B
-	msgbox MtChimney_CableCarStation_Text_22AD0E, 4
+	msgbox MtChimney_CableCarStation_Text_22AD0E, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/MtPyre_1F/scripts.inc
+++ b/data/maps/MtPyre_1F/scripts.inc
@@ -6,7 +6,7 @@ MtPyre_1F_EventScript_230F3F:: @ 8230F3F
 	faceplayer
 	checkflag FLAG_0x11A
 	goto_eq MtPyre_1F_EventScript_230F6E
-	msgbox MtPyre_1F_Text_230F8A, 4
+	msgbox MtPyre_1F_Text_230F8A, MSGBOX_DEFAULT
 	giveitem_std ITEM_CLEANSE_TAG
 	compare VAR_RESULT, 0
 	goto_eq MtPyre_1F_EventScript_272054
@@ -15,16 +15,16 @@ MtPyre_1F_EventScript_230F3F:: @ 8230F3F
 	end
 
 MtPyre_1F_EventScript_230F6E:: @ 8230F6E
-	msgbox MtPyre_1F_Text_231005, 4
+	msgbox MtPyre_1F_Text_231005, MSGBOX_DEFAULT
 	release
 	end
 
 MtPyre_1F_EventScript_230F78:: @ 8230F78
-	msgbox MtPyre_1F_Text_23104F, 2
+	msgbox MtPyre_1F_Text_23104F, MSGBOX_NPC
 	end
 
 MtPyre_1F_EventScript_230F81:: @ 8230F81
-	msgbox MtPyre_1F_Text_2310BA, 2
+	msgbox MtPyre_1F_Text_2310BA, MSGBOX_NPC
 	end
 
 MtPyre_1F_Text_230F8A: @ 8230F8A

--- a/data/maps/MtPyre_2F/scripts.inc
+++ b/data/maps/MtPyre_2F/scripts.inc
@@ -10,36 +10,36 @@ MtPyre_2F_MapScript1_23110B: @ 823110B
 	end
 
 MtPyre_2F_EventScript_231116:: @ 8231116
-	msgbox MtPyre_2F_Text_2311A3, 2
+	msgbox MtPyre_2F_Text_2311A3, MSGBOX_NPC
 	end
 
 MtPyre_2F_EventScript_23111F:: @ 823111F
-	msgbox MtPyre_2F_Text_2311E6, 2
+	msgbox MtPyre_2F_Text_2311E6, MSGBOX_NPC
 	end
 
 MtPyre_2F_EventScript_231128:: @ 8231128
 	trainerbattle 0, TRAINER_MARK, 0, MtPyre_2F_Text_231258, MtPyre_2F_Text_2312A2
-	msgbox MtPyre_2F_Text_2312CB, 6
+	msgbox MtPyre_2F_Text_2312CB, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_2F_EventScript_23113F:: @ 823113F
 	trainerbattle 4, TRAINER_DEZ_AND_LUKE, 0, MtPyre_2F_Text_23130F, MtPyre_2F_Text_2313A1, MtPyre_2F_Text_231414
-	msgbox MtPyre_2F_Text_2313B1, 6
+	msgbox MtPyre_2F_Text_2313B1, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_2F_EventScript_23115A:: @ 823115A
 	trainerbattle 4, TRAINER_DEZ_AND_LUKE, 0, MtPyre_2F_Text_231492, MtPyre_2F_Text_231534, MtPyre_2F_Text_231582
-	msgbox MtPyre_2F_Text_23154D, 6
+	msgbox MtPyre_2F_Text_23154D, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_2F_EventScript_231175:: @ 8231175
 	trainerbattle 0, TRAINER_LEAH, 0, MtPyre_2F_Text_231604, MtPyre_2F_Text_231645
-	msgbox MtPyre_2F_Text_23165A, 6
+	msgbox MtPyre_2F_Text_23165A, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_2F_EventScript_23118C:: @ 823118C
 	trainerbattle 0, TRAINER_ZANDER, 0, MtPyre_2F_Text_2316C7, MtPyre_2F_Text_2316E1
-	msgbox MtPyre_2F_Text_2316FB, 6
+	msgbox MtPyre_2F_Text_2316FB, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_2F_Text_2311A3: @ 82311A3

--- a/data/maps/MtPyre_3F/scripts.inc
+++ b/data/maps/MtPyre_3F/scripts.inc
@@ -3,12 +3,12 @@ MtPyre_3F_MapScripts:: @ 8231752
 
 MtPyre_3F_EventScript_231753:: @ 8231753
 	trainerbattle 0, TRAINER_WILLIAM, 0, MtPyre_3F_Text_2317E3, MtPyre_3F_Text_231853
-	msgbox MtPyre_3F_Text_231869, 6
+	msgbox MtPyre_3F_Text_231869, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_3F_EventScript_23176A:: @ 823176A
 	trainerbattle 0, TRAINER_KAYLA, 0, MtPyre_3F_Text_2318A1, MtPyre_3F_Text_2318DD
-	msgbox MtPyre_3F_Text_2318F2, 6
+	msgbox MtPyre_3F_Text_2318F2, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_3F_EventScript_231781:: @ 8231781
@@ -16,24 +16,24 @@ MtPyre_3F_EventScript_231781:: @ 8231781
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq MtPyre_3F_EventScript_2317CC
-	msgbox MtPyre_3F_Text_23199B, 4
+	msgbox MtPyre_3F_Text_23199B, MSGBOX_DEFAULT
 	release
 	end
 
 MtPyre_3F_EventScript_2317AD:: @ 82317AD
 	special sub_80B4808
 	waitmovement 0
-	msgbox MtPyre_3F_Text_231A49, 4
+	msgbox MtPyre_3F_Text_231A49, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 9
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 9
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 MtPyre_3F_EventScript_2317CC:: @ 82317CC
 	trainerbattle 5, TRAINER_GABRIELLE_1, 0, MtPyre_3F_Text_231AAB, MtPyre_3F_Text_231AE6
-	msgbox MtPyre_3F_Text_231B0D, 6
+	msgbox MtPyre_3F_Text_231B0D, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_3F_Text_2317E3: @ 82317E3

--- a/data/maps/MtPyre_3F/scripts.inc
+++ b/data/maps/MtPyre_3F/scripts.inc
@@ -24,10 +24,7 @@ MtPyre_3F_EventScript_2317AD:: @ 82317AD
 	special sub_80B4808
 	waitmovement 0
 	msgbox MtPyre_3F_Text_231A49, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 9
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 9
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_GABRIELLE_1
 	release
 	end
 

--- a/data/maps/MtPyre_4F/scripts.inc
+++ b/data/maps/MtPyre_4F/scripts.inc
@@ -3,7 +3,7 @@ MtPyre_4F_MapScripts:: @ 8231BC8
 
 MtPyre_5F_EventScript_231BC9:: @ 8231BC9
 	trainerbattle 0, TRAINER_ATSUSHI, 0, MtPyre_5F_Text_231BE0, MtPyre_5F_Text_231C08
-	msgbox MtPyre_5F_Text_231C24, 6
+	msgbox MtPyre_5F_Text_231C24, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_5F_Text_231BE0: @ 8231BE0

--- a/data/maps/MtPyre_5F/scripts.inc
+++ b/data/maps/MtPyre_5F/scripts.inc
@@ -3,7 +3,7 @@ MtPyre_5F_MapScripts:: @ 8231C6D
 
 MtPyre_4F_EventScript_231C6E:: @ 8231C6E
 	trainerbattle 0, TRAINER_TASHA, 0, MtPyre_4F_Text_231C85, MtPyre_4F_Text_231CDB
-	msgbox MtPyre_4F_Text_231CEE, 6
+	msgbox MtPyre_4F_Text_231CEE, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_4F_Text_231C85: @ 8231C85

--- a/data/maps/MtPyre_6F/scripts.inc
+++ b/data/maps/MtPyre_6F/scripts.inc
@@ -14,10 +14,7 @@ MtPyre_6F_EventScript_231D67:: @ 8231D67
 	special sub_80B4808
 	waitmovement 0
 	msgbox MtPyre_6F_Text_231E43, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 108
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 108
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_VALERIE_1
 	release
 	end
 

--- a/data/maps/MtPyre_6F/scripts.inc
+++ b/data/maps/MtPyre_6F/scripts.inc
@@ -6,29 +6,29 @@ MtPyre_6F_EventScript_231D3B:: @ 8231D3B
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq MtPyre_6F_EventScript_231D86
-	msgbox MtPyre_6F_Text_231DFC, 4
+	msgbox MtPyre_6F_Text_231DFC, MSGBOX_DEFAULT
 	release
 	end
 
 MtPyre_6F_EventScript_231D67:: @ 8231D67
 	special sub_80B4808
 	waitmovement 0
-	msgbox MtPyre_6F_Text_231E43, 4
+	msgbox MtPyre_6F_Text_231E43, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 108
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 108
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 MtPyre_6F_EventScript_231D86:: @ 8231D86
 	trainerbattle 5, TRAINER_VALERIE_1, 0, MtPyre_6F_Text_231EB3, MtPyre_6F_Text_231ECB
-	msgbox MtPyre_6F_Text_231EE1, 6
+	msgbox MtPyre_6F_Text_231EE1, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_6F_EventScript_231D9D:: @ 8231D9D
 	trainerbattle 0, TRAINER_CEDRIC, 0, MtPyre_6F_Text_231F11, MtPyre_6F_Text_231F4A
-	msgbox MtPyre_6F_Text_231F5C, 6
+	msgbox MtPyre_6F_Text_231F5C, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_6F_Text_231DB4: @ 8231DB4

--- a/data/maps/MtPyre_Summit/scripts.inc
+++ b/data/maps/MtPyre_Summit/scripts.inc
@@ -43,7 +43,7 @@ MtPyre_Summit_EventScript_23203C:: @ 823203C
 	call_if 1, MtPyre_Summit_EventScript_2320EB
 	compare VAR_0x8008, 2
 	call_if 1, MtPyre_Summit_EventScript_2320EC
-	msgbox MtPyre_Summit_Text_23281A, 4
+	msgbox MtPyre_Summit_Text_23281A, MSGBOX_DEFAULT
 	closemessage
 	fadescreen 1
 	removeobject 2
@@ -63,7 +63,7 @@ MtPyre_Summit_EventScript_23203C:: @ 823203C
 	call_if 1, MtPyre_Summit_EventScript_23210C
 	compare VAR_0x8008, 2
 	call_if 1, MtPyre_Summit_EventScript_232117
-	msgbox MtPyre_Summit_Text_23290E, 4
+	msgbox MtPyre_Summit_Text_23290E, MSGBOX_DEFAULT
 	giveitem_std ITEM_MAGMA_EMBLEM
 	setflag FLAG_0x0D4
 	setflag FLAG_HIDE_JAGGED_PASS_MAGMA_GUARD
@@ -133,7 +133,7 @@ MtPyre_Summit_EventScript_23213C:: @ 823213C
 	faceplayer
 	checkflag FLAG_0x09E
 	goto_eq MtPyre_Summit_EventScript_232167
-	msgbox MtPyre_Summit_Text_232E0C, 5
+	msgbox MtPyre_Summit_Text_232E0C, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	call_if 1, MtPyre_Summit_EventScript_232187
 	compare VAR_RESULT, 0
@@ -142,7 +142,7 @@ MtPyre_Summit_EventScript_23213C:: @ 823213C
 	end
 
 MtPyre_Summit_EventScript_232167:: @ 8232167
-	msgbox MtPyre_Summit_Text_2331A6, 5
+	msgbox MtPyre_Summit_Text_2331A6, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	call_if 1, MtPyre_Summit_EventScript_232199
 	compare VAR_RESULT, 0
@@ -151,15 +151,15 @@ MtPyre_Summit_EventScript_232167:: @ 8232167
 	end
 
 MtPyre_Summit_EventScript_232187:: @ 8232187
-	msgbox MtPyre_Summit_Text_232F27, 4
+	msgbox MtPyre_Summit_Text_232F27, MSGBOX_DEFAULT
 	return
 
 MtPyre_Summit_EventScript_232190:: @ 8232190
-	msgbox MtPyre_Summit_Text_233162, 4
+	msgbox MtPyre_Summit_Text_233162, MSGBOX_DEFAULT
 	return
 
 MtPyre_Summit_EventScript_232199:: @ 8232199
-	msgbox MtPyre_Summit_Text_23325D, 4
+	msgbox MtPyre_Summit_Text_23325D, MSGBOX_DEFAULT
 	return
 
 MtPyre_Summit_EventScript_2321A2:: @ 82321A2
@@ -171,23 +171,23 @@ MtPyre_Summit_EventScript_2321A2:: @ 82321A2
 	call_if 4, MtPyre_Summit_EventScript_2321CB
 	checkflag FLAG_0x081
 	goto_eq MtPyre_Summit_EventScript_2321D8
-	msgbox MtPyre_Summit_Text_232AD8, 4
+	msgbox MtPyre_Summit_Text_232AD8, MSGBOX_DEFAULT
 	release
 	end
 
 MtPyre_Summit_EventScript_2321CB:: @ 82321CB
-	msgbox MtPyre_Summit_Text_232CA6, 4
+	msgbox MtPyre_Summit_Text_232CA6, MSGBOX_DEFAULT
 	setflag FLAG_0x103
 	release
 	end
 
 MtPyre_Summit_EventScript_2321D8:: @ 82321D8
-	msgbox MtPyre_Summit_Text_232B4F, 4
+	msgbox MtPyre_Summit_Text_232B4F, MSGBOX_DEFAULT
 	release
 	end
 
 MtPyre_Summit_EventScript_2321E2:: @ 82321E2
-	msgbox MtPyre_Summit_Text_232D1E, 4
+	msgbox MtPyre_Summit_Text_232D1E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -231,7 +231,7 @@ MtPyre_Summit_EventScript_232210:: @ 8232210
 	call_if 1, MtPyre_Summit_EventScript_232328
 	compare VAR_0x8008, 2
 	call_if 1, MtPyre_Summit_EventScript_232341
-	msgbox MtPyre_Summit_Text_233183, 4
+	msgbox MtPyre_Summit_Text_233183, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_0x8008, 0
 	call_if 1, MtPyre_Summit_EventScript_23235A
@@ -426,22 +426,22 @@ MtPyre_Summit_Movement_2323F8: @ 82323F8
 
 MtPyre_Summit_EventScript_2323FD:: @ 82323FD
 	trainerbattle 0, TRAINER_GRUNT_17, 0, MtPyre_Summit_Text_232459, MtPyre_Summit_Text_2324A0
-	msgbox MtPyre_Summit_Text_2324E0, 6
+	msgbox MtPyre_Summit_Text_2324E0, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_Summit_EventScript_232414:: @ 8232414
 	trainerbattle 0, TRAINER_GRUNT_18, 0, MtPyre_Summit_Text_232513, MtPyre_Summit_Text_2325B0
-	msgbox MtPyre_Summit_Text_2325E4, 6
+	msgbox MtPyre_Summit_Text_2325E4, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_Summit_EventScript_23242B:: @ 823242B
 	trainerbattle 0, TRAINER_GRUNT_19, 0, MtPyre_Summit_Text_23261D, MtPyre_Summit_Text_232678
-	msgbox MtPyre_Summit_Text_2326B3, 6
+	msgbox MtPyre_Summit_Text_2326B3, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_Summit_EventScript_232442:: @ 8232442
 	trainerbattle 0, TRAINER_GRUNT_29, 0, MtPyre_Summit_Text_23271B, MtPyre_Summit_Text_23279A
-	msgbox MtPyre_Summit_Text_2327D8, 6
+	msgbox MtPyre_Summit_Text_2327D8, MSGBOX_AUTOCLOSE
 	end
 
 MtPyre_Summit_Text_232459: @ 8232459

--- a/data/maps/NavelRock_Harbor/scripts.inc
+++ b/data/maps/NavelRock_Harbor/scripts.inc
@@ -4,10 +4,10 @@ NavelRock_Harbor_MapScripts:: @ 82690BC
 NavelRock_Harbor_EventScript_2690BD:: @ 82690BD
 	lock
 	faceplayer
-	msgbox NavelRock_Harbor_Text_2C6CE6, 5
+	msgbox NavelRock_Harbor_Text_2C6CE6, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq NavelRock_Harbor_EventScript_269102
-	msgbox NavelRock_Harbor_Text_2A6A5D, 4
+	msgbox NavelRock_Harbor_Text_2A6A5D, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, NavelRock_Harbor_Movement_2725AA
 	waitmovement 0
@@ -21,7 +21,7 @@ NavelRock_Harbor_EventScript_2690BD:: @ 82690BD
 	end
 
 NavelRock_Harbor_EventScript_269102:: @ 8269102
-	msgbox NavelRock_Harbor_Text_2A6A82, 4
+	msgbox NavelRock_Harbor_Text_2A6A82, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/NewMauville_Entrance/scripts.inc
+++ b/data/maps/NewMauville_Entrance/scripts.inc
@@ -25,14 +25,14 @@ NewMauville_Entrance_EventScript_2372FF:: @ 82372FF
 	lockall
 	applymovement 255, NewMauville_Entrance_Movement_2725A6
 	waitmovement 0
-	msgbox NewMauville_Entrance_Text_237382, 4
+	msgbox NewMauville_Entrance_Text_237382, MSGBOX_DEFAULT
 	checkitem ITEM_BASEMENT_KEY, 1
 	compare VAR_RESULT, 0
 	goto_eq NewMauville_Entrance_EventScript_237380
-	msgbox NewMauville_Entrance_Text_237396, 5
+	msgbox NewMauville_Entrance_Text_237396, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq NewMauville_Entrance_EventScript_237380
-	msgbox NewMauville_Entrance_Text_2373AC, 4
+	msgbox NewMauville_Entrance_Text_2373AC, MSGBOX_DEFAULT
 	setmetatile 3, 0, 707, 0
 	setmetatile 4, 0, 708, 0
 	setmetatile 5, 0, 709, 0

--- a/data/maps/NewMauville_Inside/scripts.inc
+++ b/data/maps/NewMauville_Inside/scripts.inc
@@ -150,7 +150,7 @@ NewMauville_Inside_EventScript_2375D7:: @ 82375D7
 
 NewMauville_Inside_EventScript_237725:: @ 8237725
 	lockall
-	msgbox NewMauville_Inside_Text_237932, 4
+	msgbox NewMauville_Inside_Text_237932, MSGBOX_DEFAULT
 	call NewMauville_Inside_EventScript_23773A
 	setvar VAR_0x40BA, 2
 	releaseall
@@ -173,12 +173,12 @@ NewMauville_Inside_EventScript_23778F:: @ 823778F
 	lockall
 	compare VAR_0x40BA, 2
 	goto_eq NewMauville_Inside_EventScript_2377A5
-	msgbox NewMauville_Inside_Text_237896, 4
+	msgbox NewMauville_Inside_Text_237896, MSGBOX_DEFAULT
 	releaseall
 	end
 
 NewMauville_Inside_EventScript_2377A5:: @ 82377A5
-	msgbox NewMauville_Inside_Text_237916, 4
+	msgbox NewMauville_Inside_Text_237916, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/OldaleTown/scripts.inc
+++ b/data/maps/OldaleTown/scripts.inc
@@ -28,11 +28,11 @@ OldaleTown_EventScript_1E8EDE:: @ 81E8EDE
 	return
 
 OldaleTown_EventScript_1E8EEA:: @ 81E8EEA
-	msgbox OldaleTown_Text_1E94DA, 3
+	msgbox OldaleTown_Text_1E94DA, MSGBOX_SIGN
 	end
 
 OldaleTown_EventScript_1E8EF3:: @ 81E8EF3
-	msgbox OldaleTown_Text_1E918E, 2
+	msgbox OldaleTown_Text_1E918E, MSGBOX_NPC
 	end
 
 OldaleTown_EventScript_1E8EFC:: @ 81E8EFC
@@ -44,7 +44,7 @@ OldaleTown_EventScript_1E8EFC:: @ 81E8EFC
 	goto_eq OldaleTown_EventScript_1E8FB9
 	setflag FLAG_TEMP_1
 	playbgm MUS_TSURETEK, 0
-	msgbox OldaleTown_Text_1E91C0, 4
+	msgbox OldaleTown_Text_1E91C0, MSGBOX_DEFAULT
 	closemessage
 	switch VAR_FACING
 	case 1, OldaleTown_EventScript_1E8F47
@@ -74,23 +74,23 @@ OldaleTown_EventScript_1E8F75:: @ 81E8F75
 	end
 
 OldaleTown_EventScript_1E8F8C:: @ 81E8F8C
-	msgbox OldaleTown_Text_1E91FD, 4
+	msgbox OldaleTown_Text_1E91FD, MSGBOX_DEFAULT
 	giveitem_std ITEM_POTION
 	compare VAR_RESULT, 0
 	goto_eq OldaleTown_EventScript_1E8FC3
-	msgbox OldaleTown_Text_1E92AF, 4
+	msgbox OldaleTown_Text_1E92AF, MSGBOX_DEFAULT
 	setflag FLAG_0x084
 	fadedefaultbgm
 	release
 	end
 
 OldaleTown_EventScript_1E8FB9:: @ 81E8FB9
-	msgbox OldaleTown_Text_1E92AF, 4
+	msgbox OldaleTown_Text_1E92AF, MSGBOX_DEFAULT
 	release
 	end
 
 OldaleTown_EventScript_1E8FC3:: @ 81E8FC3
-	msgbox gUnknown_08272AD0, 4
+	msgbox gUnknown_08272AD0, MSGBOX_DEFAULT
 	fadedefaultbgm
 	release
 	end
@@ -197,7 +197,7 @@ OldaleTown_EventScript_1E901F:: @ 81E901F
 	faceplayer
 	checkflag FLAG_0x074
 	goto_eq OldaleTown_EventScript_1E9066
-	msgbox OldaleTown_Text_1E939A, 4
+	msgbox OldaleTown_Text_1E939A, MSGBOX_DEFAULT
 	closemessage
 	applymovement 3, OldaleTown_Movement_2725A2
 	waitmovement 0
@@ -209,7 +209,7 @@ OldaleTown_EventScript_1E903F:: @ 81E903F
 	applymovement 255, OldaleTown_Movement_1E9182
 	applymovement 3, OldaleTown_Movement_1E9185
 	waitmovement 0
-	msgbox OldaleTown_Text_1E9313, 4
+	msgbox OldaleTown_Text_1E9313, MSGBOX_DEFAULT
 	closemessage
 	applymovement 3, OldaleTown_Movement_1E918B
 	waitmovement 0
@@ -217,7 +217,7 @@ OldaleTown_EventScript_1E903F:: @ 81E903F
 	end
 
 OldaleTown_EventScript_1E9066:: @ 81E9066
-	msgbox OldaleTown_Text_1E93F8, 4
+	msgbox OldaleTown_Text_1E93F8, MSGBOX_DEFAULT
 	release
 	end
 
@@ -268,12 +268,12 @@ OldaleTown_EventScript_1E90E6:: @ 81E90E6
 	end
 
 OldaleTown_EventScript_1E90FE:: @ 81E90FE
-	msgbox OldaleTown_Text_1E9462, 4
+	msgbox OldaleTown_Text_1E9462, MSGBOX_DEFAULT
 	goto OldaleTown_EventScript_1E911A
 	end
 
 OldaleTown_EventScript_1E910C:: @ 81E910C
-	msgbox OldaleTown_Text_1E948A, 4
+	msgbox OldaleTown_Text_1E948A, MSGBOX_DEFAULT
 	goto OldaleTown_EventScript_1E911A
 	end
 

--- a/data/maps/OldaleTown_House1/scripts.inc
+++ b/data/maps/OldaleTown_House1/scripts.inc
@@ -2,7 +2,7 @@ OldaleTown_House1_MapScripts:: @ 81FBE85
 	.byte 0
 
 OldaleTown_House1_EventScript_1FBE86:: @ 81FBE86
-	msgbox OldaleTown_House1_Text_1FBE8F, 2
+	msgbox OldaleTown_House1_Text_1FBE8F, MSGBOX_NPC
 	end
 
 OldaleTown_House1_Text_1FBE8F: @ 81FBE8F

--- a/data/maps/OldaleTown_House2/scripts.inc
+++ b/data/maps/OldaleTown_House2/scripts.inc
@@ -2,11 +2,11 @@ OldaleTown_House2_MapScripts:: @ 81FBF5A
 	.byte 0
 
 OldaleTown_House2_EventScript_1FBF5B:: @ 81FBF5B
-	msgbox OldaleTown_House2_Text_1FBF6D, 2
+	msgbox OldaleTown_House2_Text_1FBF6D, MSGBOX_NPC
 	end
 
 OldaleTown_House2_EventScript_1FBF64:: @ 81FBF64
-	msgbox OldaleTown_House2_Text_1FBFB0, 2
+	msgbox OldaleTown_House2_Text_1FBFB0, MSGBOX_NPC
 	end
 
 OldaleTown_House2_Text_1FBF6D: @ 81FBF6D

--- a/data/maps/OldaleTown_Mart/scripts.inc
+++ b/data/maps/OldaleTown_Mart/scripts.inc
@@ -9,7 +9,7 @@ OldaleTown_Mart_EventScript_1FC240:: @ 81FC240
 	checkflag FLAG_0x074
 	goto_eq OldaleTown_Mart_EventScript_1FC26C
 	pokemart OldaleTown_Mart_Pokemart_1FC260
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -24,7 +24,7 @@ OldaleTown_Mart_Pokemart_1FC260: @ 81FC260
 
 OldaleTown_Mart_EventScript_1FC26C:: @ 81FC26C
 	pokemart OldaleTown_Mart_Pokemart_1FC27C
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -44,17 +44,17 @@ OldaleTown_Mart_EventScript_1FC28A:: @ 81FC28A
 	faceplayer
 	checkflag FLAG_0x074
 	goto_eq OldaleTown_Mart_EventScript_1FC29F
-	msgbox OldaleTown_Mart_Text_1FC2B2, 4
+	msgbox OldaleTown_Mart_Text_1FC2B2, MSGBOX_DEFAULT
 	release
 	end
 
 OldaleTown_Mart_EventScript_1FC29F:: @ 81FC29F
-	msgbox OldaleTown_Mart_Text_1FC2F3, 4
+	msgbox OldaleTown_Mart_Text_1FC2F3, MSGBOX_DEFAULT
 	release
 	end
 
 OldaleTown_Mart_EventScript_1FC2A9:: @ 81FC2A9
-	msgbox OldaleTown_Mart_Text_1FC338, 2
+	msgbox OldaleTown_Mart_Text_1FC338, MSGBOX_NPC
 	end
 
 OldaleTown_Mart_Text_1FC2B2: @ 81FC2B2

--- a/data/maps/OldaleTown_PokemonCenter_1F/scripts.inc
+++ b/data/maps/OldaleTown_PokemonCenter_1F/scripts.inc
@@ -17,11 +17,11 @@ OldaleTown_PokemonCenter_1F_EventScript_1FC01A:: @ 81FC01A
 	end
 
 OldaleTown_PokemonCenter_1F_EventScript_1FC028:: @ 81FC028
-	msgbox OldaleTown_PokemonCenter_1F_Text_1FC059, 2
+	msgbox OldaleTown_PokemonCenter_1F_Text_1FC059, MSGBOX_NPC
 	end
 
 OldaleTown_PokemonCenter_1F_EventScript_1FC031:: @ 81FC031
-	msgbox OldaleTown_PokemonCenter_1F_Text_1FC0CD, 2
+	msgbox OldaleTown_PokemonCenter_1F_Text_1FC0CD, MSGBOX_NPC
 	end
 
 OldaleTown_PokemonCenter_1F_EventScript_1FC03A:: @ 81FC03A
@@ -29,12 +29,12 @@ OldaleTown_PokemonCenter_1F_EventScript_1FC03A:: @ 81FC03A
 	faceplayer
 	checkflag FLAG_SYS_POKEDEX_GET
 	goto_eq OldaleTown_PokemonCenter_1F_EventScript_1FC04F
-	msgbox OldaleTown_PokemonCenter_1F_Text_1FC148, 4
+	msgbox OldaleTown_PokemonCenter_1F_Text_1FC148, MSGBOX_DEFAULT
 	release
 	end
 
 OldaleTown_PokemonCenter_1F_EventScript_1FC04F:: @ 81FC04F
-	msgbox OldaleTown_PokemonCenter_1F_Text_1FC1B9, 4
+	msgbox OldaleTown_PokemonCenter_1F_Text_1FC1B9, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/PacifidlogTown/scripts.inc
+++ b/data/maps/PacifidlogTown/scripts.inc
@@ -12,19 +12,19 @@ PacifidlogTown_MapScript1_1EBAC0: @ 81EBAC0
 	end
 
 PacifidlogTown_EventScript_1EBAC3:: @ 81EBAC3
-	msgbox PacifidlogTown_Text_1EBB6C, 2
+	msgbox PacifidlogTown_Text_1EBB6C, MSGBOX_NPC
 	end
 
 PacifidlogTown_EventScript_1EBACC:: @ 81EBACC
-	msgbox PacifidlogTown_Text_1EBAE7, 2
+	msgbox PacifidlogTown_Text_1EBAE7, MSGBOX_NPC
 	end
 
 PacifidlogTown_EventScript_1EBAD5:: @ 81EBAD5
-	msgbox PacifidlogTown_Text_1EBBAC, 2
+	msgbox PacifidlogTown_Text_1EBBAC, MSGBOX_NPC
 	end
 
 PacifidlogTown_EventScript_1EBADE:: @ 81EBADE
-	msgbox PacifidlogTown_Text_1EBC7A, 3
+	msgbox PacifidlogTown_Text_1EBC7A, MSGBOX_SIGN
 	end
 
 PacifidlogTown_Text_1EBAE7: @ 81EBAE7

--- a/data/maps/PacifidlogTown_House1/scripts.inc
+++ b/data/maps/PacifidlogTown_House1/scripts.inc
@@ -2,11 +2,11 @@ PacifidlogTown_House1_MapScripts:: @ 820365C
 	.byte 0
 
 PacifidlogTown_House1_EventScript_20365D:: @ 820365D
-	msgbox PacifidlogTown_House1_Text_20366F, 2
+	msgbox PacifidlogTown_House1_Text_20366F, MSGBOX_NPC
 	end
 
 PacifidlogTown_House1_EventScript_203666:: @ 8203666
-	msgbox PacifidlogTown_House1_Text_20373A, 2
+	msgbox PacifidlogTown_House1_Text_20373A, MSGBOX_NPC
 	end
 
 PacifidlogTown_House1_Text_20366F: @ 820366F

--- a/data/maps/PacifidlogTown_House2/scripts.inc
+++ b/data/maps/PacifidlogTown_House2/scripts.inc
@@ -31,12 +31,12 @@ PacifidlogTown_House2_EventScript_2037DE:: @ 82037DE
 	return
 
 PacifidlogTown_House2_EventScript_2037F8:: @ 82037F8
-	msgbox PacifidlogTown_House2_Text_20395B, 4
+	msgbox PacifidlogTown_House2_Text_20395B, MSGBOX_DEFAULT
 	return
 
 PacifidlogTown_House2_EventScript_203801:: @ 8203801
-	msgbox PacifidlogTown_House2_Text_2038C7, 4
-	msgbox PacifidlogTown_House2_Text_20395B, 4
+	msgbox PacifidlogTown_House2_Text_2038C7, MSGBOX_DEFAULT
+	msgbox PacifidlogTown_House2_Text_20395B, MSGBOX_DEFAULT
 	return
 
 PacifidlogTown_House2_EventScript_203812:: @ 8203812
@@ -44,36 +44,36 @@ PacifidlogTown_House2_EventScript_203812:: @ 8203812
 	return
 
 PacifidlogTown_House2_EventScript_203816:: @ 8203816
-	msgbox PacifidlogTown_House2_Text_20396D, 4
+	msgbox PacifidlogTown_House2_Text_20396D, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM27
 	compare VAR_RESULT, 0
 	goto_eq PacifidlogTown_House2_EventScript_272054
 	setflag FLAG_0x12B
 	special SetPacifidlogTMReceivedDay
-	msgbox PacifidlogTown_House2_Text_203A85, 4
+	msgbox PacifidlogTown_House2_Text_203A85, MSGBOX_DEFAULT
 	release
 	end
 
 PacifidlogTown_House2_EventScript_203845:: @ 8203845
-	msgbox PacifidlogTown_House2_Text_2039CE, 4
+	msgbox PacifidlogTown_House2_Text_2039CE, MSGBOX_DEFAULT
 	release
 	end
 
 PacifidlogTown_House2_EventScript_20384F:: @ 820384F
-	msgbox PacifidlogTown_House2_Text_203A2F, 4
+	msgbox PacifidlogTown_House2_Text_203A2F, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM21
 	compare VAR_RESULT, 0
 	goto_eq PacifidlogTown_House2_EventScript_272054
 	setflag FLAG_0x12B
 	special SetPacifidlogTMReceivedDay
-	msgbox PacifidlogTown_House2_Text_203A85, 4
+	msgbox PacifidlogTown_House2_Text_203A85, MSGBOX_DEFAULT
 	release
 	end
 
 PacifidlogTown_House2_EventScript_20387E:: @ 820387E
 	specialvar VAR_RESULT, GetDaysUntilPacifidlogTMAvailable
 	buffernumberstring 0, VAR_RESULT
-	msgbox PacifidlogTown_House2_Text_203AF4, 4
+	msgbox PacifidlogTown_House2_Text_203AF4, MSGBOX_DEFAULT
 	release
 	end
 
@@ -82,9 +82,9 @@ PacifidlogTown_House2_EventScript_203891:: @ 8203891
 	faceplayer
 	waitse
 	playmoncry SPECIES_AZURILL, 0
-	msgbox PacifidlogTown_House2_Text_203B8D, 4
+	msgbox PacifidlogTown_House2_Text_203B8D, MSGBOX_DEFAULT
 	waitmoncry
-	msgbox PacifidlogTown_House2_Text_203B9D, 4
+	msgbox PacifidlogTown_House2_Text_203B9D, MSGBOX_DEFAULT
 	release
 	end
 
@@ -93,9 +93,9 @@ PacifidlogTown_House2_EventScript_2038AC:: @ 82038AC
 	faceplayer
 	waitse
 	playmoncry SPECIES_AZURILL, 2
-	msgbox PacifidlogTown_House2_Text_203BCE, 4
+	msgbox PacifidlogTown_House2_Text_203BCE, MSGBOX_DEFAULT
 	waitmoncry
-	msgbox PacifidlogTown_House2_Text_203BDF, 4
+	msgbox PacifidlogTown_House2_Text_203BDF, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/PacifidlogTown_House3/scripts.inc
+++ b/data/maps/PacifidlogTown_House3/scripts.inc
@@ -10,7 +10,7 @@ PacifidlogTown_House3_EventScript_203C11:: @ 8203C11
 	copyvar VAR_0x8004, VAR_0x8008
 	specialvar VAR_RESULT, sub_807E73C
 	copyvar VAR_0x8009, VAR_RESULT
-	msgbox PacifidlogTown_House3_Text_203CBE, 5
+	msgbox PacifidlogTown_House3_Text_203CBE, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq PacifidlogTown_House3_EventScript_203C93
 	special sub_81B94B0
@@ -29,29 +29,29 @@ PacifidlogTown_House3_EventScript_203C11:: @ 8203C11
 	special sub_807F0E4
 	waitstate
 	bufferspeciesname 0, VAR_0x8009
-	msgbox PacifidlogTown_House3_Text_203D87, 4
+	msgbox PacifidlogTown_House3_Text_203D87, MSGBOX_DEFAULT
 	setflag FLAG_0x09A
 	release
 	end
 
 PacifidlogTown_House3_EventScript_203C93:: @ 8203C93
-	msgbox PacifidlogTown_House3_Text_203E12, 4
+	msgbox PacifidlogTown_House3_Text_203E12, MSGBOX_DEFAULT
 	release
 	end
 
 PacifidlogTown_House3_EventScript_203C9D:: @ 8203C9D
 	bufferspeciesname 0, VAR_0x8009
-	msgbox PacifidlogTown_House3_Text_203DDE, 4
+	msgbox PacifidlogTown_House3_Text_203DDE, MSGBOX_DEFAULT
 	release
 	end
 
 PacifidlogTown_House3_EventScript_203CAB:: @ 8203CAB
-	msgbox PacifidlogTown_House3_Text_203E7F, 4
+	msgbox PacifidlogTown_House3_Text_203E7F, MSGBOX_DEFAULT
 	release
 	end
 
 PacifidlogTown_House3_EventScript_203CB5:: @ 8203CB5
-	msgbox PacifidlogTown_House3_Text_203EF1, 2
+	msgbox PacifidlogTown_House3_Text_203EF1, MSGBOX_NPC
 	end
 
 PacifidlogTown_House3_Text_203CBE: @ 8203CBE

--- a/data/maps/PacifidlogTown_House4/scripts.inc
+++ b/data/maps/PacifidlogTown_House4/scripts.inc
@@ -2,17 +2,17 @@ PacifidlogTown_House4_MapScripts:: @ 8203F4B
 	.byte 0
 
 PacifidlogTown_House4_EventScript_203F4C:: @ 8203F4C
-	msgbox PacifidlogTown_House4_Text_204017, 2
+	msgbox PacifidlogTown_House4_Text_204017, MSGBOX_NPC
 	end
 
 PacifidlogTown_House4_EventScript_203F55:: @ 8203F55
-	msgbox PacifidlogTown_House4_Text_203F93, 2
+	msgbox PacifidlogTown_House4_Text_203F93, MSGBOX_NPC
 	end
 
 PacifidlogTown_House4_EventScript_203F5E:: @ 8203F5E
 	lock
 	faceplayer
-	msgbox PacifidlogTown_House4_Text_204035, 5
+	msgbox PacifidlogTown_House4_Text_204035, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq PacifidlogTown_House4_EventScript_203F7F
 	compare VAR_RESULT, 0
@@ -20,12 +20,12 @@ PacifidlogTown_House4_EventScript_203F5E:: @ 8203F5E
 	end
 
 PacifidlogTown_House4_EventScript_203F7F:: @ 8203F7F
-	msgbox PacifidlogTown_House4_Text_20404E, 4
+	msgbox PacifidlogTown_House4_Text_20404E, MSGBOX_DEFAULT
 	release
 	end
 
 PacifidlogTown_House4_EventScript_203F89:: @ 8203F89
-	msgbox PacifidlogTown_House4_Text_204084, 4
+	msgbox PacifidlogTown_House4_Text_204084, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/PacifidlogTown_House5/scripts.inc
+++ b/data/maps/PacifidlogTown_House5/scripts.inc
@@ -7,17 +7,17 @@ PacifidlogTown_House5_EventScript_204111:: @ 8204111
 	specialvar VAR_RESULT, IsMirageIslandPresent
 	compare VAR_RESULT, 1
 	goto_eq PacifidlogTown_House5_EventScript_20412D
-	msgbox PacifidlogTown_House5_Text_204140, 4
+	msgbox PacifidlogTown_House5_Text_204140, MSGBOX_DEFAULT
 	release
 	end
 
 PacifidlogTown_House5_EventScript_20412D:: @ 820412D
-	msgbox PacifidlogTown_House5_Text_204161, 4
+	msgbox PacifidlogTown_House5_Text_204161, MSGBOX_DEFAULT
 	release
 	end
 
 PacifidlogTown_House5_EventScript_204137:: @ 8204137
-	msgbox PacifidlogTown_House5_Text_20418B, 2
+	msgbox PacifidlogTown_House5_Text_20418B, MSGBOX_NPC
 	end
 
 PacifidlogTown_House5_Text_204140: @ 8204140

--- a/data/maps/PacifidlogTown_PokemonCenter_1F/scripts.inc
+++ b/data/maps/PacifidlogTown_PokemonCenter_1F/scripts.inc
@@ -16,15 +16,15 @@ PacifidlogTown_PokemonCenter_1F_EventScript_2034B6:: @ 82034B6
 	end
 
 PacifidlogTown_PokemonCenter_1F_EventScript_2034C4:: @ 82034C4
-	msgbox PacifidlogTown_PokemonCenter_1F_Text_2034DF, 2
+	msgbox PacifidlogTown_PokemonCenter_1F_Text_2034DF, MSGBOX_NPC
 	end
 
 PacifidlogTown_PokemonCenter_1F_EventScript_2034CD:: @ 82034CD
-	msgbox PacifidlogTown_PokemonCenter_1F_Text_20350F, 2
+	msgbox PacifidlogTown_PokemonCenter_1F_Text_20350F, MSGBOX_NPC
 	end
 
 PacifidlogTown_PokemonCenter_1F_EventScript_2034D6:: @ 82034D6
-	msgbox PacifidlogTown_PokemonCenter_1F_Text_20356F, 2
+	msgbox PacifidlogTown_PokemonCenter_1F_Text_20356F, MSGBOX_NPC
 	end
 
 PacifidlogTown_PokemonCenter_1F_Text_2034DF: @ 82034DF

--- a/data/maps/PetalburgCity/scripts.inc
+++ b/data/maps/PetalburgCity/scripts.inc
@@ -35,13 +35,13 @@ PetalburgCity_EventScript_1DC32E:: @ 81DC32E
 	applymovement 2, PetalburgCity_Movement_1DC451
 	applymovement 255, PetalburgCity_Movement_1DC430
 	waitmovement 0
-	msgbox PetalburgCity_Text_1EC1F8, 4
+	msgbox PetalburgCity_Text_1EC1F8, MSGBOX_DEFAULT
 	special StartWallyTutorialBattle
 	waitstate
-	msgbox PetalburgCity_Text_1EC271, 4
+	msgbox PetalburgCity_Text_1EC271, MSGBOX_DEFAULT
 	applymovement 2, PetalburgCity_Movement_2725A4, MAP_PETALBURG_CITY
 	waitmovement 2, MAP_PETALBURG_CITY
-	msgbox PetalburgCity_Text_1EC297, 4
+	msgbox PetalburgCity_Text_1EC297, MSGBOX_DEFAULT
 	closemessage
 	clearflag FLAG_SPECIAL_FLAG_0x4000
 	setvar VAR_0x4057, 3
@@ -82,7 +82,7 @@ PetalburgCity_EventScript_1DC390:: @ 81DC390
 PetalburgCity_EventScript_1DC3E6:: @ 81DC3E6
 	lock
 	faceplayer
-	msgbox PetalburgCity_Text_1DC985, 4
+	msgbox PetalburgCity_Text_1DC985, MSGBOX_DEFAULT
 	closemessage
 	applymovement 3, PetalburgCity_Movement_2725A2
 	waitmovement 0
@@ -90,7 +90,7 @@ PetalburgCity_EventScript_1DC3E6:: @ 81DC3E6
 	end
 
 PetalburgCity_EventScript_1DC3FD:: @ 81DC3FD
-	msgbox PetalburgCity_Text_1DC837, 2
+	msgbox PetalburgCity_Text_1DC837, MSGBOX_NPC
 	end
 
 PetalburgCity_Movement_1DC406: @ 81DC406
@@ -218,19 +218,19 @@ PetalburgCity_Movement_1DC451: @ 81DC451
 	step_end
 
 PetalburgCity_EventScript_1DC476:: @ 81DC476
-	msgbox PetalburgCity_Text_1DCAAA, 3
+	msgbox PetalburgCity_Text_1DCAAA, MSGBOX_SIGN
 	end
 
 PetalburgCity_EventScript_1DC47F:: @ 81DC47F
-	msgbox PetalburgCity_Text_1DCAF1, 3
+	msgbox PetalburgCity_Text_1DCAF1, MSGBOX_SIGN
 	end
 
 PetalburgCity_EventScript_1DC488:: @ 81DC488
-	msgbox PetalburgCity_Text_1DCA30, 2
+	msgbox PetalburgCity_Text_1DCA30, MSGBOX_NPC
 	end
 
 PetalburgCity_EventScript_1DC491:: @ 81DC491
-	msgbox PetalburgCity_Text_1DCB23, 3
+	msgbox PetalburgCity_Text_1DCB23, MSGBOX_SIGN
 	end
 
 PetalburgCity_EventScript_1DC49A:: @ 81DC49A
@@ -274,7 +274,7 @@ PetalburgCity_EventScript_1DC4CA:: @ 81DC4CA
 	call_if 1, PetalburgCity_EventScript_1DC59F
 	compare VAR_0x8008, 3
 	call_if 1, PetalburgCity_EventScript_1DC5B4
-	msgbox PetalburgCity_Text_1DC881, 4
+	msgbox PetalburgCity_Text_1DC881, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_0x8008, 0
 	call_if 1, PetalburgCity_EventScript_1DC5C9
@@ -284,11 +284,11 @@ PetalburgCity_EventScript_1DC4CA:: @ 81DC4CA
 	call_if 1, PetalburgCity_EventScript_1DC5ED
 	compare VAR_0x8008, 3
 	call_if 1, PetalburgCity_EventScript_1DC5FF
-	msgbox PetalburgCity_Text_1DC91B, 4
+	msgbox PetalburgCity_Text_1DC91B, MSGBOX_DEFAULT
 	applymovement 8, PetalburgCity_Movement_2725A8
 	applymovement 255, PetalburgCity_Movement_2725A8
 	waitmovement 0
-	msgbox PetalburgCity_Text_1DC93E, 4
+	msgbox PetalburgCity_Text_1DC93E, MSGBOX_DEFAULT
 	closemessage
 	applymovement 8, PetalburgCity_Movement_1DC658
 	waitmovement 0
@@ -547,17 +547,17 @@ PetalburgCity_EventScript_1DC6E9:: @ 81DC6E9
 	applymovement 255, PetalburgCity_Movement_2725A8
 	waitmovement 0
 	setvar VAR_0x40D1, 1
-	msgbox PetalburgCity_Text_1DCB31, 4
+	msgbox PetalburgCity_Text_1DCB31, MSGBOX_DEFAULT
 	closemessage
 	applymovement 9, PetalburgCity_Movement_2725A8
 	waitmovement 0
 	delay 30
-	msgbox PetalburgCity_Text_1DCB82, 4
+	msgbox PetalburgCity_Text_1DCB82, MSGBOX_DEFAULT
 	closemessage
 	applymovement 9, PetalburgCity_Movement_2725A4
 	waitmovement 0
 	delay 30
-	msgbox PetalburgCity_Text_1DCC09, 4
+	msgbox PetalburgCity_Text_1DCC09, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_0x8008, 0
 	call_if 1, PetalburgCity_EventScript_1DC78E
@@ -705,7 +705,7 @@ PetalburgCity_Movement_1DC828: @ 81DC828
 	step_end
 
 PetalburgCity_EventScript_1DC82E:: @ 81DC82E
-	msgbox PetalburgCity_Text_1DC881, 2
+	msgbox PetalburgCity_Text_1DC881, MSGBOX_NPC
 	end
 
 PetalburgCity_Text_1DC837: @ 81DC837

--- a/data/maps/PetalburgCity_Gym/scripts.inc
+++ b/data/maps/PetalburgCity_Gym/scripts.inc
@@ -88,8 +88,8 @@ PetalburgCity_Gym_MapScript2_20499A: @ 820499A
 
 PetalburgCity_Gym_EventScript_2049A4:: @ 82049A4
 	lockall
-	msgbox PetalburgCity_Gym_Text_205B32, 4
-	msgbox PetalburgCity_Gym_Text_205B4C, 4
+	msgbox PetalburgCity_Gym_Text_205B32, MSGBOX_DEFAULT
+	msgbox PetalburgCity_Gym_Text_205B4C, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, PetalburgCity_Gym_Movement_2725AA
 	applymovement 10, PetalburgCity_Gym_Movement_2049EC
@@ -100,7 +100,7 @@ PetalburgCity_Gym_EventScript_2049A4:: @ 82049A4
 	delay 30
 	applymovement 255, PetalburgCity_Gym_Movement_2725A6
 	waitmovement 0
-	msgbox PetalburgCity_Gym_Text_205C40, 4
+	msgbox PetalburgCity_Gym_Text_205C40, MSGBOX_DEFAULT
 	setvar VAR_0x4085, 2
 	releaseall
 	end
@@ -123,7 +123,7 @@ PetalburgCity_Gym_EventScript_2049F1:: @ 82049F1
 	case 6, PetalburgCity_Gym_EventScript_204E3B
 	case 7, PetalburgCity_Gym_EventScript_204D80
 	case 8, PetalburgCity_Gym_EventScript_204DB3
-	msgbox PetalburgCity_Gym_Text_2057A2, 4
+	msgbox PetalburgCity_Gym_Text_2057A2, MSGBOX_DEFAULT
 	closemessage
 	switch VAR_FACING
 	case 1, PetalburgCity_Gym_EventScript_204A80
@@ -163,10 +163,10 @@ PetalburgCity_Gym_EventScript_204AAC:: @ 8204AAC
 	call_if 1, PetalburgCity_Gym_EventScript_204C5F
 	compare VAR_0x8008, 3
 	call_if 1, PetalburgCity_Gym_EventScript_204C5F
-	msgbox PetalburgCity_Gym_Text_2058B1, 4
-	msgbox PetalburgCity_Gym_Text_2058DB, 4
-	msgbox PetalburgCity_Gym_Text_205910, 4
-	msgbox PetalburgCity_Gym_Text_2059D8, 4
+	msgbox PetalburgCity_Gym_Text_2058B1, MSGBOX_DEFAULT
+	msgbox PetalburgCity_Gym_Text_2058DB, MSGBOX_DEFAULT
+	msgbox PetalburgCity_Gym_Text_205910, MSGBOX_DEFAULT
+	msgbox PetalburgCity_Gym_Text_2059D8, MSGBOX_DEFAULT
 	compare VAR_0x8008, 0
 	call_if 1, PetalburgCity_Gym_EventScript_204CC7
 	compare VAR_0x8008, 1
@@ -175,7 +175,7 @@ PetalburgCity_Gym_EventScript_204AAC:: @ 8204AAC
 	call_if 1, PetalburgCity_Gym_EventScript_204CE4
 	compare VAR_0x8008, 3
 	call_if 1, PetalburgCity_Gym_EventScript_204CF6
-	msgbox PetalburgCity_Gym_Text_2059E8, 4
+	msgbox PetalburgCity_Gym_Text_2059E8, MSGBOX_DEFAULT
 	compare VAR_0x8008, 0
 	call_if 1, PetalburgCity_Gym_EventScript_204D08
 	compare VAR_0x8008, 1
@@ -184,9 +184,9 @@ PetalburgCity_Gym_EventScript_204AAC:: @ 8204AAC
 	call_if 1, PetalburgCity_Gym_EventScript_204D1E
 	compare VAR_0x8008, 3
 	call_if 1, PetalburgCity_Gym_EventScript_204D29
-	msgbox PetalburgCity_Gym_Text_205A46, 4
-	msgbox PetalburgCity_Gym_Text_205A89, 4
-	msgbox PetalburgCity_Gym_Text_205AF4, 4
+	msgbox PetalburgCity_Gym_Text_205A46, MSGBOX_DEFAULT
+	msgbox PetalburgCity_Gym_Text_205A89, MSGBOX_DEFAULT
+	msgbox PetalburgCity_Gym_Text_205AF4, MSGBOX_DEFAULT
 	compare VAR_0x8008, 0
 	call_if 1, PetalburgCity_Gym_EventScript_204D72
 	compare VAR_0x8008, 1
@@ -203,7 +203,7 @@ PetalburgCity_Gym_EventScript_204AAC:: @ 8204AAC
 	call_if 1, PetalburgCity_Gym_EventScript_204D34
 	compare VAR_0x8008, 3
 	call_if 1, PetalburgCity_Gym_EventScript_204D34
-	msgbox PetalburgCity_Gym_Text_205B0F, 4
+	msgbox PetalburgCity_Gym_Text_205B0F, MSGBOX_DEFAULT
 	closemessage
 	setflag FLAG_SPECIAL_FLAG_0x4001
 	playbgm MUS_TSURETEK, 0
@@ -328,22 +328,22 @@ PetalburgCity_Gym_EventScript_204D3F:: @ 8204D3F
 	return
 
 PetalburgCity_Gym_EventScript_204D4A:: @ 8204D4A
-	msgbox PetalburgCity_Gym_Text_205DB4, 4
+	msgbox PetalburgCity_Gym_Text_205DB4, MSGBOX_DEFAULT
 	release
 	end
 
 PetalburgCity_Gym_EventScript_204D54:: @ 8204D54
-	msgbox PetalburgCity_Gym_Text_205EAE, 4
+	msgbox PetalburgCity_Gym_Text_205EAE, MSGBOX_DEFAULT
 	release
 	end
 
 PetalburgCity_Gym_EventScript_204D5E:: @ 8204D5E
-	msgbox PetalburgCity_Gym_Text_205F87, 4
+	msgbox PetalburgCity_Gym_Text_205F87, MSGBOX_DEFAULT
 	release
 	end
 
 PetalburgCity_Gym_EventScript_204D68:: @ 8204D68
-	msgbox PetalburgCity_Gym_Text_205F87, 4
+	msgbox PetalburgCity_Gym_Text_205F87, MSGBOX_DEFAULT
 	release
 	end
 
@@ -369,7 +369,7 @@ PetalburgCity_Gym_EventScript_204D80:: @ 8204D80
 	goto_if 0, PetalburgCity_Gym_EventScript_204DAC
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_eq PetalburgCity_Gym_EventScript_20512D
-	msgbox PetalburgCity_Gym_Text_206417, 4
+	msgbox PetalburgCity_Gym_Text_206417, MSGBOX_DEFAULT
 	release
 	end
 
@@ -380,7 +380,7 @@ PetalburgCity_Gym_EventScript_204DAC:: @ 8204DAC
 
 PetalburgCity_Gym_EventScript_204DB3:: @ 8204DB3
 	trainerbattle 7, TRAINER_NORMAN_1, 0, PetalburgCity_Gym_Text_2074A2, PetalburgCity_Gym_Text_2075CE, PetalburgCity_Gym_Text_20764A
-	msgbox PetalburgCity_Gym_Text_2075F7, 6
+	msgbox PetalburgCity_Gym_Text_2075F7, MSGBOX_AUTOCLOSE
 	end
 
 PetalburgCity_Gym_EventScript_204DCE:: @ 8204DCE
@@ -395,7 +395,7 @@ PetalburgCity_Gym_EventScript_204DCE:: @ 8204DCE
 	goto_eq PetalburgCity_Gym_EventScript_204E17
 	compare VAR_ENIGMA_BERRY_AVAILABLE, 0
 	goto_eq PetalburgCity_Gym_EventScript_204E17
-	msgbox PetalburgCity_Gym_Text_2A6D3D, 4
+	msgbox PetalburgCity_Gym_Text_2A6D3D, MSGBOX_DEFAULT
 	setvar VAR_RESULT, 1
 	return
 
@@ -412,12 +412,12 @@ PetalburgCity_Gym_EventScript_204E1D:: @ 8204E1D
 	end
 
 PetalburgCity_Gym_EventScript_204E3B:: @ 8204E3B
-	msgbox PetalburgCity_Gym_Text_205FE5, 4
+	msgbox PetalburgCity_Gym_Text_205FE5, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_NORMAN_1, 0, PetalburgCity_Gym_Text_206107
 	message PetalburgCity_Gym_Text_206162
 	waitmessage
 	call PetalburgCity_Gym_EventScript_27207E
-	msgbox PetalburgCity_Gym_Text_20618A, 4
+	msgbox PetalburgCity_Gym_Text_20618A, MSGBOX_DEFAULT
 	setflag FLAG_0x4F4
 	setvar VAR_0x4085, 7
 	setflag FLAG_BADGE05_GET
@@ -432,7 +432,7 @@ PetalburgCity_Gym_EventScript_204E3B:: @ 8204E3B
 	special DrawWholeMapView
 	call PetalburgCity_Gym_EventScript_204ED2
 	delay 30
-	msgbox PetalburgCity_Gym_Text_2062FB, 4
+	msgbox PetalburgCity_Gym_Text_2062FB, MSGBOX_DEFAULT
 	closemessage
 	delay 40
 	playse SE_DOOR
@@ -449,7 +449,7 @@ PetalburgCity_Gym_EventScript_204ED2:: @ 8204ED2
 	compare VAR_RESULT, 0
 	goto_eq PetalburgCity_Gym_EventScript_27205E
 	setflag FLAG_0x0A9
-	msgbox PetalburgCity_Gym_Text_206254, 4
+	msgbox PetalburgCity_Gym_Text_206254, MSGBOX_DEFAULT
 	return
 
 PetalburgCity_Gym_EventScript_204EF5:: @ 8204EF5
@@ -479,7 +479,7 @@ PetalburgCity_Gym_EventScript_204F13:: @ 8204F13
 	call_if 1, PetalburgCity_Gym_EventScript_205009
 	compare VAR_0x8008, 3
 	call_if 1, PetalburgCity_Gym_EventScript_205025
-	msgbox PetalburgCity_Gym_Text_206377, 4
+	msgbox PetalburgCity_Gym_Text_206377, MSGBOX_DEFAULT
 	closemessage
 	delay 20
 	compare VAR_0x8008, 1
@@ -488,7 +488,7 @@ PetalburgCity_Gym_EventScript_204F13:: @ 8204F13
 	call_if 1, PetalburgCity_Gym_EventScript_204FD7
 	compare VAR_0x8008, 3
 	call_if 1, PetalburgCity_Gym_EventScript_204FE2
-	msgbox PetalburgCity_Gym_Text_2063CA, 4
+	msgbox PetalburgCity_Gym_Text_2063CA, MSGBOX_DEFAULT
 	closemessage
 	setflag FLAG_SPECIAL_FLAG_0x4001
 	playbgm MUS_TSURETEK, 0
@@ -780,7 +780,7 @@ PetalburgCity_Gym_Movement_205123: @ 8205123
 	step_end
 
 PetalburgCity_Gym_EventScript_20512D:: @ 820512D
-	msgbox PetalburgCity_Gym_Text_2064C3, 4
+	msgbox PetalburgCity_Gym_Text_2064C3, MSGBOX_DEFAULT
 	release
 	end
 
@@ -790,7 +790,7 @@ PetalburgCity_Gym_EventScript_205137:: @ 8205137
 	goto_if 0, PetalburgCity_Gym_EventScript_20517D
 	setvar VAR_0x8008, 7
 	setvar VAR_0x8009, 85
-	msgbox PetalburgCity_Gym_Text_20721E, 5
+	msgbox PetalburgCity_Gym_Text_20721E, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq PetalburgCity_Gym_EventScript_20516C
 	compare VAR_RESULT, 0
@@ -810,7 +810,7 @@ PetalburgCity_Gym_EventScript_20517B:: @ 820517B
 	end
 
 PetalburgCity_Gym_EventScript_20517D:: @ 820517D
-	msgbox PetalburgCity_Gym_Text_2071F4, 4
+	msgbox PetalburgCity_Gym_Text_2071F4, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -820,7 +820,7 @@ PetalburgCity_Gym_EventScript_205187:: @ 8205187
 	goto_if 0, PetalburgCity_Gym_EventScript_20517D
 	setvar VAR_0x8008, 1
 	setvar VAR_0x8009, 98
-	msgbox PetalburgCity_Gym_Text_207280, 5
+	msgbox PetalburgCity_Gym_Text_207280, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq PetalburgCity_Gym_EventScript_20516C
 	compare VAR_RESULT, 0
@@ -833,7 +833,7 @@ PetalburgCity_Gym_EventScript_2051BC:: @ 82051BC
 	goto_if 0, PetalburgCity_Gym_EventScript_20517D
 	setvar VAR_0x8008, 7
 	setvar VAR_0x8009, 46
-	msgbox PetalburgCity_Gym_Text_2072BB, 5
+	msgbox PetalburgCity_Gym_Text_2072BB, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq PetalburgCity_Gym_EventScript_20516C
 	compare VAR_RESULT, 0
@@ -846,7 +846,7 @@ PetalburgCity_Gym_EventScript_2051EF:: @ 82051EF
 	goto_if 0, PetalburgCity_Gym_EventScript_20517D
 	setvar VAR_0x8008, 1
 	setvar VAR_0x8009, 59
-	msgbox PetalburgCity_Gym_Text_2072F7, 5
+	msgbox PetalburgCity_Gym_Text_2072F7, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq PetalburgCity_Gym_EventScript_20516C
 	compare VAR_RESULT, 0
@@ -859,7 +859,7 @@ PetalburgCity_Gym_EventScript_205222:: @ 8205222
 	goto_if 0, PetalburgCity_Gym_EventScript_20517D
 	setvar VAR_0x8008, 7
 	setvar VAR_0x8009, 59
-	msgbox PetalburgCity_Gym_Text_2072F7, 5
+	msgbox PetalburgCity_Gym_Text_2072F7, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq PetalburgCity_Gym_EventScript_20516C
 	compare VAR_RESULT, 0
@@ -872,7 +872,7 @@ PetalburgCity_Gym_EventScript_205255:: @ 8205255
 	goto_if 0, PetalburgCity_Gym_EventScript_20517D
 	setvar VAR_0x8008, 1
 	setvar VAR_0x8009, 72
-	msgbox PetalburgCity_Gym_Text_207331, 5
+	msgbox PetalburgCity_Gym_Text_207331, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq PetalburgCity_Gym_EventScript_20516C
 	compare VAR_RESULT, 0
@@ -885,7 +885,7 @@ PetalburgCity_Gym_EventScript_205288:: @ 8205288
 	goto_if 0, PetalburgCity_Gym_EventScript_20517D
 	setvar VAR_0x8008, 1
 	setvar VAR_0x8009, 20
-	msgbox PetalburgCity_Gym_Text_20736C, 5
+	msgbox PetalburgCity_Gym_Text_20736C, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq PetalburgCity_Gym_EventScript_20516C
 	compare VAR_RESULT, 0
@@ -898,7 +898,7 @@ PetalburgCity_Gym_EventScript_2052BB:: @ 82052BB
 	goto_if 0, PetalburgCity_Gym_EventScript_20517D
 	setvar VAR_0x8008, 7
 	setvar VAR_0x8009, 20
-	msgbox PetalburgCity_Gym_Text_20736C, 5
+	msgbox PetalburgCity_Gym_Text_20736C, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq PetalburgCity_Gym_EventScript_20516C
 	compare VAR_RESULT, 0
@@ -911,7 +911,7 @@ PetalburgCity_Gym_EventScript_2052EE:: @ 82052EE
 	goto_if 0, PetalburgCity_Gym_EventScript_20517D
 	setvar VAR_0x8008, 1
 	setvar VAR_0x8009, 33
-	msgbox PetalburgCity_Gym_Text_2073A7, 5
+	msgbox PetalburgCity_Gym_Text_2073A7, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq PetalburgCity_Gym_EventScript_20516C
 	compare VAR_RESULT, 0
@@ -924,7 +924,7 @@ PetalburgCity_Gym_EventScript_205321:: @ 8205321
 	goto_if 0, PetalburgCity_Gym_EventScript_20517D
 	setvar VAR_0x8008, 7
 	setvar VAR_0x8009, 33
-	msgbox PetalburgCity_Gym_Text_2073A7, 5
+	msgbox PetalburgCity_Gym_Text_2073A7, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq PetalburgCity_Gym_EventScript_20516C
 	compare VAR_RESULT, 0
@@ -937,7 +937,7 @@ PetalburgCity_Gym_EventScript_205354:: @ 8205354
 	goto_if 0, PetalburgCity_Gym_EventScript_20517D
 	setvar VAR_0x8008, 1
 	setvar VAR_0x8009, 7
-	msgbox PetalburgCity_Gym_Text_2073E4, 5
+	msgbox PetalburgCity_Gym_Text_2073E4, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq PetalburgCity_Gym_EventScript_20516C
 	compare VAR_RESULT, 0
@@ -950,7 +950,7 @@ PetalburgCity_Gym_EventScript_205387:: @ 8205387
 	goto_if 0, PetalburgCity_Gym_EventScript_20517D
 	setvar VAR_0x8008, 7
 	setvar VAR_0x8009, 7
-	msgbox PetalburgCity_Gym_Text_2073E4, 5
+	msgbox PetalburgCity_Gym_Text_2073E4, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq PetalburgCity_Gym_EventScript_20516C
 	compare VAR_RESULT, 0
@@ -961,7 +961,7 @@ PetalburgCity_Gym_EventScript_2053BA:: @ 82053BA
 	trainerbattle 2, TRAINER_RANDALL, 0, PetalburgCity_Gym_Text_20674F, PetalburgCity_Gym_Text_2067B9, PetalburgCity_Gym_EventScript_2053DE
 	checkflag FLAG_0x4F4
 	goto_eq PetalburgCity_Gym_EventScript_2053ED
-	msgbox PetalburgCity_Gym_Text_2067D8, 6
+	msgbox PetalburgCity_Gym_Text_2067D8, MSGBOX_AUTOCLOSE
 	end
 
 PetalburgCity_Gym_EventScript_2053DE:: @ 82053DE
@@ -972,14 +972,14 @@ PetalburgCity_Gym_EventScript_2053DE:: @ 82053DE
 	end
 
 PetalburgCity_Gym_EventScript_2053ED:: @ 82053ED
-	msgbox PetalburgCity_Gym_Text_20685E, 2
+	msgbox PetalburgCity_Gym_Text_20685E, MSGBOX_NPC
 	end
 
 PetalburgCity_Gym_EventScript_2053F6:: @ 82053F6
 	trainerbattle 2, TRAINER_PARKER, 0, PetalburgCity_Gym_Text_2068FD, PetalburgCity_Gym_Text_20694F, PetalburgCity_Gym_EventScript_20541A
 	checkflag FLAG_0x4F4
 	goto_eq PetalburgCity_Gym_EventScript_205429
-	msgbox PetalburgCity_Gym_Text_206996, 6
+	msgbox PetalburgCity_Gym_Text_206996, MSGBOX_AUTOCLOSE
 	end
 
 PetalburgCity_Gym_EventScript_20541A:: @ 820541A
@@ -990,14 +990,14 @@ PetalburgCity_Gym_EventScript_20541A:: @ 820541A
 	end
 
 PetalburgCity_Gym_EventScript_205429:: @ 8205429
-	msgbox PetalburgCity_Gym_Text_2069D9, 2
+	msgbox PetalburgCity_Gym_Text_2069D9, MSGBOX_NPC
 	end
 
 PetalburgCity_Gym_EventScript_205432:: @ 8205432
 	trainerbattle 2, TRAINER_GEORGE, 0, PetalburgCity_Gym_Text_206A1B, PetalburgCity_Gym_Text_206AB8, PetalburgCity_Gym_EventScript_205456
 	checkflag FLAG_0x4F4
 	goto_eq PetalburgCity_Gym_EventScript_205465
-	msgbox PetalburgCity_Gym_Text_206AE9, 6
+	msgbox PetalburgCity_Gym_Text_206AE9, MSGBOX_AUTOCLOSE
 	end
 
 PetalburgCity_Gym_EventScript_205456:: @ 8205456
@@ -1008,14 +1008,14 @@ PetalburgCity_Gym_EventScript_205456:: @ 8205456
 	end
 
 PetalburgCity_Gym_EventScript_205465:: @ 8205465
-	msgbox PetalburgCity_Gym_Text_206BB1, 2
+	msgbox PetalburgCity_Gym_Text_206BB1, MSGBOX_NPC
 	end
 
 PetalburgCity_Gym_EventScript_20546E:: @ 820546E
 	trainerbattle 2, TRAINER_BERKE, 0, PetalburgCity_Gym_Text_206BF4, PetalburgCity_Gym_Text_206C7D, PetalburgCity_Gym_EventScript_205492
 	checkflag FLAG_0x4F4
 	goto_eq PetalburgCity_Gym_EventScript_2054A1
-	msgbox PetalburgCity_Gym_Text_206C9F, 6
+	msgbox PetalburgCity_Gym_Text_206C9F, MSGBOX_AUTOCLOSE
 	end
 
 PetalburgCity_Gym_EventScript_205492:: @ 8205492
@@ -1026,14 +1026,14 @@ PetalburgCity_Gym_EventScript_205492:: @ 8205492
 	end
 
 PetalburgCity_Gym_EventScript_2054A1:: @ 82054A1
-	msgbox PetalburgCity_Gym_Text_206D56, 2
+	msgbox PetalburgCity_Gym_Text_206D56, MSGBOX_NPC
 	end
 
 PetalburgCity_Gym_EventScript_2054AA:: @ 82054AA
 	trainerbattle 2, TRAINER_MARY, 0, PetalburgCity_Gym_Text_206DB2, PetalburgCity_Gym_Text_206E0D, PetalburgCity_Gym_EventScript_2054CE
 	checkflag FLAG_0x4F4
 	goto_eq PetalburgCity_Gym_EventScript_2054DD
-	msgbox PetalburgCity_Gym_Text_206E26, 6
+	msgbox PetalburgCity_Gym_Text_206E26, MSGBOX_AUTOCLOSE
 	end
 
 PetalburgCity_Gym_EventScript_2054CE:: @ 82054CE
@@ -1044,14 +1044,14 @@ PetalburgCity_Gym_EventScript_2054CE:: @ 82054CE
 	end
 
 PetalburgCity_Gym_EventScript_2054DD:: @ 82054DD
-	msgbox PetalburgCity_Gym_Text_206ED8, 2
+	msgbox PetalburgCity_Gym_Text_206ED8, MSGBOX_NPC
 	end
 
 PetalburgCity_Gym_EventScript_2054E6:: @ 82054E6
 	trainerbattle 2, TRAINER_ALEXIA, 0, PetalburgCity_Gym_Text_206F44, PetalburgCity_Gym_Text_206F82, PetalburgCity_Gym_EventScript_20550A
 	checkflag FLAG_0x4F4
 	goto_eq PetalburgCity_Gym_EventScript_205519
-	msgbox PetalburgCity_Gym_Text_206F9F, 6
+	msgbox PetalburgCity_Gym_Text_206F9F, MSGBOX_AUTOCLOSE
 	end
 
 PetalburgCity_Gym_EventScript_20550A:: @ 820550A
@@ -1062,14 +1062,14 @@ PetalburgCity_Gym_EventScript_20550A:: @ 820550A
 	end
 
 PetalburgCity_Gym_EventScript_205519:: @ 8205519
-	msgbox PetalburgCity_Gym_Text_207069, 2
+	msgbox PetalburgCity_Gym_Text_207069, MSGBOX_NPC
 	end
 
 PetalburgCity_Gym_EventScript_205522:: @ 8205522
 	trainerbattle 2, TRAINER_JODY, 0, PetalburgCity_Gym_Text_207088, PetalburgCity_Gym_Text_2070E6, PetalburgCity_Gym_EventScript_205546
 	checkflag FLAG_0x4F4
 	goto_eq PetalburgCity_Gym_EventScript_205555
-	msgbox PetalburgCity_Gym_Text_2070FB, 6
+	msgbox PetalburgCity_Gym_Text_2070FB, MSGBOX_AUTOCLOSE
 	end
 
 PetalburgCity_Gym_EventScript_205546:: @ 8205546
@@ -1080,7 +1080,7 @@ PetalburgCity_Gym_EventScript_205546:: @ 8205546
 	end
 
 PetalburgCity_Gym_EventScript_205555:: @ 8205555
-	msgbox PetalburgCity_Gym_Text_207170, 2
+	msgbox PetalburgCity_Gym_Text_207170, MSGBOX_NPC
 	end
 
 PetalburgCity_Gym_EventScript_20555E:: @ 820555E
@@ -1217,12 +1217,12 @@ PetalburgCity_Gym_EventScript_20574F:: @ 820574F
 	faceplayer
 	checkflag FLAG_0x4F4
 	goto_eq PetalburgCity_Gym_EventScript_205764
-	msgbox PetalburgCity_Gym_Text_206542, 4
+	msgbox PetalburgCity_Gym_Text_206542, MSGBOX_DEFAULT
 	release
 	end
 
 PetalburgCity_Gym_EventScript_205764:: @ 8205764
-	msgbox PetalburgCity_Gym_Text_2066F3, 4
+	msgbox PetalburgCity_Gym_Text_2066F3, MSGBOX_DEFAULT
 	release
 	end
 
@@ -1241,12 +1241,12 @@ PetalburgCity_Gym_EventScript_20577E:: @ 820577E
 	end
 
 PetalburgCity_Gym_EventScript_20578E:: @ 820578E
-	msgbox PetalburgCity_Gym_Text_207467, 4
+	msgbox PetalburgCity_Gym_Text_207467, MSGBOX_DEFAULT
 	releaseall
 	end
 
 PetalburgCity_Gym_EventScript_205798:: @ 8205798
-	msgbox PetalburgCity_Gym_Text_20744C, 4
+	msgbox PetalburgCity_Gym_Text_20744C, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/PetalburgCity_House1/scripts.inc
+++ b/data/maps/PetalburgCity_House1/scripts.inc
@@ -2,11 +2,11 @@ PetalburgCity_House1_MapScripts:: @ 8207799
 	.byte 0
 
 PetalburgCity_House1_EventScript_20779A:: @ 820779A
-	msgbox PetalburgCity_House1_Text_2077AC, 2
+	msgbox PetalburgCity_House1_Text_2077AC, MSGBOX_NPC
 	end
 
 PetalburgCity_House1_EventScript_2077A3:: @ 82077A3
-	msgbox PetalburgCity_House1_Text_2077FB, 2
+	msgbox PetalburgCity_House1_Text_2077FB, MSGBOX_NPC
 	end
 
 PetalburgCity_House1_Text_2077AC: @ 82077AC

--- a/data/maps/PetalburgCity_House2/scripts.inc
+++ b/data/maps/PetalburgCity_House2/scripts.inc
@@ -2,11 +2,11 @@ PetalburgCity_House2_MapScripts:: @ 82078F2
 	.byte 0
 
 PetalburgCity_House2_EventScript_2078F3:: @ 82078F3
-	msgbox PetalburgCity_House2_Text_207905, 2
+	msgbox PetalburgCity_House2_Text_207905, MSGBOX_NPC
 	end
 
 PetalburgCity_House2_EventScript_2078FC:: @ 82078FC
-	msgbox PetalburgCity_House2_Text_207969, 2
+	msgbox PetalburgCity_House2_Text_207969, MSGBOX_NPC
 	end
 
 PetalburgCity_House2_Text_207905: @ 8207905

--- a/data/maps/PetalburgCity_Mart/scripts.inc
+++ b/data/maps/PetalburgCity_Mart/scripts.inc
@@ -9,7 +9,7 @@ PetalburgCity_Mart_EventScript_207D69:: @ 8207D69
 	checkflag FLAG_0x128
 	goto_eq PetalburgCity_Mart_EventScript_207DA6
 	pokemart PetalburgCity_Mart_Pokemart_207D8C
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -32,7 +32,7 @@ PetalburgCity_Mart_Pokemart_207D8C: @ 8207D8C
 
 PetalburgCity_Mart_EventScript_207DA6:: @ 8207DA6
 	pokemart PetalburgCity_Mart_Pokemart_207DB8
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -56,15 +56,15 @@ PetalburgCity_Mart_Pokemart_207DB8: @ 8207DB8
 	end
 
 PetalburgCity_Mart_EventScript_207DD6:: @ 8207DD6
-	msgbox PetalburgCity_Mart_Text_207DF1, 2
+	msgbox PetalburgCity_Mart_Text_207DF1, MSGBOX_NPC
 	end
 
 PetalburgCity_Mart_EventScript_207DDF:: @ 8207DDF
-	msgbox PetalburgCity_Mart_Text_207E60, 2
+	msgbox PetalburgCity_Mart_Text_207E60, MSGBOX_NPC
 	end
 
 PetalburgCity_Mart_EventScript_207DE8:: @ 8207DE8
-	msgbox PetalburgCity_Mart_Text_207EB0, 2
+	msgbox PetalburgCity_Mart_Text_207EB0, MSGBOX_NPC
 	end
 
 PetalburgCity_Mart_Text_207DF1: @ 8207DF1

--- a/data/maps/PetalburgCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/PetalburgCity_PokemonCenter_1F/scripts.inc
@@ -17,17 +17,17 @@ PetalburgCity_PokemonCenter_1F_EventScript_2079FC:: @ 82079FC
 	end
 
 PetalburgCity_PokemonCenter_1F_EventScript_207A0A:: @ 8207A0A
-	msgbox PetalburgCity_PokemonCenter_1F_Text_207A76, 2
+	msgbox PetalburgCity_PokemonCenter_1F_Text_207A76, MSGBOX_NPC
 	end
 
 PetalburgCity_PokemonCenter_1F_EventScript_207A13:: @ 8207A13
-	msgbox PetalburgCity_PokemonCenter_1F_Text_207AD6, 2
+	msgbox PetalburgCity_PokemonCenter_1F_Text_207AD6, MSGBOX_NPC
 	end
 
 PetalburgCity_PokemonCenter_1F_EventScript_207A1C:: @ 8207A1C
 	lock
 	faceplayer
-	msgbox PetalburgCity_PokemonCenter_1F_Text_207B09, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_207B09, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, IsStarterInParty
 	compare VAR_RESULT, 1
 	goto_eq PetalburgCity_PokemonCenter_1F_EventScript_207A38
@@ -45,15 +45,15 @@ PetalburgCity_PokemonCenter_1F_EventScript_207A38:: @ 8207A38
 	end
 
 PetalburgCity_PokemonCenter_1F_EventScript_207A5B:: @ 8207A5B
-	msgbox PetalburgCity_PokemonCenter_1F_Text_207BB0, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_207BB0, MSGBOX_DEFAULT
 	return
 
 PetalburgCity_PokemonCenter_1F_EventScript_207A64:: @ 8207A64
-	msgbox PetalburgCity_PokemonCenter_1F_Text_207C35, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_207C35, MSGBOX_DEFAULT
 	return
 
 PetalburgCity_PokemonCenter_1F_EventScript_207A6D:: @ 8207A6D
-	msgbox PetalburgCity_PokemonCenter_1F_Text_207CB7, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_207CB7, MSGBOX_DEFAULT
 	return
 
 PetalburgCity_PokemonCenter_1F_Text_207A76: @ 8207A76

--- a/data/maps/PetalburgCity_WallysHouse/scripts.inc
+++ b/data/maps/PetalburgCity_WallysHouse/scripts.inc
@@ -18,10 +18,10 @@ PetalburgCity_WallysHouse_MapScript2_204247: @ 8204247
 
 PetalburgCity_WallysHouse_EventScript_204251:: @ 8204251
 	lockall
-	msgbox PetalburgCity_WallysHouse_Text_20446E, 4
+	msgbox PetalburgCity_WallysHouse_Text_20446E, MSGBOX_DEFAULT
 	giveitem_std ITEM_HM03
 	setflag FLAG_0x07A
-	msgbox PetalburgCity_WallysHouse_Text_20461A, 4
+	msgbox PetalburgCity_WallysHouse_Text_20461A, MSGBOX_DEFAULT
 	setvar VAR_0x4057, 5
 	releaseall
 	end
@@ -35,23 +35,23 @@ PetalburgCity_WallysHouse_EventScript_204278:: @ 8204278
 	goto_eq PetalburgCity_WallysHouse_EventScript_2042A2
 	checkflag FLAG_0x087
 	goto_eq PetalburgCity_WallysHouse_EventScript_2042B6
-	msgbox PetalburgCity_WallysHouse_Text_2042DF, 4
+	msgbox PetalburgCity_WallysHouse_Text_2042DF, MSGBOX_DEFAULT
 	setflag FLAG_0x087
 	release
 	end
 
 PetalburgCity_WallysHouse_EventScript_2042A2:: @ 82042A2
-	msgbox PetalburgCity_WallysHouse_Text_204661, 4
+	msgbox PetalburgCity_WallysHouse_Text_204661, MSGBOX_DEFAULT
 	release
 	end
 
 PetalburgCity_WallysHouse_EventScript_2042AC:: @ 82042AC
-	msgbox PetalburgCity_WallysHouse_Text_204698, 4
+	msgbox PetalburgCity_WallysHouse_Text_204698, MSGBOX_DEFAULT
 	release
 	end
 
 PetalburgCity_WallysHouse_EventScript_2042B6:: @ 82042B6
-	msgbox PetalburgCity_WallysHouse_Text_20444D, 4
+	msgbox PetalburgCity_WallysHouse_Text_20444D, MSGBOX_DEFAULT
 	release
 	end
 
@@ -60,12 +60,12 @@ PetalburgCity_WallysHouse_EventScript_2042C0:: @ 82042C0
 	faceplayer
 	checkflag FLAG_0x07A
 	goto_eq PetalburgCity_WallysHouse_EventScript_2042D5
-	msgbox PetalburgCity_WallysHouse_Text_204732, 4
+	msgbox PetalburgCity_WallysHouse_Text_204732, MSGBOX_DEFAULT
 	release
 	end
 
 PetalburgCity_WallysHouse_EventScript_2042D5:: @ 82042D5
-	msgbox PetalburgCity_WallysHouse_Text_2047A7, 4
+	msgbox PetalburgCity_WallysHouse_Text_2047A7, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/PetalburgWoods/scripts.inc
+++ b/data/maps/PetalburgWoods/scripts.inc
@@ -6,26 +6,26 @@ PetalburgWoods_EventScript_22DFD7:: @ 822DFD7
 	call PetalburgWoods_EventScript_22E124
 	applymovement 4, PetalburgWoods_Movement_22E1CB
 	waitmovement 0
-	msgbox PetalburgWoods_Text_22E34F, 4
+	msgbox PetalburgWoods_Text_22E34F, MSGBOX_DEFAULT
 	closemessage
 	playbgm MUS_AQA_0, 0
 	applymovement 3, PetalburgWoods_Movement_22E209
 	waitmovement 0
-	msgbox PetalburgWoods_Text_22E3AA, 4
+	msgbox PetalburgWoods_Text_22E3AA, MSGBOX_DEFAULT
 	closemessage
 	applymovement 3, PetalburgWoods_Movement_22E1F6
 	waitmovement 0
 	applymovement 4, PetalburgWoods_Movement_2725A6
 	waitmovement 0
-	msgbox PetalburgWoods_Text_22E428, 4
+	msgbox PetalburgWoods_Text_22E428, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, PetalburgWoods_Movement_22E1E4
 	waitmovement 0
-	msgbox PetalburgWoods_Text_22E457, 4
+	msgbox PetalburgWoods_Text_22E457, MSGBOX_DEFAULT
 	closemessage
 	applymovement 3, PetalburgWoods_Movement_22E20E
 	waitmovement 0
-	msgbox PetalburgWoods_Text_22E4A5, 4
+	msgbox PetalburgWoods_Text_22E4A5, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_GRUNT_8, 0, PetalburgWoods_Text_22E542
 	applymovement 3, PetalburgWoods_Movement_22E1F9
 	waitmovement 0
@@ -43,25 +43,25 @@ PetalburgWoods_EventScript_22E079:: @ 822E079
 	waitmovement 0
 	applymovement 255, PetalburgWoods_Movement_2725A4
 	waitmovement 0
-	msgbox PetalburgWoods_Text_22E34F, 4
+	msgbox PetalburgWoods_Text_22E34F, MSGBOX_DEFAULT
 	closemessage
 	playbgm MUS_AQA_0, 0
 	applymovement 3, PetalburgWoods_Movement_22E209
 	waitmovement 0
-	msgbox PetalburgWoods_Text_22E3AA, 4
+	msgbox PetalburgWoods_Text_22E3AA, MSGBOX_DEFAULT
 	closemessage
 	applymovement 3, PetalburgWoods_Movement_22E205
 	waitmovement 0
 	applymovement 4, PetalburgWoods_Movement_2725A6
 	waitmovement 0
-	msgbox PetalburgWoods_Text_22E428, 4
+	msgbox PetalburgWoods_Text_22E428, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, PetalburgWoods_Movement_22E1EA
 	waitmovement 0
-	msgbox PetalburgWoods_Text_22E457, 4
+	msgbox PetalburgWoods_Text_22E457, MSGBOX_DEFAULT
 	applymovement 255, PetalburgWoods_Movement_2725A6
 	waitmovement 0
-	msgbox PetalburgWoods_Text_22E4A5, 4
+	msgbox PetalburgWoods_Text_22E4A5, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_GRUNT_8, 0, PetalburgWoods_Text_22E542
 	applymovement 3, PetalburgWoods_Movement_22E1F9
 	waitmovement 0
@@ -75,19 +75,19 @@ PetalburgWoods_EventScript_22E079:: @ 822E079
 PetalburgWoods_EventScript_22E124:: @ 822E124
 	applymovement 4, PetalburgWoods_Movement_22E1B1
 	waitmovement 0
-	msgbox PetalburgWoods_Text_22E332, 4
+	msgbox PetalburgWoods_Text_22E332, MSGBOX_DEFAULT
 	closemessage
 	return
 
 PetalburgWoods_EventScript_22E138:: @ 822E138
-	msgbox PetalburgWoods_Text_22E563, 4
+	msgbox PetalburgWoods_Text_22E563, MSGBOX_DEFAULT
 	closemessage
 	applymovement 3, PetalburgWoods_Movement_22E1FD
 	waitmovement 0
 	removeobject 3
 	applymovement 255, PetalburgWoods_Movement_2725AA
 	waitmovement 0
-	msgbox PetalburgWoods_Text_22E63D, 4
+	msgbox PetalburgWoods_Text_22E63D, MSGBOX_DEFAULT
 	giveitem_std ITEM_GREAT_BALL
 	compare VAR_RESULT, 0
 	goto_eq PetalburgWoods_EventScript_22E17D
@@ -95,15 +95,15 @@ PetalburgWoods_EventScript_22E138:: @ 822E138
 	end
 
 PetalburgWoods_EventScript_22E17D:: @ 822E17D
-	msgbox PetalburgWoods_Text_22E741, 4
+	msgbox PetalburgWoods_Text_22E741, MSGBOX_DEFAULT
 	goto PetalburgWoods_EventScript_22E18B
 	end
 
 PetalburgWoods_EventScript_22E18B:: @ 822E18B
-	msgbox PetalburgWoods_Text_22E6C7, 4
+	msgbox PetalburgWoods_Text_22E6C7, MSGBOX_DEFAULT
 	applymovement 4, PetalburgWoods_Movement_22E1EE
 	waitmovement 0
-	msgbox PetalburgWoods_Text_22E712, 4
+	msgbox PetalburgWoods_Text_22E712, MSGBOX_DEFAULT
 	closemessage
 	return
 
@@ -239,11 +239,11 @@ PetalburgWoods_Movement_22E20E: @ 822E20E
 	step_end
 
 PetalburgWoods_EventScript_22E210:: @ 822E210
-	msgbox PetalburgWoods_Text_22EA0C, 2
+	msgbox PetalburgWoods_Text_22EA0C, MSGBOX_NPC
 	end
 
 PetalburgWoods_EventScript_22E219:: @ 822E219
-	msgbox PetalburgWoods_Text_22EA8B, 2
+	msgbox PetalburgWoods_Text_22EA8B, MSGBOX_NPC
 	end
 
 PetalburgWoods_EventScript_22E222:: @ 822E222
@@ -251,7 +251,7 @@ PetalburgWoods_EventScript_22E222:: @ 822E222
 	faceplayer
 	checkflag FLAG_0x129
 	goto_eq PetalburgWoods_EventScript_22E251
-	msgbox PetalburgWoods_Text_22EAFE, 4
+	msgbox PetalburgWoods_Text_22EAFE, MSGBOX_DEFAULT
 	giveitem_std ITEM_MIRACLE_SEED
 	compare VAR_RESULT, 0
 	goto_eq PetalburgWoods_EventScript_272054
@@ -260,21 +260,21 @@ PetalburgWoods_EventScript_22E222:: @ 822E222
 	end
 
 PetalburgWoods_EventScript_22E251:: @ 822E251
-	msgbox PetalburgWoods_Text_22EB63, 4
+	msgbox PetalburgWoods_Text_22EB63, MSGBOX_DEFAULT
 	release
 	end
 
 PetalburgWoods_EventScript_22E25B:: @ 822E25B
-	msgbox PetalburgWoods_Text_22EC10, 3
+	msgbox PetalburgWoods_Text_22EC10, MSGBOX_SIGN
 	end
 
 PetalburgWoods_EventScript_22E264:: @ 822E264
-	msgbox PetalburgWoods_Text_22ED07, 3
+	msgbox PetalburgWoods_Text_22ED07, MSGBOX_SIGN
 	end
 
 PetalburgWoods_EventScript_22E26D:: @ 822E26D
 	trainerbattle 0, TRAINER_LYLE, 0, PetalburgWoods_Text_22E77D, PetalburgWoods_Text_22E7C1
-	msgbox PetalburgWoods_Text_22E7EF, 6
+	msgbox PetalburgWoods_Text_22E7EF, MSGBOX_AUTOCLOSE
 	end
 
 PetalburgWoods_EventScript_22E284:: @ 822E284
@@ -286,7 +286,7 @@ PetalburgWoods_EventScript_22E284:: @ 822E284
 	specialvar VAR_RESULT, sub_813B4E0
 	compare VAR_RESULT, 0
 	goto_eq PetalburgWoods_EventScript_22E2EF
-	msgbox PetalburgWoods_Text_22E889, 4
+	msgbox PetalburgWoods_Text_22E889, MSGBOX_DEFAULT
 	release
 	end
 
@@ -299,33 +299,33 @@ PetalburgWoods_EventScript_22E2C5:: @ 822E2C5
 	end
 
 PetalburgWoods_EventScript_22E2D6:: @ 822E2D6
-	msgbox PetalburgWoods_Text_22E8C3, 4
+	msgbox PetalburgWoods_Text_22E8C3, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 621
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 621
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 PetalburgWoods_EventScript_22E2EF:: @ 822E2EF
 	checkflag FLAG_HAS_MATCH_CALL
 	goto_eq PetalburgWoods_EventScript_22E302
-	msgbox PetalburgWoods_Text_22E889, 4
+	msgbox PetalburgWoods_Text_22E889, MSGBOX_DEFAULT
 	release
 	end
 
 PetalburgWoods_EventScript_22E302:: @ 822E302
-	msgbox PetalburgWoods_Text_22E914, 4
+	msgbox PetalburgWoods_Text_22E914, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 621
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 621
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 PetalburgWoods_EventScript_22E31B:: @ 822E31B
 	trainerbattle 5, TRAINER_JAMES_1, 0, PetalburgWoods_Text_22E966, PetalburgWoods_Text_22E998
-	msgbox PetalburgWoods_Text_22E9B6, 6
+	msgbox PetalburgWoods_Text_22E9B6, MSGBOX_AUTOCLOSE
 	end
 
 PetalburgWoods_Text_22E332: @ 822E332

--- a/data/maps/PetalburgWoods/scripts.inc
+++ b/data/maps/PetalburgWoods/scripts.inc
@@ -300,10 +300,7 @@ PetalburgWoods_EventScript_22E2C5:: @ 822E2C5
 
 PetalburgWoods_EventScript_22E2D6:: @ 822E2D6
 	msgbox PetalburgWoods_Text_22E8C3, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 621
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 621
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_JAMES_1
 	release
 	end
 
@@ -316,10 +313,7 @@ PetalburgWoods_EventScript_22E2EF:: @ 822E2EF
 
 PetalburgWoods_EventScript_22E302:: @ 822E302
 	msgbox PetalburgWoods_Text_22E914, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 621
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 621
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_JAMES_1
 	release
 	end
 

--- a/data/maps/Route101/scripts.inc
+++ b/data/maps/Route101/scripts.inc
@@ -19,7 +19,7 @@ Route101_EventScript_1EBCD5:: @ 81EBCD5
 Route101_EventScript_1EBCDE:: @ 81EBCDE
 	lockall
 	playbgm MUS_EVENT0, 1
-	msgbox Route101_Text_1EBE8F, 4
+	msgbox Route101_Text_1EBE8F, MSGBOX_DEFAULT
 	closemessage
 	setobjectxy 2, 0, 15
 	setobjectxy 4, 0, 16
@@ -35,7 +35,7 @@ Route101_EventScript_1EBCDE:: @ 81EBCDE
 	applymovement 4, Route101_Movement_1EBDBD
 	applymovement 2, Route101_Movement_1EBDEF
 	waitmovement 0
-	msgbox Route101_Text_1EBE9A, 4
+	msgbox Route101_Text_1EBE9A, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x4060, 2
 	releaseall
@@ -43,7 +43,7 @@ Route101_EventScript_1EBCDE:: @ 81EBCDE
 
 Route101_EventScript_1EBD4E:: @ 81EBD4E
 	lockall
-	msgbox Route101_Text_1EBEDF, 4
+	msgbox Route101_Text_1EBEDF, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, Route101_Movement_1EBD90
 	waitmovement 0
@@ -52,7 +52,7 @@ Route101_EventScript_1EBD4E:: @ 81EBD4E
 
 Route101_EventScript_1EBD64:: @ 81EBD64
 	lockall
-	msgbox Route101_Text_1EBEDF, 4
+	msgbox Route101_Text_1EBEDF, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, Route101_Movement_1EBD92
 	waitmovement 0
@@ -61,7 +61,7 @@ Route101_EventScript_1EBD64:: @ 81EBD64
 
 Route101_EventScript_1EBD7A:: @ 81EBD7A
 	lockall
-	msgbox Route101_Text_1EBEDF, 4
+	msgbox Route101_Text_1EBEDF, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, Route101_Movement_1EBD94
 	waitmovement 0
@@ -204,15 +204,15 @@ Route101_Movement_1EBDF7: @ 81EBDF7
 	step_end
 
 Route101_EventScript_1EBDFB:: @ 81EBDFB
-	msgbox Route101_Text_1EBFDD, 2
+	msgbox Route101_Text_1EBFDD, MSGBOX_NPC
 	end
 
 Route101_EventScript_1EBE04:: @ 81EBE04
-	msgbox Route101_Text_1EC04A, 2
+	msgbox Route101_Text_1EC04A, MSGBOX_NPC
 	end
 
 Route101_EventScript_1EBE0D:: @ 81EBE0D
-	msgbox Route101_Text_1EC0C8, 3
+	msgbox Route101_Text_1EC0C8, MSGBOX_SIGN
 	end
 
 Route101_EventScript_1EBE16:: @ 81EBE16
@@ -229,7 +229,7 @@ Route101_EventScript_1EBE16:: @ 81EBE16
 	waitstate
 	applymovement 2, Route101_Movement_1EBE8D
 	waitmovement 0
-	msgbox Route101_Text_1EBF12, 4
+	msgbox Route101_Text_1EBF12, MSGBOX_DEFAULT
 	special HealPlayerParty
 	setflag FLAG_HIDE_ROUTE_101_BIRCH_ZIGZAGOON_BATTLE
 	clearflag FLAG_HIDE_LITTLEROOT_TOWN_BIRCHS_LAB_BIRCH

--- a/data/maps/Route102/scripts.inc
+++ b/data/maps/Route102/scripts.inc
@@ -40,10 +40,7 @@ Route102_EventScript_1EC146:: @ 81EC146
 
 Route102_EventScript_1EC157:: @ 81EC157
 	msgbox Route102_Text_294668, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 318
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 318
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_CALVIN_1
 	release
 	end
 
@@ -56,10 +53,7 @@ Route102_EventScript_1EC170:: @ 81EC170
 
 Route102_EventScript_1EC183:: @ 81EC183
 	msgbox Route102_Text_2945EB, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 318
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 318
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_CALVIN_1
 	release
 	end
 

--- a/data/maps/Route102/scripts.inc
+++ b/data/maps/Route102/scripts.inc
@@ -2,19 +2,19 @@ Route102_MapScripts:: @ 81EC0E0
 	.byte 0
 
 Route102_EventScript_1EC0E1:: @ 81EC0E1
-	msgbox Route102_Text_1EC2C0, 2
+	msgbox Route102_Text_1EC2C0, MSGBOX_NPC
 	end
 
 Route102_EventScript_1EC0EA:: @ 81EC0EA
-	msgbox Route102_Text_1EC35B, 3
+	msgbox Route102_Text_1EC35B, MSGBOX_SIGN
 	end
 
 Route102_EventScript_1EC0F3:: @ 81EC0F3
-	msgbox Route102_Text_1EC373, 3
+	msgbox Route102_Text_1EC373, MSGBOX_SIGN
 	end
 
 Route102_EventScript_1EC0FC:: @ 81EC0FC
-	msgbox Route102_Text_1EC32E, 2
+	msgbox Route102_Text_1EC32E, MSGBOX_NPC
 	end
 
 Route102_EventScript_1EC105:: @ 81EC105
@@ -26,7 +26,7 @@ Route102_EventScript_1EC105:: @ 81EC105
 	specialvar VAR_RESULT, sub_813B4E0
 	compare VAR_RESULT, 0
 	goto_eq Route102_EventScript_1EC170
-	msgbox Route102_Text_2945AC, 4
+	msgbox Route102_Text_2945AC, MSGBOX_DEFAULT
 	release
 	end
 
@@ -39,48 +39,48 @@ Route102_EventScript_1EC146:: @ 81EC146
 	end
 
 Route102_EventScript_1EC157:: @ 81EC157
-	msgbox Route102_Text_294668, 4
+	msgbox Route102_Text_294668, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 318
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 318
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route102_EventScript_1EC170:: @ 81EC170
 	checkflag FLAG_HAS_MATCH_CALL
 	goto_eq Route102_EventScript_1EC183
-	msgbox Route102_Text_2945AC, 4
+	msgbox Route102_Text_2945AC, MSGBOX_DEFAULT
 	release
 	end
 
 Route102_EventScript_1EC183:: @ 81EC183
-	msgbox Route102_Text_2945EB, 4
+	msgbox Route102_Text_2945EB, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 318
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 318
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route102_EventScript_1EC19C:: @ 81EC19C
 	trainerbattle 5, TRAINER_CALVIN_1, 0, Route102_Text_2946AE, Route102_Text_29470C
-	msgbox Route102_Text_29473C, 6
+	msgbox Route102_Text_29473C, MSGBOX_AUTOCLOSE
 	end
 
 Route102_EventScript_1EC1B3:: @ 81EC1B3
 	trainerbattle 0, TRAINER_RICK, 0, Route102_Text_29480C, Route102_Text_294847
-	msgbox Route102_Text_294859, 6
+	msgbox Route102_Text_294859, MSGBOX_AUTOCLOSE
 	end
 
 Route102_EventScript_1EC1CA:: @ 81EC1CA
 	trainerbattle 0, TRAINER_TIANA, 0, Route102_Text_29489E, Route102_Text_2948F3
-	msgbox Route102_Text_294916, 6
+	msgbox Route102_Text_294916, MSGBOX_AUTOCLOSE
 	end
 
 Route102_EventScript_1EC1E1:: @ 81EC1E1
 	trainerbattle 0, TRAINER_ALLEN, 0, Route102_Text_294775, Route102_Text_2947AA
-	msgbox Route102_Text_2947DB, 6
+	msgbox Route102_Text_2947DB, MSGBOX_AUTOCLOSE
 	end
 
 PetalburgCity_Text_1EC1F8: @ 81EC1F8

--- a/data/maps/Route103/scripts.inc
+++ b/data/maps/Route103/scripts.inc
@@ -217,10 +217,7 @@ Route103_EventScript_1EC60B:: @ 81EC60B
 
 Route103_EventScript_1EC63A:: @ 81EC63A
 	msgbox Route103_Text_294B8A, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 481
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 481
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_AMY_AND_LIV_1
 	release
 	end
 
@@ -239,10 +236,7 @@ Route103_EventScript_1EC66E:: @ 81EC66E
 
 Route103_EventScript_1EC69D:: @ 81EC69D
 	msgbox Route103_Text_294B8A, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 481
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 481
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_AMY_AND_LIV_1
 	release
 	end
 
@@ -269,10 +263,7 @@ Route103_EventScript_1EC714:: @ 81EC714
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route103_Text_294F7E, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 293
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 293
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_MIGUEL_1
 	release
 	end
 

--- a/data/maps/Route103/scripts.inc
+++ b/data/maps/Route103/scripts.inc
@@ -28,7 +28,7 @@ Route103_EventScript_1EC3C1:: @ 81EC3C1
 	end
 
 Route103_EventScript_1EC3DA:: @ 81EC3DA
-	msgbox Route103_Text_1EC7A6, 4
+	msgbox Route103_Text_1EC7A6, MSGBOX_DEFAULT
 	closemessage
 	playbgm MUS_GIRL_SUP, 1
 	applymovement 2, Route103_Movement_27259E
@@ -37,7 +37,7 @@ Route103_EventScript_1EC3DA:: @ 81EC3DA
 	waitmovement 0
 	applymovement 2, Route103_Movement_27259A
 	waitmovement 0
-	msgbox Route103_Text_1EC7DE, 4
+	msgbox Route103_Text_1EC7DE, MSGBOX_DEFAULT
 	switch VAR_STARTER_MON
 	case 0, Route103_EventScript_1EC48E
 	case 1, Route103_EventScript_1EC49E
@@ -45,7 +45,7 @@ Route103_EventScript_1EC3DA:: @ 81EC3DA
 	end
 
 Route103_EventScript_1EC434:: @ 81EC434
-	msgbox Route103_Text_1EC989, 4
+	msgbox Route103_Text_1EC989, MSGBOX_DEFAULT
 	closemessage
 	playbgm MUS_BOY_SUP, 1
 	applymovement 2, Route103_Movement_27259E
@@ -54,7 +54,7 @@ Route103_EventScript_1EC434:: @ 81EC434
 	waitmovement 0
 	applymovement 2, Route103_Movement_27259A
 	waitmovement 0
-	msgbox Route103_Text_1EC9CE, 4
+	msgbox Route103_Text_1EC9CE, MSGBOX_DEFAULT
 	switch VAR_STARTER_MON
 	case 0, Route103_EventScript_1EC4BE
 	case 1, Route103_EventScript_1EC4CE
@@ -92,12 +92,12 @@ Route103_EventScript_1EC4DE:: @ 81EC4DE
 	end
 
 Route103_EventScript_1EC4EE:: @ 81EC4EE
-	msgbox Route103_Text_1EC8AE, 4
+	msgbox Route103_Text_1EC8AE, MSGBOX_DEFAULT
 	goto Route103_EventScript_1EC50A
 	end
 
 Route103_EventScript_1EC4FC:: @ 81EC4FC
-	msgbox Route103_Text_1ECA79, 4
+	msgbox Route103_Text_1ECA79, MSGBOX_DEFAULT
 	goto Route103_EventScript_1EC50A
 	end
 
@@ -191,20 +191,20 @@ Route103_Movement_1EC5D6: @ 81EC5D6
 	step_end
 
 Route103_EventScript_1EC5D9:: @ 81EC5D9
-	msgbox Route103_Text_1ECB73, 2
+	msgbox Route103_Text_1ECB73, MSGBOX_NPC
 	end
 
 Route103_EventScript_1EC5E2:: @ 81EC5E2
-	msgbox Route103_Text_1ECBB5, 2
+	msgbox Route103_Text_1ECBB5, MSGBOX_NPC
 	end
 
 Route103_EventScript_1EC5EB:: @ 81EC5EB
-	msgbox Route103_Text_1ECC1A, 3
+	msgbox Route103_Text_1ECC1A, MSGBOX_SIGN
 	end
 
 Route103_EventScript_1EC5F4:: @ 81EC5F4
 	trainerbattle 0, TRAINER_DAISY, 0, Route103_Text_29495A, Route103_Text_29498F
-	msgbox Route103_Text_2949B4, 6
+	msgbox Route103_Text_2949B4, MSGBOX_AUTOCLOSE
 	end
 
 Route103_EventScript_1EC60B:: @ 81EC60B
@@ -212,21 +212,21 @@ Route103_EventScript_1EC60B:: @ 81EC60B
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route103_EventScript_1EC653
-	msgbox Route103_Text_294A52, 6
+	msgbox Route103_Text_294A52, MSGBOX_AUTOCLOSE
 	end
 
 Route103_EventScript_1EC63A:: @ 81EC63A
-	msgbox Route103_Text_294B8A, 4
+	msgbox Route103_Text_294B8A, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 481
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 481
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route103_EventScript_1EC653:: @ 81EC653
 	trainerbattle 7, TRAINER_AMY_AND_LIV_1, 0, Route103_Text_294C29, Route103_Text_294C6D, Route103_Text_294CEF
-	msgbox Route103_Text_294C93, 6
+	msgbox Route103_Text_294C93, MSGBOX_AUTOCLOSE
 	end
 
 Route103_EventScript_1EC66E:: @ 81EC66E
@@ -234,26 +234,26 @@ Route103_EventScript_1EC66E:: @ 81EC66E
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route103_EventScript_1EC6B6
-	msgbox Route103_Text_294B40, 6
+	msgbox Route103_Text_294B40, MSGBOX_AUTOCLOSE
 	end
 
 Route103_EventScript_1EC69D:: @ 81EC69D
-	msgbox Route103_Text_294B8A, 4
+	msgbox Route103_Text_294B8A, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 481
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 481
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route103_EventScript_1EC6B6:: @ 81EC6B6
 	trainerbattle 7, TRAINER_AMY_AND_LIV_1, 0, Route103_Text_294D3E, Route103_Text_294D63, Route103_Text_294DDB
-	msgbox Route103_Text_294D89, 6
+	msgbox Route103_Text_294D89, MSGBOX_AUTOCLOSE
 	end
 
 Route103_EventScript_1EC6D1:: @ 81EC6D1
 	trainerbattle 0, TRAINER_ANDREW, 0, Route103_Text_294E34, Route103_Text_294E92
-	msgbox Route103_Text_294EBB, 6
+	msgbox Route103_Text_294EBB, MSGBOX_AUTOCLOSE
 	end
 
 Route103_EventScript_1EC6E8:: @ 81EC6E8
@@ -261,44 +261,44 @@ Route103_EventScript_1EC6E8:: @ 81EC6E8
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route103_EventScript_1EC733
-	msgbox Route103_Text_294F42, 4
+	msgbox Route103_Text_294F42, MSGBOX_DEFAULT
 	release
 	end
 
 Route103_EventScript_1EC714:: @ 81EC714
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route103_Text_294F7E, 4
+	msgbox Route103_Text_294F7E, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 293
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 293
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route103_EventScript_1EC733:: @ 81EC733
 	trainerbattle 5, TRAINER_MIGUEL_1, 0, Route103_Text_294FC3, Route103_Text_295006
-	msgbox Route103_Text_29501E, 6
+	msgbox Route103_Text_29501E, MSGBOX_AUTOCLOSE
 	end
 
 Route103_EventScript_1EC74A:: @ 81EC74A
 	trainerbattle 0, TRAINER_MARCOS, 0, Route103_Text_295206, Route103_Text_29522B
-	msgbox Route103_Text_295246, 6
+	msgbox Route103_Text_295246, MSGBOX_AUTOCLOSE
 	end
 
 Route103_EventScript_1EC761:: @ 81EC761
 	trainerbattle 0, TRAINER_RHETT, 0, Route103_Text_295199, Route103_Text_2951C6
-	msgbox Route103_Text_2951DE, 6
+	msgbox Route103_Text_2951DE, MSGBOX_AUTOCLOSE
 	end
 
 Route103_EventScript_1EC778:: @ 81EC778
 	trainerbattle 0, TRAINER_PETE, 0, Route103_Text_295063, Route103_Text_295093
-	msgbox Route103_Text_2950AA, 6
+	msgbox Route103_Text_2950AA, MSGBOX_AUTOCLOSE
 	end
 
 Route103_EventScript_1EC78F:: @ 81EC78F
 	trainerbattle 0, TRAINER_ISABELLE, 0, Route103_Text_295116, Route103_Text_295146
-	msgbox Route103_Text_29514D, 6
+	msgbox Route103_Text_29514D, MSGBOX_AUTOCLOSE
 	end
 
 Route103_Text_1EC7A6: @ 81EC7A6

--- a/data/maps/Route104/scripts.inc
+++ b/data/maps/Route104/scripts.inc
@@ -903,10 +903,7 @@ Route104_EventScript_1ED3CE:: @ 81ED3CE
 
 Route104_EventScript_1ED3DF:: @ 81ED3DF
 	msgbox Route104_Text_29576B, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 604
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 604
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_HALEY_1
 	release
 	end
 
@@ -919,10 +916,7 @@ Route104_EventScript_1ED3F8:: @ 81ED3F8
 
 Route104_EventScript_1ED40B:: @ 81ED40B
 	msgbox Route104_Text_2956FF, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 604
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 604
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_HALEY_1
 	release
 	end
 
@@ -954,10 +948,7 @@ Route104_EventScript_1ED47C:: @ 81ED47C
 
 Route104_EventScript_1ED48D:: @ 81ED48D
 	msgbox Route104_Text_29595A, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 136
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 136
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_WINSTON_1
 	release
 	end
 
@@ -970,10 +961,7 @@ Route104_EventScript_1ED4A6:: @ 81ED4A6
 
 Route104_EventScript_1ED4B9:: @ 81ED4B9
 	msgbox Route104_Text_2958F8, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 136
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 136
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_WINSTON_1
 	release
 	end
 
@@ -1005,10 +993,7 @@ Route104_EventScript_1ED52A:: @ 81ED52A
 
 Route104_EventScript_1ED53B:: @ 81ED53B
 	msgbox Route104_Text_295B60, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 114
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 114
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_CINDY_1
 	release
 	end
 
@@ -1021,10 +1006,7 @@ Route104_EventScript_1ED554:: @ 81ED554
 
 Route104_EventScript_1ED567:: @ 81ED567
 	msgbox Route104_Text_295B01, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 114
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 114
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_CINDY_1
 	release
 	end
 

--- a/data/maps/Route104/scripts.inc
+++ b/data/maps/Route104/scripts.inc
@@ -104,27 +104,27 @@ Route104_EventScript_1ECD4B:: @ 81ECD4B
 	checkflag FLAG_0x07C
 	goto_eq Route104_EventScript_1ECDD0
 	setflag FLAG_0x07C
-	msgbox Route104_Text_1EDBFF, 4
+	msgbox Route104_Text_1EDBFF, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox Route104_Text_1EDC8F, 4
+	msgbox Route104_Text_1EDC8F, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
 	setflag FLAG_0x0FD
 	applymovement 255, Route104_Movement_1ECDCD
 	applymovement 34, Route104_Movement_1ECDC8
-	msgbox Route104_Text_1EDCB1, 4
+	msgbox Route104_Text_1EDCB1, MSGBOX_DEFAULT
 	closemessage
 	waitmovement 0
 	applymovement 34, Route104_Movement_1ECDCA
 	waitmovement 0
 	moveobjectoffscreen 34
-	msgbox Route104_Text_1EDCED, 5
+	msgbox Route104_Text_1EDCED, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route104_EventScript_1ECDED
-	msgbox Route104_Text_1EDD2A, 4
+	msgbox Route104_Text_1EDD2A, MSGBOX_DEFAULT
 	call Route104_EventScript_1ECE31
 	releaseall
 	end
@@ -144,15 +144,15 @@ Route104_Movement_1ECDCD: @ 81ECDCD
 	step_end
 
 Route104_EventScript_1ECDD0:: @ 81ECDD0
-	msgbox Route104_Text_1EDD9F, 5
+	msgbox Route104_Text_1EDD9F, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route104_EventScript_1ECDED
-	msgbox Route104_Text_1EDD2A, 4
+	msgbox Route104_Text_1EDD2A, MSGBOX_DEFAULT
 	releaseall
 	end
 
 Route104_EventScript_1ECDED:: @ 81ECDED
-	msgbox Route104_Text_1EDDDB, 4
+	msgbox Route104_Text_1EDDDB, MSGBOX_DEFAULT
 	switch VAR_STARTER_MON
 	case 0, Route104_EventScript_1ECE36
 	case 1, Route104_EventScript_1ECE49
@@ -160,7 +160,7 @@ Route104_EventScript_1ECDED:: @ 81ECDED
 	end
 
 Route104_EventScript_1ECE1C:: @ 81ECE1C
-	msgbox Route104_Text_1EDE3E, 4
+	msgbox Route104_Text_1EDE3E, MSGBOX_DEFAULT
 	compare VAR_0x8008, 0
 	call_if 1, Route104_EventScript_1ECE31
 	releaseall
@@ -195,41 +195,41 @@ Route104_EventScript_1ECE6F:: @ 81ECE6F
 	checkflag FLAG_0x07C
 	goto_eq Route104_EventScript_1ECEEC
 	setflag FLAG_0x07C
-	msgbox Route104_Text_1EDF04, 4
+	msgbox Route104_Text_1EDF04, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox Route104_Text_1EDFA0, 4
+	msgbox Route104_Text_1EDFA0, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
 	setflag FLAG_0x0FD
 	applymovement 255, Route104_Movement_1ECDCD
 	applymovement 34, Route104_Movement_1ECDC8
-	msgbox Route104_Text_1EDFC6, 4
+	msgbox Route104_Text_1EDFC6, MSGBOX_DEFAULT
 	closemessage
 	waitmovement 0
 	applymovement 34, Route104_Movement_1ECDCA
 	waitmovement 0
 	moveobjectoffscreen 34
-	msgbox Route104_Text_1EE009, 5
+	msgbox Route104_Text_1EE009, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route104_EventScript_1ECF09
-	msgbox Route104_Text_1EE04D, 4
+	msgbox Route104_Text_1EE04D, MSGBOX_DEFAULT
 	call Route104_EventScript_1ECE31
 	releaseall
 	end
 
 Route104_EventScript_1ECEEC:: @ 81ECEEC
-	msgbox Route104_Text_1EE094, 5
+	msgbox Route104_Text_1EE094, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route104_EventScript_1ECF09
-	msgbox Route104_Text_1EE04D, 4
+	msgbox Route104_Text_1EE04D, MSGBOX_DEFAULT
 	releaseall
 	end
 
 Route104_EventScript_1ECF09:: @ 81ECF09
-	msgbox Route104_Text_1EE0C7, 4
+	msgbox Route104_Text_1EE0C7, MSGBOX_DEFAULT
 	switch VAR_STARTER_MON
 	case 0, Route104_EventScript_1ECF4D
 	case 1, Route104_EventScript_1ECF60
@@ -237,7 +237,7 @@ Route104_EventScript_1ECF09:: @ 81ECF09
 	end
 
 Route104_EventScript_1ECF38:: @ 81ECF38
-	msgbox Route104_Text_1EE120, 4
+	msgbox Route104_Text_1EE120, MSGBOX_DEFAULT
 	compare VAR_0x8008, 0
 	call_if 1, Route104_EventScript_1ECE31
 	releaseall
@@ -276,17 +276,17 @@ Route104_EventScript_1ECF8C:: @ 81ECF8C
 	faceplayer
 	checkflag FLAG_0x0F6
 	goto_eq Route104_EventScript_1ECFC3
-	msgbox Route104_Text_2A6D86, 4
+	msgbox Route104_Text_2A6D86, MSGBOX_DEFAULT
 	giveitem_std ITEM_CHESTO_BERRY
 	compare VAR_RESULT, 0
 	goto_eq Route104_EventScript_272054
 	setflag FLAG_0x0F6
-	msgbox Route104_Text_2A6E32, 4
+	msgbox Route104_Text_2A6E32, MSGBOX_DEFAULT
 	release
 	end
 
 Route104_EventScript_1ECFC3:: @ 81ECFC3
-	msgbox Route104_Text_2A6E32, 4
+	msgbox Route104_Text_2A6E32, MSGBOX_DEFAULT
 	release
 	end
 
@@ -295,7 +295,7 @@ Route104_EventScript_1ECFCD:: @ 81ECFCD
 	faceplayer
 	checkflag FLAG_0x117
 	goto_eq Route104_EventScript_1ECFFC
-	msgbox Route104_Text_1ED96A, 4
+	msgbox Route104_Text_1ED96A, MSGBOX_DEFAULT
 	giveitem_std ITEM_WHITE_HERB
 	compare VAR_RESULT, 0
 	goto_eq Route104_EventScript_272054
@@ -304,44 +304,44 @@ Route104_EventScript_1ECFCD:: @ 81ECFCD
 	end
 
 Route104_EventScript_1ECFFC:: @ 81ECFFC
-	msgbox Route104_Text_1EDA0F, 4
+	msgbox Route104_Text_1EDA0F, MSGBOX_DEFAULT
 	release
 	end
 
 Route104_EventScript_1ED006:: @ 81ED006
-	msgbox Route104_Text_1ED5EC, 2
+	msgbox Route104_Text_1ED5EC, MSGBOX_NPC
 	end
 
 Route104_EventScript_1ED00F:: @ 81ED00F
-	msgbox Route104_Text_1ED662, 3
+	msgbox Route104_Text_1ED662, MSGBOX_SIGN
 	end
 
 Route104_EventScript_1ED018:: @ 81ED018
-	msgbox Route104_Text_1EDA8C, 3
+	msgbox Route104_Text_1EDA8C, MSGBOX_SIGN
 	end
 
 Route104_EventScript_1ED021:: @ 81ED021
-	msgbox Route104_Text_1EDAA1, 3
+	msgbox Route104_Text_1EDAA1, MSGBOX_SIGN
 	end
 
 Route104_EventScript_1ED02A:: @ 81ED02A
-	msgbox Route104_Text_1EDABC, 3
+	msgbox Route104_Text_1EDABC, MSGBOX_SIGN
 	end
 
 Route104_EventScript_1ED033:: @ 81ED033
-	msgbox Route104_Text_1EDAD6, 3
+	msgbox Route104_Text_1EDAD6, MSGBOX_SIGN
 	end
 
 Route104_EventScript_1ED03C:: @ 81ED03C
-	msgbox Route104_Text_1EDAEF, 3
+	msgbox Route104_Text_1EDAEF, MSGBOX_SIGN
 	end
 
 Route104_EventScript_1ED045:: @ 81ED045
-	msgbox Route104_Text_1ED6A2, 2
+	msgbox Route104_Text_1ED6A2, MSGBOX_NPC
 	end
 
 Route104_EventScript_1ED04E:: @ 81ED04E
-	msgbox Route104_Text_1ED735, 2
+	msgbox Route104_Text_1ED735, MSGBOX_NPC
 	end
 
 Route104_EventScript_1ED057:: @ 81ED057
@@ -349,7 +349,7 @@ Route104_EventScript_1ED057:: @ 81ED057
 	faceplayer
 	checkflag FLAG_0x106
 	goto_eq Route104_EventScript_1ED086
-	msgbox Route104_Text_1ED838, 4
+	msgbox Route104_Text_1ED838, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM09
 	compare VAR_RESULT, 0
 	goto_eq Route104_EventScript_272054
@@ -358,12 +358,12 @@ Route104_EventScript_1ED057:: @ 81ED057
 	end
 
 Route104_EventScript_1ED086:: @ 81ED086
-	msgbox Route104_Text_1ED8E7, 4
+	msgbox Route104_Text_1ED8E7, MSGBOX_DEFAULT
 	release
 	end
 
 Route104_EventScript_1ED090:: @ 81ED090
-	msgbox Route104_Text_1ED7A2, 2
+	msgbox Route104_Text_1ED7A2, MSGBOX_NPC
 	end
 
 Route104_EventScript_1ED099:: @ 81ED099
@@ -396,7 +396,7 @@ Route104_EventScript_1ED0EF:: @ 81ED0EF
 	waitmessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox Route104_Text_1EE463, 4
+	msgbox Route104_Text_1EE463, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
@@ -438,12 +438,12 @@ Route104_EventScript_1ED139:: @ 81ED139
 	end
 
 Route104_EventScript_1ED1B4:: @ 81ED1B4
-	msgbox Route104_Text_1E9AAF, 4
+	msgbox Route104_Text_1E9AAF, MSGBOX_DEFAULT
 	releaseall
 	end
 
 Route104_EventScript_1ED1BE:: @ 81ED1BE
-	msgbox Route104_Text_1E9C1D, 4
+	msgbox Route104_Text_1E9C1D, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -872,12 +872,12 @@ Route104_Movement_1ED35C: @ 81ED35C
 
 Route104_EventScript_1ED35F:: @ 81ED35F
 	trainerbattle 0, TRAINER_IVAN, 0, Route104_Text_2954BD, Route104_Text_295509
-	msgbox Route104_Text_29554E, 6
+	msgbox Route104_Text_29554E, MSGBOX_AUTOCLOSE
 	end
 
 Route104_EventScript_1ED376:: @ 81ED376
 	trainerbattle 0, TRAINER_BILLY, 0, Route104_Text_29558A, Route104_Text_2955B4
-	msgbox Route104_Text_2955E8, 6
+	msgbox Route104_Text_2955E8, MSGBOX_AUTOCLOSE
 	end
 
 Route104_EventScript_1ED38D:: @ 81ED38D
@@ -889,7 +889,7 @@ Route104_EventScript_1ED38D:: @ 81ED38D
 	specialvar VAR_RESULT, sub_813B4E0
 	compare VAR_RESULT, 0
 	goto_eq Route104_EventScript_1ED3F8
-	msgbox Route104_Text_295689, 4
+	msgbox Route104_Text_295689, MSGBOX_DEFAULT
 	release
 	end
 
@@ -902,33 +902,33 @@ Route104_EventScript_1ED3CE:: @ 81ED3CE
 	end
 
 Route104_EventScript_1ED3DF:: @ 81ED3DF
-	msgbox Route104_Text_29576B, 4
+	msgbox Route104_Text_29576B, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 604
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 604
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route104_EventScript_1ED3F8:: @ 81ED3F8
 	checkflag FLAG_HAS_MATCH_CALL
 	goto_eq Route104_EventScript_1ED40B
-	msgbox Route104_Text_295689, 4
+	msgbox Route104_Text_295689, MSGBOX_DEFAULT
 	release
 	end
 
 Route104_EventScript_1ED40B:: @ 81ED40B
-	msgbox Route104_Text_2956FF, 4
+	msgbox Route104_Text_2956FF, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 604
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 604
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route104_EventScript_1ED424:: @ 81ED424
 	trainerbattle 5, TRAINER_HALEY_1, 0, Route104_Text_2957D7, Route104_Text_2957F0
-	msgbox Route104_Text_29580C, 6
+	msgbox Route104_Text_29580C, MSGBOX_AUTOCLOSE
 	end
 
 Route104_EventScript_1ED43B:: @ 81ED43B
@@ -940,7 +940,7 @@ Route104_EventScript_1ED43B:: @ 81ED43B
 	specialvar VAR_RESULT, sub_813B4E0
 	compare VAR_RESULT, 0
 	goto_eq Route104_EventScript_1ED4A6
-	msgbox Route104_Text_2958C1, 4
+	msgbox Route104_Text_2958C1, MSGBOX_DEFAULT
 	release
 	end
 
@@ -953,33 +953,33 @@ Route104_EventScript_1ED47C:: @ 81ED47C
 	end
 
 Route104_EventScript_1ED48D:: @ 81ED48D
-	msgbox Route104_Text_29595A, 4
+	msgbox Route104_Text_29595A, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 136
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 136
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route104_EventScript_1ED4A6:: @ 81ED4A6
 	checkflag FLAG_HAS_MATCH_CALL
 	goto_eq Route104_EventScript_1ED4B9
-	msgbox Route104_Text_2958C1, 4
+	msgbox Route104_Text_2958C1, MSGBOX_DEFAULT
 	release
 	end
 
 Route104_EventScript_1ED4B9:: @ 81ED4B9
-	msgbox Route104_Text_2958F8, 4
+	msgbox Route104_Text_2958F8, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 136
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 136
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route104_EventScript_1ED4D2:: @ 81ED4D2
 	trainerbattle 5, TRAINER_WINSTON_1, 0, Route104_Text_2959BC, Route104_Text_2959FC
-	msgbox Route104_Text_295A1E, 6
+	msgbox Route104_Text_295A1E, MSGBOX_AUTOCLOSE
 	end
 
 Route104_EventScript_1ED4E9:: @ 81ED4E9
@@ -991,7 +991,7 @@ Route104_EventScript_1ED4E9:: @ 81ED4E9
 	specialvar VAR_RESULT, sub_813B4E0
 	compare VAR_RESULT, 0
 	goto_eq Route104_EventScript_1ED554
-	msgbox Route104_Text_295AC3, 4
+	msgbox Route104_Text_295AC3, MSGBOX_DEFAULT
 	release
 	end
 
@@ -1004,52 +1004,52 @@ Route104_EventScript_1ED52A:: @ 81ED52A
 	end
 
 Route104_EventScript_1ED53B:: @ 81ED53B
-	msgbox Route104_Text_295B60, 4
+	msgbox Route104_Text_295B60, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 114
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 114
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route104_EventScript_1ED554:: @ 81ED554
 	checkflag FLAG_HAS_MATCH_CALL
 	goto_eq Route104_EventScript_1ED567
-	msgbox Route104_Text_295AC3, 4
+	msgbox Route104_Text_295AC3, MSGBOX_DEFAULT
 	release
 	end
 
 Route104_EventScript_1ED567:: @ 81ED567
-	msgbox Route104_Text_295B01, 4
+	msgbox Route104_Text_295B01, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 114
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 114
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route104_EventScript_1ED580:: @ 81ED580
 	trainerbattle 5, TRAINER_CINDY_1, 0, Route104_Text_295BC8, Route104_Text_295BFA
-	msgbox Route104_Text_295C1F, 6
+	msgbox Route104_Text_295C1F, MSGBOX_AUTOCLOSE
 	end
 
 Route104_EventScript_1ED597:: @ 81ED597
 	trainerbattle 4, TRAINER_GINA_AND_MIA_1, 0, Route104_Text_2952BB, Route104_Text_2952E6, Route104_Text_295330
 	special GetPlayerBigGuyGirlString
-	msgbox Route104_Text_2952FE, 4
+	msgbox Route104_Text_2952FE, MSGBOX_DEFAULT
 	release
 	end
 
 Route104_EventScript_1ED5B6:: @ 81ED5B6
 	trainerbattle 4, TRAINER_GINA_AND_MIA_1, 0, Route104_Text_2953AF, Route104_Text_2953E1, Route104_Text_295449
 	special GetPlayerBigGuyGirlString
-	msgbox Route104_Text_29540D, 4
+	msgbox Route104_Text_29540D, MSGBOX_DEFAULT
 	release
 	end
 
 Route104_EventScript_1ED5D5:: @ 81ED5D5
 	trainerbattle 0, TRAINER_DARIAN, 0, Route104_Text_295C5D, Route104_Text_295CC9
-	msgbox Route104_Text_295CD3, 6
+	msgbox Route104_Text_295CD3, MSGBOX_AUTOCLOSE
 	end
 
 Route104_Text_1ED5EC: @ 81ED5EC

--- a/data/maps/Route104_MrBrineysHouse/scripts.inc
+++ b/data/maps/Route104_MrBrineysHouse/scripts.inc
@@ -35,8 +35,8 @@ Route104_MrBrineysHouse_EventScript_229D67:: @ 8229D67
 
 Route104_MrBrineysHouse_EventScript_229D8A:: @ 8229D8A
 	setflag FLAG_0x093
-	msgbox Route104_MrBrineysHouse_Text_229E70, 4
-	msgbox Route104_MrBrineysHouse_Text_229E9B, 5
+	msgbox Route104_MrBrineysHouse_Text_229E70, MSGBOX_DEFAULT
+	msgbox Route104_MrBrineysHouse_Text_229E9B, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route104_MrBrineysHouse_EventScript_229E13
 	goto Route104_MrBrineysHouse_EventScript_229E27
@@ -53,31 +53,31 @@ Route104_MrBrineysHouse_EventScript_229DAE:: @ 8229DAE
 	end
 
 Route104_MrBrineysHouse_EventScript_229DE1:: @ 8229DE1
-	msgbox Route104_MrBrineysHouse_Text_22A0AD, 5
+	msgbox Route104_MrBrineysHouse_Text_22A0AD, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route104_MrBrineysHouse_EventScript_229E13
 	goto Route104_MrBrineysHouse_EventScript_229E27
 	end
 
 Route104_MrBrineysHouse_EventScript_229DFA:: @ 8229DFA
-	msgbox Route104_MrBrineysHouse_Text_22A18F, 5
+	msgbox Route104_MrBrineysHouse_Text_22A18F, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route104_MrBrineysHouse_EventScript_229E13
 	goto Route104_MrBrineysHouse_EventScript_229E27
 	end
 
 Route104_MrBrineysHouse_EventScript_229E13:: @ 8229E13
-	msgbox Route104_MrBrineysHouse_Text_22A041, 4
+	msgbox Route104_MrBrineysHouse_Text_22A041, MSGBOX_DEFAULT
 	release
 	end
 
 Route104_MrBrineysHouse_EventScript_229E1D:: @ 8229E1D
-	msgbox Route104_MrBrineysHouse_Text_22A2C3, 4
+	msgbox Route104_MrBrineysHouse_Text_22A2C3, MSGBOX_DEFAULT
 	release
 	end
 
 Route104_MrBrineysHouse_EventScript_229E27:: @ 8229E27
-	msgbox Route104_MrBrineysHouse_Text_229FE9, 4
+	msgbox Route104_MrBrineysHouse_Text_229FE9, MSGBOX_DEFAULT
 	call Route104_MrBrineysHouse_EventScript_271E95
 	setvar VAR_0x408E, 1
 	clearflag FLAG_HIDE_ROUTE_104_MR_BRINEY
@@ -97,7 +97,7 @@ Route104_MrBrineysHouse_EventScript_229E5D:: @ 8229E5D
 	faceplayer
 	waitse
 	playmoncry SPECIES_WINGULL, 0
-	msgbox Route104_MrBrineysHouse_Text_22A337, 4
+	msgbox Route104_MrBrineysHouse_Text_22A337, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/Route104_PrettyPetalFlowerShop/scripts.inc
+++ b/data/maps/Route104_PrettyPetalFlowerShop/scripts.inc
@@ -20,11 +20,11 @@ Route104_PrettyPetalFlowerShop_EventScript_22A373:: @ 822A373
 	faceplayer
 	checkflag FLAG_TEMP_1
 	goto_eq Route104_PrettyPetalFlowerShop_EventScript_22A3E4
-	msgbox Route104_PrettyPetalFlowerShop_Text_2A7686, 4
+	msgbox Route104_PrettyPetalFlowerShop_Text_2A7686, MSGBOX_DEFAULT
 	checkflag FLAG_0x07F
 	goto_eq Route104_PrettyPetalFlowerShop_EventScript_22A3B2
 	setflag FLAG_0x07F
-	msgbox Route104_PrettyPetalFlowerShop_Text_2A7706, 5
+	msgbox Route104_PrettyPetalFlowerShop_Text_2A7706, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	call_if 1, Route104_PrettyPetalFlowerShop_EventScript_22A3D2
 	compare VAR_RESULT, 0
@@ -33,7 +33,7 @@ Route104_PrettyPetalFlowerShop_EventScript_22A373:: @ 822A373
 	end
 
 Route104_PrettyPetalFlowerShop_EventScript_22A3B2:: @ 822A3B2
-	msgbox Route104_PrettyPetalFlowerShop_Text_2A76D9, 5
+	msgbox Route104_PrettyPetalFlowerShop_Text_2A76D9, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	call_if 1, Route104_PrettyPetalFlowerShop_EventScript_22A3D2
 	compare VAR_RESULT, 0
@@ -42,18 +42,18 @@ Route104_PrettyPetalFlowerShop_EventScript_22A3B2:: @ 822A3B2
 	end
 
 Route104_PrettyPetalFlowerShop_EventScript_22A3D2:: @ 822A3D2
-	msgbox Route104_PrettyPetalFlowerShop_Text_2A775B, 4
+	msgbox Route104_PrettyPetalFlowerShop_Text_2A775B, MSGBOX_DEFAULT
 	return
 
 Route104_PrettyPetalFlowerShop_EventScript_22A3DB:: @ 822A3DB
-	msgbox Route104_PrettyPetalFlowerShop_Text_2A78DF, 4
+	msgbox Route104_PrettyPetalFlowerShop_Text_2A78DF, MSGBOX_DEFAULT
 	return
 
 Route104_PrettyPetalFlowerShop_EventScript_22A3E4:: @ 822A3E4
 	message gUnknown_08272A52
 	waitmessage
 	pokemartdecoration2 Route104_PrettyPetalFlowerShop_Pokemart_22A3FC
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -74,14 +74,14 @@ Route104_PrettyPetalFlowerShop_EventScript_22A40C:: @ 822A40C
 	faceplayer
 	checkflag FLAG_0x05E
 	goto_if 0, Route104_PrettyPetalFlowerShop_EventScript_22A421
-	msgbox Route104_PrettyPetalFlowerShop_Text_2A79A6, 4
+	msgbox Route104_PrettyPetalFlowerShop_Text_2A79A6, MSGBOX_DEFAULT
 	release
 	end
 
 Route104_PrettyPetalFlowerShop_EventScript_22A421:: @ 822A421
-	msgbox Route104_PrettyPetalFlowerShop_Text_2A7916, 4
+	msgbox Route104_PrettyPetalFlowerShop_Text_2A7916, MSGBOX_DEFAULT
 	giveitem_std ITEM_WAILMER_PAIL
-	msgbox Route104_PrettyPetalFlowerShop_Text_2A79A6, 4
+	msgbox Route104_PrettyPetalFlowerShop_Text_2A79A6, MSGBOX_DEFAULT
 	setflag FLAG_0x05E
 	release
 	end
@@ -92,19 +92,19 @@ Route104_PrettyPetalFlowerShop_EventScript_22A442:: @ 822A442
 	dodailyevents
 	checkflag FLAG_0x930
 	goto_eq Route104_PrettyPetalFlowerShop_EventScript_22A482
-	msgbox Route104_PrettyPetalFlowerShop_Text_2A7A98, 4
+	msgbox Route104_PrettyPetalFlowerShop_Text_2A7A98, MSGBOX_DEFAULT
 	random 8
 	addvar VAR_RESULT, 133
 	giveitem_std VAR_RESULT
 	compare VAR_RESULT, 0
 	goto_eq Route104_PrettyPetalFlowerShop_EventScript_272054
 	setflag FLAG_0x930
-	msgbox Route104_PrettyPetalFlowerShop_Text_2A7AF3, 4
+	msgbox Route104_PrettyPetalFlowerShop_Text_2A7AF3, MSGBOX_DEFAULT
 	release
 	end
 
 Route104_PrettyPetalFlowerShop_EventScript_22A482:: @ 822A482
-	msgbox Route104_PrettyPetalFlowerShop_Text_2A7AF3, 4
+	msgbox Route104_PrettyPetalFlowerShop_Text_2A7AF3, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/Route105/scripts.inc
+++ b/data/maps/Route105/scripts.inc
@@ -33,32 +33,32 @@ Route105_MapScript2_1EE240: @ 81EE240
 
 Route105_EventScript_1EE24A:: @ 81EE24A
 	trainerbattle 0, TRAINER_FOSTER, 0, Route105_Text_295D0F, Route105_Text_295D62
-	msgbox Route105_Text_295DAB, 6
+	msgbox Route105_Text_295DAB, MSGBOX_AUTOCLOSE
 	end
 
 Route105_EventScript_1EE261:: @ 81EE261
 	trainerbattle 0, TRAINER_LUIS, 0, Route105_Text_295DF5, Route105_Text_295E66
-	msgbox Route105_Text_295E72, 6
+	msgbox Route105_Text_295E72, MSGBOX_AUTOCLOSE
 	end
 
 Route105_EventScript_1EE278:: @ 81EE278
 	trainerbattle 0, TRAINER_DOMINIK, 0, Route105_Text_295EB7, Route105_Text_295EEA
-	msgbox Route105_Text_295F08, 6
+	msgbox Route105_Text_295F08, MSGBOX_AUTOCLOSE
 	end
 
 Route105_EventScript_1EE28F:: @ 81EE28F
 	trainerbattle 0, TRAINER_BEVERLY, 0, Route105_Text_295F5C, Route105_Text_295FA0
-	msgbox Route105_Text_295FAE, 6
+	msgbox Route105_Text_295FAE, MSGBOX_AUTOCLOSE
 	end
 
 Route105_EventScript_1EE2A6:: @ 81EE2A6
 	trainerbattle 0, TRAINER_IMANI, 0, Route105_Text_296025, Route105_Text_296059
-	msgbox Route105_Text_296076, 6
+	msgbox Route105_Text_296076, MSGBOX_AUTOCLOSE
 	end
 
 Route105_EventScript_1EE2BD:: @ 81EE2BD
 	trainerbattle 0, TRAINER_JOSUE, 0, Route105_Text_29626F, Route105_Text_2962CB
-	msgbox Route105_Text_2962EC, 6
+	msgbox Route105_Text_2962EC, MSGBOX_AUTOCLOSE
 	end
 
 Route105_EventScript_1EE2D4:: @ 81EE2D4
@@ -66,24 +66,24 @@ Route105_EventScript_1EE2D4:: @ 81EE2D4
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route105_EventScript_1EE31F
-	msgbox Route105_Text_2960FA, 4
+	msgbox Route105_Text_2960FA, MSGBOX_DEFAULT
 	release
 	end
 
 Route105_EventScript_1EE300:: @ 81EE300
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route105_Text_296159, 4
+	msgbox Route105_Text_296159, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 737
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 737
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route105_EventScript_1EE31F:: @ 81EE31F
 	trainerbattle 5, TRAINER_ANDRES_1, 0, Route105_Text_29619E, Route105_Text_2961DD
-	msgbox Route105_Text_2961FE, 6
+	msgbox Route105_Text_2961FE, MSGBOX_AUTOCLOSE
 	end
 
 Route104_Text_1EE336: @ 81EE336

--- a/data/maps/Route105/scripts.inc
+++ b/data/maps/Route105/scripts.inc
@@ -74,10 +74,7 @@ Route105_EventScript_1EE300:: @ 81EE300
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route105_Text_296159, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 737
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 737
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_ANDRES_1
 	release
 	end
 

--- a/data/maps/Route106/scripts.inc
+++ b/data/maps/Route106/scripts.inc
@@ -2,17 +2,17 @@ Route106_MapScripts:: @ 81EE489
 	.byte 0
 
 Route106_EventScript_1EE48A:: @ 81EE48A
-	msgbox Route106_Text_1EE53A, 3
+	msgbox Route106_Text_1EE53A, MSGBOX_SIGN
 	end
 
 Route106_EventScript_1EE493:: @ 81EE493
 	trainerbattle 0, TRAINER_DOUGLAS, 0, Route106_Text_2965BB, Route106_Text_2965FD
-	msgbox Route106_Text_296608, 6
+	msgbox Route106_Text_296608, MSGBOX_AUTOCLOSE
 	end
 
 Route106_EventScript_1EE4AA:: @ 81EE4AA
 	trainerbattle 0, TRAINER_KYLA, 0, Route106_Text_296628, Route106_Text_296674
-	msgbox Route106_Text_29669E, 6
+	msgbox Route106_Text_29669E, MSGBOX_AUTOCLOSE
 	end
 
 Route106_EventScript_1EE4C1:: @ 81EE4C1
@@ -20,29 +20,29 @@ Route106_EventScript_1EE4C1:: @ 81EE4C1
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route106_EventScript_1EE50C
-	msgbox Route106_Text_29638C, 4
+	msgbox Route106_Text_29638C, MSGBOX_DEFAULT
 	release
 	end
 
 Route106_EventScript_1EE4ED:: @ 81EE4ED
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route106_Text_2963E3, 4
+	msgbox Route106_Text_2963E3, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 339
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 339
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route106_EventScript_1EE50C:: @ 81EE50C
 	trainerbattle 5, TRAINER_ELLIOT_1, 0, Route106_Text_29642E, Route106_Text_296477
-	msgbox Route106_Text_296493, 6
+	msgbox Route106_Text_296493, MSGBOX_AUTOCLOSE
 	end
 
 Route106_EventScript_1EE523:: @ 81EE523
 	trainerbattle 0, TRAINER_NED, 0, Route106_Text_2964D4, Route106_Text_296553
-	msgbox Route106_Text_296588, 6
+	msgbox Route106_Text_296588, MSGBOX_AUTOCLOSE
 	end
 
 Route106_Text_1EE53A: @ 81EE53A

--- a/data/maps/Route106/scripts.inc
+++ b/data/maps/Route106/scripts.inc
@@ -28,10 +28,7 @@ Route106_EventScript_1EE4ED:: @ 81EE4ED
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route106_Text_2963E3, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 339
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 339
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_ELLIOT_1
 	release
 	end
 

--- a/data/maps/Route107/scripts.inc
+++ b/data/maps/Route107/scripts.inc
@@ -3,7 +3,7 @@ Route107_MapScripts:: @ 81EE594
 
 Route107_EventScript_1EE595:: @ 81EE595
 	trainerbattle 0, TRAINER_DARRIN, 0, Route107_Text_2966E5, Route107_Text_29672F
-	msgbox Route107_Text_29675B, 6
+	msgbox Route107_Text_29675B, MSGBOX_AUTOCLOSE
 	end
 
 Route107_EventScript_1EE5AC:: @ 81EE5AC
@@ -11,48 +11,48 @@ Route107_EventScript_1EE5AC:: @ 81EE5AC
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route107_EventScript_1EE5F7
-	msgbox Route107_Text_2967FF, 4
+	msgbox Route107_Text_2967FF, MSGBOX_DEFAULT
 	release
 	end
 
 Route107_EventScript_1EE5D8:: @ 81EE5D8
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route107_Text_29685A, 4
+	msgbox Route107_Text_29685A, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 155
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 155
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route107_EventScript_1EE5F7:: @ 81EE5F7
 	trainerbattle 5, TRAINER_TONY_1, 0, Route107_Text_296897, Route107_Text_2968D5
-	msgbox Route107_Text_296923, 6
+	msgbox Route107_Text_296923, MSGBOX_AUTOCLOSE
 	end
 
 Route107_EventScript_1EE60E:: @ 81EE60E
 	trainerbattle 0, TRAINER_DENISE, 0, Route107_Text_296974, Route107_Text_29699E
-	msgbox Route107_Text_2969AB, 6
+	msgbox Route107_Text_2969AB, MSGBOX_AUTOCLOSE
 	end
 
 Route107_EventScript_1EE625:: @ 81EE625
 	trainerbattle 0, TRAINER_BETH, 0, Route107_Text_2969E4, Route107_Text_296A17
-	msgbox Route107_Text_296A35, 6
+	msgbox Route107_Text_296A35, MSGBOX_AUTOCLOSE
 	end
 
 Route107_EventScript_1EE63C:: @ 81EE63C
 	trainerbattle 4, TRAINER_LISA_AND_RAY, 0, Route107_Text_296A77, Route107_Text_296AA7, Route107_Text_296B1E
-	msgbox Route107_Text_296ADC, 6
+	msgbox Route107_Text_296ADC, MSGBOX_AUTOCLOSE
 	end
 
 Route107_EventScript_1EE657:: @ 81EE657
 	trainerbattle 4, TRAINER_LISA_AND_RAY, 0, Route107_Text_296B57, Route107_Text_296BB3, Route107_Text_296C34
-	msgbox Route107_Text_296BE1, 6
+	msgbox Route107_Text_296BE1, MSGBOX_AUTOCLOSE
 	end
 
 Route107_EventScript_1EE672:: @ 81EE672
 	trainerbattle 0, TRAINER_CAMRON, 0, Route107_Text_296C6F, Route107_Text_296CAD
-	msgbox Route107_Text_296CC0, 6
+	msgbox Route107_Text_296CC0, MSGBOX_AUTOCLOSE
 	end
 

--- a/data/maps/Route107/scripts.inc
+++ b/data/maps/Route107/scripts.inc
@@ -19,10 +19,7 @@ Route107_EventScript_1EE5D8:: @ 81EE5D8
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route107_Text_29685A, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 155
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 155
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_TONY_1
 	release
 	end
 

--- a/data/maps/Route108/scripts.inc
+++ b/data/maps/Route108/scripts.inc
@@ -3,27 +3,27 @@ Route108_MapScripts:: @ 81EE689
 
 Route108_EventScript_1EE68A:: @ 81EE68A
 	trainerbattle 0, TRAINER_JEROME, 0, Route108_Text_296D10, Route108_Text_296D3C
-	msgbox Route108_Text_296D6E, 6
+	msgbox Route108_Text_296D6E, MSGBOX_AUTOCLOSE
 	end
 
 Route108_EventScript_1EE6A1:: @ 81EE6A1
 	trainerbattle 0, TRAINER_MATTHEW, 0, Route108_Text_296DAF, Route108_Text_296DEA
-	msgbox Route108_Text_296E03, 6
+	msgbox Route108_Text_296E03, MSGBOX_AUTOCLOSE
 	end
 
 Route108_EventScript_1EE6B8:: @ 81EE6B8
 	trainerbattle 0, TRAINER_TARA, 0, Route108_Text_296E33, Route108_Text_296E71
-	msgbox Route108_Text_296E7A, 6
+	msgbox Route108_Text_296E7A, MSGBOX_AUTOCLOSE
 	end
 
 Route108_EventScript_1EE6CF:: @ 81EE6CF
 	trainerbattle 0, TRAINER_MISSY, 0, Route108_Text_296EC7, Route108_Text_296EFC
-	msgbox Route108_Text_296F2A, 6
+	msgbox Route108_Text_296F2A, MSGBOX_AUTOCLOSE
 	end
 
 Route108_EventScript_1EE6E6:: @ 81EE6E6
 	trainerbattle 0, TRAINER_CAROLINA, 0, Route108_Text_297094, Route108_Text_2970D7
-	msgbox Route108_Text_2970F0, 6
+	msgbox Route108_Text_2970F0, MSGBOX_AUTOCLOSE
 	end
 
 Route108_EventScript_1EE6FD:: @ 81EE6FD
@@ -31,23 +31,23 @@ Route108_EventScript_1EE6FD:: @ 81EE6FD
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route108_EventScript_1EE748
-	msgbox Route108_Text_296FB0, 4
+	msgbox Route108_Text_296FB0, MSGBOX_DEFAULT
 	release
 	end
 
 Route108_EventScript_1EE729:: @ 81EE729
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route108_Text_296FD8, 4
+	msgbox Route108_Text_296FD8, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 740
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 740
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route108_EventScript_1EE748:: @ 81EE748
 	trainerbattle 5, TRAINER_CORY_1, 0, Route108_Text_297011, Route108_Text_297036
-	msgbox Route108_Text_297059, 6
+	msgbox Route108_Text_297059, MSGBOX_AUTOCLOSE
 	end
 

--- a/data/maps/Route108/scripts.inc
+++ b/data/maps/Route108/scripts.inc
@@ -39,10 +39,7 @@ Route108_EventScript_1EE729:: @ 81EE729
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route108_Text_296FD8, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 740
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 740
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_CORY_1
 	release
 	end
 

--- a/data/maps/Route109/scripts.inc
+++ b/data/maps/Route109/scripts.inc
@@ -408,10 +408,7 @@ Route109_EventScript_1EEAC5:: @ 81EEAC5
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route109_Text_2973C1, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 64
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 64
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_RICKY_1
 	release
 	end
 
@@ -433,10 +430,7 @@ Route109_EventScript_1EEB27:: @ 81EEB27
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route109_Text_297520, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 57
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 57
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_LOLA_1
 	release
 	end
 

--- a/data/maps/Route109/scripts.inc
+++ b/data/maps/Route109/scripts.inc
@@ -53,7 +53,7 @@ Route109_EventScript_1EE7D5:: @ 81EE7D5
 	clearflag FLAG_HIDE_MR_BRINEY_DEWFORD_TOWN
 	setflag FLAG_HIDE_ROUTE_109_MR_BRINEY_BOAT
 	hideobjectat 1, MAP_ROUTE109
-	msgbox Route109_Text_1E9C1D, 4
+	msgbox Route109_Text_1E9C1D, MSGBOX_DEFAULT
 	closemessage
 	copyvar VAR_0x4096, VAR_0x8008
 	resetobjectpriority 255, MAP_ROUTE109
@@ -279,7 +279,7 @@ Route109_EventScript_1EE910:: @ 81EE910
 
 Route109_EventScript_1EE921:: @ 81EE921
 	message Route109_Text_1EEC96
-	msgbox Route109_Text_1EEC96, 5
+	msgbox Route109_Text_1EEC96, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route109_EventScript_1EE981
 	goto Route109_EventScript_1EE972
@@ -296,29 +296,29 @@ Route109_EventScript_1EE93F:: @ 81EE93F
 	end
 
 Route109_EventScript_1EE972:: @ 81EE972
-	msgbox Route109_Text_1EED06, 4
+	msgbox Route109_Text_1EED06, MSGBOX_DEFAULT
 	closemessage
 	goto Route109_EventScript_1EE760
 	end
 
 Route109_EventScript_1EE981:: @ 81EE981
-	msgbox Route109_Text_1EED5E, 4
+	msgbox Route109_Text_1EED5E, MSGBOX_DEFAULT
 	release
 	end
 
 Route109_EventScript_1EE98B:: @ 81EE98B
-	msgbox Route109_Text_1EEE72, 4
+	msgbox Route109_Text_1EEE72, MSGBOX_DEFAULT
 	release
 	end
 
 Route109_EventScript_1EE995:: @ 81EE995
-	msgbox Route109_Text_1EEEB4, 2
+	msgbox Route109_Text_1EEEB4, MSGBOX_NPC
 	end
 
 Route109_EventScript_1EE99E:: @ 81EE99E
 	lock
 	faceplayer
-	msgbox Route109_Text_1EEFB0, 4
+	msgbox Route109_Text_1EEFB0, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, Route109_Movement_2725A2
 	waitmovement 0
@@ -331,7 +331,7 @@ Route109_EventScript_1EE9B5:: @ 81EE9B5
 	special GetPlayerBigGuyGirlString
 	checkflag FLAG_0x118
 	goto_eq Route109_EventScript_1EE9F2
-	msgbox Route109_Text_1EEFDE, 4
+	msgbox Route109_Text_1EEFDE, MSGBOX_DEFAULT
 	giveitem_std ITEM_SOFT_SAND
 	compare VAR_RESULT, 0
 	goto_eq Route109_EventScript_272054
@@ -343,18 +343,18 @@ Route109_EventScript_1EE9B5:: @ 81EE9B5
 	end
 
 Route109_EventScript_1EE9F2:: @ 81EE9F2
-	msgbox Route109_Text_1EEFF1, 4
+	msgbox Route109_Text_1EEFF1, MSGBOX_DEFAULT
 	applymovement VAR_LAST_TALKED, Route109_Movement_2725A2
 	waitmovement 0
 	release
 	end
 
 Route109_EventScript_1EEA06:: @ 81EEA06
-	msgbox Route109_Text_1EEF08, 2
+	msgbox Route109_Text_1EEF08, MSGBOX_NPC
 	end
 
 Route109_EventScript_1EEA0F:: @ 81EEA0F
-	msgbox Route109_Text_1EF080, 2
+	msgbox Route109_Text_1EF080, MSGBOX_NPC
 	end
 
 Route109_EventScript_1EEA18:: @ 81EEA18
@@ -362,37 +362,37 @@ Route109_EventScript_1EEA18:: @ 81EEA18
 	faceplayer
 	waitse
 	playmoncry SPECIES_ZIGZAGOON, 0
-	msgbox Route109_Text_1EF173, 4
+	msgbox Route109_Text_1EF173, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
 
 Route109_EventScript_1EEA2B:: @ 81EEA2B
-	msgbox Route109_Text_1EF185, 3
+	msgbox Route109_Text_1EF185, MSGBOX_SIGN
 	end
 
 Route109_EventScript_1EEA34:: @ 81EEA34
-	msgbox Route109_Text_1EF1D5, 3
+	msgbox Route109_Text_1EF1D5, MSGBOX_SIGN
 	end
 
 Route109_EventScript_1EEA3D:: @ 81EEA3D
 	trainerbattle 0, TRAINER_DAVID, 0, Route109_Text_297140, Route109_Text_29717D
-	msgbox Route109_Text_297191, 6
+	msgbox Route109_Text_297191, MSGBOX_AUTOCLOSE
 	end
 
 Route109_EventScript_1EEA54:: @ 81EEA54
 	trainerbattle 0, TRAINER_ALICE, 0, Route109_Text_2971D1, Route109_Text_2971FD
-	msgbox Route109_Text_29720F, 6
+	msgbox Route109_Text_29720F, MSGBOX_AUTOCLOSE
 	end
 
 Route109_EventScript_1EEA6B:: @ 81EEA6B
 	trainerbattle 0, TRAINER_HUEY, 0, Route109_Text_297235, Route109_Text_29727B
-	msgbox Route109_Text_29728C, 6
+	msgbox Route109_Text_29728C, MSGBOX_AUTOCLOSE
 	end
 
 Route109_EventScript_1EEA82:: @ 81EEA82
 	trainerbattle 0, TRAINER_EDMOND, 0, Route109_Text_2972B3, Route109_Text_2972CE
-	msgbox Route109_Text_2972ED, 6
+	msgbox Route109_Text_2972ED, MSGBOX_AUTOCLOSE
 	end
 
 Route109_EventScript_1EEA99:: @ 81EEA99
@@ -400,24 +400,24 @@ Route109_EventScript_1EEA99:: @ 81EEA99
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route109_EventScript_1EEAE4
-	msgbox Route109_Text_297380, 4
+	msgbox Route109_Text_297380, MSGBOX_DEFAULT
 	release
 	end
 
 Route109_EventScript_1EEAC5:: @ 81EEAC5
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route109_Text_2973C1, 4
+	msgbox Route109_Text_2973C1, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 64
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 64
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route109_EventScript_1EEAE4:: @ 81EEAE4
 	trainerbattle 5, TRAINER_RICKY_1, 0, Route109_Text_2973FF, Route109_Text_297437
-	msgbox Route109_Text_297458, 6
+	msgbox Route109_Text_297458, MSGBOX_AUTOCLOSE
 	end
 
 Route109_EventScript_1EEAFB:: @ 81EEAFB
@@ -425,64 +425,64 @@ Route109_EventScript_1EEAFB:: @ 81EEAFB
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route109_EventScript_1EEB46
-	msgbox Route109_Text_2974D6, 4
+	msgbox Route109_Text_2974D6, MSGBOX_DEFAULT
 	release
 	end
 
 Route109_EventScript_1EEB27:: @ 81EEB27
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route109_Text_297520, 4
+	msgbox Route109_Text_297520, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 57
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 57
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route109_EventScript_1EEB46:: @ 81EEB46
 	trainerbattle 5, TRAINER_LOLA_1, 0, Route109_Text_297538, Route109_Text_297576
-	msgbox Route109_Text_29757D, 6
+	msgbox Route109_Text_29757D, MSGBOX_AUTOCLOSE
 	end
 
 Route109_EventScript_1EEB5D:: @ 81EEB5D
 	trainerbattle 0, TRAINER_AUSTINA, 0, Route109_Text_2975C0, Route109_Text_297601
-	msgbox Route109_Text_29762A, 6
+	msgbox Route109_Text_29762A, MSGBOX_AUTOCLOSE
 	end
 
 Route109_EventScript_1EEB74:: @ 81EEB74
 	trainerbattle 0, TRAINER_GWEN, 0, Route109_Text_297667, Route109_Text_297691
-	msgbox Route109_Text_2976A4, 6
+	msgbox Route109_Text_2976A4, MSGBOX_AUTOCLOSE
 	end
 
 Route109_EventScript_1EEB8B:: @ 81EEB8B
 	trainerbattle 0, TRAINER_CARTER, 0, Route109_Text_2976C5, Route109_Text_2976FC
-	msgbox Route109_Text_297715, 6
+	msgbox Route109_Text_297715, MSGBOX_AUTOCLOSE
 	end
 
 Route109_EventScript_1EEBA2:: @ 81EEBA2
 	trainerbattle 4, TRAINER_MEL_AND_PAUL, 0, Route109_Text_297754, Route109_Text_2977B0, Route109_Text_29781D
-	msgbox Route109_Text_2977C7, 6
+	msgbox Route109_Text_2977C7, MSGBOX_AUTOCLOSE
 	end
 
 Route109_EventScript_1EEBBD:: @ 81EEBBD
 	trainerbattle 4, TRAINER_MEL_AND_PAUL, 0, Route109_Text_297872, Route109_Text_2978BD, Route109_Text_29792E
-	msgbox Route109_Text_2978F1, 6
+	msgbox Route109_Text_2978F1, MSGBOX_AUTOCLOSE
 	end
 
 Route109_EventScript_1EEBD8:: @ 81EEBD8
 	trainerbattle 0, TRAINER_CHANDLER, 0, Route109_Text_29798A, Route109_Text_2979AE
-	msgbox Route109_Text_2979BF, 6
+	msgbox Route109_Text_2979BF, MSGBOX_AUTOCLOSE
 	end
 
 Route109_EventScript_1EEBEF:: @ 81EEBEF
 	trainerbattle 0, TRAINER_HAILEY, 0, Route109_Text_2979EC, Route109_Text_297A15
-	msgbox Route109_Text_297A40, 6
+	msgbox Route109_Text_297A40, MSGBOX_AUTOCLOSE
 	end
 
 Route109_EventScript_1EEC06:: @ 81EEC06
 	trainerbattle 0, TRAINER_ELIJAH, 0, Route109_Text_297A82, Route109_Text_297AC7
-	msgbox Route109_Text_297AE5, 6
+	msgbox Route109_Text_297AE5, MSGBOX_AUTOCLOSE
 	end
 
 DewfordTown_Text_1EEC1D: @ 81EEC1D

--- a/data/maps/Route109_SeashoreHouse/scripts.inc
+++ b/data/maps/Route109_SeashoreHouse/scripts.inc
@@ -15,18 +15,18 @@ Route109_SeashoreHouse_EventScript_2693FE:: @ 82693FE
 	goto_eq Route109_SeashoreHouse_EventScript_269432
 	checkflag FLAG_TEMP_2
 	goto_eq Route109_SeashoreHouse_EventScript_269428
-	msgbox Route109_SeashoreHouse_Text_269555, 4
+	msgbox Route109_SeashoreHouse_Text_269555, MSGBOX_DEFAULT
 	setflag FLAG_TEMP_2
 	release
 	end
 
 Route109_SeashoreHouse_EventScript_269428:: @ 8269428
-	msgbox Route109_SeashoreHouse_Text_269635, 4
+	msgbox Route109_SeashoreHouse_Text_269635, MSGBOX_DEFAULT
 	release
 	end
 
 Route109_SeashoreHouse_EventScript_269432:: @ 8269432
-	msgbox Route109_SeashoreHouse_Text_269685, 4
+	msgbox Route109_SeashoreHouse_Text_269685, MSGBOX_DEFAULT
 	giveitem_std ITEM_SODA_POP, 6
 	compare VAR_RESULT, 0
 	goto_eq Route109_SeashoreHouse_EventScript_269456
@@ -35,16 +35,16 @@ Route109_SeashoreHouse_EventScript_269432:: @ 8269432
 	end
 
 Route109_SeashoreHouse_EventScript_269456:: @ 8269456
-	msgbox Route109_SeashoreHouse_Text_26973A, 4
+	msgbox Route109_SeashoreHouse_Text_26973A, MSGBOX_DEFAULT
 	release
 	end
 
 Route109_SeashoreHouse_EventScript_269460:: @ 8269460
 	showmoneybox 0, 0, 0
-	msgbox Route109_SeashoreHouse_Text_26977E, 5
+	msgbox Route109_SeashoreHouse_Text_26977E, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route109_SeashoreHouse_EventScript_269484
-	msgbox Route109_SeashoreHouse_Text_2697EF, 4
+	msgbox Route109_SeashoreHouse_Text_2697EF, MSGBOX_DEFAULT
 	hidemoneybox
 	nop
 	nop
@@ -58,7 +58,7 @@ Route109_SeashoreHouse_EventScript_269484:: @ 8269484
 	checkitemspace ITEM_SODA_POP, 1
 	compare VAR_RESULT, 0
 	goto_eq Route109_SeashoreHouse_EventScript_2694D5
-	msgbox Route109_SeashoreHouse_Text_2697C8, 4
+	msgbox Route109_SeashoreHouse_Text_2697C8, MSGBOX_DEFAULT
 	takemoney 0x12c, 0
 	updatemoneybox 0, 0
 	nop
@@ -70,7 +70,7 @@ Route109_SeashoreHouse_EventScript_269484:: @ 8269484
 	end
 
 Route109_SeashoreHouse_EventScript_2694C8:: @ 82694C8
-	msgbox Route109_SeashoreHouse_Text_2697D5, 4
+	msgbox Route109_SeashoreHouse_Text_2697D5, MSGBOX_DEFAULT
 	hidemoneybox
 	nop
 	nop
@@ -78,7 +78,7 @@ Route109_SeashoreHouse_EventScript_2694C8:: @ 82694C8
 	end
 
 Route109_SeashoreHouse_EventScript_2694D5:: @ 82694D5
-	msgbox gUnknown_08272AD0, 4
+	msgbox gUnknown_08272AD0, MSGBOX_DEFAULT
 	hidemoneybox
 	nop
 	nop
@@ -87,17 +87,17 @@ Route109_SeashoreHouse_EventScript_2694D5:: @ 82694D5
 
 Route109_SeashoreHouse_EventScript_2694E2:: @ 82694E2
 	trainerbattle 2, TRAINER_DWAYNE, 0, Route109_SeashoreHouse_Text_269803, Route109_SeashoreHouse_Text_269867, Route109_SeashoreHouse_EventScript_269533
-	msgbox Route109_SeashoreHouse_Text_26989D, 6
+	msgbox Route109_SeashoreHouse_Text_26989D, MSGBOX_AUTOCLOSE
 	end
 
 Route109_SeashoreHouse_EventScript_2694FD:: @ 82694FD
 	trainerbattle 2, TRAINER_JOHANNA, 0, Route109_SeashoreHouse_Text_2698E3, Route109_SeashoreHouse_Text_269947, Route109_SeashoreHouse_EventScript_269533
-	msgbox Route109_SeashoreHouse_Text_269953, 6
+	msgbox Route109_SeashoreHouse_Text_269953, MSGBOX_AUTOCLOSE
 	end
 
 Route109_SeashoreHouse_EventScript_269518:: @ 8269518
 	trainerbattle 2, TRAINER_SIMON, 0, Route109_SeashoreHouse_Text_269986, Route109_SeashoreHouse_Text_2699C5, Route109_SeashoreHouse_EventScript_269533
-	msgbox Route109_SeashoreHouse_Text_2699DF, 6
+	msgbox Route109_SeashoreHouse_Text_2699DF, MSGBOX_AUTOCLOSE
 	end
 
 Route109_SeashoreHouse_EventScript_269533:: @ 8269533

--- a/data/maps/Route110/scripts.inc
+++ b/data/maps/Route110/scripts.inc
@@ -187,10 +187,7 @@ Route110_EventScript_1EF44C:: @ 81EF44C
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route110_Text_298201, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 512
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 512
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_EDWIN_1
 	release
 	end
 
@@ -227,10 +224,7 @@ Route110_EventScript_1EF4F3:: @ 81EF4F3
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route110_Text_297CFE, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 353
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 353
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_BENJAMIN_1
 	release
 	end
 
@@ -257,10 +251,7 @@ Route110_EventScript_1EF56C:: @ 81EF56C
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route110_Text_297ECD, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 358
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 358
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_ABIGAIL_1
 	release
 	end
 
@@ -282,10 +273,7 @@ Route110_EventScript_1EF5CE:: @ 81EF5CE
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route110_Text_2983EE, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 302
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 302
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_ISABEL_1
 	release
 	end
 

--- a/data/maps/Route110/scripts.inc
+++ b/data/maps/Route110/scripts.inc
@@ -31,7 +31,7 @@ Route110_EventScript_1EF2A1:: @ 81EF2A1
 Route110_EventScript_1EF2AA:: @ 81EF2AA
 	lock
 	faceplayer
-	msgbox Route110_Text_1EFB5D, 4
+	msgbox Route110_Text_1EFB5D, MSGBOX_DEFAULT
 	applymovement VAR_LAST_TALKED, Route110_Movement_2725A2
 	waitmovement 0
 	release
@@ -40,7 +40,7 @@ Route110_EventScript_1EF2AA:: @ 81EF2AA
 Route110_EventScript_1EF2C0:: @ 81EF2C0
 	lock
 	faceplayer
-	msgbox Route110_Text_1EFB93, 4
+	msgbox Route110_Text_1EFB93, MSGBOX_DEFAULT
 	applymovement VAR_LAST_TALKED, Route110_Movement_2725A2
 	waitmovement 0
 	release
@@ -49,7 +49,7 @@ Route110_EventScript_1EF2C0:: @ 81EF2C0
 Route110_EventScript_1EF2D6:: @ 81EF2D6
 	lock
 	faceplayer
-	msgbox Route110_Text_1EFBCA, 4
+	msgbox Route110_Text_1EFBCA, MSGBOX_DEFAULT
 	applymovement VAR_LAST_TALKED, Route110_Movement_2725A2
 	waitmovement 0
 	release
@@ -58,74 +58,74 @@ Route110_EventScript_1EF2D6:: @ 81EF2D6
 Route110_EventScript_1EF2EC:: @ 81EF2EC
 	lock
 	faceplayer
-	msgbox Route110_Text_1EFC0D, 4
+	msgbox Route110_Text_1EFC0D, MSGBOX_DEFAULT
 	applymovement VAR_LAST_TALKED, Route110_Movement_2725A2
 	waitmovement 0
 	release
 	end
 
 Route110_EventScript_1EF302:: @ 81EF302
-	msgbox Route110_Text_1EFFC3, 2
+	msgbox Route110_Text_1EFFC3, MSGBOX_NPC
 	end
 
 Route110_EventScript_1EF30B:: @ 81EF30B
-	msgbox Route110_Text_1F0006, 2
+	msgbox Route110_Text_1F0006, MSGBOX_NPC
 	end
 
 Route110_EventScript_1EF314:: @ 81EF314
-	msgbox Route110_Text_1F006A, 2
+	msgbox Route110_Text_1F006A, MSGBOX_NPC
 	end
 
 Route110_EventScript_1EF31D:: @ 81EF31D
-	msgbox Route110_Text_1F0261, 2
+	msgbox Route110_Text_1F0261, MSGBOX_NPC
 	end
 
 Route110_EventScript_1EF326:: @ 81EF326
-	msgbox Route110_Text_1F02CA, 2
+	msgbox Route110_Text_1F02CA, MSGBOX_NPC
 	end
 
 Route110_EventScript_1EF32F:: @ 81EF32F
-	msgbox Route110_Text_1F030E, 2
+	msgbox Route110_Text_1F030E, MSGBOX_NPC
 	end
 
 Route110_EventScript_1EF338:: @ 81EF338
-	msgbox Route110_Text_1F0390, 2
+	msgbox Route110_Text_1F0390, MSGBOX_NPC
 	end
 
 Route110_EventScript_1EF341:: @ 81EF341
-	msgbox Route110_Text_1F0812, 3
+	msgbox Route110_Text_1F0812, MSGBOX_SIGN
 	end
 
 Route110_EventScript_1EF34A:: @ 81EF34A
-	msgbox Route110_Text_1F082D, 3
+	msgbox Route110_Text_1F082D, MSGBOX_SIGN
 	end
 
 Route110_EventScript_1EF353:: @ 81EF353
-	msgbox Route110_Text_1F0842, 3
+	msgbox Route110_Text_1F0842, MSGBOX_SIGN
 	end
 
 Route110_EventScript_1EF35C:: @ 81EF35C
-	msgbox Route110_Text_1F08CD, 3
+	msgbox Route110_Text_1F08CD, MSGBOX_SIGN
 	end
 
 Route110_EventScript_1EF365:: @ 81EF365
-	msgbox Route110_Text_1F08E3, 3
+	msgbox Route110_Text_1F08E3, MSGBOX_SIGN
 	end
 
 Route110_EventScript_1EF36E:: @ 81EF36E
-	msgbox Route110_Text_1F08F3, 3
+	msgbox Route110_Text_1F08F3, MSGBOX_SIGN
 	end
 
 Route110_EventScript_1EF377:: @ 81EF377
-	msgbox Route110_Text_1F090D, 3
+	msgbox Route110_Text_1F090D, MSGBOX_SIGN
 	end
 
 Route110_EventScript_1EF380:: @ 81EF380
-	msgbox Route110_Text_1F0992, 3
+	msgbox Route110_Text_1F0992, MSGBOX_SIGN
 	end
 
 Route110_EventScript_1EF389:: @ 81EF389
-	msgbox Route110_Text_1F09DB, 3
+	msgbox Route110_Text_1F09DB, MSGBOX_SIGN
 	end
 
 Route110_EventScript_1EF392:: @ 81EF392
@@ -133,12 +133,12 @@ Route110_EventScript_1EF392:: @ 81EF392
 	specialvar VAR_RESULT, GetRecordedCyclingRoadResults
 	compare VAR_RESULT, 0
 	goto_eq Route110_EventScript_1EF3AD
-	msgbox Route110_Text_1F0A1E, 4
+	msgbox Route110_Text_1F0A1E, MSGBOX_DEFAULT
 	releaseall
 	end
 
 Route110_EventScript_1EF3AD:: @ 81EF3AD
-	msgbox Route110_Text_1F0A5E, 4
+	msgbox Route110_Text_1F0A5E, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -150,28 +150,28 @@ Route110_EventScript_1EF3B7:: @ 81EF3B7
 	goto_eq Route110_EventScript_1EF3E8
 	compare VAR_CYCLING_CHALLENGE_STATE, 0
 	goto_eq Route110_EventScript_1EF3DE
-	msgbox Route110_Text_1F06FB, 4
+	msgbox Route110_Text_1F06FB, MSGBOX_DEFAULT
 	release
 	end
 
 Route110_EventScript_1EF3DE:: @ 81EF3DE
-	msgbox Route110_Text_1F0661, 4
+	msgbox Route110_Text_1F0661, MSGBOX_DEFAULT
 	release
 	end
 
 Route110_EventScript_1EF3E8:: @ 81EF3E8
-	msgbox Route110_Text_1F0755, 4
+	msgbox Route110_Text_1F0755, MSGBOX_DEFAULT
 	release
 	end
 
 Route110_EventScript_1EF3F2:: @ 81EF3F2
 	trainerbattle 0, TRAINER_EDWARD, 0, Route110_Text_29802B, Route110_Text_298064
-	msgbox Route110_Text_29808A, 6
+	msgbox Route110_Text_29808A, MSGBOX_AUTOCLOSE
 	end
 
 Route110_EventScript_1EF409:: @ 81EF409
 	trainerbattle 0, TRAINER_JACLYN, 0, Route110_Text_2980B9, Route110_Text_2980E5
-	msgbox Route110_Text_2980F8, 6
+	msgbox Route110_Text_2980F8, MSGBOX_AUTOCLOSE
 	end
 
 Route110_EventScript_1EF420:: @ 81EF420
@@ -179,39 +179,39 @@ Route110_EventScript_1EF420:: @ 81EF420
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route110_EventScript_1EF46B
-	msgbox Route110_Text_2981B3, 4
+	msgbox Route110_Text_2981B3, MSGBOX_DEFAULT
 	release
 	end
 
 Route110_EventScript_1EF44C:: @ 81EF44C
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route110_Text_298201, 4
+	msgbox Route110_Text_298201, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 512
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 512
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route110_EventScript_1EF46B:: @ 81EF46B
 	trainerbattle 5, TRAINER_EDWIN_1, 0, Route110_Text_298232, Route110_Text_298288
-	msgbox Route110_Text_2982A2, 6
+	msgbox Route110_Text_2982A2, MSGBOX_AUTOCLOSE
 	end
 
 Route110_EventScript_1EF482:: @ 81EF482
 	trainerbattle 0, TRAINER_DALE, 0, Route110_Text_2982CC, Route110_Text_2982F5
-	msgbox Route110_Text_298303, 6
+	msgbox Route110_Text_298303, MSGBOX_AUTOCLOSE
 	end
 
 Route110_EventScript_1EF499:: @ 81EF499
 	trainerbattle 0, TRAINER_JACOB, 0, Route110_Text_297B3F, Route110_Text_297B77
-	msgbox Route110_Text_297B8F, 6
+	msgbox Route110_Text_297B8F, MSGBOX_AUTOCLOSE
 	end
 
 Route110_EventScript_1EF4B0:: @ 81EF4B0
 	trainerbattle 0, TRAINER_ANTHONY, 0, Route110_Text_297BE7, Route110_Text_297C0F
-	msgbox Route110_Text_297C1F, 6
+	msgbox Route110_Text_297C1F, MSGBOX_AUTOCLOSE
 	end
 
 Route110_EventScript_1EF4C7:: @ 81EF4C7
@@ -219,29 +219,29 @@ Route110_EventScript_1EF4C7:: @ 81EF4C7
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route110_EventScript_1EF512
-	msgbox Route110_Text_297CB4, 4
+	msgbox Route110_Text_297CB4, MSGBOX_DEFAULT
 	release
 	end
 
 Route110_EventScript_1EF4F3:: @ 81EF4F3
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route110_Text_297CFE, 4
+	msgbox Route110_Text_297CFE, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 353
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 353
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route110_EventScript_1EF512:: @ 81EF512
 	trainerbattle 5, TRAINER_BENJAMIN_1, 0, Route110_Text_297D4B, Route110_Text_297D8E
-	msgbox Route110_Text_297DB0, 6
+	msgbox Route110_Text_297DB0, MSGBOX_AUTOCLOSE
 	end
 
 Route110_EventScript_1EF529:: @ 81EF529
 	trainerbattle 0, TRAINER_JASMINE, 0, Route110_Text_297F93, Route110_Text_297FD0
-	msgbox Route110_Text_297FF1, 6
+	msgbox Route110_Text_297FF1, MSGBOX_AUTOCLOSE
 	end
 
 Route110_EventScript_1EF540:: @ 81EF540
@@ -249,24 +249,24 @@ Route110_EventScript_1EF540:: @ 81EF540
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route110_EventScript_1EF58B
-	msgbox Route110_Text_297E88, 4
+	msgbox Route110_Text_297E88, MSGBOX_DEFAULT
 	release
 	end
 
 Route110_EventScript_1EF56C:: @ 81EF56C
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route110_Text_297ECD, 4
+	msgbox Route110_Text_297ECD, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 358
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 358
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route110_EventScript_1EF58B:: @ 81EF58B
 	trainerbattle 5, TRAINER_ABIGAIL_1, 0, Route110_Text_297F09, Route110_Text_297F37
-	msgbox Route110_Text_297F58, 6
+	msgbox Route110_Text_297F58, MSGBOX_AUTOCLOSE
 	end
 
 Route110_EventScript_1EF5A2:: @ 81EF5A2
@@ -274,29 +274,29 @@ Route110_EventScript_1EF5A2:: @ 81EF5A2
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route110_EventScript_1EF5ED
-	msgbox Route110_Text_2983A2, 4
+	msgbox Route110_Text_2983A2, MSGBOX_DEFAULT
 	release
 	end
 
 Route110_EventScript_1EF5CE:: @ 81EF5CE
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route110_Text_2983EE, 4
+	msgbox Route110_Text_2983EE, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 302
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 302
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route110_EventScript_1EF5ED:: @ 81EF5ED
 	trainerbattle 5, TRAINER_ISABEL_1, 0, Route110_Text_298466, Route110_Text_2984AF
-	msgbox Route110_Text_2984C8, 6
+	msgbox Route110_Text_2984C8, MSGBOX_AUTOCLOSE
 	end
 
 Route110_EventScript_1EF604:: @ 81EF604
 	trainerbattle 0, TRAINER_TIMMY, 0, Route110_Text_298525, Route110_Text_298559
-	msgbox Route110_Text_298579, 6
+	msgbox Route110_Text_298579, MSGBOX_AUTOCLOSE
 	end
 
 Route110_EventScript_1EF61B:: @ 81EF61B
@@ -304,17 +304,17 @@ Route110_EventScript_1EF61B:: @ 81EF61B
 
 Route110_EventScript_1EF61C:: @ 81EF61C
 	trainerbattle 0, TRAINER_KALEB, 0, Route110_Text_2986ED, Route110_Text_298735
-	msgbox Route110_Text_298755, 6
+	msgbox Route110_Text_298755, MSGBOX_AUTOCLOSE
 	end
 
 Route110_EventScript_1EF633:: @ 81EF633
 	trainerbattle 0, TRAINER_JOSEPH, 0, Route110_Text_298642, Route110_Text_298686
-	msgbox Route110_Text_2986A9, 6
+	msgbox Route110_Text_2986A9, MSGBOX_AUTOCLOSE
 	end
 
 Route110_EventScript_1EF64A:: @ 81EF64A
 	trainerbattle 0, TRAINER_ALYSSA, 0, Route110_Text_2985AB, Route110_Text_2985F9
-	msgbox Route110_Text_298612, 6
+	msgbox Route110_Text_298612, MSGBOX_AUTOCLOSE
 	end
 
 Route110_EventScript_1EF661:: @ 81EF661
@@ -327,7 +327,7 @@ Route110_EventScript_1EF661:: @ 81EF661
 
 Route110_EventScript_1EF673:: @ 81EF673
 	special FinishCyclingRoadChallenge
-	msgbox Route110_Text_1F03FF, 4
+	msgbox Route110_Text_1F03FF, MSGBOX_DEFAULT
 	switch VAR_RESULT
 	case 10, Route110_EventScript_1EF6FD
 	case 9, Route110_EventScript_1EF70B
@@ -343,27 +343,27 @@ Route110_EventScript_1EF673:: @ 81EF673
 	end
 
 Route110_EventScript_1EF6FD:: @ 81EF6FD
-	msgbox Route110_Text_1F0431, 4
+	msgbox Route110_Text_1F0431, MSGBOX_DEFAULT
 	goto Route110_EventScript_1EF743
 	end
 
 Route110_EventScript_1EF70B:: @ 81EF70B
-	msgbox Route110_Text_1F04A4, 4
+	msgbox Route110_Text_1F04A4, MSGBOX_DEFAULT
 	goto Route110_EventScript_1EF743
 	end
 
 Route110_EventScript_1EF719:: @ 81EF719
-	msgbox Route110_Text_1F0500, 4
+	msgbox Route110_Text_1F0500, MSGBOX_DEFAULT
 	goto Route110_EventScript_1EF743
 	end
 
 Route110_EventScript_1EF727:: @ 81EF727
-	msgbox Route110_Text_1F0567, 4
+	msgbox Route110_Text_1F0567, MSGBOX_DEFAULT
 	goto Route110_EventScript_1EF743
 	end
 
 Route110_EventScript_1EF735:: @ 81EF735
-	msgbox Route110_Text_1F05CE, 4
+	msgbox Route110_Text_1F05CE, MSGBOX_DEFAULT
 	goto Route110_EventScript_1EF743
 	end
 
@@ -425,7 +425,7 @@ Route110_EventScript_1EF7E6:: @ 81EF7E6
 	return
 
 Route110_EventScript_1EF7EB:: @ 81EF7EB
-	msgbox Route110_Text_1EFC48, 4
+	msgbox Route110_Text_1EFC48, MSGBOX_DEFAULT
 	switch VAR_STARTER_MON
 	case 0, Route110_EventScript_1EF81A
 	case 1, Route110_EventScript_1EF82A
@@ -448,14 +448,14 @@ Route110_EventScript_1EF83A:: @ 81EF83A
 	end
 
 Route110_EventScript_1EF84A:: @ 81EF84A
-	msgbox Route110_Text_1EFCF1, 4
+	msgbox Route110_Text_1EFCF1, MSGBOX_DEFAULT
 	call Route110_EventScript_1EF8DF
-	msgbox Route110_Text_1EFD58, 4
+	msgbox Route110_Text_1EFD58, MSGBOX_DEFAULT
 	goto Route110_EventScript_1EF8EC
 	end
 
 Route110_EventScript_1EF865:: @ 81EF865
-	msgbox Route110_Text_1EFE3F, 4
+	msgbox Route110_Text_1EFE3F, MSGBOX_DEFAULT
 	switch VAR_STARTER_MON
 	case 0, Route110_EventScript_1EF894
 	case 1, Route110_EventScript_1EF8A4
@@ -478,9 +478,9 @@ Route110_EventScript_1EF8B4:: @ 81EF8B4
 	end
 
 Route110_EventScript_1EF8C4:: @ 81EF8C4
-	msgbox Route110_Text_1EFECD, 4
+	msgbox Route110_Text_1EFECD, MSGBOX_DEFAULT
 	call Route110_EventScript_1EF8DF
-	msgbox Route110_Text_1EFF1C, 4
+	msgbox Route110_Text_1EFF1C, MSGBOX_DEFAULT
 	goto Route110_EventScript_1EF8EC
 	end
 
@@ -640,7 +640,7 @@ Route110_EventScript_1EF9F7:: @ 81EF9F7
 	call_if 1, Route110_EventScript_1EFAEE
 	compare VAR_0x8008, 4
 	call_if 1, Route110_EventScript_1EFAF9
-	msgbox Route110_Text_1F0AB5, 4
+	msgbox Route110_Text_1F0AB5, MSGBOX_DEFAULT
 	closemessage
 	delay 20
 	applymovement 36, Route110_Movement_2725A4
@@ -652,16 +652,16 @@ Route110_EventScript_1EF9F7:: @ 81EF9F7
 	applymovement 36, Route110_Movement_2725AA
 	waitmovement 0
 	delay 30
-	msgbox Route110_Text_1F0AFF, 4
+	msgbox Route110_Text_1F0AFF, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox Route110_Text_1F0C0C, 4
+	msgbox Route110_Text_1F0C0C, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
 	setflag FLAG_0x119
-	msgbox Route110_Text_1F0C33, 4
+	msgbox Route110_Text_1F0C33, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_0x8008, 1
 	call_if 1, Route110_EventScript_1EFB04

--- a/data/maps/Route110_SeasideCyclingRoadNorthEntrance/scripts.inc
+++ b/data/maps/Route110_SeasideCyclingRoadNorthEntrance/scripts.inc
@@ -4,7 +4,7 @@ Route110_SeasideCyclingRoadNorthEntrance_MapScripts:: @ 826EA77
 Route110_SeasideCyclingRoadNorthEntrance_EventScript_26EA78:: @ 826EA78
 	lock
 	faceplayer
-	msgbox Route110_SeasideCyclingRoadNorthEntrance_Text_26EAC1, 4
+	msgbox Route110_SeasideCyclingRoadNorthEntrance_Text_26EAC1, MSGBOX_DEFAULT
 	release
 	end
 
@@ -19,7 +19,7 @@ Route110_SeasideCyclingRoadNorthEntrance_EventScript_26EA84:: @ 826EA84
 	end
 
 Route110_SeasideCyclingRoadNorthEntrance_EventScript_26EA9F:: @ 826EA9F
-	msgbox Route110_SeasideCyclingRoadNorthEntrance_Text_26EB48, 4
+	msgbox Route110_SeasideCyclingRoadNorthEntrance_Text_26EB48, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, Route110_SeasideCyclingRoadNorthEntrance_Movement_26EAB4
 	waitmovement 0

--- a/data/maps/Route110_SeasideCyclingRoadSouthEntrance/scripts.inc
+++ b/data/maps/Route110_SeasideCyclingRoadSouthEntrance/scripts.inc
@@ -16,7 +16,7 @@ Route110_SeasideCyclingRoadSouthEntrance_EventScript_26EBBE:: @ 826EBBE
 Route110_SeasideCyclingRoadSouthEntrance_EventScript_26EBC4:: @ 826EBC4
 	lock
 	faceplayer
-	msgbox Route110_SeasideCyclingRoadSouthEntrance_Text_26EC23, 4
+	msgbox Route110_SeasideCyclingRoadSouthEntrance_Text_26EC23, MSGBOX_DEFAULT
 	release
 	end
 
@@ -37,7 +37,7 @@ Route110_SeasideCyclingRoadSouthEntrance_EventScript_26EBF6:: @ 826EBF6
 	return
 
 Route110_SeasideCyclingRoadSouthEntrance_EventScript_26EBFC:: @ 826EBFC
-	msgbox Route110_SeasideCyclingRoadSouthEntrance_Text_26ECAA, 4
+	msgbox Route110_SeasideCyclingRoadSouthEntrance_Text_26ECAA, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, Route110_SeasideCyclingRoadSouthEntrance_Movement_26EC11
 	waitmovement 0

--- a/data/maps/Route110_TrickHouseEnd/scripts.inc
+++ b/data/maps/Route110_TrickHouseEnd/scripts.inc
@@ -43,7 +43,7 @@ Route110_TrickHouseEnd_EventScript_26AD0D:: @ 826AD0D
 Route110_TrickHouseEnd_EventScript_26AD17:: @ 826AD17
 	lock
 	faceplayer
-	msgbox Route110_TrickHouseEnd_Text_26B08D, 4
+	msgbox Route110_TrickHouseEnd_Text_26B08D, MSGBOX_DEFAULT
 	setvar VAR_TEMP_2, 1
 	switch VAR_0x4044
 	case 0, Route110_TrickHouseEnd_EventScript_26AD84
@@ -57,98 +57,98 @@ Route110_TrickHouseEnd_EventScript_26AD17:: @ 826AD17
 	end
 
 Route110_TrickHouseEnd_EventScript_26AD84:: @ 826AD84
-	msgbox Route110_TrickHouseEnd_Text_26B0BC, 4
-	msgbox Route110_TrickHouseEnd_Text_26B73D, 4
+	msgbox Route110_TrickHouseEnd_Text_26B0BC, MSGBOX_DEFAULT
+	msgbox Route110_TrickHouseEnd_Text_26B73D, MSGBOX_DEFAULT
 	setvar VAR_0x40C1, 0
 	giveitem_std ITEM_RARE_CANDY
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEnd_EventScript_26AFEF
-	msgbox Route110_TrickHouseEnd_Text_26B7EF, 4
+	msgbox Route110_TrickHouseEnd_Text_26B7EF, MSGBOX_DEFAULT
 	closemessage
 	call Route110_TrickHouseEnd_EventScript_26AFCF
 	release
 	end
 
 Route110_TrickHouseEnd_EventScript_26ADC0:: @ 826ADC0
-	msgbox Route110_TrickHouseEnd_Text_26B13B, 4
-	msgbox Route110_TrickHouseEnd_Text_26B73D, 4
+	msgbox Route110_TrickHouseEnd_Text_26B13B, MSGBOX_DEFAULT
+	msgbox Route110_TrickHouseEnd_Text_26B73D, MSGBOX_DEFAULT
 	setvar VAR_0x40C1, 0
 	giveitem_std ITEM_TIMER_BALL
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEnd_EventScript_26AFEF
-	msgbox Route110_TrickHouseEnd_Text_26B7EF, 4
+	msgbox Route110_TrickHouseEnd_Text_26B7EF, MSGBOX_DEFAULT
 	closemessage
 	call Route110_TrickHouseEnd_EventScript_26AFCF
 	release
 	end
 
 Route110_TrickHouseEnd_EventScript_26ADFC:: @ 826ADFC
-	msgbox Route110_TrickHouseEnd_Text_26B1AD, 4
-	msgbox Route110_TrickHouseEnd_Text_26B73D, 4
+	msgbox Route110_TrickHouseEnd_Text_26B1AD, MSGBOX_DEFAULT
+	msgbox Route110_TrickHouseEnd_Text_26B73D, MSGBOX_DEFAULT
 	setvar VAR_0x40C1, 0
 	giveitem_std ITEM_HARD_STONE
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEnd_EventScript_26AFEF
-	msgbox Route110_TrickHouseEnd_Text_26B7EF, 4
+	msgbox Route110_TrickHouseEnd_Text_26B7EF, MSGBOX_DEFAULT
 	closemessage
 	call Route110_TrickHouseEnd_EventScript_26AFCF
 	release
 	end
 
 Route110_TrickHouseEnd_EventScript_26AE38:: @ 826AE38
-	msgbox Route110_TrickHouseEnd_Text_26B223, 4
-	msgbox Route110_TrickHouseEnd_Text_26B73D, 4
+	msgbox Route110_TrickHouseEnd_Text_26B223, MSGBOX_DEFAULT
+	msgbox Route110_TrickHouseEnd_Text_26B73D, MSGBOX_DEFAULT
 	setvar VAR_0x40C1, 0
 	giveitem_std ITEM_SMOKE_BALL
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEnd_EventScript_26AFEF
-	msgbox Route110_TrickHouseEnd_Text_26B7EF, 4
+	msgbox Route110_TrickHouseEnd_Text_26B7EF, MSGBOX_DEFAULT
 	closemessage
 	call Route110_TrickHouseEnd_EventScript_26AFCF
 	release
 	end
 
 Route110_TrickHouseEnd_EventScript_26AE74:: @ 826AE74
-	msgbox Route110_TrickHouseEnd_Text_26B293, 4
-	msgbox Route110_TrickHouseEnd_Text_26B73D, 4
+	msgbox Route110_TrickHouseEnd_Text_26B293, MSGBOX_DEFAULT
+	msgbox Route110_TrickHouseEnd_Text_26B73D, MSGBOX_DEFAULT
 	setvar VAR_0x40C1, 0
 	giveitem_std ITEM_TM12
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEnd_EventScript_26AFEF
-	msgbox Route110_TrickHouseEnd_Text_26B7EF, 4
+	msgbox Route110_TrickHouseEnd_Text_26B7EF, MSGBOX_DEFAULT
 	closemessage
 	call Route110_TrickHouseEnd_EventScript_26AFCF
 	release
 	end
 
 Route110_TrickHouseEnd_EventScript_26AEB0:: @ 826AEB0
-	msgbox Route110_TrickHouseEnd_Text_26B315, 4
-	msgbox Route110_TrickHouseEnd_Text_26B73D, 4
+	msgbox Route110_TrickHouseEnd_Text_26B315, MSGBOX_DEFAULT
+	msgbox Route110_TrickHouseEnd_Text_26B73D, MSGBOX_DEFAULT
 	setvar VAR_0x40C1, 0
 	giveitem_std ITEM_MAGNET
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEnd_EventScript_26AFEF
-	msgbox Route110_TrickHouseEnd_Text_26B7EF, 4
+	msgbox Route110_TrickHouseEnd_Text_26B7EF, MSGBOX_DEFAULT
 	closemessage
 	call Route110_TrickHouseEnd_EventScript_26AFCF
 	release
 	end
 
 Route110_TrickHouseEnd_EventScript_26AEEC:: @ 826AEEC
-	msgbox Route110_TrickHouseEnd_Text_26B365, 4
-	msgbox Route110_TrickHouseEnd_Text_26B73D, 4
+	msgbox Route110_TrickHouseEnd_Text_26B365, MSGBOX_DEFAULT
+	msgbox Route110_TrickHouseEnd_Text_26B73D, MSGBOX_DEFAULT
 	setvar VAR_0x40C1, 0
 	giveitem_std ITEM_PP_MAX
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEnd_EventScript_26AFEF
-	msgbox Route110_TrickHouseEnd_Text_26B7EF, 4
+	msgbox Route110_TrickHouseEnd_Text_26B7EF, MSGBOX_DEFAULT
 	closemessage
 	call Route110_TrickHouseEnd_EventScript_26AFCF
 	release
 	end
 
 Route110_TrickHouseEnd_EventScript_26AF28:: @ 826AF28
-	msgbox Route110_TrickHouseEnd_Text_26B3AB, 4
+	msgbox Route110_TrickHouseEnd_Text_26B3AB, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_FACING, 1
 	call_if 1, Route110_TrickHouseEnd_EventScript_26B015
@@ -159,17 +159,17 @@ Route110_TrickHouseEnd_EventScript_26AF28:: @ 826AF28
 	compare VAR_FACING, 4
 	call_if 1, Route110_TrickHouseEnd_EventScript_26B036
 	delay 30
-	msgbox Route110_TrickHouseEnd_Text_26B3FA, 4
+	msgbox Route110_TrickHouseEnd_Text_26B3FA, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, Route110_TrickHouseEnd_Movement_27259E
 	waitmovement 0
 	delay 30
-	msgbox Route110_TrickHouseEnd_Text_26B485, 4
+	msgbox Route110_TrickHouseEnd_Text_26B485, MSGBOX_DEFAULT
 	setvar VAR_0x40C1, 0
 	call Route110_TrickHouseEnd_EventScript_26AFA5
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEnd_EventScript_26B002
-	msgbox Route110_TrickHouseEnd_Text_26B69A, 4
+	msgbox Route110_TrickHouseEnd_Text_26B69A, MSGBOX_DEFAULT
 	call Route110_TrickHouseEnd_EventScript_26AFCF
 	special ResetTrickHouseEndRoomFlag
 	release
@@ -201,13 +201,13 @@ Route110_TrickHouseEnd_EventScript_26AFCF:: @ 826AFCF
 
 Route110_TrickHouseEnd_EventScript_26AFEF:: @ 826AFEF
 	call Route110_TrickHouseEnd_EventScript_27205E
-	msgbox Route110_TrickHouseEnd_Text_26B760, 4
+	msgbox Route110_TrickHouseEnd_Text_26B760, MSGBOX_DEFAULT
 	setvar VAR_0x40C1, 1
 	return
 
 Route110_TrickHouseEnd_EventScript_26B002:: @ 826B002
 	call Route110_TrickHouseEnd_EventScript_272071
-	msgbox Route110_TrickHouseEnd_Text_26B615, 4
+	msgbox Route110_TrickHouseEnd_Text_26B615, MSGBOX_DEFAULT
 	setvar VAR_0x40C1, 1
 	return
 
@@ -243,7 +243,7 @@ Route110_TrickHouseEnd_EventScript_26B041:: @ 826B041
 	playse SE_W153
 	applymovement 255, Route110_TrickHouseEnd_Movement_2725AA
 	waitmovement 0
-	msgbox Route110_TrickHouseEnd_Text_26B8BD, 4
+	msgbox Route110_TrickHouseEnd_Text_26B8BD, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, Route110_TrickHouseEnd_Movement_26B089
 	waitmovement 0

--- a/data/maps/Route110_TrickHouseEntrance/scripts.inc
+++ b/data/maps/Route110_TrickHouseEntrance/scripts.inc
@@ -214,7 +214,7 @@ Route110_TrickHouseEntrance_EventScript_269CF8:: @ 8269CF8
 	delay 20
 	compare VAR_0x4044, 0
 	call_if 1, Route110_TrickHouseEntrance_EventScript_269E48
-	msgbox Route110_TrickHouseEntrance_Text_26A78C, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A78C, MSGBOX_DEFAULT
 	closemessage
 	delay 20
 	applymovement 1, Route110_TrickHouseEntrance_Movement_269E36
@@ -271,35 +271,35 @@ Route110_TrickHouseEntrance_EventScript_269D6E:: @ 8269D6E
 	end
 
 Route110_TrickHouseEntrance_EventScript_269DEE:: @ 8269DEE
-	msgbox Route110_TrickHouseEntrance_Text_26A48A, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A48A, MSGBOX_DEFAULT
 	return
 
 Route110_TrickHouseEntrance_EventScript_269DF7:: @ 8269DF7
-	msgbox Route110_TrickHouseEntrance_Text_26A4DA, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A4DA, MSGBOX_DEFAULT
 	return
 
 Route110_TrickHouseEntrance_EventScript_269E00:: @ 8269E00
-	msgbox Route110_TrickHouseEntrance_Text_26A529, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A529, MSGBOX_DEFAULT
 	return
 
 Route110_TrickHouseEntrance_EventScript_269E09:: @ 8269E09
-	msgbox Route110_TrickHouseEntrance_Text_26A577, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A577, MSGBOX_DEFAULT
 	return
 
 Route110_TrickHouseEntrance_EventScript_269E12:: @ 8269E12
-	msgbox Route110_TrickHouseEntrance_Text_26A5C8, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A5C8, MSGBOX_DEFAULT
 	return
 
 Route110_TrickHouseEntrance_EventScript_269E1B:: @ 8269E1B
-	msgbox Route110_TrickHouseEntrance_Text_26A616, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A616, MSGBOX_DEFAULT
 	return
 
 Route110_TrickHouseEntrance_EventScript_269E24:: @ 8269E24
-	msgbox Route110_TrickHouseEntrance_Text_26A665, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A665, MSGBOX_DEFAULT
 	return
 
 Route110_TrickHouseEntrance_EventScript_269E2D:: @ 8269E2D
-	msgbox Route110_TrickHouseEntrance_Text_26A6B6, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A6B6, MSGBOX_DEFAULT
 	return
 
 Route110_TrickHouseEnd_Movement_269E36: @ 8269E36
@@ -327,11 +327,11 @@ Route110_TrickHouseEntrance_Movement_269E3F: @ 8269E3F
 	step_end
 
 Route110_TrickHouseEntrance_EventScript_269E48:: @ 8269E48
-	msgbox Route110_TrickHouseEntrance_Text_26A709, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A709, MSGBOX_DEFAULT
 	return
 
 Route110_TrickHouseEntrance_EventScript_269E51:: @ 8269E51
-	msgbox Route110_TrickHouseEntrance_Text_26A921, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A921, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, Route110_TrickHouseEntrance_Movement_27259E
 	waitmovement 0
@@ -340,7 +340,7 @@ Route110_TrickHouseEntrance_EventScript_269E51:: @ 8269E51
 	waitmovement 0
 	applymovement 1, Route110_TrickHouseEntrance_Movement_27259A
 	waitmovement 0
-	msgbox Route110_TrickHouseEntrance_Text_26A9AF, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A9AF, MSGBOX_DEFAULT
 	applymovement 1, Route110_TrickHouseEntrance_Movement_2725A6
 	waitmovement 0
 	releaseall
@@ -349,7 +349,7 @@ Route110_TrickHouseEntrance_EventScript_269E51:: @ 8269E51
 Route110_TrickHouseEntrance_EventScript_269E8F:: @ 8269E8F
 	applymovement 1, Route110_TrickHouseEntrance_Movement_27259E
 	waitmovement 0
-	msgbox Route110_TrickHouseEntrance_Text_26AA82, 4
+	msgbox Route110_TrickHouseEntrance_Text_26AA82, MSGBOX_DEFAULT
 	compare VAR_0x4044, 1
 	goto_eq Route110_TrickHouseEntrance_EventScript_269EEF
 	compare VAR_0x4044, 2
@@ -372,7 +372,7 @@ Route110_TrickHouseEntrance_EventScript_269EEF:: @ 8269EEF
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A023
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEntrance_EventScript_27205E
-	msgbox Route110_TrickHouseEntrance_Text_26AB00, 4
+	msgbox Route110_TrickHouseEntrance_Text_26AB00, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -382,7 +382,7 @@ Route110_TrickHouseEntrance_EventScript_269F1B:: @ 8269F1B
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A023
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEntrance_EventScript_27205E
-	msgbox Route110_TrickHouseEntrance_Text_26AB00, 4
+	msgbox Route110_TrickHouseEntrance_Text_26AB00, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -392,7 +392,7 @@ Route110_TrickHouseEntrance_EventScript_269F47:: @ 8269F47
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A023
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEntrance_EventScript_27205E
-	msgbox Route110_TrickHouseEntrance_Text_26AB00, 4
+	msgbox Route110_TrickHouseEntrance_Text_26AB00, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -402,7 +402,7 @@ Route110_TrickHouseEntrance_EventScript_269F73:: @ 8269F73
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A023
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEntrance_EventScript_27205E
-	msgbox Route110_TrickHouseEntrance_Text_26AB00, 4
+	msgbox Route110_TrickHouseEntrance_Text_26AB00, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -412,7 +412,7 @@ Route110_TrickHouseEntrance_EventScript_269F9F:: @ 8269F9F
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A023
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEntrance_EventScript_27205E
-	msgbox Route110_TrickHouseEntrance_Text_26AB00, 4
+	msgbox Route110_TrickHouseEntrance_Text_26AB00, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -422,7 +422,7 @@ Route110_TrickHouseEntrance_EventScript_269FCB:: @ 8269FCB
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A023
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEntrance_EventScript_27205E
-	msgbox Route110_TrickHouseEntrance_Text_26AB00, 4
+	msgbox Route110_TrickHouseEntrance_Text_26AB00, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -432,7 +432,7 @@ Route110_TrickHouseEntrance_EventScript_269FF7:: @ 8269FF7
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A023
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEntrance_EventScript_27205E
-	msgbox Route110_TrickHouseEntrance_Text_26AB00, 4
+	msgbox Route110_TrickHouseEntrance_Text_26AB00, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -447,13 +447,13 @@ Route110_TrickHouseEntrance_EventScript_26A023:: @ 826A023
 Route110_TrickHouseEntrance_EventScript_26A039:: @ 826A039
 	applymovement 1, Route110_TrickHouseEntrance_Movement_27259E
 	waitmovement 0
-	msgbox Route110_TrickHouseEntrance_Text_26AB2C, 4
+	msgbox Route110_TrickHouseEntrance_Text_26AB2C, MSGBOX_DEFAULT
 	call Route110_TrickHouseEntrance_EventScript_26A070
 	compare VAR_RESULT, 1
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A09A
 	compare VAR_RESULT, 0
 	call_if 1, Route110_TrickHouseEntrance_EventScript_272071
-	msgbox Route110_TrickHouseEntrance_Text_26ABBD, 4
+	msgbox Route110_TrickHouseEntrance_Text_26ABBD, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -472,7 +472,7 @@ Route110_TrickHouseEntrance_EventScript_26A092:: @ 826A092
 	return
 
 Route110_TrickHouseEntrance_EventScript_26A09A:: @ 826A09A
-	msgbox Route110_TrickHouseEntrance_Text_26ABAE, 4
+	msgbox Route110_TrickHouseEntrance_Text_26ABAE, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, Route110_TrickHouseEntrance_Movement_26D632
 	waitmovement 0
@@ -497,12 +497,12 @@ Route110_TrickHouseEntrance_EventScript_26A0D3:: @ 826A0D3
 	end
 
 Route110_TrickHouseEntrance_EventScript_26A106:: @ 826A106
-	msgbox Route110_TrickHouseEntrance_Text_26A878, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A878, MSGBOX_DEFAULT
 	releaseall
 	end
 
 Route110_TrickHouseEntrance_EventScript_26A110:: @ 826A110
-	msgbox Route110_TrickHouseEntrance_Text_26A887, 5
+	msgbox Route110_TrickHouseEntrance_Text_26A887, MSGBOX_YESNO
 	closemessage
 	compare VAR_RESULT, 1
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A126
@@ -581,19 +581,19 @@ Route110_TrickHouseEntrance_EventScript_26A1F6:: @ 826A1F6
 	end
 
 Route110_TrickHouseEntrance_EventScript_26A201:: @ 826A201
-	msgbox Route110_TrickHouseEntrance_Text_26A8BD, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A8BD, MSGBOX_DEFAULT
 	releaseall
 	end
 
 Route110_TrickHouseEntrance_EventScript_26A20B:: @ 826A20B
 	compare VAR_0x4044, 8
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A220
-	msgbox Route110_TrickHouseEntrance_Text_26A878, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A878, MSGBOX_DEFAULT
 	releaseall
 	end
 
 Route110_TrickHouseEntrance_EventScript_26A220:: @ 826A220
-	msgbox Route110_TrickHouseEntrance_Text_26A8BD, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A8BD, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -613,7 +613,7 @@ Route110_TrickHouseEntrance_EventScript_26A22A:: @ 826A22A
 Route110_TrickHouseEntrance_EventScript_26A289:: @ 826A289
 	compare VAR_0x40AB, 0
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A3D1
-	msgbox Route110_TrickHousePuzzle1_Text_26B98D, 4
+	msgbox Route110_TrickHousePuzzle1_Text_26B98D, MSGBOX_DEFAULT
 	playse SE_PIN
 	setvar VAR_0x40AB, 2
 	setmetatile 13, 1, 523, 0
@@ -624,7 +624,7 @@ Route110_TrickHouseEntrance_EventScript_26A289:: @ 826A289
 Route110_TrickHouseEntrance_EventScript_26A2B2:: @ 826A2B2
 	compare VAR_0x40AC, 0
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A3D1
-	msgbox Route110_TrickHousePuzzle2_Text_26BCBA, 4
+	msgbox Route110_TrickHousePuzzle2_Text_26BCBA, MSGBOX_DEFAULT
 	playse SE_PIN
 	setvar VAR_0x40AC, 2
 	setmetatile 13, 1, 523, 0
@@ -635,7 +635,7 @@ Route110_TrickHouseEntrance_EventScript_26A2B2:: @ 826A2B2
 Route110_TrickHouseEntrance_EventScript_26A2DB:: @ 826A2DB
 	compare VAR_0x40AD, 0
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A3D1
-	msgbox Route110_TrickHousePuzzle3_Text_26C609, 4
+	msgbox Route110_TrickHousePuzzle3_Text_26C609, MSGBOX_DEFAULT
 	playse SE_PIN
 	setvar VAR_0x40AD, 2
 	setmetatile 13, 1, 523, 0
@@ -646,7 +646,7 @@ Route110_TrickHouseEntrance_EventScript_26A2DB:: @ 826A2DB
 Route110_TrickHouseEntrance_EventScript_26A304:: @ 826A304
 	compare VAR_0x40AE, 0
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A3D1
-	msgbox Route110_TrickHousePuzzle4_Text_26C8C3, 4
+	msgbox Route110_TrickHousePuzzle4_Text_26C8C3, MSGBOX_DEFAULT
 	playse SE_PIN
 	setvar VAR_0x40AE, 2
 	setmetatile 13, 1, 523, 0
@@ -657,7 +657,7 @@ Route110_TrickHouseEntrance_EventScript_26A304:: @ 826A304
 Route110_TrickHouseEntrance_EventScript_26A32D:: @ 826A32D
 	compare VAR_0x40AF, 0
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A3D1
-	msgbox Route110_TrickHousePuzzle5_Text_26D660, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26D660, MSGBOX_DEFAULT
 	playse SE_PIN
 	setvar VAR_0x40AF, 2
 	setmetatile 13, 1, 523, 0
@@ -668,7 +668,7 @@ Route110_TrickHouseEntrance_EventScript_26A32D:: @ 826A32D
 Route110_TrickHouseEntrance_EventScript_26A356:: @ 826A356
 	compare VAR_0x40B0, 0
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A3D1
-	msgbox Route110_TrickHousePuzzle6_Text_26DE26, 4
+	msgbox Route110_TrickHousePuzzle6_Text_26DE26, MSGBOX_DEFAULT
 	playse SE_PIN
 	setvar VAR_0x40B0, 2
 	setmetatile 13, 1, 523, 0
@@ -679,7 +679,7 @@ Route110_TrickHouseEntrance_EventScript_26A356:: @ 826A356
 Route110_TrickHouseEntrance_EventScript_26A37F:: @ 826A37F
 	compare VAR_0x40B1, 0
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A3D1
-	msgbox Route110_TrickHousePuzzle7_EventScript_26E413, 4
+	msgbox Route110_TrickHousePuzzle7_EventScript_26E413, MSGBOX_DEFAULT
 	playse SE_PIN
 	setvar VAR_0x40B1, 2
 	setmetatile 13, 1, 523, 0
@@ -690,7 +690,7 @@ Route110_TrickHouseEntrance_EventScript_26A37F:: @ 826A37F
 Route110_TrickHouseEntrance_EventScript_26A3A8:: @ 826A3A8
 	compare VAR_0x40B2, 0
 	goto_eq Route110_TrickHouseEntrance_EventScript_26A3D1
-	msgbox Route110_TrickHousePuzzle8_EventScript_26E864, 4
+	msgbox Route110_TrickHousePuzzle8_EventScript_26E864, MSGBOX_DEFAULT
 	playse SE_PIN
 	setvar VAR_0x40B2, 2
 	setmetatile 13, 1, 523, 0
@@ -699,7 +699,7 @@ Route110_TrickHouseEntrance_EventScript_26A3A8:: @ 826A3A8
 	end
 
 Route110_TrickHouseEntrance_EventScript_26A3D1:: @ 826A3D1
-	msgbox Route110_TrickHouseEntrance_Text_26AC4F, 4
+	msgbox Route110_TrickHouseEntrance_Text_26AC4F, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -711,7 +711,7 @@ Route110_TrickHousePuzzle5_EventScript_26A3DB:: @ 826A3DB
 Route110_TrickHousePuzzle6_EventScript_26A3DB:: @ 826A3DB
 Route110_TrickHousePuzzle7_EventScript_26A3DB:: @ 826A3DB
 Route110_TrickHousePuzzle8_EventScript_26A3DB:: @ 826A3DB
-	msgbox Route110_TrickHousePuzzle1_Text_26AC2F, 4
+	msgbox Route110_TrickHousePuzzle1_Text_26AC2F, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -726,13 +726,13 @@ Route110_TrickHousePuzzle8_EventScript_26A3E5:: @ 826A3E5
 	playfanfare MUS_FANFA4
 	message Route110_TrickHousePuzzle1_Text_26ABE8
 	waitfanfare
-	msgbox Route110_TrickHousePuzzle1_Text_26ABFB, 4
+	msgbox Route110_TrickHousePuzzle1_Text_26ABFB, MSGBOX_DEFAULT
 	releaseall
 	end
 
 Route110_TrickHouseEntrance_EventScript_26A3F8:: @ 826A3F8
 	lockall
-	msgbox Route110_TrickHouseEntrance_Text_26A474, 4
+	msgbox Route110_TrickHouseEntrance_Text_26A474, MSGBOX_DEFAULT
 	releaseall
 	compare VAR_0x4044, 0
 	call_if 1, Route110_TrickHouseEntrance_EventScript_26A429

--- a/data/maps/Route110_TrickHousePuzzle1/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle1/scripts.inc
@@ -25,17 +25,17 @@ Route110_TrickHousePuzzle1_EventScript_26B93D:: @ 826B93D
 
 Route110_TrickHousePuzzle1_EventScript_26B948:: @ 826B948
 	trainerbattle 0, TRAINER_SALLY, 0, Route110_TrickHousePuzzle1_Text_26B9FB, Route110_TrickHousePuzzle1_Text_26BA3F
-	msgbox Route110_TrickHousePuzzle1_Text_26BA57, 6
+	msgbox Route110_TrickHousePuzzle1_Text_26BA57, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle1_EventScript_26B95F:: @ 826B95F
 	trainerbattle 0, TRAINER_EDDIE, 0, Route110_TrickHousePuzzle1_Text_26BA82, Route110_TrickHousePuzzle1_Text_26BAB0
-	msgbox Route110_TrickHousePuzzle1_Text_26BAC3, 6
+	msgbox Route110_TrickHousePuzzle1_Text_26BAC3, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle1_EventScript_26B976:: @ 826B976
 	trainerbattle 0, TRAINER_ROBIN, 0, Route110_TrickHousePuzzle1_Text_26BB10, Route110_TrickHousePuzzle1_Text_26BB2E
-	msgbox Route110_TrickHousePuzzle1_Text_26BB52, 6
+	msgbox Route110_TrickHousePuzzle1_Text_26BB52, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle1_Text_26B98D:: @ 826B98D

--- a/data/maps/Route110_TrickHousePuzzle2/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle2/scripts.inc
@@ -91,17 +91,17 @@ Route110_TrickHousePuzzle2_EventScript_26BC62:: @ 826BC62
 
 Route110_TrickHousePuzzle2_EventScript_26BC75:: @ 826BC75
 	trainerbattle 0, TRAINER_TED, 0, Route110_TrickHousePuzzle2_Text_26BD25, Route110_TrickHousePuzzle2_Text_26BD45
-	msgbox Route110_TrickHousePuzzle2_Text_26BD70, 6
+	msgbox Route110_TrickHousePuzzle2_Text_26BD70, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle2_EventScript_26BC8C:: @ 826BC8C
 	trainerbattle 0, TRAINER_PAUL, 0, Route110_TrickHousePuzzle2_Text_26BD9E, Route110_TrickHousePuzzle2_Text_26BDCF
-	msgbox Route110_TrickHousePuzzle2_Text_26BDEC, 6
+	msgbox Route110_TrickHousePuzzle2_Text_26BDEC, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle2_EventScript_26BCA3:: @ 826BCA3
 	trainerbattle 0, TRAINER_GEORGIA, 0, Route110_TrickHousePuzzle2_Text_26BE31, Route110_TrickHousePuzzle2_Text_26BE77
-	msgbox Route110_TrickHousePuzzle2_Text_26BE97, 6
+	msgbox Route110_TrickHousePuzzle2_Text_26BE97, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle2_Text_26BCBA: @ 826BCBA

--- a/data/maps/Route110_TrickHousePuzzle3/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle3/scripts.inc
@@ -303,17 +303,17 @@ Route110_TrickHousePuzzle3_EventScript_26C5B9:: @ 826C5B9
 
 Route110_TrickHousePuzzle3_EventScript_26C5C4:: @ 826C5C4
 	trainerbattle 0, TRAINER_JUSTIN, 0, Route110_TrickHousePuzzle3_Text_26C676, Route110_TrickHousePuzzle3_Text_26C69D
-	msgbox Route110_TrickHousePuzzle3_Text_26C6E6, 6
+	msgbox Route110_TrickHousePuzzle3_Text_26C6E6, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle3_EventScript_26C5DB:: @ 826C5DB
 	trainerbattle 0, TRAINER_MARTHA, 0, Route110_TrickHousePuzzle3_Text_26C726, Route110_TrickHousePuzzle3_Text_26C763
-	msgbox Route110_TrickHousePuzzle3_Text_26C776, 6
+	msgbox Route110_TrickHousePuzzle3_Text_26C776, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle3_EventScript_26C5F2:: @ 826C5F2
 	trainerbattle 0, TRAINER_ALAN, 0, Route110_TrickHousePuzzle3_Text_26C7AA, Route110_TrickHousePuzzle3_Text_26C7EC
-	msgbox Route110_TrickHousePuzzle3_Text_26C80C, 6
+	msgbox Route110_TrickHousePuzzle3_Text_26C80C, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle3_Text_26C609: @ 826C609

--- a/data/maps/Route110_TrickHousePuzzle4/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle4/scripts.inc
@@ -15,17 +15,17 @@ Route110_TrickHousePuzzle4_EventScript_26C873:: @ 826C873
 
 Route110_TrickHousePuzzle4_EventScript_26C87E:: @ 826C87E
 	trainerbattle 0, TRAINER_CORA, 0, Route110_TrickHousePuzzle4_Text_26C92D, Route110_TrickHousePuzzle4_Text_26C96E
-	msgbox Route110_TrickHousePuzzle4_Text_26C9A2, 6
+	msgbox Route110_TrickHousePuzzle4_Text_26C9A2, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle4_EventScript_26C895:: @ 826C895
 	trainerbattle 0, TRAINER_YUJI, 0, Route110_TrickHousePuzzle4_Text_26C9E4, Route110_TrickHousePuzzle4_Text_26CA20
-	msgbox Route110_TrickHousePuzzle4_Text_26CA53, 6
+	msgbox Route110_TrickHousePuzzle4_Text_26CA53, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle4_EventScript_26C8AC:: @ 826C8AC
 	trainerbattle 0, TRAINER_PAULA, 0, Route110_TrickHousePuzzle4_Text_26CA9C, Route110_TrickHousePuzzle4_Text_26CACB
-	msgbox Route110_TrickHousePuzzle4_Text_26CAD1, 6
+	msgbox Route110_TrickHousePuzzle4_Text_26CAD1, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle4_Text_26C8C3: @ 826C8C3

--- a/data/maps/Route110_TrickHousePuzzle5/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle5/scripts.inc
@@ -227,7 +227,7 @@ Route110_TrickHousePuzzle5_EventScript_26CCEB:: @ 826CCEB
 	call_if 1, Route110_TrickHousePuzzle5_EventScript_26D224
 	compare VAR_TEMP_9, 4
 	call_if 1, Route110_TrickHousePuzzle5_EventScript_26D25C
-	msgbox Route110_TrickHousePuzzle5_Text_26D6CE, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26D6CE, MSGBOX_DEFAULT
 	random 3
 	switch VAR_RESULT
 	case 0, Route110_TrickHousePuzzle5_EventScript_26CF45
@@ -253,7 +253,7 @@ Route110_TrickHousePuzzle5_EventScript_26CD6A:: @ 826CD6A
 	call_if 1, Route110_TrickHousePuzzle5_EventScript_26D374
 	compare VAR_TEMP_9, 5
 	call_if 1, Route110_TrickHousePuzzle5_EventScript_26D3AC
-	msgbox Route110_TrickHousePuzzle5_Text_26D8EA, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26D8EA, MSGBOX_DEFAULT
 	random 3
 	switch VAR_RESULT
 	case 0, Route110_TrickHousePuzzle5_EventScript_26CFAE
@@ -277,7 +277,7 @@ Route110_TrickHousePuzzle5_EventScript_26CDF4:: @ 826CDF4
 	call_if 1, Route110_TrickHousePuzzle5_EventScript_26D224
 	compare VAR_TEMP_9, 4
 	call_if 1, Route110_TrickHousePuzzle5_EventScript_26D25C
-	msgbox Route110_TrickHousePuzzle5_Text_26DA1E, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26DA1E, MSGBOX_DEFAULT
 	random 3
 	switch VAR_RESULT
 	case 0, Route110_TrickHousePuzzle5_EventScript_26D017
@@ -301,7 +301,7 @@ Route110_TrickHousePuzzle5_EventScript_26CE73:: @ 826CE73
 	call_if 1, Route110_TrickHousePuzzle5_EventScript_26D224
 	compare VAR_TEMP_9, 4
 	call_if 1, Route110_TrickHousePuzzle5_EventScript_26D25C
-	msgbox Route110_TrickHousePuzzle5_Text_26DB4C, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26DB4C, MSGBOX_DEFAULT
 	random 3
 	switch VAR_RESULT
 	case 0, Route110_TrickHousePuzzle5_EventScript_26D080
@@ -317,7 +317,7 @@ Route110_TrickHousePuzzle5_EventScript_26CEF2:: @ 826CEF2
 	waitmovement 0
 	applymovement 5, Route110_TrickHousePuzzle5_Movement_27259A
 	waitmovement 0
-	msgbox Route110_TrickHousePuzzle5_Text_26DC78, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26DC78, MSGBOX_DEFAULT
 	random 3
 	switch VAR_RESULT
 	case 0, Route110_TrickHousePuzzle5_EventScript_26D0E9
@@ -326,7 +326,7 @@ Route110_TrickHousePuzzle5_EventScript_26CEF2:: @ 826CEF2
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26CF45:: @ 826CF45
-	msgbox Route110_TrickHousePuzzle5_Text_26D757, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26D757, MSGBOX_DEFAULT
 	multichoice 0, 0, 25, 1
 	switch VAR_RESULT
 	case 2, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -334,7 +334,7 @@ Route110_TrickHousePuzzle5_EventScript_26CF45:: @ 826CF45
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26CF68:: @ 826CF68
-	msgbox Route110_TrickHousePuzzle5_Text_26D7AA, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26D7AA, MSGBOX_DEFAULT
 	multichoice 0, 0, 26, 1
 	switch VAR_RESULT
 	case 0, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -342,7 +342,7 @@ Route110_TrickHousePuzzle5_EventScript_26CF68:: @ 826CF68
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26CF8B:: @ 826CF8B
-	msgbox Route110_TrickHousePuzzle5_Text_26D7FC, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26D7FC, MSGBOX_DEFAULT
 	multichoice 0, 0, 27, 1
 	switch VAR_RESULT
 	case 0, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -350,7 +350,7 @@ Route110_TrickHousePuzzle5_EventScript_26CF8B:: @ 826CF8B
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26CFAE:: @ 826CFAE
-	msgbox Route110_TrickHousePuzzle5_Text_26D940, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26D940, MSGBOX_DEFAULT
 	multichoice 0, 0, 28, 1
 	switch VAR_RESULT
 	case 1, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -358,7 +358,7 @@ Route110_TrickHousePuzzle5_EventScript_26CFAE:: @ 826CFAE
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26CFD1:: @ 826CFD1
-	msgbox Route110_TrickHousePuzzle5_Text_26D98C, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26D98C, MSGBOX_DEFAULT
 	multichoice 0, 0, 29, 1
 	switch VAR_RESULT
 	case 2, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -366,7 +366,7 @@ Route110_TrickHousePuzzle5_EventScript_26CFD1:: @ 826CFD1
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26CFF4:: @ 826CFF4
-	msgbox Route110_TrickHousePuzzle5_Text_26D9CE, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26D9CE, MSGBOX_DEFAULT
 	multichoice 0, 0, 30, 1
 	switch VAR_RESULT
 	case 0, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -374,7 +374,7 @@ Route110_TrickHousePuzzle5_EventScript_26CFF4:: @ 826CFF4
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26D017:: @ 826D017
-	msgbox Route110_TrickHousePuzzle5_Text_26DA64, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26DA64, MSGBOX_DEFAULT
 	multichoice 0, 0, 31, 1
 	switch VAR_RESULT
 	case 0, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -382,7 +382,7 @@ Route110_TrickHousePuzzle5_EventScript_26D017:: @ 826D017
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26D03A:: @ 826D03A
-	msgbox Route110_TrickHousePuzzle5_Text_26DAAD, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26DAAD, MSGBOX_DEFAULT
 	multichoice 0, 0, 32, 1
 	switch VAR_RESULT
 	case 2, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -390,7 +390,7 @@ Route110_TrickHousePuzzle5_EventScript_26D03A:: @ 826D03A
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26D05D:: @ 826D05D
-	msgbox Route110_TrickHousePuzzle5_Text_26DAFF, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26DAFF, MSGBOX_DEFAULT
 	multichoice 0, 0, 33, 1
 	switch VAR_RESULT
 	case 1, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -398,7 +398,7 @@ Route110_TrickHousePuzzle5_EventScript_26D05D:: @ 826D05D
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26D080:: @ 826D080
-	msgbox Route110_TrickHousePuzzle5_Text_26DB94, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26DB94, MSGBOX_DEFAULT
 	multichoice 0, 0, 34, 1
 	switch VAR_RESULT
 	case 0, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -406,7 +406,7 @@ Route110_TrickHousePuzzle5_EventScript_26D080:: @ 826D080
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26D0A3:: @ 826D0A3
-	msgbox Route110_TrickHousePuzzle5_Text_26DBD7, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26DBD7, MSGBOX_DEFAULT
 	multichoice 0, 0, 35, 1
 	switch VAR_RESULT
 	case 0, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -414,7 +414,7 @@ Route110_TrickHousePuzzle5_EventScript_26D0A3:: @ 826D0A3
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26D0C6:: @ 826D0C6
-	msgbox Route110_TrickHousePuzzle5_Text_26DC2A, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26DC2A, MSGBOX_DEFAULT
 	multichoice 0, 0, 36, 1
 	switch VAR_RESULT
 	case 1, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -422,7 +422,7 @@ Route110_TrickHousePuzzle5_EventScript_26D0C6:: @ 826D0C6
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26D0E9:: @ 826D0E9
-	msgbox Route110_TrickHousePuzzle5_Text_26DCCB, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26DCCB, MSGBOX_DEFAULT
 	multichoice 0, 0, 37, 1
 	switch VAR_RESULT
 	case 1, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -430,7 +430,7 @@ Route110_TrickHousePuzzle5_EventScript_26D0E9:: @ 826D0E9
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26D10C:: @ 826D10C
-	msgbox Route110_TrickHousePuzzle5_Text_26DD1B, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26DD1B, MSGBOX_DEFAULT
 	multichoice 0, 0, 38, 1
 	switch VAR_RESULT
 	case 0, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -438,7 +438,7 @@ Route110_TrickHousePuzzle5_EventScript_26D10C:: @ 826D10C
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26D12F:: @ 826D12F
-	msgbox Route110_TrickHousePuzzle5_Text_26DD5F, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26DD5F, MSGBOX_DEFAULT
 	multichoice 0, 0, 39, 1
 	switch VAR_RESULT
 	case 2, Route110_TrickHousePuzzle5_EventScript_26D1A0
@@ -448,15 +448,15 @@ Route110_TrickHousePuzzle5_EventScript_26D12F:: @ 826D12F
 Route110_TrickHousePuzzle5_EventScript_26D152:: @ 826D152
 	waitse
 	playse SE_HAZURE
-	msgbox Route110_TrickHousePuzzle5_Text_26D883, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26D883, MSGBOX_DEFAULT
 	applymovement 1, Route110_TrickHousePuzzle5_Movement_26D632
 	applymovement 2, Route110_TrickHousePuzzle5_Movement_26D632
 	applymovement 3, Route110_TrickHousePuzzle5_Movement_26D632
 	applymovement 4, Route110_TrickHousePuzzle5_Movement_26D632
 	applymovement 5, Route110_TrickHousePuzzle5_Movement_26D632
-	msgbox Route110_TrickHousePuzzle5_Text_26D8A1, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26D8A1, MSGBOX_DEFAULT
 	waitmovement 0
-	msgbox Route110_TrickHousePuzzle5_Text_26D8C9, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26D8C9, MSGBOX_DEFAULT
 	closemessage
 	warp MAP_ROUTE110_TRICK_HOUSE_PUZZLE5, 255, 0, 21
 	waitstate
@@ -470,7 +470,7 @@ Route110_TrickHousePuzzle5_EventScript_26D1A0:: @ 826D1A0
 	end
 
 Route110_TrickHousePuzzle5_EventScript_26D1AA:: @ 826D1AA
-	msgbox Route110_TrickHousePuzzle5_Text_26D84D, 4
+	msgbox Route110_TrickHousePuzzle5_Text_26D84D, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/Route110_TrickHousePuzzle6/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle6/scripts.inc
@@ -29,17 +29,17 @@ Route110_TrickHousePuzzle6_EventScript_26DDD6:: @ 826DDD6
 
 Route110_TrickHousePuzzle6_EventScript_26DDE1:: @ 826DDE1
 	trainerbattle 0, TRAINER_SOPHIA, 0, Route110_TrickHousePuzzle6_Text_26DE93, Route110_TrickHousePuzzle6_Text_26DED2
-	msgbox Route110_TrickHousePuzzle6_Text_26DEF3, 6
+	msgbox Route110_TrickHousePuzzle6_Text_26DEF3, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle6_EventScript_26DDF8:: @ 826DDF8
 	trainerbattle 0, TRAINER_BENNY, 0, Route110_TrickHousePuzzle6_Text_26DF55, Route110_TrickHousePuzzle6_Text_26DF8D
-	msgbox Route110_TrickHousePuzzle6_Text_26DFA0, 6
+	msgbox Route110_TrickHousePuzzle6_Text_26DFA0, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle6_EventScript_26DE0F:: @ 826DE0F
 	trainerbattle 0, TRAINER_SEBASTIAN, 0, Route110_TrickHousePuzzle6_Text_26DFD7, Route110_TrickHousePuzzle6_Text_26E004
-	msgbox Route110_TrickHousePuzzle6_Text_26E048, 6
+	msgbox Route110_TrickHousePuzzle6_Text_26E048, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle6_Text_26DE26: @ 826DE26

--- a/data/maps/Route110_TrickHousePuzzle7/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle7/scripts.inc
@@ -305,32 +305,32 @@ Route110_TrickHousePuzzle7_EventScript_26E373:: @ 826E373
 
 Route110_TrickHousePuzzle7_EventScript_26E389:: @ 826E389
 	trainerbattle 0, TRAINER_JOSHUA, 0, Route110_TrickHousePuzzle7_Text_26E481, Route110_TrickHousePuzzle7_Text_26E4C1
-	msgbox Route110_TrickHousePuzzle7_Text_26E4F4, 6
+	msgbox Route110_TrickHousePuzzle7_Text_26E4F4, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle7_EventScript_26E3A0:: @ 826E3A0
 	trainerbattle 0, TRAINER_PATRICIA, 0, Route110_TrickHousePuzzle7_Text_26E531, Route110_TrickHousePuzzle7_Text_26E564
-	msgbox Route110_TrickHousePuzzle7_Text_26E57F, 6
+	msgbox Route110_TrickHousePuzzle7_Text_26E57F, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle7_EventScript_26E3B7:: @ 826E3B7
 	trainerbattle 0, TRAINER_ALEXIS, 0, Route110_TrickHousePuzzle7_Text_26E5C0, Route110_TrickHousePuzzle7_Text_26E604
-	msgbox Route110_TrickHousePuzzle7_Text_26E61E, 6
+	msgbox Route110_TrickHousePuzzle7_Text_26E61E, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle7_EventScript_26E3CE:: @ 826E3CE
 	trainerbattle 0, TRAINER_MARIELA, 0, Route110_TrickHousePuzzle7_Text_26E66B, Route110_TrickHousePuzzle7_Text_26E69C
-	msgbox Route110_TrickHousePuzzle7_Text_26E6BC, 6
+	msgbox Route110_TrickHousePuzzle7_Text_26E6BC, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle7_EventScript_26E3E5:: @ 826E3E5
 	trainerbattle 0, TRAINER_ALVARO, 0, Route110_TrickHousePuzzle7_Text_26E6DA, Route110_TrickHousePuzzle7_Text_26E700
-	msgbox Route110_TrickHousePuzzle7_Text_26E722, 6
+	msgbox Route110_TrickHousePuzzle7_Text_26E722, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle7_EventScript_26E3FC:: @ 826E3FC
 	trainerbattle 0, TRAINER_EVERETT, 0, Route110_TrickHousePuzzle7_Text_26E78D, Route110_TrickHousePuzzle7_Text_26E7AB
-	msgbox Route110_TrickHousePuzzle7_Text_26E7C4, 6
+	msgbox Route110_TrickHousePuzzle7_Text_26E7C4, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle7_EventScript_26E413:: @ 826E413

--- a/data/maps/Route110_TrickHousePuzzle8/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle8/scripts.inc
@@ -15,17 +15,17 @@ Route110_TrickHousePuzzle8_EventScript_26E814:: @ 826E814
 
 Route110_TrickHousePuzzle8_EventScript_26E81F:: @ 826E81F
 	trainerbattle 0, TRAINER_VINCENT, 0, Route110_TrickHousePuzzle8_Text_26E8CD, Route110_TrickHousePuzzle8_Text_26E8F6
-	msgbox Route110_TrickHousePuzzle8_Text_26E918, 6
+	msgbox Route110_TrickHousePuzzle8_Text_26E918, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle8_EventScript_26E836:: @ 826E836
 	trainerbattle 0, TRAINER_KEIRA, 0, Route110_TrickHousePuzzle8_Text_26E954, Route110_TrickHousePuzzle8_Text_26E97F
-	msgbox Route110_TrickHousePuzzle8_Text_26E99F, 6
+	msgbox Route110_TrickHousePuzzle8_Text_26E99F, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle8_EventScript_26E84D:: @ 826E84D
 	trainerbattle 0, TRAINER_LEROY, 0, Route110_TrickHousePuzzle8_Text_26E9D7, Route110_TrickHousePuzzle8_Text_26EA14
-	msgbox Route110_TrickHousePuzzle8_Text_26EA3F, 6
+	msgbox Route110_TrickHousePuzzle8_Text_26EA3F, MSGBOX_AUTOCLOSE
 	end
 
 Route110_TrickHousePuzzle8_EventScript_26E864:: @ 826E864

--- a/data/maps/Route111/scripts.inc
+++ b/data/maps/Route111/scripts.inc
@@ -484,10 +484,7 @@ Route111_EventScript_1F128C:: @ 81F128C
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route111_Text_298C00, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 44
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 44
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_DUSTY_1
 	release
 	end
 
@@ -524,10 +521,7 @@ Route111_EventScript_1F1333:: @ 81F1333
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route111_Text_29903D, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 78
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 78
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_WILTON_1
 	release
 	end
 
@@ -549,10 +543,7 @@ Route111_EventScript_1F1395:: @ 81F1395
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route111_Text_29921D, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 94
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 94
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_BROOKE_1
 	release
 	end
 

--- a/data/maps/Route111/scripts.inc
+++ b/data/maps/Route111/scripts.inc
@@ -140,12 +140,12 @@ Route111_EventScript_1F0E60:: @ 81F0E60
 	clearflag FLAG_HIDE_DESERT_UNDERPASS_FOSSIL
 	checkflag FLAG_0x150
 	goto_eq Route111_EventScript_1F0EA7
-	msgbox Route111_Text_1F1C74, 4
+	msgbox Route111_Text_1F1C74, MSGBOX_DEFAULT
 	releaseall
 	end
 
 Route111_EventScript_1F0EA7:: @ 81F0EA7
-	msgbox Route111_Text_1F1C9F, 4
+	msgbox Route111_Text_1F1C9F, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -165,18 +165,18 @@ Route111_EventScript_1F0EB9:: @ 81F0EB9
 	dodailyevents
 	checkflag FLAG_0x92C
 	goto_eq Route111_EventScript_1F0EF4
-	msgbox Route111_Text_2A6EBD, 4
+	msgbox Route111_Text_2A6EBD, MSGBOX_DEFAULT
 	giveitem_std ITEM_RAZZ_BERRY
 	compare VAR_RESULT, 0
 	goto_eq Route111_EventScript_272054
 	setflag FLAG_0x92C
 	special GetPlayerBigGuyGirlString
-	msgbox Route111_Text_2A6F3D, 4
+	msgbox Route111_Text_2A6F3D, MSGBOX_DEFAULT
 	release
 	end
 
 Route111_EventScript_1F0EF4:: @ 81F0EF4
-	msgbox Route111_Text_2A6F9A, 4
+	msgbox Route111_Text_2A6F9A, MSGBOX_DEFAULT
 	release
 	end
 
@@ -213,7 +213,7 @@ Route111_EventScript_1F0F2E:: @ 81F0F2E
 	end
 
 Route111_EventScript_1F0F45:: @ 81F0F45
-	msgbox gUnknown_08272C5F, 4
+	msgbox gUnknown_08272C5F, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_0x8004, 0
 	call_if 1, Route111_EventScript_1F0F7C
@@ -279,20 +279,20 @@ Route111_EventScript_1F0FC5:: @ 81F0FC5
 	lock
 	faceplayer
 	setflag FLAG_LANDMARK_WINSTRATE_FAMILY
-	msgbox Route111_Text_1F1475, 5
+	msgbox Route111_Text_1F1475, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route111_EventScript_1F0FE7
-	msgbox Route111_Text_1F14F5, 4
+	msgbox Route111_Text_1F14F5, MSGBOX_DEFAULT
 	release
 	end
 
 Route111_EventScript_1F0FE7:: @ 81F0FE7
-	msgbox Route111_Text_1F1523, 4
+	msgbox Route111_Text_1F1523, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_VICTOR, 0, Route111_Text_1F1542
 	applymovement 1, Route111_Movement_2725A6
 	waitmovement 0
 	call Route111_EventScript_1F113C
-	msgbox Route111_Text_1F156F, 4
+	msgbox Route111_Text_1F156F, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, Route111_Movement_1F114A
 	waitmovement 0
@@ -305,12 +305,12 @@ Route111_EventScript_1F0FE7:: @ 81F0FE7
 	applymovement 2, Route111_Movement_1F114D
 	waitmovement 0
 	call Route111_EventScript_1F1143
-	msgbox Route111_Text_1F159D, 4
+	msgbox Route111_Text_1F159D, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_VICTORIA, 0, Route111_Text_1F1616
 	applymovement 2, Route111_Movement_2725A6
 	waitmovement 0
 	call Route111_EventScript_1F113C
-	msgbox Route111_Text_1F1645, 4
+	msgbox Route111_Text_1F1645, MSGBOX_DEFAULT
 	closemessage
 	applymovement 2, Route111_Movement_1F114A
 	waitmovement 0
@@ -323,12 +323,12 @@ Route111_EventScript_1F0FE7:: @ 81F0FE7
 	applymovement 3, Route111_Movement_1F114D
 	waitmovement 0
 	call Route111_EventScript_1F1143
-	msgbox Route111_Text_1F167E, 4
+	msgbox Route111_Text_1F167E, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_VIVI, 0, Route111_Text_1F16C6
 	applymovement 3, Route111_Movement_2725A6
 	waitmovement 0
 	call Route111_EventScript_1F113C
-	msgbox Route111_Text_1F16DC, 4
+	msgbox Route111_Text_1F16DC, MSGBOX_DEFAULT
 	closemessage
 	applymovement 3, Route111_Movement_1F114A
 	waitmovement 0
@@ -341,9 +341,9 @@ Route111_EventScript_1F0FE7:: @ 81F0FE7
 	applymovement 4, Route111_Movement_1F114D
 	waitmovement 0
 	call Route111_EventScript_1F1143
-	msgbox Route111_Text_1F16FB, 4
+	msgbox Route111_Text_1F16FB, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_VICKY, 0, Route111_Text_1F1756
-	msgbox Route111_Text_1F1788, 4
+	msgbox Route111_Text_1F1788, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, Route111_Movement_2725A6
 	waitmovement 0
@@ -381,35 +381,35 @@ Route111_Movement_1F114F: @ 81F114F
 	step_end
 
 Route111_EventScript_1F1153:: @ 81F1153
-	msgbox Route111_Text_1F18CE, 3
+	msgbox Route111_Text_1F18CE, MSGBOX_SIGN
 	end
 
 Route111_EventScript_1F115C:: @ 81F115C
-	msgbox Route111_Text_1F18E8, 3
+	msgbox Route111_Text_1F18E8, MSGBOX_SIGN
 	end
 
 Route111_EventScript_1F1165:: @ 81F1165
-	msgbox Route111_Text_1F1921, 3
+	msgbox Route111_Text_1F1921, MSGBOX_SIGN
 	end
 
 Route111_EventScript_1F116E:: @ 81F116E
-	msgbox Route111_Text_1F1937, 3
+	msgbox Route111_Text_1F1937, MSGBOX_SIGN
 	end
 
 Route111_EventScript_1F1177:: @ 81F1177
-	msgbox Route111_Text_1F194D, 3
+	msgbox Route111_Text_1F194D, MSGBOX_SIGN
 	end
 
 Route111_EventScript_1F1180:: @ 81F1180
-	msgbox Route111_Text_1F1987, 3
+	msgbox Route111_Text_1F1987, MSGBOX_SIGN
 	end
 
 Route111_EventScript_1F1189:: @ 81F1189
-	msgbox Route111_Text_1F17BA, 2
+	msgbox Route111_Text_1F17BA, MSGBOX_NPC
 	end
 
 Route111_EventScript_1F1192:: @ 81F1192
-	msgbox Route111_Text_1F186E, 2
+	msgbox Route111_Text_1F186E, MSGBOX_NPC
 	end
 
 Route111_EventScript_1F119B:: @ 81F119B
@@ -421,22 +421,22 @@ Route111_EventScript_1F119B:: @ 81F119B
 	goto_eq Route111_EventScript_1F11D0
 	checkflag FLAG_0x14E
 	goto_eq Route111_EventScript_1F11DA
-	msgbox Route111_Text_1F1A22, 4
+	msgbox Route111_Text_1F1A22, MSGBOX_DEFAULT
 	release
 	end
 
 Route111_EventScript_1F11C6:: @ 81F11C6
-	msgbox Route111_Text_1F1C12, 4
+	msgbox Route111_Text_1F1C12, MSGBOX_DEFAULT
 	release
 	end
 
 Route111_EventScript_1F11D0:: @ 81F11D0
-	msgbox Route111_Text_1F1B92, 4
+	msgbox Route111_Text_1F1B92, MSGBOX_DEFAULT
 	release
 	end
 
 Route111_EventScript_1F11DA:: @ 81F11DA
-	msgbox Route111_Text_1F1AC7, 4
+	msgbox Route111_Text_1F1AC7, MSGBOX_DEFAULT
 	release
 	end
 
@@ -444,7 +444,7 @@ Route111_EventScript_1F11E4:: @ 81F11E4
 	lockall
 	applymovement 46, Route111_Movement_27259E
 	waitmovement 0
-	msgbox Route111_Text_1F1CCA, 4
+	msgbox Route111_Text_1F1CCA, MSGBOX_DEFAULT
 	closemessage
 	applymovement 46, Route111_Movement_2725A2
 	waitmovement 0
@@ -453,22 +453,22 @@ Route111_EventScript_1F11E4:: @ 81F11E4
 
 Route111_EventScript_1F1204:: @ 81F1204
 	trainerbattle 0, TRAINER_DREW, 0, Route111_Text_29878E, Route111_Text_29880A
-	msgbox Route111_Text_298853, 6
+	msgbox Route111_Text_298853, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F121B:: @ 81F121B
 	trainerbattle 0, TRAINER_HEIDI, 0, Route111_Text_2988A3, Route111_Text_298908
-	msgbox Route111_Text_29891B, 6
+	msgbox Route111_Text_29891B, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F1232:: @ 81F1232
 	trainerbattle 0, TRAINER_BEAU, 0, Route111_Text_29898E, Route111_Text_2989E6
-	msgbox Route111_Text_298A03, 6
+	msgbox Route111_Text_298A03, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F1249:: @ 81F1249
 	trainerbattle 0, TRAINER_BECKY, 0, Route111_Text_298A65, Route111_Text_298AAF
-	msgbox Route111_Text_298AC0, 6
+	msgbox Route111_Text_298AC0, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F1260:: @ 81F1260
@@ -476,39 +476,39 @@ Route111_EventScript_1F1260:: @ 81F1260
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route111_EventScript_1F12AB
-	msgbox Route111_Text_298B9A, 4
+	msgbox Route111_Text_298B9A, MSGBOX_DEFAULT
 	release
 	end
 
 Route111_EventScript_1F128C:: @ 81F128C
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route111_Text_298C00, 4
+	msgbox Route111_Text_298C00, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 44
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 44
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route111_EventScript_1F12AB:: @ 81F12AB
 	trainerbattle 5, TRAINER_DUSTY_1, 0, Route111_Text_298C5F, Route111_Text_298CD2
-	msgbox Route111_Text_298D0C, 6
+	msgbox Route111_Text_298D0C, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F12C2:: @ 81F12C2
 	trainerbattle 0, TRAINER_TRAVIS, 0, Route111_Text_298DA9, Route111_Text_298DD8
-	msgbox Route111_Text_298DF1, 6
+	msgbox Route111_Text_298DF1, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F12D9:: @ 81F12D9
 	trainerbattle 0, TRAINER_IRENE, 0, Route111_Text_298E2F, Route111_Text_298E6E
-	msgbox Route111_Text_298E8C, 6
+	msgbox Route111_Text_298E8C, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F12F0:: @ 81F12F0
 	trainerbattle 0, TRAINER_DAISUKE, 0, Route111_Text_298EE6, Route111_Text_298F14
-	msgbox Route111_Text_298F26, 6
+	msgbox Route111_Text_298F26, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F1307:: @ 81F1307
@@ -516,24 +516,24 @@ Route111_EventScript_1F1307:: @ 81F1307
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route111_EventScript_1F1352
-	msgbox Route111_Text_298FD4, 4
+	msgbox Route111_Text_298FD4, MSGBOX_DEFAULT
 	release
 	end
 
 Route111_EventScript_1F1333:: @ 81F1333
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route111_Text_29903D, 4
+	msgbox Route111_Text_29903D, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 78
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 78
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route111_EventScript_1F1352:: @ 81F1352
 	trainerbattle 5, TRAINER_WILTON_1, 0, Route111_Text_29909B, Route111_Text_2990EE
-	msgbox Route111_Text_299102, 6
+	msgbox Route111_Text_299102, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F1369:: @ 81F1369
@@ -541,63 +541,63 @@ Route111_EventScript_1F1369:: @ 81F1369
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route111_EventScript_1F13B4
-	msgbox Route111_Text_2991C2, 4
+	msgbox Route111_Text_2991C2, MSGBOX_DEFAULT
 	release
 	end
 
 Route111_EventScript_1F1395:: @ 81F1395
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route111_Text_29921D, 4
+	msgbox Route111_Text_29921D, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 94
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 94
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route111_EventScript_1F13B4:: @ 81F13B4
 	trainerbattle 5, TRAINER_BROOKE_1, 0, Route111_Text_29925D, Route111_Text_2992D6
-	msgbox Route111_Text_2992F5, 6
+	msgbox Route111_Text_2992F5, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F13CB:: @ 81F13CB
 	trainerbattle 0, TRAINER_HAYDEN, 0, Route111_Text_299682, Route111_Text_2996BE
-	msgbox Route111_Text_2996C5, 6
+	msgbox Route111_Text_2996C5, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F13E2:: @ 81F13E2
 	trainerbattle 0, TRAINER_BIANCA, 0, Route111_Text_2996FE, Route111_Text_29973D
-	msgbox Route111_Text_29975D, 6
+	msgbox Route111_Text_29975D, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F13F9:: @ 81F13F9
 	trainerbattle 0, TRAINER_TYRON, 0, Route111_Text_299524, Route111_Text_299549
-	msgbox Route111_Text_299576, 6
+	msgbox Route111_Text_299576, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F1410:: @ 81F1410
 	trainerbattle 0, TRAINER_CELINA, 0, Route111_Text_2995F0, Route111_Text_299625
-	msgbox Route111_Text_29964B, 6
+	msgbox Route111_Text_29964B, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F1427:: @ 81F1427
 	trainerbattle 0, TRAINER_CELIA, 0, Route111_Text_29934B, Route111_Text_299384
-	msgbox Route111_Text_2993A7, 6
+	msgbox Route111_Text_2993A7, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F143E:: @ 81F143E
 	trainerbattle 0, TRAINER_BRYAN, 0, Route111_Text_299401, Route111_Text_299431
-	msgbox Route111_Text_29945F, 6
+	msgbox Route111_Text_29945F, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F1455:: @ 81F1455
 	trainerbattle 0, TRAINER_BRANDEN, 0, Route111_Text_299493, Route111_Text_2994C5
-	msgbox Route111_Text_2994FB, 6
+	msgbox Route111_Text_2994FB, MSGBOX_AUTOCLOSE
 	end
 
 Route111_EventScript_1F146C:: @ 81F146C
-	msgbox Route111_Text_1F1D61, 3
+	msgbox Route111_Text_1F1D61, MSGBOX_SIGN
 	end
 
 Route111_Text_1F1475: @ 81F1475

--- a/data/maps/Route111_OldLadysRestStop/scripts.inc
+++ b/data/maps/Route111_OldLadysRestStop/scripts.inc
@@ -9,7 +9,7 @@ Route111_OldLadysRestStop_MapScript1_22A91C: @ 822A91C
 Route111_OldLadysRestStop_EventScript_22A920:: @ 822A920
 	lock
 	faceplayer
-	msgbox Route111_OldLadysRestStop_Text_22A978, 5
+	msgbox Route111_OldLadysRestStop_Text_22A978, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route111_OldLadysRestStop_EventScript_22A941
 	compare VAR_RESULT, 0
@@ -17,10 +17,10 @@ Route111_OldLadysRestStop_EventScript_22A920:: @ 822A920
 	end
 
 Route111_OldLadysRestStop_EventScript_22A941:: @ 822A941
-	msgbox Route111_OldLadysRestStop_Text_22A9EC, 4
+	msgbox Route111_OldLadysRestStop_Text_22A9EC, MSGBOX_DEFAULT
 	closemessage
 	call Route111_OldLadysRestStop_EventScript_272083
-	msgbox Route111_OldLadysRestStop_Text_22AA16, 5
+	msgbox Route111_OldLadysRestStop_Text_22AA16, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route111_OldLadysRestStop_EventScript_22A941
 	compare VAR_RESULT, 0
@@ -28,7 +28,7 @@ Route111_OldLadysRestStop_EventScript_22A941:: @ 822A941
 	end
 
 Route111_OldLadysRestStop_EventScript_22A96E:: @ 822A96E
-	msgbox Route111_OldLadysRestStop_Text_22AA8F, 4
+	msgbox Route111_OldLadysRestStop_Text_22AA8F, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/Route111_WinstrateFamilysHouse/scripts.inc
+++ b/data/maps/Route111_WinstrateFamilysHouse/scripts.inc
@@ -5,7 +5,7 @@ Route111_WinstrateFamilysHouse_EventScript_22A48D:: @ 822A48D
 	lock
 	faceplayer
 	setvar VAR_0x8008, 2
-	msgbox Route111_WinstrateFamilysHouse_Text_22A539, 4
+	msgbox Route111_WinstrateFamilysHouse_Text_22A539, MSGBOX_DEFAULT
 	goto Route111_WinstrateFamilysHouse_EventScript_22A52C
 	end
 
@@ -15,7 +15,7 @@ Route111_WinstrateFamilysHouse_EventScript_22A4A2:: @ 822A4A2
 	setvar VAR_0x8008, 3
 	checkflag FLAG_0x115
 	goto_eq Route111_WinstrateFamilysHouse_EventScript_22A4DA
-	msgbox Route111_WinstrateFamilysHouse_Text_22A5F4, 4
+	msgbox Route111_WinstrateFamilysHouse_Text_22A5F4, MSGBOX_DEFAULT
 	giveitem_std ITEM_MACHO_BRACE
 	compare VAR_RESULT, 0
 	goto_eq Route111_WinstrateFamilysHouse_EventScript_272054
@@ -24,7 +24,7 @@ Route111_WinstrateFamilysHouse_EventScript_22A4A2:: @ 822A4A2
 	end
 
 Route111_WinstrateFamilysHouse_EventScript_22A4DA:: @ 822A4DA
-	msgbox Route111_WinstrateFamilysHouse_Text_22A6B4, 4
+	msgbox Route111_WinstrateFamilysHouse_Text_22A6B4, MSGBOX_DEFAULT
 	goto Route111_WinstrateFamilysHouse_EventScript_22A52C
 	end
 
@@ -32,7 +32,7 @@ Route111_WinstrateFamilysHouse_EventScript_22A4E8:: @ 822A4E8
 	lock
 	faceplayer
 	setvar VAR_0x8008, 1
-	msgbox Route111_WinstrateFamilysHouse_Text_22A6F7, 4
+	msgbox Route111_WinstrateFamilysHouse_Text_22A6F7, MSGBOX_DEFAULT
 	goto Route111_WinstrateFamilysHouse_EventScript_22A52C
 	end
 
@@ -42,13 +42,13 @@ Route111_WinstrateFamilysHouse_EventScript_22A4FD:: @ 822A4FD
 	setvar VAR_0x8008, 4
 	checkflag FLAG_TEMP_4
 	goto_eq Route111_WinstrateFamilysHouse_EventScript_22A51E
-	msgbox Route111_WinstrateFamilysHouse_Text_22A780, 4
+	msgbox Route111_WinstrateFamilysHouse_Text_22A780, MSGBOX_DEFAULT
 	setflag FLAG_TEMP_4
 	goto Route111_WinstrateFamilysHouse_EventScript_22A52C
 	end
 
 Route111_WinstrateFamilysHouse_EventScript_22A51E:: @ 822A51E
-	msgbox Route111_WinstrateFamilysHouse_Text_22A89B, 4
+	msgbox Route111_WinstrateFamilysHouse_Text_22A89B, MSGBOX_DEFAULT
 	goto Route111_WinstrateFamilysHouse_EventScript_22A52C
 	end
 

--- a/data/maps/Route112/scripts.inc
+++ b/data/maps/Route112/scripts.inc
@@ -78,10 +78,7 @@ Route112_EventScript_1F1EAD:: @ 81F1EAD
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route112_Text_29993C, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 627
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 627
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_TRENT_1
 	release
 	end
 

--- a/data/maps/Route112/scripts.inc
+++ b/data/maps/Route112/scripts.inc
@@ -13,7 +13,7 @@ Route112_EventScript_1F1DB7:: @ 81F1DB7
 	applymovement 1, Route112_Movement_2725A8
 	waitmovement 0
 	delay 20
-	msgbox Route112_Text_1F1F3F, 4
+	msgbox Route112_Text_1F1F3F, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, Route112_Movement_2725A2
 	waitmovement 0
@@ -21,7 +21,7 @@ Route112_EventScript_1F1DB7:: @ 81F1DB7
 	applymovement 6, Route112_Movement_2725A4
 	waitmovement 0
 	delay 20
-	msgbox Route112_Text_1F1F7A, 4
+	msgbox Route112_Text_1F1F7A, MSGBOX_DEFAULT
 	closemessage
 	applymovement 6, Route112_Movement_2725A2
 	waitmovement 0
@@ -29,7 +29,7 @@ Route112_EventScript_1F1DB7:: @ 81F1DB7
 	applymovement 1, Route112_Movement_2725A8
 	waitmovement 0
 	delay 20
-	msgbox Route112_Text_1F1FBA, 4
+	msgbox Route112_Text_1F1FBA, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, Route112_Movement_2725A2
 	waitmovement 0
@@ -37,7 +37,7 @@ Route112_EventScript_1F1DB7:: @ 81F1DB7
 	applymovement 6, Route112_Movement_2725A4
 	waitmovement 0
 	delay 20
-	msgbox Route112_Text_1F2003, 4
+	msgbox Route112_Text_1F2003, MSGBOX_DEFAULT
 	closemessage
 	applymovement 6, Route112_Movement_2725A2
 	waitmovement 0
@@ -45,24 +45,24 @@ Route112_EventScript_1F1DB7:: @ 81F1DB7
 	end
 
 Route112_EventScript_1F1E46:: @ 81F1E46
-	msgbox Route112_Text_1F20C1, 3
+	msgbox Route112_Text_1F20C1, MSGBOX_SIGN
 	end
 
 Route112_EventScript_1F1E4F:: @ 81F1E4F
-	msgbox Route112_Text_1F20ED, 3
+	msgbox Route112_Text_1F20ED, MSGBOX_SIGN
 	end
 
 Route112_EventScript_1F1E58:: @ 81F1E58
-	msgbox Route112_Text_1F2138, 3
+	msgbox Route112_Text_1F2138, MSGBOX_SIGN
 	end
 
 Route112_EventScript_1F1E61:: @ 81F1E61
-	msgbox Route112_Text_1F204E, 2
+	msgbox Route112_Text_1F204E, MSGBOX_NPC
 	end
 
 Route112_EventScript_1F1E6A:: @ 81F1E6A
 	trainerbattle 0, TRAINER_BRICE, 0, Route112_Text_29978E, Route112_Text_2997CA
-	msgbox Route112_Text_2997DC, 6
+	msgbox Route112_Text_2997DC, MSGBOX_AUTOCLOSE
 	end
 
 Route112_EventScript_1F1E81:: @ 81F1E81
@@ -70,44 +70,44 @@ Route112_EventScript_1F1E81:: @ 81F1E81
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route112_EventScript_1F1ECC
-	msgbox Route112_Text_299896, 4
+	msgbox Route112_Text_299896, MSGBOX_DEFAULT
 	release
 	end
 
 Route112_EventScript_1F1EAD:: @ 81F1EAD
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route112_Text_29993C, 4
+	msgbox Route112_Text_29993C, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 627
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 627
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route112_EventScript_1F1ECC:: @ 81F1ECC
 	trainerbattle 5, TRAINER_TRENT_1, 0, Route112_Text_2999BD, Route112_Text_2999F7
-	msgbox Route112_Text_299A0F, 6
+	msgbox Route112_Text_299A0F, MSGBOX_AUTOCLOSE
 	end
 
 Route112_EventScript_1F1EE3:: @ 81F1EE3
 	trainerbattle 0, TRAINER_LARRY, 0, Route112_Text_299A89, Route112_Text_299AAC
-	msgbox Route112_Text_299AB4, 6
+	msgbox Route112_Text_299AB4, MSGBOX_AUTOCLOSE
 	end
 
 Route112_EventScript_1F1EFA:: @ 81F1EFA
 	trainerbattle 0, TRAINER_CAROL, 0, Route112_Text_299AE4, Route112_Text_299B36
-	msgbox Route112_Text_299B4C, 6
+	msgbox Route112_Text_299B4C, MSGBOX_AUTOCLOSE
 	end
 
 Route112_EventScript_1F1F11:: @ 81F1F11
 	trainerbattle 0, TRAINER_BRYANT, 0, Route112_Text_299BAE, Route112_Text_299BDF
-	msgbox Route112_Text_299BFB, 6
+	msgbox Route112_Text_299BFB, MSGBOX_AUTOCLOSE
 	end
 
 Route112_EventScript_1F1F28:: @ 81F1F28
 	trainerbattle 0, TRAINER_SHAYLA, 0, Route112_Text_299C34, Route112_Text_299C8F
-	msgbox Route112_Text_299CC6, 6
+	msgbox Route112_Text_299CC6, MSGBOX_AUTOCLOSE
 	end
 
 Route112_Text_1F1F3F: @ 81F1F3F

--- a/data/maps/Route112_CableCarStation/scripts.inc
+++ b/data/maps/Route112_CableCarStation/scripts.inc
@@ -32,7 +32,7 @@ Route112_CableCarStation_EventScript_22AAF3:: @ 822AAF3
 Route112_CableCarStation_EventScript_22AB17:: @ 822AB17
 	lock
 	faceplayer
-	msgbox Route112_CableCarStation_Text_22AB85, 5
+	msgbox Route112_CableCarStation_Text_22AB85, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route112_CableCarStation_EventScript_22AB38
 	compare VAR_RESULT, 0
@@ -40,7 +40,7 @@ Route112_CableCarStation_EventScript_22AB17:: @ 822AB17
 	end
 
 Route112_CableCarStation_EventScript_22AB38:: @ 822AB38
-	msgbox Route112_CableCarStation_Text_22ABC2, 4
+	msgbox Route112_CableCarStation_Text_22ABC2, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, Route112_CableCarStation_Movement_22AB71
 	applymovement 255, Route112_CableCarStation_Movement_22AB7B
@@ -55,7 +55,7 @@ Route112_CableCarStation_EventScript_22AB38:: @ 822AB38
 	end
 
 Route112_CableCarStation_EventScript_22AB67:: @ 822AB67
-	msgbox Route112_CableCarStation_Text_22ABD8, 4
+	msgbox Route112_CableCarStation_Text_22ABD8, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/Route113/scripts.inc
+++ b/data/maps/Route113/scripts.inc
@@ -71,10 +71,7 @@ Route113_EventScript_1F221A:: @ 81F221A
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route113_Text_299F49, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 434
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 434
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_MADELINE_1
 	release
 	end
 
@@ -96,10 +93,7 @@ Route113_EventScript_1F227C:: @ 81F227C
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route113_Text_29A0A2, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 419
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 419
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_LAO_1
 	release
 	end
 

--- a/data/maps/Route113/scripts.inc
+++ b/data/maps/Route113/scripts.inc
@@ -25,37 +25,37 @@ Route113_EventScript_1F2189:: @ 81F2189
 	return
 
 Route113_EventScript_1F218A:: @ 81F218A
-	msgbox Route113_Text_1F235B, 2
+	msgbox Route113_Text_1F235B, MSGBOX_NPC
 	end
 
 Route113_EventScript_1F2193:: @ 81F2193
-	msgbox Route113_Text_1F23CA, 2
+	msgbox Route113_Text_1F23CA, MSGBOX_NPC
 	end
 
 Route113_EventScript_1F219C:: @ 81F219C
-	msgbox Route113_Text_1F2440, 3
+	msgbox Route113_Text_1F2440, MSGBOX_SIGN
 	end
 
 Route113_EventScript_1F21A5:: @ 81F21A5
-	msgbox Route113_Text_1F2456, 3
+	msgbox Route113_Text_1F2456, MSGBOX_SIGN
 	end
 
 Route113_EventScript_1F21AE:: @ 81F21AE
-	msgbox Route113_Text_1F24F8, 3
+	msgbox Route113_Text_1F24F8, MSGBOX_SIGN
 	end
 
 Route113_EventScript_1F21B7:: @ 81F21B7
-	msgbox Route113_Text_1F2471, 3
+	msgbox Route113_Text_1F2471, MSGBOX_SIGN
 	end
 
 Route113_EventScript_1F21C0:: @ 81F21C0
 	trainerbattle 0, TRAINER_JAYLEN, 0, Route113_Text_299D3C, Route113_Text_299D68
-	msgbox Route113_Text_299D7D, 6
+	msgbox Route113_Text_299D7D, MSGBOX_AUTOCLOSE
 	end
 
 Route113_EventScript_1F21D7:: @ 81F21D7
 	trainerbattle 0, TRAINER_DILLON, 0, Route113_Text_299DE3, Route113_Text_299E1C
-	msgbox Route113_Text_299E38, 6
+	msgbox Route113_Text_299E38, MSGBOX_AUTOCLOSE
 	end
 
 Route113_EventScript_1F21EE:: @ 81F21EE
@@ -63,24 +63,24 @@ Route113_EventScript_1F21EE:: @ 81F21EE
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route113_EventScript_1F2239
-	msgbox Route113_Text_299F15, 4
+	msgbox Route113_Text_299F15, MSGBOX_DEFAULT
 	release
 	end
 
 Route113_EventScript_1F221A:: @ 81F221A
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route113_Text_299F49, 4
+	msgbox Route113_Text_299F49, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 434
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 434
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route113_EventScript_1F2239:: @ 81F2239
 	trainerbattle 5, TRAINER_MADELINE_1, 0, Route113_Text_299F8A, Route113_Text_299FC9
-	msgbox Route113_Text_299FD8, 6
+	msgbox Route113_Text_299FD8, MSGBOX_AUTOCLOSE
 	end
 
 Route113_EventScript_1F2250:: @ 81F2250
@@ -88,59 +88,59 @@ Route113_EventScript_1F2250:: @ 81F2250
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route113_EventScript_1F229B
-	msgbox Route113_Text_29A067, 4
+	msgbox Route113_Text_29A067, MSGBOX_DEFAULT
 	release
 	end
 
 Route113_EventScript_1F227C:: @ 81F227C
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route113_Text_29A0A2, 4
+	msgbox Route113_Text_29A0A2, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 419
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 419
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route113_EventScript_1F229B:: @ 81F229B
 	trainerbattle 5, TRAINER_LAO_1, 0, Route113_Text_29A0E8, Route113_Text_29A11F
-	msgbox Route113_Text_29A13A, 6
+	msgbox Route113_Text_29A13A, MSGBOX_AUTOCLOSE
 	end
 
 Route113_EventScript_1F22B2:: @ 81F22B2
 	trainerbattle 0, TRAINER_LUNG, 0, Route113_Text_29A192, Route113_Text_29A1C6
-	msgbox Route113_Text_29A219, 6
+	msgbox Route113_Text_29A219, MSGBOX_AUTOCLOSE
 	end
 
 Route113_EventScript_1F22C9:: @ 81F22C9
 	trainerbattle 4, TRAINER_TORI_AND_TIA, 0, Route113_Text_29A261, Route113_Text_29A29D, Route113_Text_29A31F
-	msgbox Route113_Text_29A2DE, 6
+	msgbox Route113_Text_29A2DE, MSGBOX_AUTOCLOSE
 	end
 
 Route113_EventScript_1F22E4:: @ 81F22E4
 	trainerbattle 4, TRAINER_TORI_AND_TIA, 0, Route113_Text_29A35C, Route113_Text_29A397, Route113_Text_29A419
-	msgbox Route113_Text_29A3DA, 6
+	msgbox Route113_Text_29A3DA, MSGBOX_AUTOCLOSE
 	end
 
 Route113_EventScript_1F22FF:: @ 81F22FF
 	trainerbattle 0, TRAINER_SOPHIE, 0, Route113_Text_29A4BF, Route113_Text_29A508
-	msgbox Route113_Text_29A529, 6
+	msgbox Route113_Text_29A529, MSGBOX_AUTOCLOSE
 	end
 
 Route113_EventScript_1F2316:: @ 81F2316
 	trainerbattle 0, TRAINER_COBY, 0, Route113_Text_29A453, Route113_Text_29A480
-	msgbox Route113_Text_29A489, 6
+	msgbox Route113_Text_29A489, MSGBOX_AUTOCLOSE
 	end
 
 Route113_EventScript_1F232D:: @ 81F232D
 	trainerbattle 0, TRAINER_LAWRENCE, 0, Route113_Text_29A566, Route113_Text_29A5A0
-	msgbox Route113_Text_29A5BE, 6
+	msgbox Route113_Text_29A5BE, MSGBOX_AUTOCLOSE
 	end
 
 Route113_EventScript_1F2344:: @ 81F2344
 	trainerbattle 0, TRAINER_WYATT, 0, Route113_Text_29A5E4, Route113_Text_29A628
-	msgbox Route113_Text_29A65D, 6
+	msgbox Route113_Text_29A65D, MSGBOX_AUTOCLOSE
 	end
 
 Route113_Text_1F235B: @ 81F235B

--- a/data/maps/Route113_GlassWorkshop/scripts.inc
+++ b/data/maps/Route113_GlassWorkshop/scripts.inc
@@ -21,15 +21,15 @@ Route113_GlassWorkshop_EventScript_26ED1E:: @ 826ED1E
 	goto_eq Route113_GlassWorkshop_EventScript_26ED6E
 	compare VAR_0x40BE, 1
 	goto_eq Route113_GlassWorkshop_EventScript_26ED64
-	msgbox Route113_GlassWorkshop_Text_26F19D, 4
+	msgbox Route113_GlassWorkshop_Text_26F19D, MSGBOX_DEFAULT
 	giveitem_std ITEM_SOOT_SACK
 	setvar VAR_0x40BE, 1
-	msgbox Route113_GlassWorkshop_Text_26F252, 4
+	msgbox Route113_GlassWorkshop_Text_26F252, MSGBOX_DEFAULT
 	release
 	end
 
 Route113_GlassWorkshop_EventScript_26ED64:: @ 826ED64
-	msgbox Route113_GlassWorkshop_Text_26F252, 4
+	msgbox Route113_GlassWorkshop_Text_26F252, MSGBOX_DEFAULT
 	release
 	end
 
@@ -37,7 +37,7 @@ Route113_GlassWorkshop_EventScript_26ED6E:: @ 826ED6E
 	checkitem ITEM_SOOT_SACK, 1
 	compare VAR_RESULT, 0
 	goto_eq Route113_GlassWorkshop_EventScript_26ED9D
-	msgbox Route113_GlassWorkshop_Text_26F312, 4
+	msgbox Route113_GlassWorkshop_Text_26F312, MSGBOX_DEFAULT
 	compare VAR_ASH_GATHER_COUNT, 250
 	goto_if 0, Route113_GlassWorkshop_EventScript_26EFD6
 	message Route113_GlassWorkshop_Text_26F40A
@@ -46,7 +46,7 @@ Route113_GlassWorkshop_EventScript_26ED6E:: @ 826ED6E
 	end
 
 Route113_GlassWorkshop_EventScript_26ED9D:: @ 826ED9D
-	msgbox Route113_GlassWorkshop_Text_26F772, 4
+	msgbox Route113_GlassWorkshop_Text_26F772, MSGBOX_DEFAULT
 	release
 	end
 
@@ -73,7 +73,7 @@ Route113_GlassWorkshop_EventScript_26EE1E:: @ 826EE1E
 	setvar VAR_0x800A, 250
 	compare VAR_ASH_GATHER_COUNT, 250
 	goto_if 0, Route113_GlassWorkshop_EventScript_26EFEE
-	msgbox Route113_GlassWorkshop_Text_26F480, 5
+	msgbox Route113_GlassWorkshop_Text_26F480, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route113_GlassWorkshop_EventScript_26F003
 	setvar VAR_0x40BE, 10
@@ -87,7 +87,7 @@ Route113_GlassWorkshop_EventScript_26EE5A:: @ 826EE5A
 	setvar VAR_0x800A, 500
 	compare VAR_ASH_GATHER_COUNT, 500
 	goto_if 0, Route113_GlassWorkshop_EventScript_26EFEE
-	msgbox Route113_GlassWorkshop_Text_26F480, 5
+	msgbox Route113_GlassWorkshop_Text_26F480, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route113_GlassWorkshop_EventScript_26F003
 	setvar VAR_0x40BE, 11
@@ -101,7 +101,7 @@ Route113_GlassWorkshop_EventScript_26EE96:: @ 826EE96
 	setvar VAR_0x800A, 500
 	compare VAR_ASH_GATHER_COUNT, 500
 	goto_if 0, Route113_GlassWorkshop_EventScript_26EFEE
-	msgbox Route113_GlassWorkshop_Text_26F480, 5
+	msgbox Route113_GlassWorkshop_Text_26F480, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route113_GlassWorkshop_EventScript_26F003
 	setvar VAR_0x40BE, 12
@@ -115,7 +115,7 @@ Route113_GlassWorkshop_EventScript_26EED2:: @ 826EED2
 	setvar VAR_0x800A, 1000
 	compare VAR_ASH_GATHER_COUNT, 1000
 	goto_if 0, Route113_GlassWorkshop_EventScript_26EFEE
-	msgbox Route113_GlassWorkshop_Text_26F480, 5
+	msgbox Route113_GlassWorkshop_Text_26F480, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route113_GlassWorkshop_EventScript_26F003
 	setvar VAR_0x40BE, 13
@@ -129,7 +129,7 @@ Route113_GlassWorkshop_EventScript_26EF0E:: @ 826EF0E
 	setvar VAR_0x800A, 1000
 	compare VAR_ASH_GATHER_COUNT, 1000
 	goto_if 0, Route113_GlassWorkshop_EventScript_26EFEE
-	msgbox Route113_GlassWorkshop_Text_26F480, 5
+	msgbox Route113_GlassWorkshop_Text_26F480, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route113_GlassWorkshop_EventScript_26F003
 	setvar VAR_0x40BE, 14
@@ -144,7 +144,7 @@ Route113_GlassWorkshop_EventScript_26EF4A:: @ 826EF4A
 	setvar VAR_0x800A, 6000
 	compare VAR_ASH_GATHER_COUNT, 6000
 	goto_if 0, Route113_GlassWorkshop_EventScript_26EFEE
-	msgbox Route113_GlassWorkshop_Text_26F480, 5
+	msgbox Route113_GlassWorkshop_Text_26F480, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route113_GlassWorkshop_EventScript_26F003
 	setvar VAR_0x40BE, 15
@@ -159,7 +159,7 @@ Route113_GlassWorkshop_EventScript_26EF8B:: @ 826EF8B
 	setvar VAR_0x800A, 8000
 	compare VAR_ASH_GATHER_COUNT, 8000
 	goto_if 0, Route113_GlassWorkshop_EventScript_26EFEE
-	msgbox Route113_GlassWorkshop_Text_26F480, 5
+	msgbox Route113_GlassWorkshop_Text_26F480, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route113_GlassWorkshop_EventScript_26F003
 	setvar VAR_0x40BE, 16
@@ -168,7 +168,7 @@ Route113_GlassWorkshop_EventScript_26EF8B:: @ 826EF8B
 	end
 
 Route113_GlassWorkshop_EventScript_26EFCC:: @ 826EFCC
-	msgbox Route113_GlassWorkshop_Text_26F641, 4
+	msgbox Route113_GlassWorkshop_Text_26F641, MSGBOX_DEFAULT
 	release
 	end
 
@@ -176,7 +176,7 @@ Route113_GlassWorkshop_EventScript_26EFD6:: @ 826EFD6
 	setvar VAR_0x800A, 250
 	subvar VAR_0x800A, 16456
 	buffernumberstring 0, VAR_0x800A
-	msgbox Route113_GlassWorkshop_Text_26F34E, 4
+	msgbox Route113_GlassWorkshop_Text_26F34E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -195,13 +195,13 @@ Route113_GlassWorkshop_EventScript_26F003:: @ 826F003
 	end
 
 Route113_GlassWorkshop_EventScript_26F00F:: @ 826F00F
-	msgbox Route113_GlassWorkshop_Text_26F4DA, 4
+	msgbox Route113_GlassWorkshop_Text_26F4DA, MSGBOX_DEFAULT
 	closemessage
 	fadescreen 1
 	playse SE_SELECT
 	delay 30
 	fadescreen 0
-	msgbox Route113_GlassWorkshop_Text_26F688, 4
+	msgbox Route113_GlassWorkshop_Text_26F688, MSGBOX_DEFAULT
 	compare VAR_0x8009, 0
 	call_if 1, Route113_GlassWorkshop_EventScript_26F047
 	compare VAR_0x8009, 1
@@ -224,13 +224,13 @@ Route113_GlassWorkshop_EventScript_26F05F:: @ 826F05F
 
 Route113_GlassWorkshop_EventScript_26F072:: @ 826F072
 	call Route113_GlassWorkshop_EventScript_27205E
-	msgbox Route113_GlassWorkshop_Text_26F6B7, 4
+	msgbox Route113_GlassWorkshop_Text_26F6B7, MSGBOX_DEFAULT
 	release
 	end
 
 Route113_GlassWorkshop_EventScript_26F081:: @ 826F081
 	call Route113_GlassWorkshop_EventScript_272071
-	msgbox Route113_GlassWorkshop_Text_26F715, 4
+	msgbox Route113_GlassWorkshop_Text_26F715, MSGBOX_DEFAULT
 	release
 	end
 
@@ -295,7 +295,7 @@ Route113_GlassWorkshop_EventScript_26F15B:: @ 826F15B
 	end
 
 Route113_GlassWorkshop_EventScript_26F16F:: @ 826F16F
-	msgbox Route113_GlassWorkshop_Text_26F688, 4
+	msgbox Route113_GlassWorkshop_Text_26F688, MSGBOX_DEFAULT
 	compare VAR_0x8009, 0
 	call_if 1, Route113_GlassWorkshop_EventScript_26F047
 	compare VAR_0x8009, 1
@@ -305,7 +305,7 @@ Route113_GlassWorkshop_EventScript_26F16F:: @ 826F16F
 	end
 
 Route113_GlassWorkshop_EventScript_26F194:: @ 826F194
-	msgbox Route113_GlassWorkshop_Text_26F7EC, 2
+	msgbox Route113_GlassWorkshop_Text_26F7EC, MSGBOX_NPC
 	end
 
 Route113_GlassWorkshop_Text_26F19D: @ 826F19D

--- a/data/maps/Route114/scripts.inc
+++ b/data/maps/Route114/scripts.inc
@@ -121,10 +121,7 @@ Route114_EventScript_1F26C8:: @ 81F26C8
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route114_Text_29A9F7, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 143
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 143
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_STEVE_1
 	release
 	end
 
@@ -146,10 +143,7 @@ Route114_EventScript_1F272A:: @ 81F272A
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route114_Text_29ABA6, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 206
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 206
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_BERNIE_1
 	release
 	end
 

--- a/data/maps/Route114/scripts.inc
+++ b/data/maps/Route114/scripts.inc
@@ -30,7 +30,7 @@ Route114_EventScript_1F2582:: @ 81F2582
 	dodailyevents
 	checkflag FLAG_0x92B
 	goto_eq Route114_EventScript_1F25C7
-	msgbox Route114_Text_2A6FCB, 4
+	msgbox Route114_Text_2A6FCB, MSGBOX_DEFAULT
 	random 5
 	addvar VAR_RESULT, 15
 	addvar VAR_RESULT, 133
@@ -38,12 +38,12 @@ Route114_EventScript_1F2582:: @ 81F2582
 	compare VAR_RESULT, 0
 	goto_eq Route114_EventScript_272054
 	setflag FLAG_0x92B
-	msgbox Route114_Text_2A7034, 4
+	msgbox Route114_Text_2A7034, MSGBOX_DEFAULT
 	release
 	end
 
 Route114_EventScript_1F25C7:: @ 81F25C7
-	msgbox Route114_Text_2A706E, 4
+	msgbox Route114_Text_2A706E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -52,17 +52,17 @@ Route114_EventScript_1F25D1:: @ 81F25D1
 	faceplayer
 	checkflag FLAG_0x0E7
 	goto_eq Route114_EventScript_1F2608
-	msgbox Route114_Text_1F2809, 4
+	msgbox Route114_Text_1F2809, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM05
 	compare VAR_RESULT, 0
 	goto_eq Route114_EventScript_272054
 	setflag FLAG_0x0E7
-	msgbox Route114_Text_1F2872, 4
+	msgbox Route114_Text_1F2872, MSGBOX_DEFAULT
 	release
 	end
 
 Route114_EventScript_1F2608:: @ 81F2608
-	msgbox Route114_Text_1F2872, 4
+	msgbox Route114_Text_1F2872, MSGBOX_DEFAULT
 	release
 	end
 
@@ -71,41 +71,41 @@ Route114_EventScript_1F2612:: @ 81F2612
 	faceplayer
 	waitse
 	playmoncry SPECIES_POOCHYENA, 2
-	msgbox Route114_Text_1F28A6, 4
+	msgbox Route114_Text_1F28A6, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
 
 Route114_EventScript_1F2625:: @ 81F2625
-	msgbox Route114_Text_1F28B3, 3
+	msgbox Route114_Text_1F28B3, MSGBOX_SIGN
 	end
 
 Route114_EventScript_1F262E:: @ 81F262E
-	msgbox Route114_Text_1F28DB, 3
+	msgbox Route114_Text_1F28DB, MSGBOX_SIGN
 	end
 
 Route114_EventScript_1F2637:: @ 81F2637
-	msgbox Route114_Text_1F2910, 3
+	msgbox Route114_Text_1F2910, MSGBOX_SIGN
 	end
 
 Route114_EventScript_1F2640:: @ 81F2640
 	trainerbattle 0, TRAINER_LENNY, 0, Route114_Text_29A6B1, Route114_Text_29A707
-	msgbox Route114_Text_29A715, 6
+	msgbox Route114_Text_29A715, MSGBOX_AUTOCLOSE
 	end
 
 Route114_EventScript_1F2657:: @ 81F2657
 	trainerbattle 0, TRAINER_LUCAS_1, 0, Route114_Text_29A777, Route114_Text_29A7B5
-	msgbox Route114_Text_29A7D4, 6
+	msgbox Route114_Text_29A7D4, MSGBOX_AUTOCLOSE
 	end
 
 Route114_EventScript_1F266E:: @ 81F266E
 	trainerbattle 0, TRAINER_SHANE, 0, Route114_Text_29A818, Route114_Text_29A88F
-	msgbox Route114_Text_29A89F, 6
+	msgbox Route114_Text_29A89F, MSGBOX_AUTOCLOSE
 	end
 
 Route114_EventScript_1F2685:: @ 81F2685
 	trainerbattle 0, TRAINER_NANCY, 0, Route114_Text_29A8D9, Route114_Text_29A90E
-	msgbox Route114_Text_29A916, 6
+	msgbox Route114_Text_29A916, MSGBOX_AUTOCLOSE
 	end
 
 Route114_EventScript_1F269C:: @ 81F269C
@@ -113,24 +113,24 @@ Route114_EventScript_1F269C:: @ 81F269C
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route114_EventScript_1F26E7
-	msgbox Route114_Text_29A981, 4
+	msgbox Route114_Text_29A981, MSGBOX_DEFAULT
 	release
 	end
 
 Route114_EventScript_1F26C8:: @ 81F26C8
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route114_Text_29A9F7, 4
+	msgbox Route114_Text_29A9F7, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 143
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 143
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route114_EventScript_1F26E7:: @ 81F26E7
 	trainerbattle 5, TRAINER_STEVE_1, 0, Route114_Text_29AA3E, Route114_Text_29AA67
-	msgbox Route114_Text_29AA94, 6
+	msgbox Route114_Text_29AA94, MSGBOX_AUTOCLOSE
 	end
 
 Route114_EventScript_1F26FE:: @ 81F26FE
@@ -138,59 +138,59 @@ Route114_EventScript_1F26FE:: @ 81F26FE
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route114_EventScript_1F2749
-	msgbox Route114_Text_29AB36, 4
+	msgbox Route114_Text_29AB36, MSGBOX_DEFAULT
 	release
 	end
 
 Route114_EventScript_1F272A:: @ 81F272A
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route114_Text_29ABA6, 4
+	msgbox Route114_Text_29ABA6, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 206
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 206
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route114_EventScript_1F2749:: @ 81F2749
 	trainerbattle 5, TRAINER_BERNIE_1, 0, Route114_Text_29ABDC, Route114_Text_29AC10
-	msgbox Route114_Text_29AC43, 6
+	msgbox Route114_Text_29AC43, MSGBOX_AUTOCLOSE
 	end
 
 Route114_EventScript_1F2760:: @ 81F2760
 	trainerbattle 0, TRAINER_CLAUDE, 0, Route114_Text_29ACB3, Route114_Text_29AD0A
-	msgbox Route114_Text_29AD2E, 6
+	msgbox Route114_Text_29AD2E, MSGBOX_AUTOCLOSE
 	end
 
 Route114_EventScript_1F2777:: @ 81F2777
 	trainerbattle 0, TRAINER_NOLAN, 0, Route114_Text_29ADA1, Route114_Text_29AE05
-	msgbox Route114_Text_29AE3D, 6
+	msgbox Route114_Text_29AE3D, MSGBOX_AUTOCLOSE
 	end
 
 Route114_EventScript_1F278E:: @ 81F278E
 	trainerbattle 4, TRAINER_TYRA_AND_IVY, 0, Route114_Text_29AE96, Route114_Text_29AEE7, Route114_Text_29AF3D
-	msgbox Route114_Text_29AF0B, 6
+	msgbox Route114_Text_29AF0B, MSGBOX_AUTOCLOSE
 	end
 
 Route114_EventScript_1F27A9:: @ 81F27A9
 	trainerbattle 4, TRAINER_TYRA_AND_IVY, 0, Route114_Text_29AF89, Route114_Text_29AFAC, Route114_Text_29B01B
-	msgbox Route114_Text_29AFCF, 6
+	msgbox Route114_Text_29AFCF, MSGBOX_AUTOCLOSE
 	end
 
 Route114_EventScript_1F27C4:: @ 81F27C4
 	trainerbattle 0, TRAINER_ANGELINA, 0, Route114_Text_29B16F, Route114_Text_29B19C
-	msgbox Route114_Text_29B1BC, 6
+	msgbox Route114_Text_29B1BC, MSGBOX_AUTOCLOSE
 	end
 
 Route114_EventScript_1F27DB:: @ 81F27DB
 	trainerbattle 0, TRAINER_CHARLOTTE, 0, Route114_Text_29B0DB, Route114_Text_29B0FB
-	msgbox Route114_Text_29B11A, 6
+	msgbox Route114_Text_29B11A, MSGBOX_AUTOCLOSE
 	end
 
 Route114_EventScript_1F27F2:: @ 81F27F2
 	trainerbattle 0, TRAINER_KAI, 0, Route114_Text_29B05D, Route114_Text_29B089
-	msgbox Route114_Text_29B0B5, 6
+	msgbox Route114_Text_29B0B5, MSGBOX_AUTOCLOSE
 	end
 
 Route114_Text_1F2809: @ 81F2809

--- a/data/maps/Route114_FossilManiacsHouse/scripts.inc
+++ b/data/maps/Route114_FossilManiacsHouse/scripts.inc
@@ -11,7 +11,7 @@ Route114_FossilManiacsHouse_EventScript_22AD3A:: @ 822AD3A
 	faceplayer
 	checkflag FLAG_0x105
 	goto_eq Route114_FossilManiacsHouse_EventScript_22AD69
-	msgbox Route114_FossilManiacsHouse_Text_22AD85, 4
+	msgbox Route114_FossilManiacsHouse_Text_22AD85, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM28
 	compare VAR_RESULT, 0
 	goto_eq Route114_FossilManiacsHouse_EventScript_272054
@@ -20,16 +20,16 @@ Route114_FossilManiacsHouse_EventScript_22AD3A:: @ 822AD3A
 	end
 
 Route114_FossilManiacsHouse_EventScript_22AD69:: @ 822AD69
-	msgbox Route114_FossilManiacsHouse_Text_22AE48, 4
+	msgbox Route114_FossilManiacsHouse_Text_22AE48, MSGBOX_DEFAULT
 	release
 	end
 
 Route114_FossilManiacsHouse_EventScript_22AD73:: @ 822AD73
-	msgbox Route114_FossilManiacsHouse_Text_22AE92, 3
+	msgbox Route114_FossilManiacsHouse_Text_22AE92, MSGBOX_SIGN
 	end
 
 Route114_FossilManiacsHouse_EventScript_22AD7C:: @ 822AD7C
-	msgbox Route114_FossilManiacsHouse_Text_22AEC2, 3
+	msgbox Route114_FossilManiacsHouse_Text_22AEC2, MSGBOX_SIGN
 	end
 
 Route114_FossilManiacsHouse_Text_22AD85: @ 822AD85

--- a/data/maps/Route114_FossilManiacsTunnel/scripts.inc
+++ b/data/maps/Route114_FossilManiacsTunnel/scripts.inc
@@ -28,7 +28,7 @@ Route114_FossilManiacsTunnel_EventScript_22AF66:: @ 822AF66
 	applymovement 1, Route114_FossilManiacsTunnel_Movement_2725A6
 	applymovement 255, Route114_FossilManiacsTunnel_Movement_2725AA
 	waitmovement 0
-	msgbox Route114_FossilManiacsTunnel_Text_22B1F7, 4
+	msgbox Route114_FossilManiacsTunnel_Text_22B1F7, MSGBOX_DEFAULT
 	setvar VAR_0x40CC, 2
 	releaseall
 	end
@@ -44,17 +44,17 @@ Route114_FossilManiacsTunnel_EventScript_22AF87:: @ 822AF87
 	checkitem ITEM_CLAW_FOSSIL, 1
 	compare VAR_RESULT, 1
 	goto_eq Route114_FossilManiacsTunnel_EventScript_22AFBC
-	msgbox Route114_FossilManiacsTunnel_Text_22AFD0, 4
+	msgbox Route114_FossilManiacsTunnel_Text_22AFD0, MSGBOX_DEFAULT
 	release
 	end
 
 Route114_FossilManiacsTunnel_EventScript_22AFBC:: @ 822AFBC
-	msgbox Route114_FossilManiacsTunnel_Text_22B0D6, 4
+	msgbox Route114_FossilManiacsTunnel_Text_22B0D6, MSGBOX_DEFAULT
 	release
 	end
 
 Route114_FossilManiacsTunnel_EventScript_22AFC6:: @ 822AFC6
-	msgbox Route114_FossilManiacsTunnel_Text_22B1CC, 4
+	msgbox Route114_FossilManiacsTunnel_Text_22B1CC, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/Route114_LanettesHouse/scripts.inc
+++ b/data/maps/Route114_LanettesHouse/scripts.inc
@@ -12,7 +12,7 @@ Route114_LanettesHouse_EventScript_22B2D2:: @ 822B2D2
 	checkflag FLAG_0x083
 	goto_eq Route114_LanettesHouse_EventScript_22B2FF
 	setflag FLAG_SYS_PC_LANETTE
-	msgbox Route114_LanettesHouse_Text_22B34E, 4
+	msgbox Route114_LanettesHouse_Text_22B34E, MSGBOX_DEFAULT
 	givedecoration_std 99
 	compare VAR_RESULT, 0
 	goto_eq Route114_LanettesHouse_EventScript_272067
@@ -21,32 +21,32 @@ Route114_LanettesHouse_EventScript_22B2D2:: @ 822B2D2
 	end
 
 Route114_LanettesHouse_EventScript_22B2FF:: @ 822B2FF
-	msgbox Route114_LanettesHouse_Text_22B407, 4
+	msgbox Route114_LanettesHouse_Text_22B407, MSGBOX_DEFAULT
 	release
 	end
 
 Route114_LanettesHouse_EventScript_22B309:: @ 822B309
 	lockall
-	msgbox Route114_LanettesHouse_Text_22B485, 5
+	msgbox Route114_LanettesHouse_Text_22B485, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route114_LanettesHouse_EventScript_22B327
-	msgbox Route114_LanettesHouse_Text_22B6E4, 4
+	msgbox Route114_LanettesHouse_Text_22B6E4, MSGBOX_DEFAULT
 	releaseall
 	end
 
 Route114_LanettesHouse_EventScript_22B327:: @ 822B327
-	msgbox Route114_LanettesHouse_Text_22B53C, 5
+	msgbox Route114_LanettesHouse_Text_22B53C, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	call_if 1, Route114_LanettesHouse_EventScript_22B33C
 	releaseall
 	end
 
 Route114_LanettesHouse_EventScript_22B33C:: @ 822B33C
-	msgbox Route114_LanettesHouse_Text_22B5EF, 4
+	msgbox Route114_LanettesHouse_Text_22B5EF, MSGBOX_DEFAULT
 	return
 
 Route114_LanettesHouse_EventScript_22B345:: @ 822B345
-	msgbox Route114_LanettesHouse_Text_22B6FC, 3
+	msgbox Route114_LanettesHouse_Text_22B6FC, MSGBOX_SIGN
 	end
 
 Route114_LanettesHouse_Text_22B34E: @ 822B34E

--- a/data/maps/Route115/scripts.inc
+++ b/data/maps/Route115/scripts.inc
@@ -25,15 +25,15 @@ Route115_MapScript2_1F2969: @ 81F2969
 	.2byte 0
 
 Route115_EventScript_1F2973:: @ 81F2973
-	msgbox Route115_Text_1F2B55, 2
+	msgbox Route115_Text_1F2B55, MSGBOX_NPC
 	end
 
 Route115_EventScript_1F297C:: @ 81F297C
-	msgbox Route115_Text_1F2BC9, 3
+	msgbox Route115_Text_1F2BC9, MSGBOX_SIGN
 	end
 
 Route115_EventScript_1F2985:: @ 81F2985
-	msgbox Route115_Text_1F2BE3, 3
+	msgbox Route115_Text_1F2BE3, MSGBOX_SIGN
 	end
 
 Route115_EventScript_1F298E:: @ 81F298E
@@ -41,29 +41,29 @@ Route115_EventScript_1F298E:: @ 81F298E
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route115_EventScript_1F29D9
-	msgbox Route115_Text_29B258, 4
+	msgbox Route115_Text_29B258, MSGBOX_DEFAULT
 	release
 	end
 
 Route115_EventScript_1F29BA:: @ 81F29BA
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route115_Text_29B2B3, 4
+	msgbox Route115_Text_29B2B3, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 307
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 307
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route115_EventScript_1F29D9:: @ 81F29D9
 	trainerbattle 5, TRAINER_TIMOTHY_1, 0, Route115_Text_29B32C, Route115_Text_29B372
-	msgbox Route115_Text_29B385, 6
+	msgbox Route115_Text_29B385, MSGBOX_AUTOCLOSE
 	end
 
 Route115_EventScript_1F29F0:: @ 81F29F0
 	trainerbattle 0, TRAINER_KOICHI, 0, Route115_Text_29B3CC, Route115_Text_29B3ED
-	msgbox Route115_Text_29B3FF, 6
+	msgbox Route115_Text_29B3FF, MSGBOX_AUTOCLOSE
 	end
 
 Route115_EventScript_1F2A07:: @ 81F2A07
@@ -71,24 +71,24 @@ Route115_EventScript_1F2A07:: @ 81F2A07
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route115_EventScript_1F2A52
-	msgbox Route115_Text_29B49D, 4
+	msgbox Route115_Text_29B49D, MSGBOX_DEFAULT
 	release
 	end
 
 Route115_EventScript_1F2A33:: @ 81F2A33
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route115_Text_29B50B, 4
+	msgbox Route115_Text_29B50B, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 183
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 183
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route115_EventScript_1F2A52:: @ 81F2A52
 	trainerbattle 5, TRAINER_NOB_1, 0, Route115_Text_29B547, Route115_Text_29B59D
-	msgbox Route115_Text_29B5B5, 6
+	msgbox Route115_Text_29B5B5, MSGBOX_AUTOCLOSE
 	end
 
 Route115_EventScript_1F2A69:: @ 81F2A69
@@ -96,54 +96,54 @@ Route115_EventScript_1F2A69:: @ 81F2A69
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route115_EventScript_1F2AB4
-	msgbox Route115_Text_29B647, 4
+	msgbox Route115_Text_29B647, MSGBOX_DEFAULT
 	release
 	end
 
 Route115_EventScript_1F2A95:: @ 81F2A95
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route115_Text_29B6AB, 4
+	msgbox Route115_Text_29B6AB, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 427
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 427
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route115_EventScript_1F2AB4:: @ 81F2AB4
 	trainerbattle 5, TRAINER_CYNDY_1, 0, Route115_Text_29B6FA, Route115_Text_29B71A
-	msgbox Route115_Text_29B737, 6
+	msgbox Route115_Text_29B737, MSGBOX_AUTOCLOSE
 	end
 
 Route115_EventScript_1F2ACB:: @ 81F2ACB
 	trainerbattle 0, TRAINER_HECTOR, 0, Route115_Text_29B78F, Route115_Text_29B7C5
-	msgbox Route115_Text_29B7EA, 6
+	msgbox Route115_Text_29B7EA, MSGBOX_AUTOCLOSE
 	end
 
 Route115_EventScript_1F2AE2:: @ 81F2AE2
 	trainerbattle 0, TRAINER_KYRA, 0, Route115_Text_29B826, Route115_Text_29B85D
-	msgbox Route115_Text_29B869, 6
+	msgbox Route115_Text_29B869, MSGBOX_AUTOCLOSE
 	end
 
 Route115_EventScript_1F2AF9:: @ 81F2AF9
 	trainerbattle 0, TRAINER_JAIDEN, 0, Route115_Text_29B8C1, Route115_Text_29B8E8
-	msgbox Route115_Text_29B904, 6
+	msgbox Route115_Text_29B904, MSGBOX_AUTOCLOSE
 	end
 
 Route115_EventScript_1F2B10:: @ 81F2B10
 	trainerbattle 0, TRAINER_ALIX, 0, Route115_Text_29B9CB, Route115_Text_29B9F6
-	msgbox Route115_Text_29BA04, 6
+	msgbox Route115_Text_29BA04, MSGBOX_AUTOCLOSE
 	end
 
 Route115_EventScript_1F2B27:: @ 81F2B27
 	trainerbattle 0, TRAINER_HELENE, 0, Route115_Text_29B92D, Route115_Text_29B958
-	msgbox Route115_Text_29B971, 6
+	msgbox Route115_Text_29B971, MSGBOX_AUTOCLOSE
 	end
 
 Route115_EventScript_1F2B3E:: @ 81F2B3E
 	trainerbattle 0, TRAINER_MARLENE, 0, Route115_Text_29BA2C, Route115_Text_29BA67
-	msgbox Route115_Text_29BA87, 6
+	msgbox Route115_Text_29BA87, MSGBOX_AUTOCLOSE
 	end
 
 Route115_Text_1F2B55: @ 81F2B55

--- a/data/maps/Route115/scripts.inc
+++ b/data/maps/Route115/scripts.inc
@@ -49,10 +49,7 @@ Route115_EventScript_1F29BA:: @ 81F29BA
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route115_Text_29B2B3, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 307
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 307
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_TIMOTHY_1
 	release
 	end
 
@@ -79,10 +76,7 @@ Route115_EventScript_1F2A33:: @ 81F2A33
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route115_Text_29B50B, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 183
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 183
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_NOB_1
 	release
 	end
 
@@ -104,10 +98,7 @@ Route115_EventScript_1F2A95:: @ 81F2A95
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route115_Text_29B6AB, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 427
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 427
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_CYNDY_1
 	release
 	end
 

--- a/data/maps/Route116/scripts.inc
+++ b/data/maps/Route116/scripts.inc
@@ -280,10 +280,7 @@ Route116_EventScript_1F2F03:: @ 81F2F03
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route116_Text_29BE71, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 273
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 273
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_JERRY_1
 	release
 	end
 
@@ -296,10 +293,7 @@ Route116_EventScript_1F2F22:: @ 81F2F22
 
 Route116_EventScript_1F2F35:: @ 81F2F35
 	msgbox Route116_Text_29BDEF, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 273
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 273
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_JERRY_1
 	release
 	end
 
@@ -341,10 +335,7 @@ Route116_EventScript_1F2FDF:: @ 81F2FDF
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route116_Text_29C096, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 280
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 280
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_KAREN_1
 	release
 	end
 
@@ -357,10 +348,7 @@ Route116_EventScript_1F2FFE:: @ 81F2FFE
 
 Route116_EventScript_1F3011:: @ 81F3011
 	msgbox Route116_Text_29C052, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 280
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 280
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_KAREN_1
 	release
 	end
 

--- a/data/maps/Route116/scripts.inc
+++ b/data/maps/Route116/scripts.inc
@@ -37,17 +37,17 @@ Route116_EventScript_1F2C70:: @ 81F2C70
 	goto_eq Route116_EventScript_1F2C8E
 	checkflag FLAG_0x08E
 	goto_eq Route116_EventScript_1F2C98
-	msgbox Route116_Text_1F3140, 4
+	msgbox Route116_Text_1F3140, MSGBOX_DEFAULT
 	release
 	end
 
 Route116_EventScript_1F2C8E:: @ 81F2C8E
-	msgbox Route116_Text_1F32C1, 4
+	msgbox Route116_Text_1F32C1, MSGBOX_DEFAULT
 	release
 	end
 
 Route116_EventScript_1F2C98:: @ 81F2C98
-	msgbox Route116_Text_1F3166, 4
+	msgbox Route116_Text_1F3166, MSGBOX_DEFAULT
 	release
 	end
 
@@ -56,7 +56,7 @@ Route116_EventScript_1F2CA2:: @ 81F2CA2
 	faceplayer
 	checkflag FLAG_0x11F
 	goto_eq Route116_EventScript_1F2D2B
-	msgbox Route116_Text_1F3317, 4
+	msgbox Route116_Text_1F3317, MSGBOX_DEFAULT
 	goto Route116_EventScript_1F2CBB
 	end
 
@@ -65,7 +65,7 @@ Route116_EventScript_1F2CBB:: @ 81F2CBB
 	giveitem_std ITEM_REPEAT_BALL
 	compare VAR_RESULT, 0
 	goto_eq Route116_EventScript_1F2D39
-	msgbox Route116_Text_1F3521, 4
+	msgbox Route116_Text_1F3521, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_FACING, 2
 	call_if 1, Route116_EventScript_1F2D15
@@ -92,12 +92,12 @@ Route116_EventScript_1F2D20:: @ 81F2D20
 	return
 
 Route116_EventScript_1F2D2B:: @ 81F2D2B
-	msgbox Route116_Text_1F35CE, 4
+	msgbox Route116_Text_1F35CE, MSGBOX_DEFAULT
 	goto Route116_EventScript_1F2CBB
 	end
 
 Route116_EventScript_1F2D39:: @ 81F2D39
-	msgbox Route116_Text_1F3593, 4
+	msgbox Route116_Text_1F3593, MSGBOX_DEFAULT
 	release
 	end
 
@@ -126,29 +126,29 @@ Route116_Movement_1F2D4C: @ 81F2D4C
 	step_end
 
 Route116_EventScript_1F2D57:: @ 81F2D57
-	msgbox Route116_Text_1F379D, 3
+	msgbox Route116_Text_1F379D, MSGBOX_SIGN
 	end
 
 Route116_EventScript_1F2D60:: @ 81F2D60
-	msgbox Route116_Text_1F37B7, 3
+	msgbox Route116_Text_1F37B7, MSGBOX_SIGN
 	end
 
 Route116_EventScript_1F2D69:: @ 81F2D69
-	msgbox Route116_Text_1F380F, 3
+	msgbox Route116_Text_1F380F, MSGBOX_SIGN
 	end
 
 Route116_EventScript_1F2D72:: @ 81F2D72
-	msgbox Route116_Text_1F3825, 3
+	msgbox Route116_Text_1F3825, MSGBOX_SIGN
 	end
 
 Route116_EventScript_1F2D7B:: @ 81F2D7B
-	msgbox Route116_Text_1F38D4, 3
+	msgbox Route116_Text_1F38D4, MSGBOX_SIGN
 	end
 
 Route116_EventScript_1F2D84:: @ 81F2D84
 	lock
 	faceplayer
-	msgbox Route116_Text_1F309D, 4
+	msgbox Route116_Text_1F309D, MSGBOX_DEFAULT
 	setvar VAR_0x406F, 2
 	release
 	end
@@ -158,7 +158,7 @@ Route116_EventScript_1F2D95:: @ 81F2D95
 	applymovement 11, Route116_Movement_2725A8
 	applymovement 255, Route116_Movement_2725A4
 	waitmovement 0
-	msgbox Route116_Text_1F309D, 4
+	msgbox Route116_Text_1F309D, MSGBOX_DEFAULT
 	setvar VAR_0x406F, 2
 	releaseall
 	end
@@ -172,28 +172,28 @@ Route116_EventScript_1F2DB6:: @ 81F2DB6
 	specialvar VAR_RESULT, FoundBlackGlasses
 	compare VAR_RESULT, 1
 	goto_eq Route116_EventScript_1F2DE2
-	msgbox Route116_Text_1F3657, 4
+	msgbox Route116_Text_1F3657, MSGBOX_DEFAULT
 	release
 	end
 
 Route116_EventScript_1F2DE2:: @ 81F2DE2
-	msgbox Route116_Text_1F3718, 4
+	msgbox Route116_Text_1F3718, MSGBOX_DEFAULT
 	closemessage
 	goto Route116_EventScript_1F2E2A
 	end
 
 Route116_EventScript_1F2DF1:: @ 81F2DF1
-	msgbox Route116_Text_1F3657, 4
-	msgbox Route116_Text_1F3688, 4
+	msgbox Route116_Text_1F3657, MSGBOX_DEFAULT
+	msgbox Route116_Text_1F3688, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, FoundBlackGlasses
 	compare VAR_RESULT, 1
 	goto_eq Route116_EventScript_1F2E1B
-	msgbox Route116_Text_1F375E, 4
+	msgbox Route116_Text_1F375E, MSGBOX_DEFAULT
 	release
 	end
 
 Route116_EventScript_1F2E1B:: @ 81F2E1B
-	msgbox Route116_Text_1F36B4, 4
+	msgbox Route116_Text_1F36B4, MSGBOX_DEFAULT
 	closemessage
 	goto Route116_EventScript_1F2E2A
 	end
@@ -249,12 +249,12 @@ Route116_Movement_1F2E7E: @ 81F2E7E
 
 Route116_EventScript_1F2E89:: @ 81F2E89
 	trainerbattle 0, TRAINER_JOEY, 0, Route116_Text_29BB79, Route116_Text_29BB9A
-	msgbox Route116_Text_29BBC6, 6
+	msgbox Route116_Text_29BBC6, MSGBOX_AUTOCLOSE
 	end
 
 Route116_EventScript_1F2EA0:: @ 81F2EA0
 	trainerbattle 0, TRAINER_JOSE, 0, Route116_Text_29BBFD, Route116_Text_29BC25
-	msgbox Route116_Text_29BC42, 6
+	msgbox Route116_Text_29BC42, MSGBOX_AUTOCLOSE
 	end
 
 Route116_EventScript_1F2EB7:: @ 81F2EB7
@@ -266,7 +266,7 @@ Route116_EventScript_1F2EB7:: @ 81F2EB7
 	specialvar VAR_RESULT, sub_813B4E0
 	compare VAR_RESULT, 0
 	goto_eq Route116_EventScript_1F2F22
-	msgbox Route116_Text_29BD92, 4
+	msgbox Route116_Text_29BD92, MSGBOX_DEFAULT
 	release
 	end
 
@@ -279,43 +279,43 @@ Route116_EventScript_1F2EF8:: @ 81F2EF8
 Route116_EventScript_1F2F03:: @ 81F2F03
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route116_Text_29BE71, 4
+	msgbox Route116_Text_29BE71, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 273
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 273
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route116_EventScript_1F2F22:: @ 81F2F22
 	checkflag FLAG_HAS_MATCH_CALL
 	goto_eq Route116_EventScript_1F2F35
-	msgbox Route116_Text_29BD92, 4
+	msgbox Route116_Text_29BD92, MSGBOX_DEFAULT
 	release
 	end
 
 Route116_EventScript_1F2F35:: @ 81F2F35
-	msgbox Route116_Text_29BDEF, 4
+	msgbox Route116_Text_29BDEF, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 273
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 273
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route116_EventScript_1F2F4E:: @ 81F2F4E
 	trainerbattle 5, TRAINER_JERRY_1, 0, Route116_Text_29BEF3, Route116_Text_29BF4C
-	msgbox Route116_Text_29BF68, 6
+	msgbox Route116_Text_29BF68, MSGBOX_AUTOCLOSE
 	end
 
 Route116_EventScript_1F2F65:: @ 81F2F65
 	trainerbattle 0, TRAINER_CLARK, 0, Route116_Text_29BACD, Route116_Text_29BB0F
-	msgbox Route116_Text_29BB31, 6
+	msgbox Route116_Text_29BB31, MSGBOX_AUTOCLOSE
 	end
 
 Route116_EventScript_1F2F7C:: @ 81F2F7C
 	trainerbattle 0, TRAINER_JANICE, 0, Route116_Text_29BC7F, Route116_Text_29BCB3
-	msgbox Route116_Text_29BCCC, 6
+	msgbox Route116_Text_29BCCC, MSGBOX_AUTOCLOSE
 	end
 
 Route116_EventScript_1F2F93:: @ 81F2F93
@@ -327,7 +327,7 @@ Route116_EventScript_1F2F93:: @ 81F2F93
 	specialvar VAR_RESULT, sub_813B4E0
 	compare VAR_RESULT, 0
 	goto_eq Route116_EventScript_1F2FFE
-	msgbox Route116_Text_29C010, 4
+	msgbox Route116_Text_29C010, MSGBOX_DEFAULT
 	release
 	end
 
@@ -340,53 +340,53 @@ Route116_EventScript_1F2FD4:: @ 81F2FD4
 Route116_EventScript_1F2FDF:: @ 81F2FDF
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route116_Text_29C096, 4
+	msgbox Route116_Text_29C096, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 280
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 280
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route116_EventScript_1F2FFE:: @ 81F2FFE
 	checkflag FLAG_HAS_MATCH_CALL
 	goto_eq Route116_EventScript_1F3011
-	msgbox Route116_Text_29C010, 4
+	msgbox Route116_Text_29C010, MSGBOX_DEFAULT
 	release
 	end
 
 Route116_EventScript_1F3011:: @ 81F3011
-	msgbox Route116_Text_29C052, 4
+	msgbox Route116_Text_29C052, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 280
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 280
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route116_EventScript_1F302A:: @ 81F302A
 	trainerbattle 5, TRAINER_KAREN_1, 0, Route116_Text_29C0DA, Route116_Text_29C11F
-	msgbox Route116_Text_29C13B, 6
+	msgbox Route116_Text_29C13B, MSGBOX_AUTOCLOSE
 	end
 
 Route116_EventScript_1F3041:: @ 81F3041
 	trainerbattle 0, TRAINER_SARAH, 0, Route116_Text_29C173, Route116_Text_29C1B8
-	msgbox Route116_Text_29C1EA, 6
+	msgbox Route116_Text_29C1EA, MSGBOX_AUTOCLOSE
 	end
 
 Route116_EventScript_1F3058:: @ 81F3058
 	trainerbattle 0, TRAINER_DAWSON, 0, Route116_Text_29C266, Route116_Text_29C2C2
-	msgbox Route116_Text_29C2DD, 6
+	msgbox Route116_Text_29C2DD, MSGBOX_AUTOCLOSE
 	end
 
 Route116_EventScript_1F306F:: @ 81F306F
 	trainerbattle 0, TRAINER_DEVAN, 0, Route116_Text_29C350, Route116_Text_29C365
-	msgbox Route116_Text_29C380, 6
+	msgbox Route116_Text_29C380, MSGBOX_AUTOCLOSE
 	end
 
 Route116_EventScript_1F3086:: @ 81F3086
 	trainerbattle 0, TRAINER_JOHNSON, 0, Route116_Text_29C3C1, Route116_Text_29C3F7
-	msgbox Route116_Text_29C418, 6
+	msgbox Route116_Text_29C418, MSGBOX_AUTOCLOSE
 	end
 
 Route116_Text_1F309D: @ 81F309D

--- a/data/maps/Route116_TunnelersRestHouse/scripts.inc
+++ b/data/maps/Route116_TunnelersRestHouse/scripts.inc
@@ -7,11 +7,11 @@ Route116_TunnelersRestHouse_MapScript1_22B856: @ 822B856
 	end
 
 Route116_TunnelersRestHouse_EventScript_22B85A:: @ 822B85A
-	msgbox Route116_TunnelersRestHouse_Text_22B88B, 2
+	msgbox Route116_TunnelersRestHouse_Text_22B88B, MSGBOX_NPC
 	end
 
 Route116_TunnelersRestHouse_EventScript_22B863:: @ 822B863
-	msgbox Route116_TunnelersRestHouse_Text_22B99F, 2
+	msgbox Route116_TunnelersRestHouse_Text_22B99F, MSGBOX_NPC
 	end
 
 Route116_TunnelersRestHouse_EventScript_22B86C:: @ 822B86C
@@ -19,12 +19,12 @@ Route116_TunnelersRestHouse_EventScript_22B86C:: @ 822B86C
 	faceplayer
 	checkflag FLAG_RUSTURF_TUNNEL_OPENED
 	goto_eq Route116_TunnelersRestHouse_EventScript_22B881
-	msgbox Route116_TunnelersRestHouse_Text_22BAAF, 4
+	msgbox Route116_TunnelersRestHouse_Text_22BAAF, MSGBOX_DEFAULT
 	release
 	end
 
 Route116_TunnelersRestHouse_EventScript_22B881:: @ 822B881
-	msgbox Route116_TunnelersRestHouse_Text_22BB3B, 4
+	msgbox Route116_TunnelersRestHouse_Text_22BB3B, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/Route117/scripts.inc
+++ b/data/maps/Route117/scripts.inc
@@ -15,27 +15,27 @@ Route117_EventScript_1F3999:: @ 81F3999
 	return
 
 Route117_EventScript_1F399A:: @ 81F399A
-	msgbox Route117_Text_1F3CFD, 2
+	msgbox Route117_Text_1F3CFD, MSGBOX_NPC
 	end
 
 Route117_EventScript_1F39A3:: @ 81F39A3
-	msgbox Route117_Text_1F3D41, 2
+	msgbox Route117_Text_1F3D41, MSGBOX_NPC
 	end
 
 Route117_EventScript_1F39AC:: @ 81F39AC
-	msgbox Route117_Text_1F3C7C, 2
+	msgbox Route117_Text_1F3C7C, MSGBOX_NPC
 	end
 
 Route117_EventScript_1F39B5:: @ 81F39B5
-	msgbox Route117_Text_1F3D58, 3
+	msgbox Route117_Text_1F3D58, MSGBOX_SIGN
 	end
 
 Route117_EventScript_1F39BE:: @ 81F39BE
-	msgbox Route117_Text_1F3D74, 3
+	msgbox Route117_Text_1F3D74, MSGBOX_SIGN
 	end
 
 Route117_EventScript_1F39C7:: @ 81F39C7
-	msgbox Route117_Text_1F3D8E, 3
+	msgbox Route117_Text_1F3D8E, MSGBOX_SIGN
 	end
 
 Route117_EventScript_1F39D0:: @ 81F39D0
@@ -43,24 +43,24 @@ Route117_EventScript_1F39D0:: @ 81F39D0
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route117_EventScript_1F3A1B
-	msgbox Route117_Text_29C498, 4
+	msgbox Route117_Text_29C498, MSGBOX_DEFAULT
 	release
 	end
 
 Route117_EventScript_1F39FC:: @ 81F39FC
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route117_Text_29C508, 4
+	msgbox Route117_Text_29C508, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 538
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 538
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route117_EventScript_1F3A1B:: @ 81F3A1B
 	trainerbattle 5, TRAINER_ISAAC_1, 0, Route117_Text_29C549, Route117_Text_29C58B
-	msgbox Route117_Text_29C5D0, 6
+	msgbox Route117_Text_29C5D0, MSGBOX_AUTOCLOSE
 	end
 
 Route117_EventScript_1F3A32:: @ 81F3A32
@@ -68,24 +68,24 @@ Route117_EventScript_1F3A32:: @ 81F3A32
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route117_EventScript_1F3A7D
-	msgbox Route117_Text_29C679, 4
+	msgbox Route117_Text_29C679, MSGBOX_DEFAULT
 	release
 	end
 
 Route117_EventScript_1F3A5E:: @ 81F3A5E
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route117_Text_29C6BC, 4
+	msgbox Route117_Text_29C6BC, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 545
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 545
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route117_EventScript_1F3A7D:: @ 81F3A7D
 	trainerbattle 5, TRAINER_LYDIA_1, 0, Route117_Text_29C6FD, Route117_Text_29C73E
-	msgbox Route117_Text_29C75A, 6
+	msgbox Route117_Text_29C75A, MSGBOX_AUTOCLOSE
 	end
 
 Route117_EventScript_1F3A94:: @ 81F3A94
@@ -93,24 +93,24 @@ Route117_EventScript_1F3A94:: @ 81F3A94
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route117_EventScript_1F3ADF
-	msgbox Route117_Text_29C800, 4
+	msgbox Route117_Text_29C800, MSGBOX_DEFAULT
 	release
 	end
 
 Route117_EventScript_1F3AC0:: @ 81F3AC0
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route117_Text_29C846, 4
+	msgbox Route117_Text_29C846, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 364
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 364
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route117_EventScript_1F3ADF:: @ 81F3ADF
 	trainerbattle 5, TRAINER_DYLAN_1, 0, Route117_Text_29C880, Route117_Text_29C8E3
-	msgbox Route117_Text_29C8FE, 6
+	msgbox Route117_Text_29C8FE, MSGBOX_AUTOCLOSE
 	end
 
 Route117_EventScript_1F3AF6:: @ 81F3AF6
@@ -118,29 +118,29 @@ Route117_EventScript_1F3AF6:: @ 81F3AF6
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route117_EventScript_1F3B41
-	msgbox Route117_Text_29C9D0, 4
+	msgbox Route117_Text_29C9D0, MSGBOX_DEFAULT
 	release
 	end
 
 Route117_EventScript_1F3B22:: @ 81F3B22
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route117_Text_29CA32, 4
+	msgbox Route117_Text_29CA32, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 369
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 369
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route117_EventScript_1F3B41:: @ 81F3B41
 	trainerbattle 5, TRAINER_MARIA_1, 0, Route117_Text_29CA7C, Route117_Text_29CACC
-	msgbox Route117_Text_29CAF6, 6
+	msgbox Route117_Text_29CAF6, MSGBOX_AUTOCLOSE
 	end
 
 Route117_EventScript_1F3B58:: @ 81F3B58
 	trainerbattle 0, TRAINER_DEREK, 0, Route117_Text_29CB32, Route117_Text_29CB87
-	msgbox Route117_Text_29CBAD, 6
+	msgbox Route117_Text_29CBAD, MSGBOX_AUTOCLOSE
 	end
 
 Route117_EventScript_1F3B6F:: @ 81F3B6F
@@ -148,22 +148,22 @@ Route117_EventScript_1F3B6F:: @ 81F3B6F
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route117_EventScript_1F3BB8
-	msgbox Route117_Text_29CCCB, 4
+	msgbox Route117_Text_29CCCB, MSGBOX_DEFAULT
 	release
 	end
 
 Route117_EventScript_1F3B9F:: @ 81F3B9F
-	msgbox Route117_Text_29CD1D, 4
+	msgbox Route117_Text_29CD1D, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 287
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 287
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route117_EventScript_1F3BB8:: @ 81F3BB8
 	trainerbattle 7, TRAINER_ANNA_AND_MEG_1, 0, Route117_Text_29CEB6, Route117_Text_29CEF6, Route117_Text_29CF6E
-	msgbox Route117_Text_29CF1C, 6
+	msgbox Route117_Text_29CF1C, MSGBOX_AUTOCLOSE
 	end
 
 Route117_EventScript_1F3BD3:: @ 81F3BD3
@@ -171,37 +171,37 @@ Route117_EventScript_1F3BD3:: @ 81F3BD3
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route117_EventScript_1F3C1C
-	msgbox Route117_Text_29CE17, 4
+	msgbox Route117_Text_29CE17, MSGBOX_DEFAULT
 	release
 	end
 
 Route117_EventScript_1F3C03:: @ 81F3C03
-	msgbox Route117_Text_29CD1D, 4
+	msgbox Route117_Text_29CD1D, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 287
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 287
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route117_EventScript_1F3C1C:: @ 81F3C1C
 	trainerbattle 7, TRAINER_ANNA_AND_MEG_1, 0, Route117_Text_29CFAA, Route117_Text_29CFED, Route117_Text_29D053
-	msgbox Route117_Text_29CFFE, 6
+	msgbox Route117_Text_29CFFE, MSGBOX_AUTOCLOSE
 	end
 
 Route117_EventScript_1F3C37:: @ 81F3C37
 	trainerbattle 0, TRAINER_MELINA, 0, Route117_Text_29D0B7, Route117_Text_29D0F1
-	msgbox Route117_Text_29D10E, 6
+	msgbox Route117_Text_29D10E, MSGBOX_AUTOCLOSE
 	end
 
 Route117_EventScript_1F3C4E:: @ 81F3C4E
 	trainerbattle 0, TRAINER_BRANDI, 0, Route117_Text_29D14B, Route117_Text_29D189
-	msgbox Route117_Text_29D196, 6
+	msgbox Route117_Text_29D196, MSGBOX_AUTOCLOSE
 	end
 
 Route117_EventScript_1F3C65:: @ 81F3C65
 	trainerbattle 0, TRAINER_AISHA, 0, Route117_Text_29D1D1, Route117_Text_29D206
-	msgbox Route117_Text_29D24C, 6
+	msgbox Route117_Text_29D24C, MSGBOX_AUTOCLOSE
 	end
 
 Route117_Text_1F3C7C: @ 81F3C7C

--- a/data/maps/Route117/scripts.inc
+++ b/data/maps/Route117/scripts.inc
@@ -51,10 +51,7 @@ Route117_EventScript_1F39FC:: @ 81F39FC
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route117_Text_29C508, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 538
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 538
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_ISAAC_1
 	release
 	end
 
@@ -76,10 +73,7 @@ Route117_EventScript_1F3A5E:: @ 81F3A5E
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route117_Text_29C6BC, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 545
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 545
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_LYDIA_1
 	release
 	end
 
@@ -101,10 +95,7 @@ Route117_EventScript_1F3AC0:: @ 81F3AC0
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route117_Text_29C846, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 364
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 364
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_DYLAN_1
 	release
 	end
 
@@ -126,10 +117,7 @@ Route117_EventScript_1F3B22:: @ 81F3B22
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route117_Text_29CA32, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 369
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 369
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_MARIA_1
 	release
 	end
 
@@ -154,10 +142,7 @@ Route117_EventScript_1F3B6F:: @ 81F3B6F
 
 Route117_EventScript_1F3B9F:: @ 81F3B9F
 	msgbox Route117_Text_29CD1D, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 287
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 287
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_ANNA_AND_MEG_1
 	release
 	end
 
@@ -177,10 +162,7 @@ Route117_EventScript_1F3BD3:: @ 81F3BD3
 
 Route117_EventScript_1F3C03:: @ 81F3C03
 	msgbox Route117_Text_29CD1D, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 287
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 287
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_ANNA_AND_MEG_1
 	release
 	end
 

--- a/data/maps/Route118/scripts.inc
+++ b/data/maps/Route118/scripts.inc
@@ -199,10 +199,7 @@ Route118_EventScript_1F3FB3:: @ 81F3FB3
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route118_Text_29D343, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 37
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 37
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_ROSE_1
 	release
 	end
 
@@ -234,10 +231,7 @@ Route118_EventScript_1F4043:: @ 81F4043
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route118_Text_29D74A, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 196
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 196
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_DALTON_1
 	release
 	end
 

--- a/data/maps/Route118/scripts.inc
+++ b/data/maps/Route118/scripts.inc
@@ -30,7 +30,7 @@ Route118_EventScript_1F3E14:: @ 81F3E14
 	faceplayer
 	checkflag FLAG_0x0E3
 	goto_eq Route118_EventScript_1F3E69
-	msgbox Route118_Text_1F427B, 5
+	msgbox Route118_Text_1F427B, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route118_EventScript_1F3E3E
 	compare VAR_RESULT, 0
@@ -38,33 +38,33 @@ Route118_EventScript_1F3E14:: @ 81F3E14
 	end
 
 Route118_EventScript_1F3E3E:: @ 81F3E3E
-	msgbox Route118_Text_1F42AF, 4
+	msgbox Route118_Text_1F42AF, MSGBOX_DEFAULT
 	giveitem_std ITEM_GOOD_ROD
 	setflag FLAG_0x0E3
-	msgbox Route118_Text_1F42E7, 4
+	msgbox Route118_Text_1F42E7, MSGBOX_DEFAULT
 	release
 	end
 
 Route118_EventScript_1F3E5F:: @ 81F3E5F
-	msgbox Route118_Text_1F4319, 4
+	msgbox Route118_Text_1F4319, MSGBOX_DEFAULT
 	release
 	end
 
 Route118_EventScript_1F3E69:: @ 81F3E69
-	msgbox Route118_Text_1F4331, 4
+	msgbox Route118_Text_1F4331, MSGBOX_DEFAULT
 	release
 	end
 
 Route118_EventScript_1F3E73:: @ 81F3E73
-	msgbox Route118_Text_1F4367, 2
+	msgbox Route118_Text_1F4367, MSGBOX_NPC
 	end
 
 Route118_EventScript_1F3E7C:: @ 81F3E7C
-	msgbox Route118_Text_1F43F4, 3
+	msgbox Route118_Text_1F43F4, MSGBOX_SIGN
 	end
 
 Route118_EventScript_1F3E85:: @ 81F3E85
-	msgbox Route118_Text_1F440E, 3
+	msgbox Route118_Text_1F440E, MSGBOX_SIGN
 	end
 
 Route118_EventScript_1F3E8E:: @ 81F3E8E
@@ -100,7 +100,7 @@ Route118_EventScript_1F3EE4:: @ 81F3EE4
 	applymovement 19, Route118_Movement_1F3F65
 	waitmovement 0
 	delay 30
-	msgbox Route118_Text_1F40BE, 4
+	msgbox Route118_Text_1F40BE, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_0x8008, 0
 	call_if 1, Route118_EventScript_1F3F28
@@ -191,34 +191,34 @@ Route118_EventScript_1F3F87:: @ 81F3F87
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route118_EventScript_1F3FD2
-	msgbox Route118_Text_29D2FA, 4
+	msgbox Route118_Text_29D2FA, MSGBOX_DEFAULT
 	release
 	end
 
 Route118_EventScript_1F3FB3:: @ 81F3FB3
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route118_Text_29D343, 4
+	msgbox Route118_Text_29D343, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 37
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 37
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route118_EventScript_1F3FD2:: @ 81F3FD2
 	trainerbattle 5, TRAINER_ROSE_1, 0, Route118_Text_29D382, Route118_Text_29D3AA
-	msgbox Route118_Text_29D3D9, 6
+	msgbox Route118_Text_29D3D9, MSGBOX_AUTOCLOSE
 	end
 
 Route118_EventScript_1F3FE9:: @ 81F3FE9
 	trainerbattle 0, TRAINER_BARNY, 0, Route118_Text_29D515, Route118_Text_29D55C
-	msgbox Route118_Text_29D587, 6
+	msgbox Route118_Text_29D587, MSGBOX_AUTOCLOSE
 	end
 
 Route118_EventScript_1F4000:: @ 81F4000
 	trainerbattle 0, TRAINER_WADE, 0, Route118_Text_29D5DF, Route118_Text_29D64C
-	msgbox Route118_Text_29D663, 6
+	msgbox Route118_Text_29D663, MSGBOX_AUTOCLOSE
 	end
 
 Route118_EventScript_1F4017:: @ 81F4017
@@ -226,39 +226,39 @@ Route118_EventScript_1F4017:: @ 81F4017
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route118_EventScript_1F4062
-	msgbox Route118_Text_29D6D8, 4
+	msgbox Route118_Text_29D6D8, MSGBOX_DEFAULT
 	release
 	end
 
 Route118_EventScript_1F4043:: @ 81F4043
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route118_Text_29D74A, 4
+	msgbox Route118_Text_29D74A, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 196
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 196
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route118_EventScript_1F4062:: @ 81F4062
 	trainerbattle 5, TRAINER_DALTON_1, 0, Route118_Text_29D789, Route118_Text_29D7CA
-	msgbox Route118_Text_29D7D5, 6
+	msgbox Route118_Text_29D7D5, MSGBOX_AUTOCLOSE
 	end
 
 Route118_EventScript_1F4079:: @ 81F4079
 	trainerbattle 0, TRAINER_PERRY, 0, Route118_Text_29D41D, Route118_Text_29D45B
-	msgbox Route118_Text_29D46C, 6
+	msgbox Route118_Text_29D46C, MSGBOX_AUTOCLOSE
 	end
 
 Route118_EventScript_1F4090:: @ 81F4090
 	trainerbattle 0, TRAINER_CHESTER, 0, Route118_Text_29D4A6, Route118_Text_29D4C4
-	msgbox Route118_Text_29D4DA, 6
+	msgbox Route118_Text_29D4DA, MSGBOX_AUTOCLOSE
 	end
 
 Route118_EventScript_1F40A7:: @ 81F40A7
 	trainerbattle 0, TRAINER_DEANDRE, 0, Route118_Text_29D81B, Route118_Text_29D83C
-	msgbox Route118_Text_29D872, 6
+	msgbox Route118_Text_29D872, MSGBOX_AUTOCLOSE
 	end
 
 Route118_Text_1F40BE: @ 81F40BE

--- a/data/maps/Route119/scripts.inc
+++ b/data/maps/Route119/scripts.inc
@@ -379,10 +379,7 @@ Route119_EventScript_1F483C:: @ 81F483C
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route119_Text_29DD1C, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 552
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 552
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_JACKSON_1
 	release
 	end
 
@@ -404,10 +401,7 @@ Route119_EventScript_1F489E:: @ 81F489E
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route119_Text_29DEF7, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 559
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 559
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_CATHERINE_1
 	release
 	end
 

--- a/data/maps/Route119/scripts.inc
+++ b/data/maps/Route119/scripts.inc
@@ -79,7 +79,7 @@ Route119_EventScript_1F4506:: @ 81F4506
 	return
 
 Route119_EventScript_1F450B:: @ 81F450B
-	msgbox Route119_Text_1F49FD, 4
+	msgbox Route119_Text_1F49FD, MSGBOX_DEFAULT
 	switch VAR_STARTER_MON
 	case 0, Route119_EventScript_1F453A
 	case 1, Route119_EventScript_1F454A
@@ -102,14 +102,14 @@ Route119_EventScript_1F455A:: @ 81F455A
 	end
 
 Route119_EventScript_1F456A:: @ 81F456A
-	msgbox Route119_Text_1F4AF3, 4
+	msgbox Route119_Text_1F4AF3, MSGBOX_DEFAULT
 	call Route119_EventScript_1F45FF
-	msgbox Route119_Text_1F4B56, 4
+	msgbox Route119_Text_1F4B56, MSGBOX_DEFAULT
 	goto Route119_EventScript_1F460F
 	end
 
 Route119_EventScript_1F4585:: @ 81F4585
-	msgbox Route119_Text_1F4C9A, 4
+	msgbox Route119_Text_1F4C9A, MSGBOX_DEFAULT
 	switch VAR_STARTER_MON
 	case 0, Route119_EventScript_1F45B4
 	case 1, Route119_EventScript_1F45C4
@@ -132,9 +132,9 @@ Route119_EventScript_1F45D4:: @ 81F45D4
 	end
 
 Route119_EventScript_1F45E4:: @ 81F45E4
-	msgbox Route119_Text_1F4D4B, 4
+	msgbox Route119_Text_1F4D4B, MSGBOX_DEFAULT
 	call Route119_EventScript_1F45FF
-	msgbox Route119_Text_1F4DB5, 4
+	msgbox Route119_Text_1F4DB5, MSGBOX_DEFAULT
 	goto Route119_EventScript_1F460F
 	end
 
@@ -169,7 +169,7 @@ Route119_EventScript_1F460F:: @ 81F460F
 	applymovement 43, Route119_Movement_1F4752
 	waitmovement 0
 	addvar VAR_0x40D1, 1
-	msgbox Route119_Text_1F4E60, 4
+	msgbox Route119_Text_1F4E60, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_TEMP_1, 1
 	call_if 1, Route119_EventScript_1F46B0
@@ -325,45 +325,45 @@ Route119_Movement_1F4763: @ 81F4763
 	step_end
 
 Route119_EventScript_1F476B:: @ 81F476B
-	msgbox Route119_Text_1F5261, 2
+	msgbox Route119_Text_1F5261, MSGBOX_NPC
 	end
 
 Route119_EventScript_1F4774:: @ 81F4774
-	msgbox Route119_Text_1F530E, 3
+	msgbox Route119_Text_1F530E, MSGBOX_SIGN
 	end
 
 Route119_EventScript_1F477D:: @ 81F477D
-	msgbox Route119_Text_1F5327, 3
+	msgbox Route119_Text_1F5327, MSGBOX_SIGN
 	end
 
 Route119_EventScript_1F4786:: @ 81F4786
 	trainerbattle 0, TRAINER_BRENT, 0, Route119_Text_29D8C2, Route119_Text_29D8F0
-	msgbox Route119_Text_29D902, 6
+	msgbox Route119_Text_29D902, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F479D:: @ 81F479D
 	trainerbattle 0, TRAINER_DONALD, 0, Route119_Text_29D941, Route119_Text_29D97C
-	msgbox Route119_Text_29D993, 6
+	msgbox Route119_Text_29D993, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F47B4:: @ 81F47B4
 	trainerbattle 0, TRAINER_TAYLOR, 0, Route119_Text_29D9CD, Route119_Text_29DA14
-	msgbox Route119_Text_29DA2C, 6
+	msgbox Route119_Text_29DA2C, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F47CB:: @ 81F47CB
 	trainerbattle 0, TRAINER_DOUG, 0, Route119_Text_29DA7D, Route119_Text_29DABC
-	msgbox Route119_Text_29DADB, 6
+	msgbox Route119_Text_29DADB, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F47E2:: @ 81F47E2
 	trainerbattle 0, TRAINER_GREG, 0, Route119_Text_29DB17, Route119_Text_29DB66
-	msgbox Route119_Text_29DB7C, 6
+	msgbox Route119_Text_29DB7C, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F47F9:: @ 81F47F9
 	trainerbattle 0, TRAINER_KENT, 0, Route119_Text_29DBC2, Route119_Text_29DC20
-	msgbox Route119_Text_29DC2B, 6
+	msgbox Route119_Text_29DC2B, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F4810:: @ 81F4810
@@ -371,24 +371,24 @@ Route119_EventScript_1F4810:: @ 81F4810
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route119_EventScript_1F485B
-	msgbox Route119_Text_29DCC6, 4
+	msgbox Route119_Text_29DCC6, MSGBOX_DEFAULT
 	release
 	end
 
 Route119_EventScript_1F483C:: @ 81F483C
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route119_Text_29DD1C, 4
+	msgbox Route119_Text_29DD1C, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 552
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 552
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route119_EventScript_1F485B:: @ 81F485B
 	trainerbattle 5, TRAINER_JACKSON_1, 0, Route119_Text_29DD62, Route119_Text_29DDA5
-	msgbox Route119_Text_29DDBD, 6
+	msgbox Route119_Text_29DDBD, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F4872:: @ 81F4872
@@ -396,75 +396,75 @@ Route119_EventScript_1F4872:: @ 81F4872
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route119_EventScript_1F48BD
-	msgbox Route119_Text_29DE88, 4
+	msgbox Route119_Text_29DE88, MSGBOX_DEFAULT
 	release
 	end
 
 Route119_EventScript_1F489E:: @ 81F489E
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route119_Text_29DEF7, 4
+	msgbox Route119_Text_29DEF7, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 559
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 559
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route119_EventScript_1F48BD:: @ 81F48BD
 	trainerbattle 5, TRAINER_CATHERINE_1, 0, Route119_Text_29DF6B, Route119_Text_29DF92
-	msgbox Route119_Text_29DFAF, 6
+	msgbox Route119_Text_29DFAF, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F48D4:: @ 81F48D4
 	trainerbattle 0, TRAINER_HUGH, 0, Route119_Text_29E007, Route119_Text_29E063
-	msgbox Route119_Text_29E071, 6
+	msgbox Route119_Text_29E071, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F48EB:: @ 81F48EB
 	trainerbattle 0, TRAINER_PHIL, 0, Route119_Text_29E0A5, Route119_Text_29E0E1
-	msgbox Route119_Text_29E0F6, 6
+	msgbox Route119_Text_29E0F6, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F4902:: @ 81F4902
 	trainerbattle 0, TRAINER_YASU, 0, Route119_Text_29E134, Route119_Text_29E18D
-	msgbox Route119_Text_29E19D, 6
+	msgbox Route119_Text_29E19D, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F4919:: @ 81F4919
 	trainerbattle 0, TRAINER_TAKASHI, 0, Route119_Text_29E1F5, Route119_Text_29E22B
-	msgbox Route119_Text_29E245, 6
+	msgbox Route119_Text_29E245, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F4930:: @ 81F4930
 	trainerbattle 0, TRAINER_HIDEO, 0, Route119_Text_29E26A, Route119_Text_29E288
-	msgbox Route119_Text_29E2A3, 6
+	msgbox Route119_Text_29E2A3, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F4947:: @ 81F4947
 	trainerbattle 0, TRAINER_CHRIS, 0, Route119_Text_29E30D, Route119_Text_29E372
-	msgbox Route119_Text_29E3A2, 6
+	msgbox Route119_Text_29E3A2, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F495E:: @ 81F495E
 	trainerbattle 0, TRAINER_FABIAN, 0, Route119_Text_29E3FF, Route119_Text_29E44F
-	msgbox Route119_Text_29E492, 6
+	msgbox Route119_Text_29E492, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F4975:: @ 81F4975
 	trainerbattle 0, TRAINER_DAYTON, 0, Route119_Text_29E4DF, Route119_Text_29E513
-	msgbox Route119_Text_29E532, 6
+	msgbox Route119_Text_29E532, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F498C:: @ 81F498C
 	trainerbattle 0, TRAINER_RACHEL, 0, Route119_Text_29E56F, Route119_Text_29E5B1
-	msgbox Route119_Text_29E5CB, 6
+	msgbox Route119_Text_29E5CB, MSGBOX_AUTOCLOSE
 	end
 
 Route119_EventScript_1F49A3:: @ 81F49A3
 	lock
 	faceplayer
-	msgbox Route119_Text_1F50EB, 4
+	msgbox Route119_Text_1F50EB, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, Route119_Movement_2725A2
 	waitmovement 0
@@ -474,7 +474,7 @@ Route119_EventScript_1F49A3:: @ 81F49A3
 Route119_EventScript_1F49BA:: @ 81F49BA
 	lock
 	faceplayer
-	msgbox Route119_Text_1F5147, 4
+	msgbox Route119_Text_1F5147, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, Route119_Movement_2725A2
 	waitmovement 0
@@ -482,15 +482,15 @@ Route119_EventScript_1F49BA:: @ 81F49BA
 	end
 
 Route119_EventScript_1F49D1:: @ 81F49D1
-	msgbox Route119_Text_1F51A2, 2
+	msgbox Route119_Text_1F51A2, MSGBOX_NPC
 	end
 
 Route119_EventScript_1F49DA:: @ 81F49DA
-	msgbox Route119_Text_1F52B9, 2
+	msgbox Route119_Text_1F52B9, MSGBOX_NPC
 	end
 
 Route119_EventScript_1F49E3:: @ 81F49E3
-	msgbox Route119_Text_1F5339, 3
+	msgbox Route119_Text_1F5339, MSGBOX_SIGN
 	end
 
 Route119_EventScript_1F49EC:: @ 81F49EC

--- a/data/maps/Route119_House/scripts.inc
+++ b/data/maps/Route119_House/scripts.inc
@@ -2,7 +2,7 @@ Route119_House_MapScripts:: @ 8270965
 	.byte 0
 
 Route119_House_EventScript_270966:: @ 8270966
-	msgbox Route119_House_Text_270982, 2
+	msgbox Route119_House_Text_270982, MSGBOX_NPC
 	end
 
 Route119_House_EventScript_27096F:: @ 827096F
@@ -10,7 +10,7 @@ Route119_House_EventScript_27096F:: @ 827096F
 	faceplayer
 	waitse
 	playmoncry SPECIES_WINGULL, 0
-	msgbox Route119_House_Text_270A17, 4
+	msgbox Route119_House_Text_270A17, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/Route119_WeatherInstitute_1F/scripts.inc
+++ b/data/maps/Route119_WeatherInstitute_1F/scripts.inc
@@ -18,12 +18,12 @@ Route119_WeatherInstitute_1F_EventScript_26FAA4:: @ 826FAA4
 	special GetPlayerBigGuyGirlString
 	compare VAR_WEATHER_INSTITUTE_STATE, 0
 	goto_eq Route119_WeatherInstitute_1F_EventScript_26FABE
-	msgbox Route119_WeatherInstitute_1F_Text_26FCE5, 4
+	msgbox Route119_WeatherInstitute_1F_Text_26FCE5, MSGBOX_DEFAULT
 	release
 	end
 
 Route119_WeatherInstitute_1F_EventScript_26FABE:: @ 826FABE
-	msgbox Route119_WeatherInstitute_1F_Text_26FCB7, 4
+	msgbox Route119_WeatherInstitute_1F_Text_26FCB7, MSGBOX_DEFAULT
 	release
 	end
 
@@ -39,7 +39,7 @@ Route119_WeatherInstitute_1F_EventScript_26FAC8:: @ 826FAC8
 	call_if 1, Route119_WeatherInstitute_1F_EventScript_26FAFF
 	compare VAR_0x8004, 2
 	goto_eq Route119_WeatherInstitute_1F_EventScript_26FB05
-	msgbox Route119_WeatherInstitute_1F_Text_26FDE8, 4
+	msgbox Route119_WeatherInstitute_1F_Text_26FDE8, MSGBOX_DEFAULT
 	release
 	end
 
@@ -48,17 +48,17 @@ Route119_WeatherInstitute_1F_EventScript_26FAFF:: @ 826FAFF
 	return
 
 Route119_WeatherInstitute_1F_EventScript_26FB05:: @ 826FB05
-	msgbox Route119_WeatherInstitute_1F_Text_26FD2E, 4
+	msgbox Route119_WeatherInstitute_1F_Text_26FD2E, MSGBOX_DEFAULT
 	release
 	end
 
 Route119_WeatherInstitute_1F_EventScript_26FB0F:: @ 826FB0F
-	msgbox Route119_WeatherInstitute_1F_Text_26FE94, 2
+	msgbox Route119_WeatherInstitute_1F_Text_26FE94, MSGBOX_NPC
 	end
 
 Route119_WeatherInstitute_1F_EventScript_26FB18:: @ 826FB18
 	lockall
-	msgbox Route119_WeatherInstitute_1F_Text_26FEFC, 4
+	msgbox Route119_WeatherInstitute_1F_Text_26FEFC, MSGBOX_DEFAULT
 	closemessage
 	call Route119_WeatherInstitute_1F_EventScript_272083
 	releaseall
@@ -66,12 +66,12 @@ Route119_WeatherInstitute_1F_EventScript_26FB18:: @ 826FB18
 
 Route119_WeatherInstitute_1F_EventScript_26FB29:: @ 826FB29
 	trainerbattle 0, TRAINER_GRUNT_11, 0, Route119_WeatherInstitute_1F_Text_26FB57, Route119_WeatherInstitute_1F_Text_26FBBB
-	msgbox Route119_WeatherInstitute_1F_Text_26FBD7, 6
+	msgbox Route119_WeatherInstitute_1F_Text_26FBD7, MSGBOX_AUTOCLOSE
 	end
 
 Route119_WeatherInstitute_1F_EventScript_26FB40:: @ 826FB40
 	trainerbattle 0, TRAINER_GRUNT_20, 0, Route119_WeatherInstitute_1F_Text_26FC34, Route119_WeatherInstitute_1F_Text_26FC52
-	msgbox Route119_WeatherInstitute_1F_Text_26FC60, 6
+	msgbox Route119_WeatherInstitute_1F_Text_26FC60, MSGBOX_AUTOCLOSE
 	end
 
 Route119_WeatherInstitute_1F_Text_26FB57: @ 826FB57

--- a/data/maps/Route119_WeatherInstitute_2F/scripts.inc
+++ b/data/maps/Route119_WeatherInstitute_2F/scripts.inc
@@ -28,39 +28,39 @@ Route119_WeatherInstitute_2F_EventScript_26FF5C:: @ 826FF5C
 
 Route119_WeatherInstitute_2F_EventScript_26FF68:: @ 826FF68
 	trainerbattle 0, TRAINER_GRUNT_37, 0, Route119_WeatherInstitute_2F_Text_270335, Route119_WeatherInstitute_2F_Text_27039F
-	msgbox Route119_WeatherInstitute_2F_Text_2703C0, 6
+	msgbox Route119_WeatherInstitute_2F_Text_2703C0, MSGBOX_AUTOCLOSE
 	end
 
 Route119_WeatherInstitute_2F_EventScript_26FF7F:: @ 826FF7F
 	trainerbattle 0, TRAINER_GRUNT_12, 0, Route119_WeatherInstitute_2F_Text_27019C, Route119_WeatherInstitute_2F_Text_270208
-	msgbox Route119_WeatherInstitute_2F_Text_27022B, 6
+	msgbox Route119_WeatherInstitute_2F_Text_27022B, MSGBOX_AUTOCLOSE
 	end
 
 Route119_WeatherInstitute_2F_EventScript_26FF96:: @ 826FF96
 	trainerbattle 0, TRAINER_GRUNT_13, 0, Route119_WeatherInstitute_2F_Text_270292, Route119_WeatherInstitute_2F_Text_2702CE
-	msgbox Route119_WeatherInstitute_2F_Text_2702DA, 6
+	msgbox Route119_WeatherInstitute_2F_Text_2702DA, MSGBOX_AUTOCLOSE
 	end
 
 Route119_WeatherInstitute_2F_EventScript_26FFAD:: @ 826FFAD
 	trainerbattle 2, TRAINER_SHELLY_1, 0, Route119_WeatherInstitute_2F_Text_270409, Route119_WeatherInstitute_2F_Text_2704BD, Route119_WeatherInstitute_2F_EventScript_26FFC8
-	msgbox Route119_WeatherInstitute_2F_Text_2704E4, 6
+	msgbox Route119_WeatherInstitute_2F_Text_2704E4, MSGBOX_AUTOCLOSE
 	end
 
 Route119_WeatherInstitute_2F_EventScript_26FFC8:: @ 826FFC8
-	msgbox Route119_WeatherInstitute_2F_Text_2704E4, 4
+	msgbox Route119_WeatherInstitute_2F_Text_2704E4, MSGBOX_DEFAULT
 	closemessage
 	addobject 7
 	applymovement 7, Route119_WeatherInstitute_2F_Movement_270170
 	applymovement 255, Route119_WeatherInstitute_2F_Movement_27017C
 	waitmovement 0
-	msgbox Route119_WeatherInstitute_2F_Text_270568, 4
+	msgbox Route119_WeatherInstitute_2F_Text_270568, MSGBOX_DEFAULT
 	closemessage
 	playse SE_PIN
 	applymovement 3, Route119_WeatherInstitute_2F_Movement_272598
 	waitmovement 0
 	applymovement 3, Route119_WeatherInstitute_2F_Movement_27259A
 	waitmovement 0
-	msgbox Route119_WeatherInstitute_2F_Text_2705DD, 4
+	msgbox Route119_WeatherInstitute_2F_Text_2705DD, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_WEATHER_INSTITUTE_STATE, 1
 	clearflag FLAG_HIDE_WEATHER_INSTITUTE_2F_WORKERS
@@ -83,7 +83,7 @@ Route119_WeatherInstitute_2F_EventScript_26FFC8:: @ 826FFC8
 	end
 
 Route119_WeatherInstitute_2F_EventScript_27004D:: @ 827004D
-	msgbox Route119_WeatherInstitute_2F_Text_270650, 4
+	msgbox Route119_WeatherInstitute_2F_Text_270650, MSGBOX_DEFAULT
 	setvar VAR_TEMP_1, 385
 	givemon SPECIES_CASTFORM, 25, ITEM_MYSTIC_WATER, 0x0, 0x0, 0
 	compare VAR_RESULT, 0
@@ -95,7 +95,7 @@ Route119_WeatherInstitute_2F_EventScript_27004D:: @ 827004D
 
 Route119_WeatherInstitute_2F_EventScript_270085:: @ 8270085
 	call Route119_WeatherInstitute_2F_EventScript_2700DB
-	msgbox gUnknown_08273374, 5
+	msgbox gUnknown_08273374, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route119_WeatherInstitute_2F_EventScript_2700EA
 	call Route119_WeatherInstitute_2F_EventScript_27378B
@@ -105,7 +105,7 @@ Route119_WeatherInstitute_2F_EventScript_270085:: @ 8270085
 
 Route119_WeatherInstitute_2F_EventScript_2700AD:: @ 82700AD
 	call Route119_WeatherInstitute_2F_EventScript_2700DB
-	msgbox gUnknown_08273374, 5
+	msgbox gUnknown_08273374, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route119_WeatherInstitute_2F_EventScript_2700D0
 	call Route119_WeatherInstitute_2F_EventScript_273797
@@ -126,7 +126,7 @@ Route119_WeatherInstitute_2F_EventScript_2700DB:: @ 82700DB
 	return
 
 Route119_WeatherInstitute_2F_EventScript_2700EA:: @ 82700EA
-	msgbox Route119_WeatherInstitute_2F_Text_2706FE, 4
+	msgbox Route119_WeatherInstitute_2F_Text_2706FE, MSGBOX_DEFAULT
 	setflag FLAG_0x097
 	release
 	end
@@ -134,7 +134,7 @@ Route119_WeatherInstitute_2F_EventScript_2700EA:: @ 82700EA
 Route119_WeatherInstitute_2F_EventScript_2700F7:: @ 82700F7
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_eq Route119_WeatherInstitute_2F_EventScript_27010A
-	msgbox Route119_WeatherInstitute_2F_Text_27077E, 4
+	msgbox Route119_WeatherInstitute_2F_Text_27077E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -151,12 +151,12 @@ Route119_WeatherInstitute_2F_EventScript_27010A:: @ 827010A
 	specialvar VAR_RESULT, sub_813B374
 	compare VAR_RESULT, 1
 	goto_eq Route119_WeatherInstitute_2F_EventScript_27014F
-	msgbox Route119_WeatherInstitute_2F_Text_2707F1, 4
+	msgbox Route119_WeatherInstitute_2F_Text_2707F1, MSGBOX_DEFAULT
 	release
 	end
 
 Route119_WeatherInstitute_2F_EventScript_27014F:: @ 827014F
-	msgbox Route119_WeatherInstitute_2F_Text_270873, 4
+	msgbox Route119_WeatherInstitute_2F_Text_270873, MSGBOX_DEFAULT
 	release
 	end
 
@@ -170,7 +170,7 @@ Route119_WeatherInstitute_2F_EventScript_270160:: @ 8270160
 	return
 
 Route119_WeatherInstitute_2F_EventScript_270166:: @ 8270166
-	msgbox Route119_WeatherInstitute_2F_Text_2708FC, 4
+	msgbox Route119_WeatherInstitute_2F_Text_2708FC, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/Route120/scripts.inc
+++ b/data/maps/Route120/scripts.inc
@@ -105,7 +105,7 @@ Route120_EventScript_1F5527:: @ 81F5527
 	dodailyevents
 	checkflag FLAG_0x92E
 	goto_eq Route120_EventScript_1F5625
-	msgbox Route120_Text_2A70C7, 5
+	msgbox Route120_Text_2A70C7, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	call_if 1, Route120_EventScript_1F562F
 	compare VAR_RESULT, 0
@@ -154,21 +154,21 @@ Route120_EventScript_1F5601:: @ 81F5601
 	compare VAR_RESULT, 0
 	goto_eq Route120_EventScript_272054
 	setflag FLAG_0x92E
-	msgbox Route120_Text_2A71D5, 4
+	msgbox Route120_Text_2A71D5, MSGBOX_DEFAULT
 	release
 	end
 
 Route120_EventScript_1F5625:: @ 81F5625
-	msgbox Route120_Text_2A7217, 4
+	msgbox Route120_Text_2A7217, MSGBOX_DEFAULT
 	release
 	end
 
 Route120_EventScript_1F562F:: @ 81F562F
-	msgbox Route120_Text_2A7147, 4
+	msgbox Route120_Text_2A7147, MSGBOX_DEFAULT
 	return
 
 Route120_EventScript_1F5638:: @ 81F5638
-	msgbox Route120_Text_2A7183, 4
+	msgbox Route120_Text_2A7183, MSGBOX_DEFAULT
 	return
 
 Route120_EventScript_1F5641:: @ 81F5641
@@ -176,27 +176,27 @@ Route120_EventScript_1F5641:: @ 81F5641
 	faceplayer
 	checkflag FLAG_0x122
 	goto_eq Route120_EventScript_1F5672
-	msgbox Route120_Text_1F5998, 5
+	msgbox Route120_Text_1F5998, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route120_EventScript_1F5665
 	goto Route120_EventScript_1F568B
 	end
 
 Route120_EventScript_1F5665:: @ 81F5665
-	msgbox Route120_Text_1F5AAC, 4
+	msgbox Route120_Text_1F5AAC, MSGBOX_DEFAULT
 	setflag FLAG_0x122
 	release
 	end
 
 Route120_EventScript_1F5672:: @ 81F5672
-	msgbox Route120_Text_1F5ADE, 5
+	msgbox Route120_Text_1F5ADE, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route120_EventScript_1F5665
 	goto Route120_EventScript_1F568B
 	end
 
 Route120_EventScript_1F568B:: @ 81F568B
-	msgbox Route120_Text_1F5B0F, 4
+	msgbox Route120_Text_1F5B0F, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_FACING, 2
 	call_if 1, Route120_EventScript_1F57A3
@@ -205,7 +205,7 @@ Route120_EventScript_1F568B:: @ 81F568B
 	applymovement 31, Route120_Movement_2725A4
 	waitmovement 0
 	delay 20
-	msgbox Route120_Text_1F5B43, 4
+	msgbox Route120_Text_1F5B43, MSGBOX_DEFAULT
 	closemessage
 	applymovement 30, Route120_Movement_2725A8
 	waitmovement 0
@@ -242,10 +242,10 @@ Route120_EventScript_1F572C:: @ 81F572C
 	applymovement 31, Route120_Movement_2725AA
 	applymovement 255, Route120_Movement_2725A6
 	waitmovement 0
-	msgbox Route120_Text_1F5BAF, 4
+	msgbox Route120_Text_1F5BAF, MSGBOX_DEFAULT
 	giveitem_std ITEM_DEVON_SCOPE
 	setflag FLAG_0x11D
-	msgbox Route120_Text_1F5C7B, 4
+	msgbox Route120_Text_1F5C7B, MSGBOX_DEFAULT
 	closemessage
 	applymovement 31, Route120_Movement_2725AA
 	waitmovement 0
@@ -279,20 +279,20 @@ Route120_Movement_1F57B9: @ 81F57B9
 	step_end
 
 Route120_EventScript_1F57BC:: @ 81F57BC
-	msgbox Route120_Text_1F5D00, 2
+	msgbox Route120_Text_1F5D00, MSGBOX_NPC
 	end
 
 Route120_EventScript_1F57C5:: @ 81F57C5
-	msgbox Route120_Text_1F5DCB, 3
+	msgbox Route120_Text_1F5DCB, MSGBOX_SIGN
 	end
 
 Route120_EventScript_1F57CE:: @ 81F57CE
-	msgbox Route120_Text_1F5DE4, 3
+	msgbox Route120_Text_1F5DE4, MSGBOX_SIGN
 	end
 
 Route120_EventScript_1F57D7:: @ 81F57D7
 	trainerbattle 0, TRAINER_COLIN, 0, Route120_Text_29E62D, Route120_Text_29E665
-	msgbox Route120_Text_29E67A, 6
+	msgbox Route120_Text_29E67A, MSGBOX_AUTOCLOSE
 	end
 
 Route120_EventScript_1F57EE:: @ 81F57EE
@@ -300,34 +300,34 @@ Route120_EventScript_1F57EE:: @ 81F57EE
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route120_EventScript_1F5839
-	msgbox Route120_Text_29E726, 4
+	msgbox Route120_Text_29E726, MSGBOX_DEFAULT
 	release
 	end
 
 Route120_EventScript_1F581A:: @ 81F581A
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route120_Text_29E75D, 4
+	msgbox Route120_Text_29E75D, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 406
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 406
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route120_EventScript_1F5839:: @ 81F5839
 	trainerbattle 5, TRAINER_ROBERT_1, 0, Route120_Text_29E7AA, Route120_Text_29E7E1
-	msgbox Route120_Text_29E804, 6
+	msgbox Route120_Text_29E804, MSGBOX_AUTOCLOSE
 	end
 
 Route120_EventScript_1F5850:: @ 81F5850
 	trainerbattle 0, TRAINER_LORENZO, 0, Route120_Text_29E843, Route120_Text_29E884
-	msgbox Route120_Text_29E8C5, 6
+	msgbox Route120_Text_29E8C5, MSGBOX_AUTOCLOSE
 	end
 
 Route120_EventScript_1F5867:: @ 81F5867
 	trainerbattle 0, TRAINER_JENNA, 0, Route120_Text_29E91C, Route120_Text_29E980
-	msgbox Route120_Text_29E996, 6
+	msgbox Route120_Text_29E996, MSGBOX_AUTOCLOSE
 	end
 
 Route120_EventScript_1F587E:: @ 81F587E
@@ -335,64 +335,64 @@ Route120_EventScript_1F587E:: @ 81F587E
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route120_EventScript_1F58C9
-	msgbox Route120_Text_29EA08, 4
+	msgbox Route120_Text_29EA08, MSGBOX_DEFAULT
 	release
 	end
 
 Route120_EventScript_1F58AA:: @ 81F58AA
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route120_Text_29EA31, 4
+	msgbox Route120_Text_29EA31, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 226
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 226
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route120_EventScript_1F58C9:: @ 81F58C9
 	trainerbattle 5, TRAINER_JEFFREY_1, 0, Route120_Text_29EA61, Route120_Text_29EA8F
-	msgbox Route120_Text_29EAA9, 6
+	msgbox Route120_Text_29EAA9, MSGBOX_AUTOCLOSE
 	end
 
 Route120_EventScript_1F58E0:: @ 81F58E0
 	trainerbattle 0, TRAINER_JENNIFER, 0, Route120_Text_29EAEF, Route120_Text_29EB53
-	msgbox Route120_Text_29EB6E, 6
+	msgbox Route120_Text_29EB6E, MSGBOX_AUTOCLOSE
 	end
 
 Route120_EventScript_1F58F7:: @ 81F58F7
 	trainerbattle 0, TRAINER_CHIP, 0, Route120_Text_29EBAF, Route120_Text_29EC25
-	msgbox Route120_Text_29EC41, 6
+	msgbox Route120_Text_29EC41, MSGBOX_AUTOCLOSE
 	end
 
 Route120_EventScript_1F590E:: @ 81F590E
 	trainerbattle 0, TRAINER_CLARISSA, 0, Route120_Text_29ECA6, Route120_Text_29ECEF
-	msgbox Route120_Text_29ED19, 6
+	msgbox Route120_Text_29ED19, MSGBOX_AUTOCLOSE
 	end
 
 Route120_EventScript_1F5925:: @ 81F5925
 	trainerbattle 0, TRAINER_ANGELICA, 0, Route120_Text_29ED71, Route120_Text_29EDD3
-	msgbox Route120_Text_29EDF7, 6
+	msgbox Route120_Text_29EDF7, MSGBOX_AUTOCLOSE
 	end
 
 Route120_EventScript_1F593C:: @ 81F593C
 	trainerbattle 0, TRAINER_KEIGO, 0, Route120_Text_29EE50, Route120_Text_29EE97
-	msgbox Route120_Text_29EED4, 6
+	msgbox Route120_Text_29EED4, MSGBOX_AUTOCLOSE
 	end
 
 Route120_EventScript_1F5953:: @ 81F5953
 	trainerbattle 0, TRAINER_RILEY, 0, Route120_Text_29EF08, Route120_Text_29EF63
-	msgbox Route120_Text_29EF89, 6
+	msgbox Route120_Text_29EF89, MSGBOX_AUTOCLOSE
 	end
 
 Route120_EventScript_1F596A:: @ 81F596A
 	trainerbattle 0, TRAINER_LEONEL, 0, Route120_Text_29F04F, Route120_Text_29F080
-	msgbox Route120_Text_29F0A1, 6
+	msgbox Route120_Text_29F0A1, MSGBOX_AUTOCLOSE
 	end
 
 Route120_EventScript_1F5981:: @ 81F5981
 	trainerbattle 0, TRAINER_CALLIE, 0, Route120_Text_29EFB1, Route120_Text_29EFE1
-	msgbox Route120_Text_29F002, 6
+	msgbox Route120_Text_29F002, MSGBOX_AUTOCLOSE
 	end
 
 Route120_Text_1F5998: @ 81F5998

--- a/data/maps/Route120/scripts.inc
+++ b/data/maps/Route120/scripts.inc
@@ -308,10 +308,7 @@ Route120_EventScript_1F581A:: @ 81F581A
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route120_Text_29E75D, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 406
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 406
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_ROBERT_1
 	release
 	end
 
@@ -343,10 +340,7 @@ Route120_EventScript_1F58AA:: @ 81F58AA
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route120_Text_29EA31, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 226
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 226
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_JEFFREY_1
 	release
 	end
 

--- a/data/maps/Route121/scripts.inc
+++ b/data/maps/Route121/scripts.inc
@@ -83,10 +83,7 @@ Route121_EventScript_1F5EB7:: @ 81F5EB7
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route121_Text_29F25B, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 254
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 254
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_WALTER_1
 	release
 	end
 
@@ -123,10 +120,7 @@ Route121_EventScript_1F5F66:: @ 81F5F66
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route121_Text_29F69F, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 127
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 127
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_JESSICA_1
 	release
 	end
 
@@ -168,10 +162,7 @@ Route121_EventScript_1F6024:: @ 81F6024
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route121_Text_29F80D, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 767
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 767
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_CRISTIN_1
 	release
 	end
 

--- a/data/maps/Route121/scripts.inc
+++ b/data/maps/Route121/scripts.inc
@@ -2,15 +2,15 @@ Route121_MapScripts:: @ 81F5DFC
 	.byte 0
 
 Route121_EventScript_1F5DFD:: @ 81F5DFD
-	msgbox Route121_Text_1F607F, 2
+	msgbox Route121_Text_1F607F, MSGBOX_NPC
 	end
 
 Route121_EventScript_1F5E06:: @ 81F5E06
-	msgbox Route121_Text_1F60D3, 3
+	msgbox Route121_Text_1F60D3, MSGBOX_SIGN
 	end
 
 Route121_EventScript_1F5E0F:: @ 81F5E0F
-	msgbox Route121_Text_1F611E, 3
+	msgbox Route121_Text_1F611E, MSGBOX_SIGN
 	end
 
 Route121_EventScript_1F5E18:: @ 81F5E18
@@ -18,7 +18,7 @@ Route121_EventScript_1F5E18:: @ 81F5E18
 	playbgm MUS_AQA_0, 0
 	applymovement 13, Route121_Movement_2725B8
 	waitmovement 0
-	msgbox Route121_Text_1F605A, 4
+	msgbox Route121_Text_1F605A, MSGBOX_DEFAULT
 	closemessage
 	applymovement 12, Route121_Movement_1F5E59
 	applymovement 13, Route121_Movement_1F5E62
@@ -67,7 +67,7 @@ Route121_Movement_1F5E6B: @ 81F5E6B
 
 Route121_EventScript_1F5E74:: @ 81F5E74
 	trainerbattle 0, TRAINER_VANESSA, 0, Route121_Text_29F0EC, Route121_Text_29F11F
-	msgbox Route121_Text_29F138, 6
+	msgbox Route121_Text_29F138, MSGBOX_AUTOCLOSE
 	end
 
 Route121_EventScript_1F5E8B:: @ 81F5E8B
@@ -75,39 +75,39 @@ Route121_EventScript_1F5E8B:: @ 81F5E8B
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route121_EventScript_1F5ED6
-	msgbox Route121_Text_29F21E, 4
+	msgbox Route121_Text_29F21E, MSGBOX_DEFAULT
 	release
 	end
 
 Route121_EventScript_1F5EB7:: @ 81F5EB7
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route121_Text_29F25B, 4
+	msgbox Route121_Text_29F25B, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 254
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 254
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route121_EventScript_1F5ED6:: @ 81F5ED6
 	trainerbattle 5, TRAINER_WALTER_1, 0, Route121_Text_29F2A6, Route121_Text_29F31A
-	msgbox Route121_Text_29F32B, 6
+	msgbox Route121_Text_29F32B, MSGBOX_AUTOCLOSE
 	end
 
 Route121_EventScript_1F5EED:: @ 81F5EED
 	trainerbattle 0, TRAINER_TAMMY, 0, Route121_Text_29F381, Route121_Text_29F3B9
-	msgbox Route121_Text_29F3C6, 6
+	msgbox Route121_Text_29F3C6, MSGBOX_AUTOCLOSE
 	end
 
 Route121_EventScript_1F5F04:: @ 81F5F04
 	trainerbattle 4, TRAINER_KATE_AND_JOY, 0, Route121_Text_29F3FB, Route121_Text_29F43F, Route121_Text_29F4C9
-	msgbox Route121_Text_29F476, 6
+	msgbox Route121_Text_29F476, MSGBOX_AUTOCLOSE
 	end
 
 Route121_EventScript_1F5F1F:: @ 81F5F1F
 	trainerbattle 4, TRAINER_KATE_AND_JOY, 0, Route121_Text_29F521, Route121_Text_29F564, Route121_Text_29F5CE
-	msgbox Route121_Text_29F582, 6
+	msgbox Route121_Text_29F582, MSGBOX_AUTOCLOSE
 	end
 
 Route121_EventScript_1F5F3A:: @ 81F5F3A
@@ -115,44 +115,44 @@ Route121_EventScript_1F5F3A:: @ 81F5F3A
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route121_EventScript_1F5F85
-	msgbox Route121_Text_29F66F, 4
+	msgbox Route121_Text_29F66F, MSGBOX_DEFAULT
 	release
 	end
 
 Route121_EventScript_1F5F66:: @ 81F5F66
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route121_Text_29F69F, 4
+	msgbox Route121_Text_29F69F, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 127
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 127
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route121_EventScript_1F5F85:: @ 81F5F85
 	trainerbattle 5, TRAINER_JESSICA_1, 0, Route121_Text_29F6E4, Route121_Text_29F710
-	msgbox Route121_Text_29F740, 6
+	msgbox Route121_Text_29F740, MSGBOX_AUTOCLOSE
 	end
 
 Route121_EventScript_1F5F9C:: @ 81F5F9C
 	trainerbattle 0, TRAINER_CALE, 0, Route121_Text_29F91A, Route121_Text_29F97B
-	msgbox Route121_Text_29F9AE, 6
+	msgbox Route121_Text_29F9AE, MSGBOX_AUTOCLOSE
 	end
 
 Route121_EventScript_1F5FB3:: @ 81F5FB3
 	trainerbattle 0, TRAINER_MYLES, 0, Route121_Text_29FA1E, Route121_Text_29FA64
-	msgbox Route121_Text_29FA73, 6
+	msgbox Route121_Text_29FA73, MSGBOX_AUTOCLOSE
 	end
 
 Route121_EventScript_1F5FCA:: @ 81F5FCA
 	trainerbattle 0, TRAINER_PAT, 0, Route121_Text_29FAA7, Route121_Text_29FAD8
-	msgbox Route121_Text_29FAEA, 6
+	msgbox Route121_Text_29FAEA, MSGBOX_AUTOCLOSE
 	end
 
 Route121_EventScript_1F5FE1:: @ 81F5FE1
 	trainerbattle 0, TRAINER_MARCEL, 0, Route121_Text_29FB35, Route121_Text_29FB8C
-	msgbox Route121_Text_29FBA8, 6
+	msgbox Route121_Text_29FBA8, MSGBOX_AUTOCLOSE
 	end
 
 Route121_EventScript_1F5FF8:: @ 81F5FF8
@@ -160,24 +160,24 @@ Route121_EventScript_1F5FF8:: @ 81F5FF8
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route121_EventScript_1F6043
-	msgbox Route121_Text_29F7D4, 4
+	msgbox Route121_Text_29F7D4, MSGBOX_DEFAULT
 	release
 	end
 
 Route121_EventScript_1F6024:: @ 81F6024
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route121_Text_29F80D, 4
+	msgbox Route121_Text_29F80D, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 767
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 767
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route121_EventScript_1F6043:: @ 81F6043
 	trainerbattle 5, TRAINER_CRISTIN_1, 0, Route121_Text_29F855, Route121_Text_29F8A8
-	msgbox Route121_Text_29F8D0, 6
+	msgbox Route121_Text_29F8D0, MSGBOX_AUTOCLOSE
 	end
 
 Route121_Text_1F605A: @ 81F605A

--- a/data/maps/Route121_SafariZoneEntrance/scripts.inc
+++ b/data/maps/Route121_SafariZoneEntrance/scripts.inc
@@ -26,21 +26,21 @@ Route121_SafariZoneEntrance_Movement_22BBDD: @ 822BBDD
 	step_end
 
 Route121_SafariZoneEntrance_EventScript_22BBE6:: @ 822BBE6
-	msgbox Route121_SafariZoneEntrance_Text_2A4D12, 2
+	msgbox Route121_SafariZoneEntrance_Text_2A4D12, MSGBOX_NPC
 	end
 
 Route121_SafariZoneEntrance_EventScript_22BBEF:: @ 822BBEF
 	lock
 	faceplayer
-	msgbox Route121_SafariZoneEntrance_Text_2A4E46, 5
+	msgbox Route121_SafariZoneEntrance_Text_2A4E46, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route121_SafariZoneEntrance_EventScript_22BC0E
-	msgbox Route121_SafariZoneEntrance_Text_2A4E7E, 4
+	msgbox Route121_SafariZoneEntrance_Text_2A4E7E, MSGBOX_DEFAULT
 	release
 	end
 
 Route121_SafariZoneEntrance_EventScript_22BC0E:: @ 822BC0E
-	msgbox Route121_SafariZoneEntrance_Text_2A4EA1, 4
+	msgbox Route121_SafariZoneEntrance_Text_2A4EA1, MSGBOX_DEFAULT
 	release
 	end
 
@@ -49,10 +49,10 @@ Route121_SafariZoneEntrance_EventScript_22BC18:: @ 822BC18
 	applymovement 255, Route121_SafariZoneEntrance_Movement_2725A6
 	waitmovement 0
 	showmoneybox 0, 0, 0
-	msgbox Route121_SafariZoneEntrance_Text_2A4F74, 5
+	msgbox Route121_SafariZoneEntrance_Text_2A4F74, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route121_SafariZoneEntrance_EventScript_22BC48
-	msgbox Route121_SafariZoneEntrance_Text_2A4FD7, 4
+	msgbox Route121_SafariZoneEntrance_Text_2A4FD7, MSGBOX_DEFAULT
 	goto Route121_SafariZoneEntrance_EventScript_22BD06
 	end
 
@@ -65,15 +65,15 @@ Route121_SafariZoneEntrance_EventScript_22BC48:: @ 822BC48
 	compare VAR_RESULT, 0
 	goto_eq Route121_SafariZoneEntrance_EventScript_22BCF8
 	playse SE_REGI
-	msgbox Route121_SafariZoneEntrance_Text_2A501B, 4
+	msgbox Route121_SafariZoneEntrance_Text_2A501B, MSGBOX_DEFAULT
 	takemoney 0x1f4, 0
 	updatemoneybox 0, 0
 	nop
-	msgbox Route121_SafariZoneEntrance_Text_2A5036, 4
+	msgbox Route121_SafariZoneEntrance_Text_2A5036, MSGBOX_DEFAULT
 	playfanfare MUS_FANFA4
 	message Route121_SafariZoneEntrance_Text_2A5052
 	waitfanfare
-	msgbox Route121_SafariZoneEntrance_Text_2A506F, 4
+	msgbox Route121_SafariZoneEntrance_Text_2A506F, MSGBOX_DEFAULT
 	closemessage
 	hidemoneybox
 	nop
@@ -94,7 +94,7 @@ Route121_SafariZoneEntrance_EventScript_22BCBF:: @ 822BCBF
 	specialvar VAR_RESULT, ScriptCheckFreePokemonStorageSpace
 	compare VAR_RESULT, 1
 	goto_eq Route121_SafariZoneEntrance_EventScript_22BCE9
-	msgbox Route121_SafariZoneEntrance_Text_2A50E5, 4
+	msgbox Route121_SafariZoneEntrance_Text_2A50E5, MSGBOX_DEFAULT
 	goto Route121_SafariZoneEntrance_EventScript_22BD06
 	end
 
@@ -102,12 +102,12 @@ Route121_SafariZoneEntrance_EventScript_22BCE9:: @ 822BCE9
 	return
 
 Route121_SafariZoneEntrance_EventScript_22BCEA:: @ 822BCEA
-	msgbox Route121_SafariZoneEntrance_Text_2A5105, 4
+	msgbox Route121_SafariZoneEntrance_Text_2A5105, MSGBOX_DEFAULT
 	goto Route121_SafariZoneEntrance_EventScript_22BD06
 	end
 
 Route121_SafariZoneEntrance_EventScript_22BCF8:: @ 822BCF8
-	msgbox Route121_SafariZoneEntrance_Text_2A4FF7, 4
+	msgbox Route121_SafariZoneEntrance_Text_2A4FF7, MSGBOX_DEFAULT
 	goto Route121_SafariZoneEntrance_EventScript_22BD06
 	end
 
@@ -137,6 +137,6 @@ Route121_SafariZoneEntrance_Movement_22BD18: @ 822BD18
 	step_end
 
 Route121_SafariZoneEntrance_EventScript_22BD21:: @ 822BD21
-	msgbox Route121_SafariZoneEntrance_Text_2A55BB, 3
+	msgbox Route121_SafariZoneEntrance_Text_2A55BB, MSGBOX_SIGN
 	end
 

--- a/data/maps/Route123/scripts.inc
+++ b/data/maps/Route123/scripts.inc
@@ -11,16 +11,16 @@ Route123_EventScript_1F6151:: @ 81F6151
 	faceplayer
 	checkflag FLAG_0x0E8
 	goto_eq Route123_EventScript_1F61A0
-	msgbox Route123_Text_1F641E, 4
+	msgbox Route123_Text_1F641E, MSGBOX_DEFAULT
 	special IsGrassTypeInParty
 	compare VAR_RESULT, 0
 	goto_eq Route123_EventScript_1F619E
-	msgbox Route123_Text_1F645D, 4
+	msgbox Route123_Text_1F645D, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM19
 	compare VAR_RESULT, 0
 	goto_eq Route123_EventScript_272054
 	setflag FLAG_0x0E8
-	msgbox Route123_Text_1F64CF, 4
+	msgbox Route123_Text_1F64CF, MSGBOX_DEFAULT
 	release
 	end
 
@@ -29,35 +29,35 @@ Route123_EventScript_1F619E:: @ 81F619E
 	end
 
 Route123_EventScript_1F61A0:: @ 81F61A0
-	msgbox Route123_Text_1F64CF, 4
+	msgbox Route123_Text_1F64CF, MSGBOX_DEFAULT
 	release
 	end
 
 Route123_EventScript_1F61AA:: @ 81F61AA
-	msgbox Route123_Text_1F6511, 3
+	msgbox Route123_Text_1F6511, MSGBOX_SIGN
 	end
 
 Route123_EventScript_1F61B3:: @ 81F61B3
-	msgbox Route123_Text_1F6529, 3
+	msgbox Route123_Text_1F6529, MSGBOX_SIGN
 	end
 
 Route123_EventScript_1F61BC:: @ 81F61BC
-	msgbox Route123_Text_1F6557, 3
+	msgbox Route123_Text_1F6557, MSGBOX_SIGN
 	end
 
 Route123_EventScript_1F61C5:: @ 81F61C5
 	trainerbattle 0, TRAINER_WENDY, 0, Route123_Text_29FBEB, Route123_Text_29FC23
-	msgbox Route123_Text_29FC42, 6
+	msgbox Route123_Text_29FC42, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F61DC:: @ 81F61DC
 	trainerbattle 0, TRAINER_BRAXTON, 0, Route123_Text_29FC6F, Route123_Text_29FCD6
-	msgbox Route123_Text_29FCF4, 6
+	msgbox Route123_Text_29FCF4, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F61F3:: @ 81F61F3
 	trainerbattle 0, TRAINER_VIOLET, 0, Route123_Text_29FD1D, Route123_Text_29FD53
-	msgbox Route123_Text_29FD7B, 6
+	msgbox Route123_Text_29FD7B, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F620A:: @ 81F620A
@@ -65,24 +65,24 @@ Route123_EventScript_1F620A:: @ 81F620A
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route123_EventScript_1F6255
-	msgbox Route123_Text_29FE2A, 4
+	msgbox Route123_Text_29FE2A, MSGBOX_DEFAULT
 	release
 	end
 
 Route123_EventScript_1F6236:: @ 81F6236
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route123_Text_29FE70, 4
+	msgbox Route123_Text_29FE70, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 238
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 238
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route123_EventScript_1F6255:: @ 81F6255
 	trainerbattle 5, TRAINER_CAMERON_1, 0, Route123_Text_29FED4, Route123_Text_29FF1B
-	msgbox Route123_Text_29FF27, 6
+	msgbox Route123_Text_29FF27, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F626C:: @ 81F626C
@@ -90,74 +90,74 @@ Route123_EventScript_1F626C:: @ 81F626C
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route123_EventScript_1F62B7
-	msgbox Route123_Text_29FFE5, 4
+	msgbox Route123_Text_29FFE5, MSGBOX_DEFAULT
 	release
 	end
 
 Route123_EventScript_1F6298:: @ 81F6298
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route123_Text_2A0027, 4
+	msgbox Route123_Text_2A0027, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 249
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 249
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route123_EventScript_1F62B7:: @ 81F62B7
 	trainerbattle 5, TRAINER_JACKI_1, 0, Route123_Text_2A005E, Route123_Text_2A008D
-	msgbox Route123_Text_2A0099, 6
+	msgbox Route123_Text_2A0099, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F62CE:: @ 81F62CE
 	trainerbattle 4, TRAINER_MIU_AND_YUKI, 0, Route123_Text_2A00D6, Route123_Text_2A0119, Route123_Text_2A016D
-	msgbox Route123_Text_2A012E, 6
+	msgbox Route123_Text_2A012E, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F62E9:: @ 81F62E9
 	trainerbattle 4, TRAINER_MIU_AND_YUKI, 0, Route123_Text_2A01A7, Route123_Text_2A01D8, Route123_Text_2A0224
-	msgbox Route123_Text_2A01EE, 6
+	msgbox Route123_Text_2A01EE, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F6304:: @ 81F6304
 	trainerbattle 0, TRAINER_KINDRA, 0, Route123_Text_2A025F, Route123_Text_2A02A6
-	msgbox Route123_Text_2A02C1, 6
+	msgbox Route123_Text_2A02C1, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F631B:: @ 81F631B
 	trainerbattle 0, TRAINER_FREDRICK, 0, Route123_Text_2A060A, Route123_Text_2A0631
-	msgbox Route123_Text_2A0672, 6
+	msgbox Route123_Text_2A0672, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F6332:: @ 81F6332
 	trainerbattle 0, TRAINER_ALBERTO, 0, Route123_Text_2A06AF, Route123_Text_2A0704
-	msgbox Route123_Text_2A072B, 6
+	msgbox Route123_Text_2A072B, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F6349:: @ 81F6349
 	trainerbattle 0, TRAINER_ED, 0, Route123_Text_2A079B, Route123_Text_2A07F0
-	msgbox Route123_Text_2A080D, 6
+	msgbox Route123_Text_2A080D, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F6360:: @ 81F6360
 	trainerbattle 0, TRAINER_KAYLEY, 0, Route123_Text_2A0902, Route123_Text_2A0943
-	msgbox Route123_Text_2A096E, 6
+	msgbox Route123_Text_2A096E, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F6377:: @ 81F6377
 	trainerbattle 0, TRAINER_JONAS, 0, Route123_Text_2A0854, Route123_Text_2A088A
-	msgbox Route123_Text_2A08CA, 6
+	msgbox Route123_Text_2A08CA, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F638E:: @ 81F638E
 	trainerbattle 0, TRAINER_JAZMYN, 0, Route123_Text_2A054E, Route123_Text_2A0592
-	msgbox Route123_Text_2A05AC, 6
+	msgbox Route123_Text_2A05AC, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F63A5:: @ 81F63A5
 	trainerbattle 0, TRAINER_DAVIS, 0, Route123_Text_2A04C0, Route123_Text_2A04FE
-	msgbox Route123_Text_2A0512, 6
+	msgbox Route123_Text_2A0512, MSGBOX_AUTOCLOSE
 	end
 
 Route123_EventScript_1F63BC:: @ 81F63BC
@@ -165,24 +165,24 @@ Route123_EventScript_1F63BC:: @ 81F63BC
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route123_EventScript_1F6407
-	msgbox Route123_Text_2A0389, 4
+	msgbox Route123_Text_2A0389, MSGBOX_DEFAULT
 	release
 	end
 
 Route123_EventScript_1F63E8:: @ 81F63E8
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route123_Text_2A03C1, 4
+	msgbox Route123_Text_2A03C1, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 195
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 195
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route123_EventScript_1F6407:: @ 81F6407
 	trainerbattle 5, TRAINER_FERNANDO_1, 0, Route123_Text_2A03FB, Route123_Text_2A045A
-	msgbox Route123_Text_2A0487, 6
+	msgbox Route123_Text_2A0487, MSGBOX_AUTOCLOSE
 	end
 
 Route123_Text_1F641E: @ 81F641E

--- a/data/maps/Route123/scripts.inc
+++ b/data/maps/Route123/scripts.inc
@@ -73,10 +73,7 @@ Route123_EventScript_1F6236:: @ 81F6236
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route123_Text_29FE70, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 238
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 238
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_CAMERON_1
 	release
 	end
 
@@ -98,10 +95,7 @@ Route123_EventScript_1F6298:: @ 81F6298
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route123_Text_2A0027, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 249
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 249
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_JACKI_1
 	release
 	end
 
@@ -173,10 +167,7 @@ Route123_EventScript_1F63E8:: @ 81F63E8
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route123_Text_2A03C1, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 195
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 195
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_FERNANDO_1
 	release
 	end
 

--- a/data/maps/Route123_BerryMastersHouse/scripts.inc
+++ b/data/maps/Route123_BerryMastersHouse/scripts.inc
@@ -12,7 +12,7 @@ Route123_BerryMastersHouse_EventScript_26F845:: @ 826F845
 	dodailyevents
 	checkflag FLAG_0x92D
 	goto_eq Route123_BerryMastersHouse_EventScript_26F8B6
-	msgbox Route123_BerryMastersHouse_Text_2A7386, 4
+	msgbox Route123_BerryMastersHouse_Text_2A7386, MSGBOX_DEFAULT
 	random 10
 	addvar VAR_RESULT, 20
 	addvar VAR_RESULT, 133
@@ -20,19 +20,19 @@ Route123_BerryMastersHouse_EventScript_26F845:: @ 826F845
 	compare VAR_RESULT, 0
 	goto_eq Route123_BerryMastersHouse_EventScript_272054
 	setflag FLAG_0x92D
-	msgbox Route123_BerryMastersHouse_Text_2A7428, 4
+	msgbox Route123_BerryMastersHouse_Text_2A7428, MSGBOX_DEFAULT
 	random 10
 	addvar VAR_RESULT, 20
 	addvar VAR_RESULT, 133
 	giveitem_std VAR_RESULT
 	compare VAR_RESULT, 0
 	goto_eq Route123_BerryMastersHouse_EventScript_272054
-	msgbox Route123_BerryMastersHouse_Text_2A7445, 4
+	msgbox Route123_BerryMastersHouse_Text_2A7445, MSGBOX_DEFAULT
 	release
 	end
 
 Route123_BerryMastersHouse_EventScript_26F8B6:: @ 826F8B6
-	msgbox Route123_BerryMastersHouse_Text_2A749E, 4
+	msgbox Route123_BerryMastersHouse_Text_2A749E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -42,7 +42,7 @@ Route123_BerryMastersHouse_EventScript_26F8C0:: @ 826F8C0
 	dodailyevents
 	checkflag FLAG_0x931
 	goto_eq Route123_BerryMastersHouse_EventScript_26FA6F
-	msgbox Route123_BerryMastersHouse_Text_2A74E6, 4
+	msgbox Route123_BerryMastersHouse_Text_2A74E6, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 13
 	call Route123_BerryMastersHouse_EventScript_271E7C
 	lock
@@ -54,8 +54,8 @@ Route123_BerryMastersHouse_EventScript_26F8C0:: @ 826F8C0
 	end
 
 Route123_BerryMastersHouse_EventScript_26F8F7:: @ 826F8F7
-	msgbox Route123_BerryMastersHouse_Text_2A7682, 4
-	msgbox Route123_BerryMastersHouse_Text_2A761B, 4
+	msgbox Route123_BerryMastersHouse_Text_2A7682, MSGBOX_DEFAULT
+	msgbox Route123_BerryMastersHouse_Text_2A761B, MSGBOX_DEFAULT
 	release
 	end
 
@@ -75,7 +75,7 @@ Route123_BerryMastersHouse_EventScript_26F909:: @ 826F909
 	end
 
 Route123_BerryMastersHouse_EventScript_26F94C:: @ 826F94C
-	msgbox Route123_BerryMastersHouse_Text_2A75D0, 4
+	msgbox Route123_BerryMastersHouse_Text_2A75D0, MSGBOX_DEFAULT
 	random 10
 	addvar VAR_RESULT, 133
 	giveitem_std VAR_RESULT
@@ -88,7 +88,7 @@ Route123_BerryMastersHouse_EventScript_26F94C:: @ 826F94C
 Route123_BerryMastersHouse_EventScript_26F97A:: @ 826F97A
 	checkflag FLAG_0x0F8
 	goto_eq Route123_BerryMastersHouse_EventScript_26F94C
-	msgbox Route123_BerryMastersHouse_Text_2A7583, 4
+	msgbox Route123_BerryMastersHouse_Text_2A7583, MSGBOX_DEFAULT
 	giveitem_std ITEM_SPELON_BERRY
 	compare VAR_RESULT, 0
 	goto_eq Route123_BerryMastersHouse_EventScript_272054
@@ -99,7 +99,7 @@ Route123_BerryMastersHouse_EventScript_26F97A:: @ 826F97A
 Route123_BerryMastersHouse_EventScript_26F9AB:: @ 826F9AB
 	checkflag FLAG_0x0F9
 	goto_eq Route123_BerryMastersHouse_EventScript_26F94C
-	msgbox Route123_BerryMastersHouse_Text_2A7583, 4
+	msgbox Route123_BerryMastersHouse_Text_2A7583, MSGBOX_DEFAULT
 	giveitem_std ITEM_PAMTRE_BERRY
 	compare VAR_RESULT, 0
 	goto_eq Route123_BerryMastersHouse_EventScript_272054
@@ -110,7 +110,7 @@ Route123_BerryMastersHouse_EventScript_26F9AB:: @ 826F9AB
 Route123_BerryMastersHouse_EventScript_26F9DC:: @ 826F9DC
 	checkflag FLAG_0x0FA
 	goto_eq Route123_BerryMastersHouse_EventScript_26F94C
-	msgbox Route123_BerryMastersHouse_Text_2A7583, 4
+	msgbox Route123_BerryMastersHouse_Text_2A7583, MSGBOX_DEFAULT
 	giveitem_std ITEM_WATMEL_BERRY
 	compare VAR_RESULT, 0
 	goto_eq Route123_BerryMastersHouse_EventScript_272054
@@ -121,7 +121,7 @@ Route123_BerryMastersHouse_EventScript_26F9DC:: @ 826F9DC
 Route123_BerryMastersHouse_EventScript_26FA0D:: @ 826FA0D
 	checkflag FLAG_0x0FB
 	goto_eq Route123_BerryMastersHouse_EventScript_26F94C
-	msgbox Route123_BerryMastersHouse_Text_2A7583, 4
+	msgbox Route123_BerryMastersHouse_Text_2A7583, MSGBOX_DEFAULT
 	giveitem_std ITEM_DURIN_BERRY
 	compare VAR_RESULT, 0
 	goto_eq Route123_BerryMastersHouse_EventScript_272054
@@ -132,7 +132,7 @@ Route123_BerryMastersHouse_EventScript_26FA0D:: @ 826FA0D
 Route123_BerryMastersHouse_EventScript_26FA3E:: @ 826FA3E
 	checkflag FLAG_0x0FC
 	goto_eq Route123_BerryMastersHouse_EventScript_26F94C
-	msgbox Route123_BerryMastersHouse_Text_2A7583, 4
+	msgbox Route123_BerryMastersHouse_Text_2A7583, MSGBOX_DEFAULT
 	giveitem_std ITEM_BELUE_BERRY
 	compare VAR_RESULT, 0
 	goto_eq Route123_BerryMastersHouse_EventScript_272054
@@ -141,13 +141,13 @@ Route123_BerryMastersHouse_EventScript_26FA3E:: @ 826FA3E
 	end
 
 Route123_BerryMastersHouse_EventScript_26FA6F:: @ 826FA6F
-	msgbox Route123_BerryMastersHouse_Text_2A761B, 4
+	msgbox Route123_BerryMastersHouse_Text_2A761B, MSGBOX_DEFAULT
 	release
 	end
 
 Route123_BerryMastersHouse_EventScript_26FA79:: @ 826FA79
 	setflag FLAG_0x931
-	msgbox Route123_BerryMastersHouse_Text_2A761B, 4
+	msgbox Route123_BerryMastersHouse_Text_2A761B, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/Route124/scripts.inc
+++ b/data/maps/Route124/scripts.inc
@@ -34,10 +34,7 @@ Route124_EventScript_1F65DF:: @ 81F65DF
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route124_Text_2A0C14, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 449
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 449
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_JENNY_1
 	release
 	end
 
@@ -67,10 +64,7 @@ Route124_EventScript_1F6643:: @ 81F6643
 
 Route124_EventScript_1F6673:: @ 81F6673
 	msgbox Route124_Text_2A109F, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 687
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 687
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_LILA_AND_ROY_1
 	release
 	end
 
@@ -90,10 +84,7 @@ Route124_EventScript_1F66A7:: @ 81F66A7
 
 Route124_EventScript_1F66D7:: @ 81F66D7
 	msgbox Route124_Text_2A109F, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 687
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 687
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_LILA_AND_ROY_1
 	release
 	end
 

--- a/data/maps/Route124/scripts.inc
+++ b/data/maps/Route124/scripts.inc
@@ -8,17 +8,17 @@ Route124_MapScript1_1F6572: @ 81F6572
 	end
 
 Route124_EventScript_1F657C:: @ 81F657C
-	msgbox Route124_Text_1F6739, 3
+	msgbox Route124_Text_1F6739, MSGBOX_SIGN
 	end
 
 Route124_EventScript_1F6585:: @ 81F6585
 	trainerbattle 0, TRAINER_SPENCER, 0, Route124_Text_2A09B1, Route124_Text_2A0A02
-	msgbox Route124_Text_2A0A20, 6
+	msgbox Route124_Text_2A0A20, MSGBOX_AUTOCLOSE
 	end
 
 Route124_EventScript_1F659C:: @ 81F659C
 	trainerbattle 0, TRAINER_ROLAND, 0, Route124_Text_2A0A84, Route124_Text_2A0ACC
-	msgbox Route124_Text_2A0AD9, 6
+	msgbox Route124_Text_2A0AD9, MSGBOX_AUTOCLOSE
 	end
 
 Route124_EventScript_1F65B3:: @ 81F65B3
@@ -26,34 +26,34 @@ Route124_EventScript_1F65B3:: @ 81F65B3
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route124_EventScript_1F65FE
-	msgbox Route124_Text_2A0B9A, 4
+	msgbox Route124_Text_2A0B9A, MSGBOX_DEFAULT
 	release
 	end
 
 Route124_EventScript_1F65DF:: @ 81F65DF
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route124_Text_2A0C14, 4
+	msgbox Route124_Text_2A0C14, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 449
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 449
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route124_EventScript_1F65FE:: @ 81F65FE
 	trainerbattle 5, TRAINER_JENNY_1, 0, Route124_Text_2A0C60, Route124_Text_2A0CA0
-	msgbox Route124_Text_2A0CBE, 6
+	msgbox Route124_Text_2A0CBE, MSGBOX_AUTOCLOSE
 	end
 
 Route124_EventScript_1F6615:: @ 81F6615
 	trainerbattle 0, TRAINER_GRACE, 0, Route124_Text_2A0D0A, Route124_Text_2A0D3D
-	msgbox Route124_Text_2A0D66, 6
+	msgbox Route124_Text_2A0D66, MSGBOX_AUTOCLOSE
 	end
 
 Route124_EventScript_1F662C:: @ 81F662C
 	trainerbattle 0, TRAINER_CHAD, 0, Route124_Text_2A0DA0, Route124_Text_2A0DFF
-	msgbox Route124_Text_2A0E1E, 6
+	msgbox Route124_Text_2A0E1E, MSGBOX_AUTOCLOSE
 	end
 
 Route124_EventScript_1F6643:: @ 81F6643
@@ -61,22 +61,22 @@ Route124_EventScript_1F6643:: @ 81F6643
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route124_EventScript_1F668C
-	msgbox Route124_Text_2A0F3A, 4
+	msgbox Route124_Text_2A0F3A, MSGBOX_DEFAULT
 	release
 	end
 
 Route124_EventScript_1F6673:: @ 81F6673
-	msgbox Route124_Text_2A109F, 4
+	msgbox Route124_Text_2A109F, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 687
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 687
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route124_EventScript_1F668C:: @ 81F668C
 	trainerbattle 7, TRAINER_LILA_AND_ROY_1, 0, Route124_Text_2A111E, Route124_Text_2A11B2, Route124_Text_2A1255
-	msgbox Route124_Text_2A1203, 6
+	msgbox Route124_Text_2A1203, MSGBOX_AUTOCLOSE
 	end
 
 Route124_EventScript_1F66A7:: @ 81F66A7
@@ -84,32 +84,32 @@ Route124_EventScript_1F66A7:: @ 81F66A7
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route124_EventScript_1F66F0
-	msgbox Route124_Text_2A103E, 4
+	msgbox Route124_Text_2A103E, MSGBOX_DEFAULT
 	release
 	end
 
 Route124_EventScript_1F66D7:: @ 81F66D7
-	msgbox Route124_Text_2A109F, 4
+	msgbox Route124_Text_2A109F, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 687
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 687
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route124_EventScript_1F66F0:: @ 81F66F0
 	trainerbattle 7, TRAINER_LILA_AND_ROY_1, 0, Route124_Text_2A129A, Route124_Text_2A12DD, Route124_Text_2A1384
-	msgbox Route124_Text_2A130F, 6
+	msgbox Route124_Text_2A130F, MSGBOX_AUTOCLOSE
 	end
 
 Route124_EventScript_1F670B:: @ 81F670B
 	trainerbattle 0, TRAINER_DECLAN, 0, Route124_Text_2A13BD, Route124_Text_2A142C
-	msgbox Route124_Text_2A144F, 6
+	msgbox Route124_Text_2A144F, MSGBOX_AUTOCLOSE
 	end
 
 Route124_EventScript_1F6722:: @ 81F6722
 	trainerbattle 0, TRAINER_ISABELLA, 0, Route124_Text_2A148E, Route124_Text_2A14BC
-	msgbox Route124_Text_2A14ED, 6
+	msgbox Route124_Text_2A14ED, MSGBOX_AUTOCLOSE
 	end
 
 Route124_Text_1F6739: @ 81F6739

--- a/data/maps/Route124_DivingTreasureHuntersHouse/scripts.inc
+++ b/data/maps/Route124_DivingTreasureHuntersHouse/scripts.inc
@@ -11,13 +11,13 @@ Route124_DivingTreasureHuntersHouse_EventScript_270A32:: @ 8270A32
 	faceplayer
 	checkflag FLAG_0x0D9
 	goto_eq Route124_DivingTreasureHuntersHouse_EventScript_270A4E
-	msgbox Route124_DivingTreasureHuntersHouse_Text_270F6C, 4
+	msgbox Route124_DivingTreasureHuntersHouse_Text_270F6C, MSGBOX_DEFAULT
 	setflag FLAG_0x0D9
 	goto Route124_DivingTreasureHuntersHouse_EventScript_270A5C
 	end
 
 Route124_DivingTreasureHuntersHouse_EventScript_270A4E:: @ 8270A4E
-	msgbox Route124_DivingTreasureHuntersHouse_Text_270FE5, 4
+	msgbox Route124_DivingTreasureHuntersHouse_Text_270FE5, MSGBOX_DEFAULT
 	goto Route124_DivingTreasureHuntersHouse_EventScript_270A5C
 	end
 
@@ -61,7 +61,7 @@ Route124_DivingTreasureHuntersHouse_EventScript_270ACA:: @ 8270ACA
 	return
 
 Route124_DivingTreasureHuntersHouse_EventScript_270AD0:: @ 8270AD0
-	msgbox Route124_DivingTreasureHuntersHouse_Text_271098, 4
+	msgbox Route124_DivingTreasureHuntersHouse_Text_271098, MSGBOX_DEFAULT
 	goto Route124_DivingTreasureHuntersHouse_EventScript_270ADE
 	end
 
@@ -246,7 +246,7 @@ Route124_DivingTreasureHuntersHouse_EventScript_270EB1:: @ 8270EB1
 Route124_DivingTreasureHuntersHouse_EventScript_270EC0:: @ 8270EC0
 	bufferitemname 0, VAR_0x8008
 	bufferitemname 1, VAR_0x8009
-	msgbox Route124_DivingTreasureHuntersHouse_Text_271132, 5
+	msgbox Route124_DivingTreasureHuntersHouse_Text_271132, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route124_DivingTreasureHuntersHouse_EventScript_270F4D
 	checkitemspace VAR_0x8009, 1
@@ -261,28 +261,28 @@ Route124_DivingTreasureHuntersHouse_EventScript_270EC0:: @ 8270EC0
 Route124_DivingTreasureHuntersHouse_EventScript_270F01:: @ 8270F01
 	takeitem VAR_0x8008, 1
 	giveitem_std VAR_0x8009
-	msgbox Route124_DivingTreasureHuntersHouse_Text_271158, 4
+	msgbox Route124_DivingTreasureHuntersHouse_Text_271158, MSGBOX_DEFAULT
 	call Route124_DivingTreasureHuntersHouse_EventScript_270A72
 	compare VAR_TEMP_1, 0
 	goto_eq Route124_DivingTreasureHuntersHouse_EventScript_270F61
-	msgbox Route124_DivingTreasureHuntersHouse_Text_27117B, 5
+	msgbox Route124_DivingTreasureHuntersHouse_Text_27117B, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route124_DivingTreasureHuntersHouse_EventScript_270ADE
 	goto Route124_DivingTreasureHuntersHouse_EventScript_270F4D
 	end
 
 Route124_DivingTreasureHuntersHouse_EventScript_270F43:: @ 8270F43
-	msgbox Route124_DivingTreasureHuntersHouse_Text_2711A0, 4
+	msgbox Route124_DivingTreasureHuntersHouse_Text_2711A0, MSGBOX_DEFAULT
 	release
 	end
 
 Route124_DivingTreasureHuntersHouse_EventScript_270F4D:: @ 8270F4D
-	msgbox Route124_DivingTreasureHuntersHouse_Text_2711D8, 4
+	msgbox Route124_DivingTreasureHuntersHouse_Text_2711D8, MSGBOX_DEFAULT
 	release
 	end
 
 Route124_DivingTreasureHuntersHouse_EventScript_270F57:: @ 8270F57
-	msgbox Route124_DivingTreasureHuntersHouse_Text_271027, 4
+	msgbox Route124_DivingTreasureHuntersHouse_Text_271027, MSGBOX_DEFAULT
 	release
 	end
 
@@ -291,7 +291,7 @@ Route124_DivingTreasureHuntersHouse_EventScript_270F61:: @ 8270F61
 	end
 
 Route124_DivingTreasureHuntersHouse_EventScript_270F63:: @ 8270F63
-	msgbox Route124_DivingTreasureHuntersHouse_Text_271217, 3
+	msgbox Route124_DivingTreasureHuntersHouse_Text_271217, MSGBOX_SIGN
 	end
 
 Route124_DivingTreasureHuntersHouse_Text_270F6C: @ 8270F6C

--- a/data/maps/Route125/scripts.inc
+++ b/data/maps/Route125/scripts.inc
@@ -28,22 +28,22 @@ Route125_MapScript2_1F679A: @ 81F679A
 
 Route125_EventScript_1F67A4:: @ 81F67A4
 	trainerbattle 0, TRAINER_NOLEN, 0, Route125_Text_2A1527, Route125_Text_2A155A
-	msgbox Route125_Text_2A1567, 6
+	msgbox Route125_Text_2A1567, MSGBOX_AUTOCLOSE
 	end
 
 Route125_EventScript_1F67BB:: @ 81F67BB
 	trainerbattle 0, TRAINER_STAN, 0, Route125_Text_2A159F, Route125_Text_2A15C7
-	msgbox Route125_Text_2A15D5, 6
+	msgbox Route125_Text_2A15D5, MSGBOX_AUTOCLOSE
 	end
 
 Route125_EventScript_1F67D2:: @ 81F67D2
 	trainerbattle 0, TRAINER_TANYA, 0, Route125_Text_2A1615, Route125_Text_2A164D
-	msgbox Route125_Text_2A165E, 6
+	msgbox Route125_Text_2A165E, MSGBOX_AUTOCLOSE
 	end
 
 Route125_EventScript_1F67E9:: @ 81F67E9
 	trainerbattle 0, TRAINER_SHARON, 0, Route125_Text_2A1686, Route125_Text_2A16C5
-	msgbox Route125_Text_2A16CE, 6
+	msgbox Route125_Text_2A16CE, MSGBOX_AUTOCLOSE
 	end
 
 Route125_EventScript_1F6800:: @ 81F6800
@@ -51,43 +51,43 @@ Route125_EventScript_1F6800:: @ 81F6800
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route125_EventScript_1F684B
-	msgbox Route125_Text_2A1755, 4
+	msgbox Route125_Text_2A1755, MSGBOX_DEFAULT
 	release
 	end
 
 Route125_EventScript_1F682C:: @ 81F682C
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route125_Text_2A17CF, 4
+	msgbox Route125_Text_2A17CF, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 492
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 492
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route125_EventScript_1F684B:: @ 81F684B
 	trainerbattle 5, TRAINER_ERNEST_1, 0, Route125_Text_2A180E, Route125_Text_2A1851
-	msgbox Route125_Text_2A187A, 6
+	msgbox Route125_Text_2A187A, MSGBOX_AUTOCLOSE
 	end
 
 Route125_EventScript_1F6862:: @ 81F6862
 	trainerbattle 4, TRAINER_KIM_AND_IRIS, 0, Route125_Text_2A192B, Route125_Text_2A1989, Route125_Text_2A19F8
-	msgbox Route125_Text_2A19A6, 6
+	msgbox Route125_Text_2A19A6, MSGBOX_AUTOCLOSE
 	end
 
 Route125_EventScript_1F687D:: @ 81F687D
 	trainerbattle 4, TRAINER_KIM_AND_IRIS, 0, Route125_Text_2A1A35, Route125_Text_2A1A71, Route125_Text_2A1AD9
-	msgbox Route125_Text_2A1A92, 6
+	msgbox Route125_Text_2A1A92, MSGBOX_AUTOCLOSE
 	end
 
 Route125_EventScript_1F6898:: @ 81F6898
 	trainerbattle 0, TRAINER_PRESLEY, 0, Route125_Text_2A1B1A, Route125_Text_2A1B4E
-	msgbox Route125_Text_2A1B70, 6
+	msgbox Route125_Text_2A1B70, MSGBOX_AUTOCLOSE
 	end
 
 Route125_EventScript_1F68AF:: @ 81F68AF
 	trainerbattle 0, TRAINER_AURON, 0, Route125_Text_2A1BCE, Route125_Text_2A1BFD
-	msgbox Route125_Text_2A1C2A, 6
+	msgbox Route125_Text_2A1C2A, MSGBOX_AUTOCLOSE
 	end
 

--- a/data/maps/Route125/scripts.inc
+++ b/data/maps/Route125/scripts.inc
@@ -59,10 +59,7 @@ Route125_EventScript_1F682C:: @ 81F682C
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route125_Text_2A17CF, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 492
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 492
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_ERNEST_1
 	release
 	end
 

--- a/data/maps/Route126/scripts.inc
+++ b/data/maps/Route126/scripts.inc
@@ -9,37 +9,37 @@ Route126_MapScript1_1F68CC: @ 81F68CC
 
 Route126_EventScript_1F68D6:: @ 81F68D6
 	trainerbattle 0, TRAINER_BARRY, 0, Route126_Text_2A1C95, Route126_Text_2A1CC8
-	msgbox Route126_Text_2A1CDD, 6
+	msgbox Route126_Text_2A1CDD, MSGBOX_AUTOCLOSE
 	end
 
 Route126_EventScript_1F68ED:: @ 81F68ED
 	trainerbattle 0, TRAINER_DEAN, 0, Route126_Text_2A1D2A, Route126_Text_2A1D63
-	msgbox Route126_Text_2A1D72, 6
+	msgbox Route126_Text_2A1D72, MSGBOX_AUTOCLOSE
 	end
 
 Route126_EventScript_1F6904:: @ 81F6904
 	trainerbattle 0, TRAINER_NIKKI, 0, Route126_Text_2A1DAE, Route126_Text_2A1DC8
-	msgbox Route126_Text_2A1E03, 6
+	msgbox Route126_Text_2A1E03, MSGBOX_AUTOCLOSE
 	end
 
 Route126_EventScript_1F691B:: @ 81F691B
 	trainerbattle 0, TRAINER_BRENDA, 0, Route126_Text_2A1E3E, Route126_Text_2A1E63
-	msgbox Route126_Text_2A1E70, 6
+	msgbox Route126_Text_2A1E70, MSGBOX_AUTOCLOSE
 	end
 
 Route126_EventScript_1F6932:: @ 81F6932
 	trainerbattle 0, TRAINER_LEONARDO, 0, Route126_Text_2A2063, Route126_Text_2A20C6
-	msgbox Route126_Text_2A20F7, 6
+	msgbox Route126_Text_2A20F7, MSGBOX_AUTOCLOSE
 	end
 
 Route126_EventScript_1F6949:: @ 81F6949
 	trainerbattle 0, TRAINER_ISOBEL, 0, Route126_Text_2A216A, Route126_Text_2A21A3
-	msgbox Route126_Text_2A21B8, 6
+	msgbox Route126_Text_2A21B8, MSGBOX_AUTOCLOSE
 	end
 
 Route126_EventScript_1F6960:: @ 81F6960
 	trainerbattle 0, TRAINER_SIENNA, 0, Route126_Text_2A21EF, Route126_Text_2A2216
-	msgbox Route126_Text_2A222A, 6
+	msgbox Route126_Text_2A222A, MSGBOX_AUTOCLOSE
 	end
 
 Route126_EventScript_1F6977:: @ 81F6977
@@ -47,23 +47,23 @@ Route126_EventScript_1F6977:: @ 81F6977
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route126_EventScript_1F69C2
-	msgbox Route126_Text_2A1F10, 4
+	msgbox Route126_Text_2A1F10, MSGBOX_DEFAULT
 	release
 	end
 
 Route126_EventScript_1F69A3:: @ 81F69A3
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route126_Text_2A1F5A, 4
+	msgbox Route126_Text_2A1F5A, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 377
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 377
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route126_EventScript_1F69C2:: @ 81F69C2
 	trainerbattle 5, TRAINER_PABLO_1, 0, Route126_Text_2A1F98, Route126_Text_2A1FD8
-	msgbox Route126_Text_2A200C, 6
+	msgbox Route126_Text_2A200C, MSGBOX_AUTOCLOSE
 	end
 

--- a/data/maps/Route126/scripts.inc
+++ b/data/maps/Route126/scripts.inc
@@ -55,10 +55,7 @@ Route126_EventScript_1F69A3:: @ 81F69A3
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route126_Text_2A1F5A, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 377
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 377
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_PABLO_1
 	release
 	end
 

--- a/data/maps/Route127/scripts.inc
+++ b/data/maps/Route127/scripts.inc
@@ -74,10 +74,7 @@ Route127_EventScript_1F6B02:: @ 81F6B02
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route127_Text_2A26EE, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 672
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 672
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_KOJI_1
 	release
 	end
 

--- a/data/maps/Route127/scripts.inc
+++ b/data/maps/Route127/scripts.inc
@@ -28,37 +28,37 @@ Route127_MapScript2_1F6A2B: @ 81F6A2B
 
 Route127_EventScript_1F6A35:: @ 81F6A35
 	trainerbattle 0, TRAINER_CAMDEN, 0, Route127_Text_2A225F, Route127_Text_2A2294
-	msgbox Route127_Text_2A22A1, 6
+	msgbox Route127_Text_2A22A1, MSGBOX_AUTOCLOSE
 	end
 
 Route127_EventScript_1F6A4C:: @ 81F6A4C
 	trainerbattle 0, TRAINER_DONNY, 0, Route127_Text_2A22DD, Route127_Text_2A2315
-	msgbox Route127_Text_2A232C, 6
+	msgbox Route127_Text_2A232C, MSGBOX_AUTOCLOSE
 	end
 
 Route127_EventScript_1F6A63:: @ 81F6A63
 	trainerbattle 0, TRAINER_JONAH, 0, Route127_Text_2A2381, Route127_Text_2A23E1
-	msgbox Route127_Text_2A240C, 6
+	msgbox Route127_Text_2A240C, MSGBOX_AUTOCLOSE
 	end
 
 Route127_EventScript_1F6A7A:: @ 81F6A7A
 	trainerbattle 0, TRAINER_HENRY, 0, Route127_Text_2A2450, Route127_Text_2A2483
-	msgbox Route127_Text_2A2494, 6
+	msgbox Route127_Text_2A2494, MSGBOX_AUTOCLOSE
 	end
 
 Route127_EventScript_1F6A91:: @ 81F6A91
 	trainerbattle 0, TRAINER_ROGER, 0, Route127_Text_2A24C6, Route127_Text_2A250B
-	msgbox Route127_Text_2A2538, 6
+	msgbox Route127_Text_2A2538, MSGBOX_AUTOCLOSE
 	end
 
 Route127_EventScript_1F6AA8:: @ 81F6AA8
 	trainerbattle 0, TRAINER_AIDAN, 0, Route127_Text_2A257A, Route127_Text_2A25C1
-	msgbox Route127_Text_2A25D2, 6
+	msgbox Route127_Text_2A25D2, MSGBOX_AUTOCLOSE
 	end
 
 Route127_EventScript_1F6ABF:: @ 81F6ABF
 	trainerbattle 0, TRAINER_ATHENA, 0, Route127_Text_2A27D0, Route127_Text_2A27FC
-	msgbox Route127_Text_2A2832, 6
+	msgbox Route127_Text_2A2832, MSGBOX_AUTOCLOSE
 	end
 
 Route127_EventScript_1F6AD6:: @ 81F6AD6
@@ -66,23 +66,23 @@ Route127_EventScript_1F6AD6:: @ 81F6AD6
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route127_EventScript_1F6B21
-	msgbox Route127_Text_2A26AC, 4
+	msgbox Route127_Text_2A26AC, MSGBOX_DEFAULT
 	release
 	end
 
 Route127_EventScript_1F6B02:: @ 81F6B02
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route127_Text_2A26EE, 4
+	msgbox Route127_Text_2A26EE, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 672
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 672
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route127_EventScript_1F6B21:: @ 81F6B21
 	trainerbattle 5, TRAINER_KOJI_1, 0, Route127_Text_2A2734, Route127_Text_2A276B
-	msgbox Route127_Text_2A278E, 6
+	msgbox Route127_Text_2A278E, MSGBOX_AUTOCLOSE
 	end
 

--- a/data/maps/Route128/scripts.inc
+++ b/data/maps/Route128/scripts.inc
@@ -17,29 +17,29 @@ Route128_EventScript_1F6B57:: @ 81F6B57
 	delay 20
 	applymovement 4, Route128_Movement_1F6C89
 	waitmovement 0
-	msgbox Route128_Text_1F6DF5, 4
+	msgbox Route128_Text_1F6DF5, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, Route128_Movement_1F6C91
 	waitmovement 0
-	msgbox Route128_Text_1F6E48, 4
+	msgbox Route128_Text_1F6E48, MSGBOX_DEFAULT
 	closemessage
 	applymovement 5, Route128_Movement_1F6CAD
 	waitmovement 0
 	applymovement 4, Route128_Movement_2725A6
 	waitmovement 0
-	msgbox Route128_Text_1F6E5A, 4
+	msgbox Route128_Text_1F6E5A, MSGBOX_DEFAULT
 	closemessage
 	applymovement 5, Route128_Movement_1F6CBB
 	waitmovement 0
 	applymovement 255, Route128_Movement_2725A6
 	waitmovement 0
-	msgbox Route128_Text_1F6F1E, 4
+	msgbox Route128_Text_1F6F1E, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, Route128_Movement_1F6C96
 	applymovement 255, Route128_Movement_2725A4
 	applymovement 5, Route128_Movement_1F6CA8
 	waitmovement 0
-	msgbox Route128_Text_1F704F, 4
+	msgbox Route128_Text_1F704F, MSGBOX_DEFAULT
 	closemessage
 	delay 40
 	applymovement 5, Route128_Movement_1F6CB0
@@ -56,15 +56,15 @@ Route128_EventScript_1F6B57:: @ 81F6B57
 	waitmovement 0
 	applymovement 255, Route128_Movement_2725A8
 	waitmovement 0
-	msgbox Route128_Text_1F70C9, 4
+	msgbox Route128_Text_1F70C9, MSGBOX_DEFAULT
 	closemessage
 	applymovement 3, Route128_Movement_1F6C85
 	applymovement 255, Route128_Movement_2725A6
 	waitmovement 0
-	msgbox Route128_Text_1F70EA, 4
+	msgbox Route128_Text_1F70EA, MSGBOX_DEFAULT
 	applymovement 3, Route128_Movement_2725AA
 	waitmovement 0
-	msgbox Route128_Text_1F721B, 4
+	msgbox Route128_Text_1F721B, MSGBOX_DEFAULT
 	closemessage
 	applymovement 3, Route128_Movement_2725AA
 	waitmovement 0
@@ -180,24 +180,24 @@ Route128_EventScript_1F6CBE:: @ 81F6CBE
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route128_EventScript_1F6D09
-	msgbox Route128_Text_2A28D7, 4
+	msgbox Route128_Text_2A28D7, MSGBOX_DEFAULT
 	release
 	end
 
 Route128_EventScript_1F6CEA:: @ 81F6CEA
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route128_Text_2A2916, 4
+	msgbox Route128_Text_2A2916, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 376
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 376
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route128_EventScript_1F6D09:: @ 81F6D09
 	trainerbattle 5, TRAINER_ISAIAH_1, 0, Route128_Text_2A2975, Route128_Text_2A29B8
-	msgbox Route128_Text_2A29DC, 6
+	msgbox Route128_Text_2A29DC, MSGBOX_AUTOCLOSE
 	end
 
 Route128_EventScript_1F6D20:: @ 81F6D20
@@ -205,49 +205,49 @@ Route128_EventScript_1F6D20:: @ 81F6D20
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq Route128_EventScript_1F6D6B
-	msgbox Route128_Text_2A2AB7, 4
+	msgbox Route128_Text_2A2AB7, MSGBOX_DEFAULT
 	release
 	end
 
 Route128_EventScript_1F6D4C:: @ 81F6D4C
 	special sub_80B4808
 	waitmovement 0
-	msgbox Route128_Text_2A2AF9, 4
+	msgbox Route128_Text_2A2AF9, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 386
 	special SetMatchCallRegisteredFlag
 	setorcopyvar VAR_0x8000, 386
-	callstd 8
+	callstd STD_REGISTER_MATCH_CALL
 	release
 	end
 
 Route128_EventScript_1F6D6B:: @ 81F6D6B
 	trainerbattle 5, TRAINER_KATELYN_1, 0, Route128_Text_2A2B41, Route128_Text_2A2BAB
-	msgbox Route128_Text_2A2BDD, 6
+	msgbox Route128_Text_2A2BDD, MSGBOX_AUTOCLOSE
 	end
 
 Route128_EventScript_1F6D82:: @ 81F6D82
 	trainerbattle 0, TRAINER_ALEXA, 0, Route128_Text_2A2C1C, Route128_Text_2A2C79
-	msgbox Route128_Text_2A2C95, 6
+	msgbox Route128_Text_2A2C95, MSGBOX_AUTOCLOSE
 	end
 
 Route128_EventScript_1F6D99:: @ 81F6D99
 	trainerbattle 0, TRAINER_RUBEN, 0, Route128_Text_2A2CD9, Route128_Text_2A2CFE
-	msgbox Route128_Text_2A2D0D, 6
+	msgbox Route128_Text_2A2D0D, MSGBOX_AUTOCLOSE
 	end
 
 Route128_EventScript_1F6DB0:: @ 81F6DB0
 	trainerbattle 0, TRAINER_WAYNE, 0, Route128_Text_2A2D3D, Route128_Text_2A2DA9
-	msgbox Route128_Text_2A2DBA, 6
+	msgbox Route128_Text_2A2DBA, MSGBOX_AUTOCLOSE
 	end
 
 Route128_EventScript_1F6DC7:: @ 81F6DC7
 	trainerbattle 0, TRAINER_HARRISON, 0, Route128_Text_2A2E0F, Route128_Text_2A2E44
-	msgbox Route128_Text_2A2E6C, 6
+	msgbox Route128_Text_2A2E6C, MSGBOX_AUTOCLOSE
 	end
 
 Route128_EventScript_1F6DDE:: @ 81F6DDE
 	trainerbattle 0, TRAINER_CARLEE, 0, Route128_Text_2A2EC8, Route128_Text_2A2EFA
-	msgbox Route128_Text_2A2F2F, 6
+	msgbox Route128_Text_2A2F2F, MSGBOX_AUTOCLOSE
 	end
 
 Route128_Text_1F6DF5: @ 81F6DF5

--- a/data/maps/Route128/scripts.inc
+++ b/data/maps/Route128/scripts.inc
@@ -188,10 +188,7 @@ Route128_EventScript_1F6CEA:: @ 81F6CEA
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route128_Text_2A2916, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 376
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 376
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_ISAIAH_1
 	release
 	end
 
@@ -213,10 +210,7 @@ Route128_EventScript_1F6D4C:: @ 81F6D4C
 	special sub_80B4808
 	waitmovement 0
 	msgbox Route128_Text_2A2AF9, MSGBOX_DEFAULT
-	setvar VAR_0x8004, 386
-	special SetMatchCallRegisteredFlag
-	setorcopyvar VAR_0x8000, 386
-	callstd STD_REGISTER_MATCH_CALL
+	register_matchcall TRAINER_KATELYN_1
 	release
 	end
 

--- a/data/maps/Route129/scripts.inc
+++ b/data/maps/Route129/scripts.inc
@@ -33,26 +33,26 @@ Route129_MapScript2_1F72E2: @ 81F72E2
 
 Route129_EventScript_1F72EC:: @ 81F72EC
 	trainerbattle 0, TRAINER_CHASE, 0, Route129_Text_2A2F66, Route129_Text_2A2F9D
-	msgbox Route129_Text_2A2FB9, 6
+	msgbox Route129_Text_2A2FB9, MSGBOX_AUTOCLOSE
 	end
 
 Route129_EventScript_1F7303:: @ 81F7303
 	trainerbattle 0, TRAINER_ALLISON, 0, Route129_Text_2A2FF2, Route129_Text_2A3034
-	msgbox Route129_Text_2A3048, 6
+	msgbox Route129_Text_2A3048, MSGBOX_AUTOCLOSE
 	end
 
 Route129_EventScript_1F731A:: @ 81F731A
 	trainerbattle 0, TRAINER_REED, 0, Route129_Text_2A30CD, Route129_Text_2A30F1
-	msgbox Route129_Text_2A3114, 6
+	msgbox Route129_Text_2A3114, MSGBOX_AUTOCLOSE
 	end
 
 Route129_EventScript_1F7331:: @ 81F7331
 	trainerbattle 0, TRAINER_TISHA, 0, Route129_Text_2A314E, Route129_Text_2A317D
-	msgbox Route129_Text_2A31A6, 6
+	msgbox Route129_Text_2A31A6, MSGBOX_AUTOCLOSE
 	end
 
 Route129_EventScript_1F7348:: @ 81F7348
 	trainerbattle 0, TRAINER_CLARENCE, 0, Route129_Text_2A3204, Route129_Text_2A3239
-	msgbox Route129_Text_2A3252, 6
+	msgbox Route129_Text_2A3252, MSGBOX_AUTOCLOSE
 	end
 

--- a/data/maps/Route130/scripts.inc
+++ b/data/maps/Route130/scripts.inc
@@ -37,16 +37,16 @@ Route130_EventScript_1F73B5:: @ 81F73B5
 
 Route130_EventScript_1F73BF:: @ 81F73BF
 	trainerbattle 0, TRAINER_RODNEY, 0, Route130_Text_2A328A, Route130_Text_2A32E6
-	msgbox Route130_Text_2A3300, 6
+	msgbox Route130_Text_2A3300, MSGBOX_AUTOCLOSE
 	end
 
 Route130_EventScript_1F73D6:: @ 81F73D6
 	trainerbattle 0, TRAINER_KATIE, 0, Route130_Text_2A3363, Route130_Text_2A33AC
-	msgbox Route130_Text_2A33F5, 6
+	msgbox Route130_Text_2A33F5, MSGBOX_AUTOCLOSE
 	end
 
 Route130_EventScript_1F73ED:: @ 81F73ED
 	trainerbattle 0, TRAINER_SANTIAGO, 0, Route130_Text_2A343A, Route130_Text_2A346D
-	msgbox Route130_Text_2A3494, 6
+	msgbox Route130_Text_2A3494, MSGBOX_AUTOCLOSE
 	end
 

--- a/data/maps/Route131/scripts.inc
+++ b/data/maps/Route131/scripts.inc
@@ -19,41 +19,41 @@ Route131_EventScript_1F741F:: @ 81F741F
 
 Route131_EventScript_1F7429:: @ 81F7429
 	trainerbattle 0, TRAINER_RICHARD, 0, Route131_Text_2A34C8, Route131_Text_2A350D
-	msgbox Route131_Text_2A353D, 6
+	msgbox Route131_Text_2A353D, MSGBOX_AUTOCLOSE
 	end
 
 Route131_EventScript_1F7440:: @ 81F7440
 	trainerbattle 0, TRAINER_HERMAN, 0, Route131_Text_2A35C6, Route131_Text_2A3626
-	msgbox Route131_Text_2A362D, 6
+	msgbox Route131_Text_2A362D, MSGBOX_AUTOCLOSE
 	end
 
 Route131_EventScript_1F7457:: @ 81F7457
 	trainerbattle 0, TRAINER_SUSIE, 0, Route131_Text_2A367B, Route131_Text_2A36AB
-	msgbox Route131_Text_2A36D6, 6
+	msgbox Route131_Text_2A36D6, MSGBOX_AUTOCLOSE
 	end
 
 Route131_EventScript_1F746E:: @ 81F746E
 	trainerbattle 0, TRAINER_KARA, 0, Route131_Text_2A3751, Route131_Text_2A378A
-	msgbox Route131_Text_2A379F, 6
+	msgbox Route131_Text_2A379F, MSGBOX_AUTOCLOSE
 	end
 
 Route131_EventScript_1F7485:: @ 81F7485
 	trainerbattle 4, TRAINER_RELI_AND_IAN, 0, Route131_Text_2A37E9, Route131_Text_2A381F, Route131_Text_2A38B7
-	msgbox Route131_Text_2A3855, 6
+	msgbox Route131_Text_2A3855, MSGBOX_AUTOCLOSE
 	end
 
 Route131_EventScript_1F74A0:: @ 81F74A0
 	trainerbattle 4, TRAINER_RELI_AND_IAN, 0, Route131_Text_2A38F8, Route131_Text_2A3925, Route131_Text_2A39CD
-	msgbox Route131_Text_2A3960, 6
+	msgbox Route131_Text_2A3960, MSGBOX_AUTOCLOSE
 	end
 
 Route131_EventScript_1F74BB:: @ 81F74BB
 	trainerbattle 0, TRAINER_TALIA, 0, Route131_Text_2A39FE, Route131_Text_2A3A38
-	msgbox Route131_Text_2A3A48, 6
+	msgbox Route131_Text_2A3A48, MSGBOX_AUTOCLOSE
 	end
 
 Route131_EventScript_1F74D2:: @ 81F74D2
 	trainerbattle 0, TRAINER_KEVIN, 0, Route131_Text_2A3AA0, Route131_Text_2A3AFC
-	msgbox Route131_Text_2A3B02, 6
+	msgbox Route131_Text_2A3B02, MSGBOX_AUTOCLOSE
 	end
 

--- a/data/maps/Route132/scripts.inc
+++ b/data/maps/Route132/scripts.inc
@@ -3,41 +3,41 @@ Route132_MapScripts:: @ 81F74E9
 
 Route132_EventScript_1F74EA:: @ 81F74EA
 	trainerbattle 0, TRAINER_GILBERT, 0, Route132_Text_2A3B4C, Route132_Text_2A3BAC
-	msgbox Route132_Text_2A3BC0, 6
+	msgbox Route132_Text_2A3BC0, MSGBOX_AUTOCLOSE
 	end
 
 Route132_EventScript_1F7501:: @ 81F7501
 	trainerbattle 0, TRAINER_DANA, 0, Route132_Text_2A3C04, Route132_Text_2A3C39
-	msgbox Route132_Text_2A3C49, 6
+	msgbox Route132_Text_2A3C49, MSGBOX_AUTOCLOSE
 	end
 
 Route132_EventScript_1F7518:: @ 81F7518
 	trainerbattle 0, TRAINER_RONALD, 0, Route132_Text_2A3C7F, Route132_Text_2A3CAD
-	msgbox Route132_Text_2A3CC5, 6
+	msgbox Route132_Text_2A3CC5, MSGBOX_AUTOCLOSE
 	end
 
 Route132_EventScript_1F752F:: @ 81F752F
 	trainerbattle 0, TRAINER_KIYO, 0, Route132_Text_2A3D26, Route132_Text_2A3D6C
-	msgbox Route132_Text_2A3D8B, 6
+	msgbox Route132_Text_2A3D8B, MSGBOX_AUTOCLOSE
 	end
 
 Route132_EventScript_1F7546:: @ 81F7546
 	trainerbattle 0, TRAINER_PAXTON, 0, Route132_Text_2A3F4F, Route132_Text_2A3FA8
-	msgbox Route132_Text_2A3FE5, 6
+	msgbox Route132_Text_2A3FE5, MSGBOX_AUTOCLOSE
 	end
 
 Route132_EventScript_1F755D:: @ 81F755D
 	trainerbattle 0, TRAINER_DARCY, 0, Route132_Text_2A4026, Route132_Text_2A406E
-	msgbox Route132_Text_2A40A4, 6
+	msgbox Route132_Text_2A40A4, MSGBOX_AUTOCLOSE
 	end
 
 Route132_EventScript_1F7574:: @ 81F7574
 	trainerbattle 0, TRAINER_JONATHAN, 0, Route132_Text_2A3EAC, Route132_Text_2A3EDD
-	msgbox Route132_Text_2A3F03, 6
+	msgbox Route132_Text_2A3F03, MSGBOX_AUTOCLOSE
 	end
 
 Route132_EventScript_1F758B:: @ 81F758B
 	trainerbattle 0, TRAINER_MAKAYLA, 0, Route132_Text_2A3DF0, Route132_Text_2A3E2C
-	msgbox Route132_Text_2A3E4E, 6
+	msgbox Route132_Text_2A3E4E, MSGBOX_AUTOCLOSE
 	end
 

--- a/data/maps/Route133/scripts.inc
+++ b/data/maps/Route133/scripts.inc
@@ -3,36 +3,36 @@ Route133_MapScripts:: @ 81F75A2
 
 Route133_EventScript_1F75A3:: @ 81F75A3
 	trainerbattle 0, TRAINER_FRANKLIN, 0, Route133_Text_2A40F0, Route133_Text_2A413F
-	msgbox Route133_Text_2A4154, 6
+	msgbox Route133_Text_2A4154, MSGBOX_AUTOCLOSE
 	end
 
 Route133_EventScript_1F75BA:: @ 81F75BA
 	trainerbattle 0, TRAINER_DEBRA, 0, Route133_Text_2A41A8, Route133_Text_2A4200
-	msgbox Route133_Text_2A420E, 6
+	msgbox Route133_Text_2A420E, MSGBOX_AUTOCLOSE
 	end
 
 Route133_EventScript_1F75D1:: @ 81F75D1
 	trainerbattle 0, TRAINER_LINDA, 0, Route133_Text_2A4236, Route133_Text_2A4258
-	msgbox Route133_Text_2A4264, 6
+	msgbox Route133_Text_2A4264, MSGBOX_AUTOCLOSE
 	end
 
 Route133_EventScript_1F75E8:: @ 81F75E8
 	trainerbattle 0, TRAINER_WARREN, 0, Route133_Text_2A4290, Route133_Text_2A42E0
-	msgbox Route133_Text_2A4304, 6
+	msgbox Route133_Text_2A4304, MSGBOX_AUTOCLOSE
 	end
 
 Route133_EventScript_1F75FF:: @ 81F75FF
 	trainerbattle 0, TRAINER_BECK, 0, Route133_Text_2A436A, Route133_Text_2A439C
-	msgbox Route133_Text_2A43B9, 6
+	msgbox Route133_Text_2A43B9, MSGBOX_AUTOCLOSE
 	end
 
 Route133_EventScript_1F7616:: @ 81F7616
 	trainerbattle 0, TRAINER_MOLLIE, 0, Route133_Text_2A4401, Route133_Text_2A443A
-	msgbox Route133_Text_2A4477, 6
+	msgbox Route133_Text_2A4477, MSGBOX_AUTOCLOSE
 	end
 
 Route133_EventScript_1F762D:: @ 81F762D
 	trainerbattle 0, TRAINER_CONOR, 0, Route133_Text_2A44BA, Route133_Text_2A4505
-	msgbox Route133_Text_2A4527, 6
+	msgbox Route133_Text_2A4527, MSGBOX_AUTOCLOSE
 	end
 

--- a/data/maps/Route134/scripts.inc
+++ b/data/maps/Route134/scripts.inc
@@ -8,46 +8,46 @@ Route134_MapScript1_1F764A: @ 81F764A
 
 Route134_EventScript_1F7653:: @ 81F7653
 	trainerbattle 0, TRAINER_JACK, 0, Route134_Text_2A4571, Route134_Text_2A45BB
-	msgbox Route134_Text_2A45C5, 6
+	msgbox Route134_Text_2A45C5, MSGBOX_AUTOCLOSE
 	end
 
 Route134_EventScript_1F766A:: @ 81F766A
 	trainerbattle 0, TRAINER_LAUREL, 0, Route134_Text_2A4609, Route134_Text_2A4643
-	msgbox Route134_Text_2A464B, 6
+	msgbox Route134_Text_2A464B, MSGBOX_AUTOCLOSE
 	end
 
 Route134_EventScript_1F7681:: @ 81F7681
 	trainerbattle 0, TRAINER_ALEX, 0, Route134_Text_2A4682, Route134_Text_2A46BE
-	msgbox Route134_Text_2A46D2, 6
+	msgbox Route134_Text_2A46D2, MSGBOX_AUTOCLOSE
 	end
 
 Route134_EventScript_1F7698:: @ 81F7698
 	trainerbattle 0, TRAINER_AARON, 0, Route134_Text_2A479E, Route134_Text_2A47E1
-	msgbox Route134_Text_2A47FD, 6
+	msgbox Route134_Text_2A47FD, MSGBOX_AUTOCLOSE
 	end
 
 Route134_EventScript_1F76AF:: @ 81F76AF
 	trainerbattle 0, TRAINER_HITOSHI, 0, Route134_Text_2A4709, Route134_Text_2A4745
-	msgbox Route134_Text_2A475D, 6
+	msgbox Route134_Text_2A475D, MSGBOX_AUTOCLOSE
 	end
 
 Route134_EventScript_1F76C6:: @ 81F76C6
 	trainerbattle 0, TRAINER_HUDSON, 0, Route134_Text_2A4A8F, Route134_Text_2A4AC1
-	msgbox Route134_Text_2A4AD8, 6
+	msgbox Route134_Text_2A4AD8, MSGBOX_AUTOCLOSE
 	end
 
 Route134_EventScript_1F76DD:: @ 81F76DD
 	trainerbattle 0, TRAINER_REYNA, 0, Route134_Text_2A49E9, Route134_Text_2A4A10
-	msgbox Route134_Text_2A4A34, 6
+	msgbox Route134_Text_2A4A34, MSGBOX_AUTOCLOSE
 	end
 
 Route134_EventScript_1F76F4:: @ 81F76F4
 	trainerbattle 0, TRAINER_MARLEY, 0, Route134_Text_2A4937, Route134_Text_2A496B
-	msgbox Route134_Text_2A49B1, 6
+	msgbox Route134_Text_2A49B1, MSGBOX_AUTOCLOSE
 	end
 
 Route134_EventScript_1F770B:: @ 81F770B
 	trainerbattle 0, TRAINER_KELVIN, 0, Route134_Text_2A4875, Route134_Text_2A489B
-	msgbox Route134_Text_2A48BD, 6
+	msgbox Route134_Text_2A48BD, MSGBOX_AUTOCLOSE
 	end
 

--- a/data/maps/RustboroCity/scripts.inc
+++ b/data/maps/RustboroCity/scripts.inc
@@ -50,7 +50,7 @@ RustboroCity_EventScript_1E0715:: @ 81E0715
 	waitmovement 0
 	applymovement 15, RustboroCity_Movement_1E084E
 	waitmovement 0
-	msgbox RustboroCity_Text_1E22A5, 4
+	msgbox RustboroCity_Text_1E22A5, MSGBOX_DEFAULT
 	closemessage
 	setflag FLAG_HAS_MATCH_CALL
 	applymovement 15, RustboroCity_Movement_2725A4
@@ -65,13 +65,13 @@ RustboroCity_EventScript_1E0715:: @ 81E0715
 	delay 20
 	applymovement 15, RustboroCity_Movement_2725AA
 	waitmovement 0
-	msgbox RustboroCity_Text_1E2331, 4
+	msgbox RustboroCity_Text_1E2331, MSGBOX_DEFAULT
 	closemessage
 	delay 20
 	goto RustboroCity_EventScript_1E07BD
 
 RustboroCity_EventScript_1E07AC:: @ 81E07AC
-	msgbox RustboroCity_Text_1E2449, 4
+	msgbox RustboroCity_Text_1E2449, MSGBOX_DEFAULT
 	closemessage
 	delay 10
 	goto RustboroCity_EventScript_1E07BD
@@ -92,7 +92,7 @@ RustboroCity_EventScript_1E07BD:: @ 81E07BD
 	special sub_81C72A4
 	waitstate
 	delay 20
-	msgbox RustboroCity_Text_1E2464, 4
+	msgbox RustboroCity_Text_1E2464, MSGBOX_DEFAULT
 	closemessage
 	applymovement 15, RustboroCity_Movement_1E085D
 	waitmovement 0
@@ -136,24 +136,24 @@ RustboroCity_EventScript_1E085F:: @ 81E085F
 	faceplayer
 	checkflag FLAG_0x08E
 	goto_eq RustboroCity_EventScript_1E0874
-	msgbox RustboroCity_Text_1E123F, 4
+	msgbox RustboroCity_Text_1E123F, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_EventScript_1E0874:: @ 81E0874
-	msgbox RustboroCity_Text_1E12AC, 4
+	msgbox RustboroCity_Text_1E12AC, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_EventScript_1E087E:: @ 81E087E
 	lock
 	faceplayer
-	msgbox RustboroCity_Text_1E1407, 4
+	msgbox RustboroCity_Text_1E1407, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_EventScript_1E088A:: @ 81E088A
-	msgbox RustboroCity_Text_1E1480, 2
+	msgbox RustboroCity_Text_1E1480, MSGBOX_NPC
 	end
 
 RustboroCity_EventScript_1E0893:: @ 81E0893
@@ -161,12 +161,12 @@ RustboroCity_EventScript_1E0893:: @ 81E0893
 	faceplayer
 	checkflag FLAG_BADGE01_GET
 	goto_eq RustboroCity_EventScript_1E08A8
-	msgbox RustboroCity_Text_1E130D, 4
+	msgbox RustboroCity_Text_1E130D, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_EventScript_1E08A8:: @ 81E08A8
-	msgbox RustboroCity_Text_1E139E, 4
+	msgbox RustboroCity_Text_1E139E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -175,55 +175,55 @@ RustboroCity_EventScript_1E08B2:: @ 81E08B2
 	faceplayer
 	checkflag FLAG_0x0BC
 	goto_eq RustboroCity_EventScript_1E08C7
-	msgbox RustboroCity_Text_1E1520, 4
+	msgbox RustboroCity_Text_1E1520, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_EventScript_1E08C7:: @ 81E08C7
-	msgbox RustboroCity_Text_1E1589, 4
+	msgbox RustboroCity_Text_1E1589, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_EventScript_1E08D1:: @ 81E08D1
-	msgbox RustboroCity_Text_1E1633, 2
+	msgbox RustboroCity_Text_1E1633, MSGBOX_NPC
 	end
 
 RustboroCity_EventScript_1E08DA:: @ 81E08DA
-	msgbox RustboroCity_Text_1E1695, 3
+	msgbox RustboroCity_Text_1E1695, MSGBOX_SIGN
 	end
 
 RustboroCity_EventScript_1E08E3:: @ 81E08E3
-	msgbox RustboroCity_Text_1E20A6, 3
+	msgbox RustboroCity_Text_1E20A6, MSGBOX_SIGN
 	end
 
 RustboroCity_EventScript_1E08EC:: @ 81E08EC
-	msgbox RustboroCity_Text_1E2128, 3
+	msgbox RustboroCity_Text_1E2128, MSGBOX_SIGN
 	end
 
 RustboroCity_EventScript_1E08F5:: @ 81E08F5
-	msgbox RustboroCity_Text_1E2167, 3
+	msgbox RustboroCity_Text_1E2167, MSGBOX_SIGN
 	end
 
 RustboroCity_EventScript_1E08FE:: @ 81E08FE
-	msgbox RustboroCity_Text_1E21B3, 3
+	msgbox RustboroCity_Text_1E21B3, MSGBOX_SIGN
 	end
 
 RustboroCity_EventScript_1E0907:: @ 81E0907
-	msgbox RustboroCity_Text_1E220B, 3
+	msgbox RustboroCity_Text_1E220B, MSGBOX_SIGN
 	end
 
 RustboroCity_EventScript_1E0910:: @ 81E0910
-	msgbox RustboroCity_Text_1E2253, 3
+	msgbox RustboroCity_Text_1E2253, MSGBOX_SIGN
 	end
 
 RustboroCity_EventScript_1E0919:: @ 81E0919
-	msgbox RustboroCity_Text_1E2296, 3
+	msgbox RustboroCity_Text_1E2296, MSGBOX_SIGN
 	end
 
 RustboroCity_EventScript_1E0922:: @ 81E0922
 	lock
 	faceplayer
-	msgbox RustboroCity_Text_1E16F4, 4
+	msgbox RustboroCity_Text_1E16F4, MSGBOX_DEFAULT
 	applymovement 7, RustboroCity_Movement_2725A2
 	waitmovement 0
 	release
@@ -232,7 +232,7 @@ RustboroCity_EventScript_1E0922:: @ 81E0922
 RustboroCity_EventScript_1E0938:: @ 81E0938
 	lock
 	faceplayer
-	msgbox RustboroCity_Text_1E174B, 4
+	msgbox RustboroCity_Text_1E174B, MSGBOX_DEFAULT
 	applymovement 8, RustboroCity_Movement_2725A2
 	waitmovement 0
 	release
@@ -241,7 +241,7 @@ RustboroCity_EventScript_1E0938:: @ 81E0938
 RustboroCity_EventScript_1E094E:: @ 81E094E
 	lock
 	faceplayer
-	msgbox RustboroCity_Text_1E1789, 4
+	msgbox RustboroCity_Text_1E1789, MSGBOX_DEFAULT
 	release
 	end
 
@@ -286,7 +286,7 @@ RustboroCity_EventScript_1E09B6:: @ 81E09B6
 	end
 
 RustboroCity_EventScript_1E09CD:: @ 81E09CD
-	msgbox RustboroCity_Text_1E17FE, 4
+	msgbox RustboroCity_Text_1E17FE, MSGBOX_DEFAULT
 	closemessage
 	playbgm MUS_AQA_0, 0
 	addobject 10
@@ -296,7 +296,7 @@ RustboroCity_EventScript_1E09CD:: @ 81E09CD
 	removeobject 10
 	applymovement 9, RustboroCity_Movement_1E0AB1
 	waitmovement 0
-	msgbox RustboroCity_Text_1E1817, 4
+	msgbox RustboroCity_Text_1E1817, MSGBOX_DEFAULT
 	closemessage
 	applymovement 9, RustboroCity_Movement_1E0AB9
 	waitmovement 0
@@ -317,11 +317,11 @@ RustboroCity_EventScript_1E09CD:: @ 81E09CD
 	end
 
 RustboroCity_EventScript_1E0A3B:: @ 81E0A3B
-	msgbox RustboroCity_Text_1E1904, 4
+	msgbox RustboroCity_Text_1E1904, MSGBOX_DEFAULT
 	return
 
 RustboroCity_EventScript_1E0A44:: @ 81E0A44
-	msgbox RustboroCity_Text_1E194D, 4
+	msgbox RustboroCity_Text_1E194D, MSGBOX_DEFAULT
 	return
 
 RustboroCity_EventScript_1E0A4D:: @ 81E0A4D
@@ -453,7 +453,7 @@ RustboroCity_EventScript_1E0ADD:: @ 81E0ADD
 	faceplayer
 	checkflag FLAG_0x08F
 	goto_eq RustboroCity_EventScript_1E0AF2
-	msgbox RustboroCity_Text_1E1904, 4
+	msgbox RustboroCity_Text_1E1904, MSGBOX_DEFAULT
 	release
 	end
 
@@ -499,7 +499,7 @@ RustboroCity_EventScript_1E0B2E:: @ 81E0B2E
 	setflag FLAG_0x09F
 	setvar VAR_0x405A, 3
 	moveobjectoffscreen 9
-	msgbox RustboroCity_Text_1E183E, 4
+	msgbox RustboroCity_Text_1E183E, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -592,11 +592,11 @@ RustboroCity_EventScript_1E0C5B:: @ 81E0C5B
 	call_if 1, RustboroCity_EventScript_1E0D60
 	compare VAR_TEMP_1, 4
 	call_if 1, RustboroCity_EventScript_1E0D96
-	msgbox RustboroCity_Text_1E194D, 4
+	msgbox RustboroCity_Text_1E194D, MSGBOX_DEFAULT
 	giveitem_std ITEM_GREAT_BALL
 	compare VAR_RESULT, 0
 	call_if 1, RustboroCity_EventScript_1E0CD3
-	msgbox RustboroCity_Text_1E1A21, 4
+	msgbox RustboroCity_Text_1E1A21, MSGBOX_DEFAULT
 	closemessage
 	setflag FLAG_0x090
 	setflag FLAG_HIDE_RUSTBORO_CITY_DEVON_EMPLOYEE_1
@@ -608,7 +608,7 @@ RustboroCity_EventScript_1E0C5B:: @ 81E0C5B
 	end
 
 RustboroCity_EventScript_1E0CD3:: @ 81E0CD3
-	msgbox RustboroCity_Text_1E19E5, 4
+	msgbox RustboroCity_Text_1E19E5, MSGBOX_DEFAULT
 	return
 
 RustboroCity_EventScript_1E0CDC:: @ 81E0CDC
@@ -838,11 +838,11 @@ RustboroCity_EventScript_1E100B:: @ 81E100B
 	checkflag FLAG_0x120
 	goto_eq RustboroCity_EventScript_1E1070
 	setflag FLAG_0x120
-	msgbox RustboroCity_Text_1E1A49, 4
+	msgbox RustboroCity_Text_1E1A49, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox RustboroCity_Text_1E1ADB, 4
+	msgbox RustboroCity_Text_1E1ADB, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
@@ -850,25 +850,25 @@ RustboroCity_EventScript_1E100B:: @ 81E100B
 	setvar VAR_0x405A, 8
 	setvar VAR_0x4063, 2
 	setvar VAR_0x8008, 0
-	msgbox RustboroCity_Text_1E1AFA, 5
+	msgbox RustboroCity_Text_1E1AFA, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq RustboroCity_EventScript_1E1092
-	msgbox RustboroCity_Text_1E1BD3, 4
+	msgbox RustboroCity_Text_1E1BD3, MSGBOX_DEFAULT
 	call RustboroCity_EventScript_1E10D6
 	releaseall
 	end
 
 RustboroCity_EventScript_1E1070:: @ 81E1070
 	setvar VAR_0x8008, 1
-	msgbox RustboroCity_Text_1E1C48, 5
+	msgbox RustboroCity_Text_1E1C48, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq RustboroCity_EventScript_1E1092
-	msgbox RustboroCity_Text_1E1BD3, 4
+	msgbox RustboroCity_Text_1E1BD3, MSGBOX_DEFAULT
 	releaseall
 	end
 
 RustboroCity_EventScript_1E1092:: @ 81E1092
-	msgbox RustboroCity_Text_1E1C84, 4
+	msgbox RustboroCity_Text_1E1C84, MSGBOX_DEFAULT
 	switch VAR_STARTER_MON
 	case 0, RustboroCity_EventScript_1E10DB
 	case 1, RustboroCity_EventScript_1E10EE
@@ -876,7 +876,7 @@ RustboroCity_EventScript_1E1092:: @ 81E1092
 	end
 
 RustboroCity_EventScript_1E10C1:: @ 81E10C1
-	msgbox RustboroCity_Text_1E1CE7, 4
+	msgbox RustboroCity_Text_1E1CE7, MSGBOX_DEFAULT
 	compare VAR_0x8008, 0
 	call_if 1, RustboroCity_EventScript_1E10D6
 	releaseall
@@ -911,35 +911,35 @@ RustboroCity_EventScript_1E1114:: @ 81E1114
 	checkflag FLAG_0x120
 	goto_eq RustboroCity_EventScript_1E1174
 	setflag FLAG_0x120
-	msgbox RustboroCity_Text_1E1D7D, 4
+	msgbox RustboroCity_Text_1E1D7D, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox RustboroCity_Text_1E1E11, 4
+	msgbox RustboroCity_Text_1E1E11, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
 	setflag FLAG_0x0FD
 	setvar VAR_0x405A, 8
 	setvar VAR_0x4063, 2
-	msgbox RustboroCity_Text_1E1E34, 5
+	msgbox RustboroCity_Text_1E1E34, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq RustboroCity_EventScript_1E1191
-	msgbox RustboroCity_Text_1E1F2F, 4
+	msgbox RustboroCity_Text_1E1F2F, MSGBOX_DEFAULT
 	call RustboroCity_EventScript_1E10D6
 	releaseall
 	end
 
 RustboroCity_EventScript_1E1174:: @ 81E1174
-	msgbox RustboroCity_Text_1E1F76, 5
+	msgbox RustboroCity_Text_1E1F76, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq RustboroCity_EventScript_1E1191
-	msgbox RustboroCity_Text_1E1F2F, 4
+	msgbox RustboroCity_Text_1E1F2F, MSGBOX_DEFAULT
 	releaseall
 	end
 
 RustboroCity_EventScript_1E1191:: @ 81E1191
-	msgbox RustboroCity_Text_1E1FA9, 4
+	msgbox RustboroCity_Text_1E1FA9, MSGBOX_DEFAULT
 	switch VAR_STARTER_MON
 	case 0, RustboroCity_EventScript_1E11D5
 	case 1, RustboroCity_EventScript_1E11E8
@@ -947,7 +947,7 @@ RustboroCity_EventScript_1E1191:: @ 81E1191
 	end
 
 RustboroCity_EventScript_1E11C0:: @ 81E11C0
-	msgbox RustboroCity_Text_1E2002, 4
+	msgbox RustboroCity_Text_1E2002, MSGBOX_DEFAULT
 	compare VAR_0x8008, 0
 	call_if 1, RustboroCity_EventScript_1E10D6
 	releaseall
@@ -1028,7 +1028,7 @@ RustboroCity_Movement_1E1230: @ 81E1230
 	step_end
 
 RustboroCity_EventScript_1E1236:: @ 81E1236
-	msgbox RustboroCity_Text_1E249D, 2
+	msgbox RustboroCity_Text_1E249D, MSGBOX_NPC
 	end
 
 RustboroCity_Text_1E123F: @ 81E123F

--- a/data/maps/RustboroCity_CuttersHouse/scripts.inc
+++ b/data/maps/RustboroCity_CuttersHouse/scripts.inc
@@ -6,20 +6,20 @@ RustboroCity_CuttersHouse_EventScript_215BD4:: @ 8215BD4
 	faceplayer
 	checkflag FLAG_0x089
 	goto_eq RustboroCity_CuttersHouse_EventScript_215C00
-	msgbox RustboroCity_CuttersHouse_Text_215C13, 4
+	msgbox RustboroCity_CuttersHouse_Text_215C13, MSGBOX_DEFAULT
 	giveitem_std ITEM_HM01
 	setflag FLAG_0x089
-	msgbox RustboroCity_CuttersHouse_Text_215D33, 4
+	msgbox RustboroCity_CuttersHouse_Text_215D33, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_CuttersHouse_EventScript_215C00:: @ 8215C00
-	msgbox RustboroCity_CuttersHouse_Text_215D33, 4
+	msgbox RustboroCity_CuttersHouse_Text_215D33, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_CuttersHouse_EventScript_215C0A:: @ 8215C0A
-	msgbox RustboroCity_CuttersHouse_Text_215E39, 2
+	msgbox RustboroCity_CuttersHouse_Text_215E39, MSGBOX_NPC
 	end
 
 RustboroCity_CuttersHouse_Text_215C13: @ 8215C13

--- a/data/maps/RustboroCity_DevonCorp_1F/scripts.inc
+++ b/data/maps/RustboroCity_DevonCorp_1F/scripts.inc
@@ -19,17 +19,17 @@ RustboroCity_DevonCorp_1F_EventScript_211261:: @ 8211261
 	goto_eq RustboroCity_DevonCorp_1F_EventScript_211289
 	checkflag FLAG_0x08E
 	goto_eq RustboroCity_DevonCorp_1F_EventScript_21127F
-	msgbox RustboroCity_DevonCorp_1F_Text_2113D1, 4
+	msgbox RustboroCity_DevonCorp_1F_Text_2113D1, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_DevonCorp_1F_EventScript_21127F:: @ 821127F
-	msgbox RustboroCity_DevonCorp_1F_Text_211446, 4
+	msgbox RustboroCity_DevonCorp_1F_Text_211446, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_DevonCorp_1F_EventScript_211289:: @ 8211289
-	msgbox RustboroCity_DevonCorp_1F_Text_2114DE, 4
+	msgbox RustboroCity_DevonCorp_1F_Text_2114DE, MSGBOX_DEFAULT
 	release
 	end
 
@@ -42,17 +42,17 @@ RustboroCity_DevonCorp_1F_EventScript_211293:: @ 8211293
 	goto_eq RustboroCity_DevonCorp_1F_EventScript_2112C4
 	checkflag FLAG_0x08E
 	goto_eq RustboroCity_DevonCorp_1F_EventScript_2112C4
-	msgbox RustboroCity_DevonCorp_1F_Text_21151B, 4
+	msgbox RustboroCity_DevonCorp_1F_Text_21151B, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_DevonCorp_1F_EventScript_2112BA:: @ 82112BA
-	msgbox RustboroCity_DevonCorp_1F_Text_211585, 4
+	msgbox RustboroCity_DevonCorp_1F_Text_211585, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_DevonCorp_1F_EventScript_2112C4:: @ 82112C4
-	msgbox RustboroCity_DevonCorp_1F_Text_211558, 4
+	msgbox RustboroCity_DevonCorp_1F_Text_211558, MSGBOX_DEFAULT
 	release
 	end
 
@@ -65,26 +65,26 @@ RustboroCity_DevonCorp_1F_EventScript_2112CE:: @ 82112CE
 	goto_eq RustboroCity_DevonCorp_1F_EventScript_2112FF
 	checkflag FLAG_0x08E
 	goto_eq RustboroCity_DevonCorp_1F_EventScript_2112FF
-	msgbox RustboroCity_DevonCorp_1F_Text_21131B, 4
+	msgbox RustboroCity_DevonCorp_1F_Text_21131B, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_DevonCorp_1F_EventScript_2112F5:: @ 82112F5
-	msgbox RustboroCity_DevonCorp_1F_Text_21131B, 4
+	msgbox RustboroCity_DevonCorp_1F_Text_21131B, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_DevonCorp_1F_EventScript_2112FF:: @ 82112FF
-	msgbox RustboroCity_DevonCorp_1F_Text_21138B, 4
+	msgbox RustboroCity_DevonCorp_1F_Text_21138B, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_DevonCorp_1F_EventScript_211309:: @ 8211309
-	msgbox RustboroCity_DevonCorp_1F_Text_2115AC, 3
+	msgbox RustboroCity_DevonCorp_1F_Text_2115AC, MSGBOX_SIGN
 	end
 
 RustboroCity_DevonCorp_1F_EventScript_211312:: @ 8211312
-	msgbox RustboroCity_DevonCorp_1F_Text_211722, 3
+	msgbox RustboroCity_DevonCorp_1F_Text_211722, MSGBOX_SIGN
 	end
 
 RustboroCity_DevonCorp_1F_Text_21131B: @ 821131B

--- a/data/maps/RustboroCity_DevonCorp_2F/scripts.inc
+++ b/data/maps/RustboroCity_DevonCorp_2F/scripts.inc
@@ -16,7 +16,7 @@ RustboroCity_DevonCorp_2F_EventScript_21186F:: @ 821186F
 	faceplayer
 	compare VAR_0x40C4, 1
 	call_if 1, RustboroCity_DevonCorp_2F_EventScript_211869
-	msgbox RustboroCity_DevonCorp_2F_Text_211BFB, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_211BFB, MSGBOX_DEFAULT
 	release
 	end
 
@@ -27,12 +27,12 @@ RustboroCity_DevonCorp_2F_EventScript_211886:: @ 8211886
 	call_if 1, RustboroCity_DevonCorp_2F_EventScript_211869
 	checkflag FLAG_0x11F
 	goto_eq RustboroCity_DevonCorp_2F_EventScript_2118A6
-	msgbox RustboroCity_DevonCorp_2F_Text_211C50, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_211C50, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_DevonCorp_2F_EventScript_2118A6:: @ 82118A6
-	msgbox RustboroCity_DevonCorp_2F_Text_211C99, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_211C99, MSGBOX_DEFAULT
 	release
 	end
 
@@ -43,12 +43,12 @@ RustboroCity_DevonCorp_2F_EventScript_2118B0:: @ 82118B0
 	call_if 1, RustboroCity_DevonCorp_2F_EventScript_211869
 	checkflag FLAG_0x0BC
 	goto_eq RustboroCity_DevonCorp_2F_EventScript_2118D0
-	msgbox RustboroCity_DevonCorp_2F_Text_211D9F, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_211D9F, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_DevonCorp_2F_EventScript_2118D0:: @ 82118D0
-	msgbox RustboroCity_DevonCorp_2F_Text_211DF3, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_211DF3, MSGBOX_DEFAULT
 	release
 	end
 
@@ -57,7 +57,7 @@ RustboroCity_DevonCorp_2F_EventScript_2118DA:: @ 82118DA
 	faceplayer
 	compare VAR_0x40C4, 1
 	call_if 1, RustboroCity_DevonCorp_2F_EventScript_211869
-	msgbox RustboroCity_DevonCorp_2F_Text_211EE0, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_211EE0, MSGBOX_DEFAULT
 	release
 	end
 
@@ -68,7 +68,7 @@ RustboroCity_DevonCorp_2F_EventScript_2118F1:: @ 82118F1
 	goto_eq RustboroCity_DevonCorp_2F_EventScript_211A03
 	compare VAR_0x40C4, 1
 	goto_eq RustboroCity_DevonCorp_2F_EventScript_2119F9
-	msgbox RustboroCity_DevonCorp_2F_Text_211F48, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_211F48, MSGBOX_DEFAULT
 	checkitem ITEM_ROOT_FOSSIL, 1
 	compare VAR_RESULT, 1
 	goto_eq RustboroCity_DevonCorp_2F_EventScript_211933
@@ -85,7 +85,7 @@ RustboroCity_DevonCorp_2F_EventScript_211933:: @ 8211933
 	waitmovement 0
 	applymovement 5, RustboroCity_DevonCorp_2F_Movement_27259A
 	waitmovement 0
-	msgbox RustboroCity_DevonCorp_2F_Text_211FA6, 5
+	msgbox RustboroCity_DevonCorp_2F_Text_211FA6, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq RustboroCity_DevonCorp_2F_EventScript_2119EF
 	checkitem ITEM_CLAW_FOSSIL, 1
@@ -96,7 +96,7 @@ RustboroCity_DevonCorp_2F_EventScript_211933:: @ 8211933
 
 RustboroCity_DevonCorp_2F_EventScript_211974:: @ 8211974
 	bufferitemname 0, ITEM_ROOT_FOSSIL
-	msgbox RustboroCity_DevonCorp_2F_Text_212153, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_212153, MSGBOX_DEFAULT
 	takeitem ITEM_ROOT_FOSSIL, 1
 	setvar VAR_0x40C4, 1
 	setvar VAR_0x40C5, 1
@@ -110,7 +110,7 @@ RustboroCity_DevonCorp_2F_EventScript_211991:: @ 8211991
 	waitmovement 0
 	applymovement 5, RustboroCity_DevonCorp_2F_Movement_27259A
 	waitmovement 0
-	msgbox RustboroCity_DevonCorp_2F_Text_211FA6, 5
+	msgbox RustboroCity_DevonCorp_2F_Text_211FA6, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq RustboroCity_DevonCorp_2F_EventScript_2119EF
 	checkitem ITEM_ROOT_FOSSIL, 1
@@ -121,7 +121,7 @@ RustboroCity_DevonCorp_2F_EventScript_211991:: @ 8211991
 
 RustboroCity_DevonCorp_2F_EventScript_2119D2:: @ 82119D2
 	bufferitemname 0, ITEM_CLAW_FOSSIL
-	msgbox RustboroCity_DevonCorp_2F_Text_212153, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_212153, MSGBOX_DEFAULT
 	takeitem ITEM_CLAW_FOSSIL, 1
 	setvar VAR_0x40C4, 1
 	setvar VAR_0x40C5, 2
@@ -129,12 +129,12 @@ RustboroCity_DevonCorp_2F_EventScript_2119D2:: @ 82119D2
 	end
 
 RustboroCity_DevonCorp_2F_EventScript_2119EF:: @ 82119EF
-	msgbox RustboroCity_DevonCorp_2F_Text_212046, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_212046, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_DevonCorp_2F_EventScript_2119F9:: @ 82119F9
-	msgbox RustboroCity_DevonCorp_2F_Text_2121A2, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_2121A2, MSGBOX_DEFAULT
 	release
 	end
 
@@ -147,13 +147,13 @@ RustboroCity_DevonCorp_2F_EventScript_211A03:: @ 8211A03
 
 RustboroCity_DevonCorp_2F_EventScript_211A1A:: @ 8211A1A
 	bufferspeciesname 1, SPECIES_LILEEP
-	msgbox RustboroCity_DevonCorp_2F_Text_212251, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_212251, MSGBOX_DEFAULT
 	goto RustboroCity_DevonCorp_2F_EventScript_211A3E
 	end
 
 RustboroCity_DevonCorp_2F_EventScript_211A2C:: @ 8211A2C
 	bufferspeciesname 1, SPECIES_ANORITH
-	msgbox RustboroCity_DevonCorp_2F_Text_212251, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_212251, MSGBOX_DEFAULT
 	goto RustboroCity_DevonCorp_2F_EventScript_211AE1
 	end
 
@@ -169,7 +169,7 @@ RustboroCity_DevonCorp_2F_EventScript_211A3E:: @ 8211A3E
 
 RustboroCity_DevonCorp_2F_EventScript_211A6E:: @ 8211A6E
 	call RustboroCity_DevonCorp_2F_EventScript_211AC4
-	msgbox gUnknown_08273374, 5
+	msgbox gUnknown_08273374, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq RustboroCity_DevonCorp_2F_EventScript_211AD7
 	call RustboroCity_DevonCorp_2F_EventScript_27378B
@@ -179,7 +179,7 @@ RustboroCity_DevonCorp_2F_EventScript_211A6E:: @ 8211A6E
 
 RustboroCity_DevonCorp_2F_EventScript_211A96:: @ 8211A96
 	call RustboroCity_DevonCorp_2F_EventScript_211AC4
-	msgbox gUnknown_08273374, 5
+	msgbox gUnknown_08273374, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq RustboroCity_DevonCorp_2F_EventScript_211AB9
 	call RustboroCity_DevonCorp_2F_EventScript_273797
@@ -218,7 +218,7 @@ RustboroCity_DevonCorp_2F_EventScript_211AE1:: @ 8211AE1
 
 RustboroCity_DevonCorp_2F_EventScript_211B11:: @ 8211B11
 	call RustboroCity_DevonCorp_2F_EventScript_211B67
-	msgbox gUnknown_08273374, 5
+	msgbox gUnknown_08273374, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq RustboroCity_DevonCorp_2F_EventScript_211B7A
 	call RustboroCity_DevonCorp_2F_EventScript_27378B
@@ -228,7 +228,7 @@ RustboroCity_DevonCorp_2F_EventScript_211B11:: @ 8211B11
 
 RustboroCity_DevonCorp_2F_EventScript_211B39:: @ 8211B39
 	call RustboroCity_DevonCorp_2F_EventScript_211B67
-	msgbox gUnknown_08273374, 5
+	msgbox gUnknown_08273374, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq RustboroCity_DevonCorp_2F_EventScript_211B5C
 	call RustboroCity_DevonCorp_2F_EventScript_273797
@@ -285,12 +285,12 @@ RustboroCity_DevonCorp_2F_EventScript_211BCF:: @ 8211BCF
 	call_if 1, RustboroCity_DevonCorp_2F_EventScript_211869
 	compare VAR_0x405A, 6
 	goto_if 4, RustboroCity_DevonCorp_2F_EventScript_211BF1
-	msgbox RustboroCity_DevonCorp_2F_Text_212338, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_212338, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_DevonCorp_2F_EventScript_211BF1:: @ 8211BF1
-	msgbox RustboroCity_DevonCorp_2F_Text_212386, 4
+	msgbox RustboroCity_DevonCorp_2F_Text_212386, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/RustboroCity_DevonCorp_3F/scripts.inc
+++ b/data/maps/RustboroCity_DevonCorp_3F/scripts.inc
@@ -28,38 +28,38 @@ RustboroCity_DevonCorp_3F_MapScript2_212464: @ 8212464
 
 RustboroCity_DevonCorp_3F_EventScript_21246E:: @ 821246E
 	lockall
-	msgbox RustboroCity_DevonCorp_3F_Text_212C37, 4
+	msgbox RustboroCity_DevonCorp_3F_Text_212C37, MSGBOX_DEFAULT
 	closemessage
 	applymovement 2, RustboroCity_DevonCorp_3F_Movement_212546
 	waitmovement 0
 	delay 80
 	applymovement 2, RustboroCity_DevonCorp_3F_Movement_21254F
 	waitmovement 0
-	msgbox RustboroCity_DevonCorp_3F_Text_212DE8, 4
+	msgbox RustboroCity_DevonCorp_3F_Text_212DE8, MSGBOX_DEFAULT
 	closemessage
 	playbgm MUS_TSURETEK, 0
 	applymovement 2, RustboroCity_DevonCorp_3F_Movement_212534
 	applymovement 255, RustboroCity_DevonCorp_3F_Movement_212558
 	waitmovement 0
-	msgbox RustboroCity_DevonCorp_3F_Text_212E2F, 4
+	msgbox RustboroCity_DevonCorp_3F_Text_212E2F, MSGBOX_DEFAULT
 	closemessage
 	fadedefaultbgm
 	applymovement 2, RustboroCity_DevonCorp_3F_Movement_212543
 	applymovement 255, RustboroCity_DevonCorp_3F_Movement_212566
 	waitmovement 0
-	msgbox RustboroCity_DevonCorp_3F_Text_212609, 4
+	msgbox RustboroCity_DevonCorp_3F_Text_212609, MSGBOX_DEFAULT
 	giveitem_std ITEM_LETTER
-	msgbox RustboroCity_DevonCorp_3F_Text_21277C, 4
+	msgbox RustboroCity_DevonCorp_3F_Text_21277C, MSGBOX_DEFAULT
 	playfanfare MUS_FANFA4
 	message RustboroCity_DevonCorp_3F_Text_212820
 	waitfanfare
 	setflag FLAG_SYS_POKENAV_GET
 	setflag FLAG_0x0BC
 	setflag FLAG_HIDE_RUSTBORO_CITY_POKEMON_SCHOOL_SCOTT
-	msgbox RustboroCity_DevonCorp_3F_Text_212837, 4
+	msgbox RustboroCity_DevonCorp_3F_Text_212837, MSGBOX_DEFAULT
 	closemessage
 	call RustboroCity_DevonCorp_3F_EventScript_272083
-	msgbox RustboroCity_DevonCorp_3F_Text_2129D2, 4
+	msgbox RustboroCity_DevonCorp_3F_Text_2129D2, MSGBOX_DEFAULT
 	setflag FLAG_HIDE_ROUTE_116_TUNNELER
 	clearflag FLAG_HIDE_RUSTURF_TUNNEL_LOVER_MAN
 	clearflag FLAG_HIDE_RUSTURF_TUNNEL_LOVER_WOMAN
@@ -154,7 +154,7 @@ RustboroCity_DevonCorp_3F_EventScript_21256C:: @ 821256C
 	goto_eq RustboroCity_DevonCorp_3F_EventScript_2125CC
 	checkflag FLAG_0x0BD
 	goto_eq RustboroCity_DevonCorp_3F_EventScript_212595
-	msgbox RustboroCity_DevonCorp_3F_Text_212A09, 4
+	msgbox RustboroCity_DevonCorp_3F_Text_212A09, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, RustboroCity_DevonCorp_3F_Movement_2725A2
 	waitmovement 0
@@ -162,12 +162,12 @@ RustboroCity_DevonCorp_3F_EventScript_21256C:: @ 821256C
 	end
 
 RustboroCity_DevonCorp_3F_EventScript_212595:: @ 8212595
-	msgbox RustboroCity_DevonCorp_3F_Text_212A29, 4
+	msgbox RustboroCity_DevonCorp_3F_Text_212A29, MSGBOX_DEFAULT
 	giveitem_std ITEM_EXP_SHARE
 	compare VAR_RESULT, 0
 	goto_eq RustboroCity_DevonCorp_3F_EventScript_272054
 	setflag FLAG_0x110
-	msgbox RustboroCity_DevonCorp_3F_Text_212A9E, 4
+	msgbox RustboroCity_DevonCorp_3F_Text_212A9E, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, RustboroCity_DevonCorp_3F_Movement_2725A2
 	waitmovement 0
@@ -175,7 +175,7 @@ RustboroCity_DevonCorp_3F_EventScript_212595:: @ 8212595
 	end
 
 RustboroCity_DevonCorp_3F_EventScript_2125CC:: @ 82125CC
-	msgbox RustboroCity_DevonCorp_3F_Text_212B78, 4
+	msgbox RustboroCity_DevonCorp_3F_Text_212B78, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, RustboroCity_DevonCorp_3F_Movement_2725A2
 	waitmovement 0
@@ -187,17 +187,17 @@ RustboroCity_DevonCorp_3F_EventScript_2125E1:: @ 82125E1
 	faceplayer
 	checkflag FLAG_0x100
 	goto_eq RustboroCity_DevonCorp_3F_EventScript_2125F6
-	msgbox RustboroCity_DevonCorp_3F_Text_212E41, 4
+	msgbox RustboroCity_DevonCorp_3F_Text_212E41, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_DevonCorp_3F_EventScript_2125F6:: @ 82125F6
-	msgbox RustboroCity_DevonCorp_3F_Text_212E88, 4
+	msgbox RustboroCity_DevonCorp_3F_Text_212E88, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_DevonCorp_3F_EventScript_212600:: @ 8212600
-	msgbox RustboroCity_DevonCorp_3F_Text_212EE9, 3
+	msgbox RustboroCity_DevonCorp_3F_Text_212EE9, MSGBOX_SIGN
 	end
 
 RustboroCity_DevonCorp_3F_Text_212609: @ 8212609

--- a/data/maps/RustboroCity_Flat1_1F/scripts.inc
+++ b/data/maps/RustboroCity_Flat1_1F/scripts.inc
@@ -2,11 +2,11 @@ RustboroCity_Flat1_1F_MapScripts:: @ 82150CD
 	.byte 0
 
 RustboroCity_Flat1_1F_EventScript_2150CE:: @ 82150CE
-	msgbox RustboroCity_Flat1_1F_Text_2150E0, 2
+	msgbox RustboroCity_Flat1_1F_Text_2150E0, MSGBOX_NPC
 	end
 
 RustboroCity_Flat1_1F_EventScript_2150D7:: @ 82150D7
-	msgbox RustboroCity_Flat1_1F_Text_215115, 2
+	msgbox RustboroCity_Flat1_1F_Text_215115, MSGBOX_NPC
 	end
 
 RustboroCity_Flat1_1F_Text_2150E0: @ 82150E0

--- a/data/maps/RustboroCity_Flat1_2F/scripts.inc
+++ b/data/maps/RustboroCity_Flat1_2F/scripts.inc
@@ -25,50 +25,50 @@ RustboroCity_Flat1_2F_EventScript_215157:: @ 8215157
 	end
 
 RustboroCity_Flat1_2F_EventScript_21518D:: @ 821518D
-	msgbox RustboroCity_Flat1_2F_Text_2152FA, 5
+	msgbox RustboroCity_Flat1_2F_Text_2152FA, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq RustboroCity_Flat1_2F_EventScript_2151CD
-	msgbox RustboroCity_Flat1_2F_Text_2154AD, 4
+	msgbox RustboroCity_Flat1_2F_Text_2154AD, MSGBOX_DEFAULT
 	goto RustboroCity_Flat1_2F_EventScript_215157
 
 RustboroCity_Flat1_2F_EventScript_2151AD:: @ 82151AD
-	msgbox RustboroCity_Flat1_2F_Text_215448, 5
+	msgbox RustboroCity_Flat1_2F_Text_215448, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq RustboroCity_Flat1_2F_EventScript_2151CD
-	msgbox RustboroCity_Flat1_2F_Text_2154AD, 4
+	msgbox RustboroCity_Flat1_2F_Text_2154AD, MSGBOX_DEFAULT
 	goto RustboroCity_Flat1_2F_EventScript_215157
 
 RustboroCity_Flat1_2F_EventScript_2151CD:: @ 82151CD
-	msgbox RustboroCity_Flat1_2F_Text_2154E7, 4
+	msgbox RustboroCity_Flat1_2F_Text_2154E7, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_Flat1_2F_EventScript_2151D7:: @ 82151D7
-	msgbox RustboroCity_Flat1_2F_Text_2156E3, 4
+	msgbox RustboroCity_Flat1_2F_Text_2156E3, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_Flat1_2F_EventScript_2151E1:: @ 82151E1
-	msgbox RustboroCity_Flat1_2F_Text_21561E, 4
+	msgbox RustboroCity_Flat1_2F_Text_21561E, MSGBOX_DEFAULT
 	call RustboroCity_Flat1_2F_EventScript_215238
-	msgbox RustboroCity_Flat1_2F_Text_215699, 4
+	msgbox RustboroCity_Flat1_2F_Text_215699, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_Flat1_2F_EventScript_2151F8:: @ 82151F8
-	msgbox RustboroCity_Flat1_2F_Text_215535, 4
+	msgbox RustboroCity_Flat1_2F_Text_215535, MSGBOX_DEFAULT
 	call RustboroCity_Flat1_2F_EventScript_215238
-	msgbox RustboroCity_Flat1_2F_Text_215565, 4
+	msgbox RustboroCity_Flat1_2F_Text_215565, MSGBOX_DEFAULT
 	applymovement 6, RustboroCity_Flat1_2F_Movement_27259E
 	waitmovement 0
-	msgbox RustboroCity_Flat1_2F_Text_215792, 4
+	msgbox RustboroCity_Flat1_2F_Text_215792, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_Flat1_2F_EventScript_215221:: @ 8215221
-	msgbox RustboroCity_Flat1_2F_Text_2155A4, 4
+	msgbox RustboroCity_Flat1_2F_Text_2155A4, MSGBOX_DEFAULT
 	call RustboroCity_Flat1_2F_EventScript_215238
-	msgbox RustboroCity_Flat1_2F_Text_2155D4, 4
+	msgbox RustboroCity_Flat1_2F_Text_2155D4, MSGBOX_DEFAULT
 	release
 	end
 
@@ -77,11 +77,11 @@ RustboroCity_Flat1_2F_EventScript_215238:: @ 8215238
 	return
 
 RustboroCity_Flat1_2F_EventScript_21523D:: @ 821523D
-	msgbox RustboroCity_Flat1_2F_Text_21524F, 2
+	msgbox RustboroCity_Flat1_2F_Text_21524F, MSGBOX_NPC
 	end
 
 RustboroCity_Flat1_2F_EventScript_215246:: @ 8215246
-	msgbox RustboroCity_Flat1_2F_Text_215923, 3
+	msgbox RustboroCity_Flat1_2F_Text_215923, MSGBOX_SIGN
 	end
 
 RustboroCity_Flat1_2F_Text_21524F: @ 821524F

--- a/data/maps/RustboroCity_Flat2_1F/scripts.inc
+++ b/data/maps/RustboroCity_Flat2_1F/scripts.inc
@@ -2,7 +2,7 @@ RustboroCity_Flat2_1F_MapScripts:: @ 8215F76
 	.byte 0
 
 RustboroCity_Flat2_1F_EventScript_215F77:: @ 8215F77
-	msgbox RustboroCity_Flat2_1F_Text_215F93, 2
+	msgbox RustboroCity_Flat2_1F_Text_215F93, MSGBOX_NPC
 	end
 
 RustboroCity_Flat2_1F_EventScript_215F80:: @ 8215F80
@@ -10,7 +10,7 @@ RustboroCity_Flat2_1F_EventScript_215F80:: @ 8215F80
 	faceplayer
 	waitse
 	playmoncry SPECIES_SKITTY, 0
-	msgbox RustboroCity_Flat2_1F_Text_215FC6, 4
+	msgbox RustboroCity_Flat2_1F_Text_215FC6, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/RustboroCity_Flat2_2F/scripts.inc
+++ b/data/maps/RustboroCity_Flat2_2F/scripts.inc
@@ -2,7 +2,7 @@ RustboroCity_Flat2_2F_MapScripts:: @ 8215FD7
 	.byte 0
 
 RustboroCity_Flat2_2F_EventScript_215FD8:: @ 8215FD8
-	msgbox RustboroCity_Flat2_2F_Text_21601A, 2
+	msgbox RustboroCity_Flat2_2F_Text_21601A, MSGBOX_NPC
 	end
 
 RustboroCity_Flat2_2F_EventScript_215FE1:: @ 8215FE1
@@ -10,7 +10,7 @@ RustboroCity_Flat2_2F_EventScript_215FE1:: @ 8215FE1
 	faceplayer
 	checkflag FLAG_0x0D5
 	goto_eq RustboroCity_Flat2_2F_EventScript_216010
-	msgbox RustboroCity_Flat2_2F_Text_21605A, 4
+	msgbox RustboroCity_Flat2_2F_Text_21605A, MSGBOX_DEFAULT
 	giveitem_std ITEM_PREMIER_BALL
 	compare VAR_RESULT, 0
 	goto_eq RustboroCity_Flat2_2F_EventScript_272054
@@ -19,7 +19,7 @@ RustboroCity_Flat2_2F_EventScript_215FE1:: @ 8215FE1
 	end
 
 RustboroCity_Flat2_2F_EventScript_216010:: @ 8216010
-	msgbox RustboroCity_Flat2_2F_Text_2160BD, 4
+	msgbox RustboroCity_Flat2_2F_Text_2160BD, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/RustboroCity_Flat2_3F/scripts.inc
+++ b/data/maps/RustboroCity_Flat2_3F/scripts.inc
@@ -2,11 +2,11 @@ RustboroCity_Flat2_3F_MapScripts:: @ 8216116
 	.byte 0
 
 RustboroCity_Flat2_3F_EventScript_216117:: @ 8216117
-	msgbox RustboroCity_Flat2_3F_Text_216129, 2
+	msgbox RustboroCity_Flat2_3F_Text_216129, MSGBOX_NPC
 	end
 
 RustboroCity_Flat2_3F_EventScript_216120:: @ 8216120
-	msgbox RustboroCity_Flat2_3F_Text_216159, 2
+	msgbox RustboroCity_Flat2_3F_Text_216159, MSGBOX_NPC
 	end
 
 RustboroCity_Flat2_3F_Text_216129: @ 8216129

--- a/data/maps/RustboroCity_Gym/scripts.inc
+++ b/data/maps/RustboroCity_Gym/scripts.inc
@@ -8,7 +8,7 @@ RustboroCity_Gym_EventScript_212F31:: @ 8212F31
 	goto_eq RustboroCity_Gym_EventScript_212FC8
 	checkflag FLAG_0x0A5
 	goto_if 0, RustboroCity_Gym_EventScript_212FA4
-	msgbox RustboroCity_Gym_Text_2139A7, 4
+	msgbox RustboroCity_Gym_Text_2139A7, MSGBOX_DEFAULT
 	release
 	end
 
@@ -16,7 +16,7 @@ RustboroCity_Gym_EventScript_212F66:: @ 8212F66
 	message RustboroCity_Gym_Text_2137EC
 	waitmessage
 	call RustboroCity_Gym_EventScript_27207E
-	msgbox RustboroCity_Gym_Text_213816, 4
+	msgbox RustboroCity_Gym_Text_213816, MSGBOX_DEFAULT
 	setflag FLAG_0x4F0
 	setflag FLAG_BADGE01_GET
 	setvar VAR_0x405A, 1
@@ -33,28 +33,28 @@ RustboroCity_Gym_EventScript_212FA4:: @ 8212FA4
 	compare VAR_RESULT, 0
 	goto_eq RustboroCity_Gym_EventScript_272054
 	setflag FLAG_0x0A5
-	msgbox RustboroCity_Gym_Text_2138B1, 4
+	msgbox RustboroCity_Gym_Text_2138B1, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_Gym_EventScript_212FC8:: @ 8212FC8
 	trainerbattle 7, TRAINER_ROXANNE_1, 0, RustboroCity_Gym_Text_213C2F, RustboroCity_Gym_Text_213CF9, RustboroCity_Gym_Text_213D93
-	msgbox RustboroCity_Gym_Text_213D12, 6
+	msgbox RustboroCity_Gym_Text_213D12, MSGBOX_AUTOCLOSE
 	end
 
 RustboroCity_Gym_EventScript_212FE3:: @ 8212FE3
 	trainerbattle 0, TRAINER_JOSH, 0, RustboroCity_Gym_Text_2133E9, RustboroCity_Gym_Text_21342D
-	msgbox RustboroCity_Gym_Text_213447, 6
+	msgbox RustboroCity_Gym_Text_213447, MSGBOX_AUTOCLOSE
 	end
 
 RustboroCity_Gym_EventScript_212FFA:: @ 8212FFA
 	trainerbattle 0, TRAINER_TOMMY, 0, RustboroCity_Gym_Text_213486, RustboroCity_Gym_Text_2134C6
-	msgbox RustboroCity_Gym_Text_2134E6, 6
+	msgbox RustboroCity_Gym_Text_2134E6, MSGBOX_AUTOCLOSE
 	end
 
 RustboroCity_Gym_EventScript_213011:: @ 8213011
 	trainerbattle 0, TRAINER_MARC, 0, RustboroCity_Gym_Text_213533, RustboroCity_Gym_Text_213589
-	msgbox RustboroCity_Gym_Text_2135C0, 6
+	msgbox RustboroCity_Gym_Text_2135C0, MSGBOX_AUTOCLOSE
 	end
 
 RustboroCity_Gym_EventScript_213028:: @ 8213028
@@ -62,12 +62,12 @@ RustboroCity_Gym_EventScript_213028:: @ 8213028
 	faceplayer
 	checkflag FLAG_0x4F0
 	goto_eq RustboroCity_Gym_EventScript_21303D
-	msgbox RustboroCity_Gym_Text_21309D, 4
+	msgbox RustboroCity_Gym_Text_21309D, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_Gym_EventScript_21303D:: @ 821303D
-	msgbox RustboroCity_Gym_Text_2132E2, 4
+	msgbox RustboroCity_Gym_Text_2132E2, MSGBOX_DEFAULT
 	release
 	end
 
@@ -86,12 +86,12 @@ RustboroCity_Gym_EventScript_213057:: @ 8213057
 	end
 
 RustboroCity_Gym_EventScript_213067:: @ 8213067
-	msgbox RustboroCity_Gym_Text_213A3B, 4
+	msgbox RustboroCity_Gym_Text_213A3B, MSGBOX_DEFAULT
 	releaseall
 	end
 
 RustboroCity_Gym_EventScript_213071:: @ 8213071
-	msgbox RustboroCity_Gym_Text_213A21, 4
+	msgbox RustboroCity_Gym_Text_213A21, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -101,7 +101,7 @@ RustboroCity_Gym_EventScript_21307B:: @ 821307B
 	waitmessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox RustboroCity_Gym_Text_213C01, 4
+	msgbox RustboroCity_Gym_Text_213C01, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30

--- a/data/maps/RustboroCity_House1/scripts.inc
+++ b/data/maps/RustboroCity_House1/scripts.inc
@@ -10,7 +10,7 @@ RustboroCity_House1_EventScript_21593F:: @ 821593F
 	copyvar VAR_0x8004, VAR_0x8008
 	specialvar VAR_RESULT, sub_807E73C
 	copyvar VAR_0x8009, VAR_RESULT
-	msgbox RustboroCity_House1_Text_2159E8, 5
+	msgbox RustboroCity_House1_Text_2159E8, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq RustboroCity_House1_EventScript_2159BD
 	special sub_81B94B0
@@ -28,29 +28,29 @@ RustboroCity_House1_EventScript_21593F:: @ 821593F
 	special sub_807EA10
 	special sub_807F0E4
 	waitstate
-	msgbox RustboroCity_House1_Text_215A77, 4
+	msgbox RustboroCity_House1_Text_215A77, MSGBOX_DEFAULT
 	setflag FLAG_0x099
 	release
 	end
 
 RustboroCity_House1_EventScript_2159BD:: @ 82159BD
-	msgbox RustboroCity_House1_Text_215ACE, 4
+	msgbox RustboroCity_House1_Text_215ACE, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_House1_EventScript_2159C7:: @ 82159C7
 	bufferspeciesname 0, VAR_0x8009
-	msgbox RustboroCity_House1_Text_215A9D, 4
+	msgbox RustboroCity_House1_Text_215A9D, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_House1_EventScript_2159D5:: @ 82159D5
-	msgbox RustboroCity_House1_Text_215B17, 4
+	msgbox RustboroCity_House1_Text_215B17, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_House1_EventScript_2159DF:: @ 82159DF
-	msgbox RustboroCity_House1_Text_215B57, 2
+	msgbox RustboroCity_House1_Text_215B57, MSGBOX_NPC
 	end
 
 RustboroCity_House1_Text_2159E8: @ 82159E8

--- a/data/maps/RustboroCity_House2/scripts.inc
+++ b/data/maps/RustboroCity_House2/scripts.inc
@@ -2,11 +2,11 @@ RustboroCity_House2_MapScripts:: @ 8215EB3
 	.byte 0
 
 RustboroCity_House2_EventScript_215EB4:: @ 8215EB4
-	msgbox RustboroCity_House2_Text_215EC6, 2
+	msgbox RustboroCity_House2_Text_215EC6, MSGBOX_NPC
 	end
 
 RustboroCity_House2_EventScript_215EBD:: @ 8215EBD
-	msgbox RustboroCity_House2_Text_215F21, 2
+	msgbox RustboroCity_House2_Text_215F21, MSGBOX_NPC
 	end
 
 RustboroCity_House2_Text_215EC6: @ 8215EC6

--- a/data/maps/RustboroCity_House3/scripts.inc
+++ b/data/maps/RustboroCity_House3/scripts.inc
@@ -2,11 +2,11 @@ RustboroCity_House3_MapScripts:: @ 8216190
 	.byte 0
 
 RustboroCity_House3_EventScript_216191:: @ 8216191
-	msgbox RustboroCity_House3_Text_2161B6, 2
+	msgbox RustboroCity_House3_Text_2161B6, MSGBOX_NPC
 	end
 
 RustboroCity_House3_EventScript_21619A:: @ 821619A
-	msgbox RustboroCity_House3_Text_21622A, 2
+	msgbox RustboroCity_House3_Text_21622A, MSGBOX_NPC
 	end
 
 RustboroCity_House3_EventScript_2161A3:: @ 82161A3
@@ -14,7 +14,7 @@ RustboroCity_House3_EventScript_2161A3:: @ 82161A3
 	faceplayer
 	waitse
 	playmoncry SPECIES_PIKACHU, 0
-	msgbox RustboroCity_House3_Text_2162AB, 4
+	msgbox RustboroCity_House3_Text_2162AB, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/RustboroCity_Mart/scripts.inc
+++ b/data/maps/RustboroCity_Mart/scripts.inc
@@ -14,7 +14,7 @@ RustboroCity_Mart_EventScript_214F06:: @ 8214F06
 
 RustboroCity_Mart_EventScript_214F21:: @ 8214F21
 	pokemart RustboroCity_Mart_Pokemart_214F30
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -35,7 +35,7 @@ RustboroCity_Mart_Pokemart_214F30: @ 8214F30
 
 RustboroCity_Mart_EventScript_214F48:: @ 8214F48
 	pokemart RustboroCity_Mart_Pokemart_214F58
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -58,15 +58,15 @@ RustboroCity_Mart_Pokemart_214F58: @ 8214F58
 	end
 
 RustboroCity_Mart_EventScript_214F74:: @ 8214F74
-	msgbox RustboroCity_Mart_Text_214F8F, 2
+	msgbox RustboroCity_Mart_Text_214F8F, MSGBOX_NPC
 	end
 
 RustboroCity_Mart_EventScript_214F7D:: @ 8214F7D
-	msgbox RustboroCity_Mart_Text_214FF1, 2
+	msgbox RustboroCity_Mart_Text_214FF1, MSGBOX_NPC
 	end
 
 RustboroCity_Mart_EventScript_214F86:: @ 8214F86
-	msgbox RustboroCity_Mart_Text_21505C, 2
+	msgbox RustboroCity_Mart_Text_21505C, MSGBOX_NPC
 	end
 
 RustboroCity_Mart_Text_214F8F: @ 8214F8F

--- a/data/maps/RustboroCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/RustboroCity_PokemonCenter_1F/scripts.inc
@@ -17,15 +17,15 @@ RustboroCity_PokemonCenter_1F_EventScript_214D76:: @ 8214D76
 	end
 
 RustboroCity_PokemonCenter_1F_EventScript_214D84:: @ 8214D84
-	msgbox RustboroCity_PokemonCenter_1F_Text_214D9F, 2
+	msgbox RustboroCity_PokemonCenter_1F_Text_214D9F, MSGBOX_NPC
 	end
 
 RustboroCity_PokemonCenter_1F_EventScript_214D8D:: @ 8214D8D
-	msgbox RustboroCity_PokemonCenter_1F_Text_214E13, 2
+	msgbox RustboroCity_PokemonCenter_1F_Text_214E13, MSGBOX_NPC
 	end
 
 RustboroCity_PokemonCenter_1F_EventScript_214D96:: @ 8214D96
-	msgbox RustboroCity_PokemonCenter_1F_Text_214E81, 2
+	msgbox RustboroCity_PokemonCenter_1F_Text_214E81, MSGBOX_NPC
 	end
 
 RustboroCity_PokemonCenter_1F_Text_214D9F: @ 8214D9F

--- a/data/maps/RustboroCity_PokemonSchool/scripts.inc
+++ b/data/maps/RustboroCity_PokemonSchool/scripts.inc
@@ -3,7 +3,7 @@ RustboroCity_PokemonSchool_MapScripts:: @ 8213EA8
 
 RustboroCity_PokemonSchool_EventScript_213EA9:: @ 8213EA9
 	lockall
-	msgbox RustboroCity_PokemonSchool_Text_2140B2, 4
+	msgbox RustboroCity_PokemonSchool_Text_2140B2, MSGBOX_DEFAULT
 	goto RustboroCity_PokemonSchool_EventScript_213EB8
 	end
 
@@ -22,27 +22,27 @@ RustboroCity_PokemonSchool_EventScript_213EB8:: @ 8213EB8
 	end
 
 RustboroCity_PokemonSchool_EventScript_213F17:: @ 8213F17
-	msgbox RustboroCity_PokemonSchool_Text_21411A, 4
+	msgbox RustboroCity_PokemonSchool_Text_21411A, MSGBOX_DEFAULT
 	goto RustboroCity_PokemonSchool_EventScript_213EB8
 	end
 
 RustboroCity_PokemonSchool_EventScript_213F25:: @ 8213F25
-	msgbox RustboroCity_PokemonSchool_Text_2141D8, 4
+	msgbox RustboroCity_PokemonSchool_Text_2141D8, MSGBOX_DEFAULT
 	goto RustboroCity_PokemonSchool_EventScript_213EB8
 	end
 
 RustboroCity_PokemonSchool_EventScript_213F33:: @ 8213F33
-	msgbox RustboroCity_PokemonSchool_Text_21427D, 4
+	msgbox RustboroCity_PokemonSchool_Text_21427D, MSGBOX_DEFAULT
 	goto RustboroCity_PokemonSchool_EventScript_213EB8
 	end
 
 RustboroCity_PokemonSchool_EventScript_213F41:: @ 8213F41
-	msgbox RustboroCity_PokemonSchool_Text_214336, 4
+	msgbox RustboroCity_PokemonSchool_Text_214336, MSGBOX_DEFAULT
 	goto RustboroCity_PokemonSchool_EventScript_213EB8
 	end
 
 RustboroCity_PokemonSchool_EventScript_213F4F:: @ 8213F4F
-	msgbox RustboroCity_PokemonSchool_Text_2143B8, 4
+	msgbox RustboroCity_PokemonSchool_Text_2143B8, MSGBOX_DEFAULT
 	goto RustboroCity_PokemonSchool_EventScript_213EB8
 	end
 
@@ -51,27 +51,27 @@ RustboroCity_PokemonSchool_EventScript_213F5D:: @ 8213F5D
 	end
 
 RustboroCity_PokemonSchool_EventScript_213F5F:: @ 8213F5F
-	msgbox RustboroCity_PokemonSchool_Text_21459F, 2
+	msgbox RustboroCity_PokemonSchool_Text_21459F, MSGBOX_NPC
 	end
 
 RustboroCity_PokemonSchool_EventScript_213F68:: @ 8213F68
-	msgbox RustboroCity_PokemonSchool_Text_2145CD, 2
+	msgbox RustboroCity_PokemonSchool_Text_2145CD, MSGBOX_NPC
 	end
 
 RustboroCity_PokemonSchool_EventScript_213F71:: @ 8213F71
-	msgbox RustboroCity_PokemonSchool_Text_214604, 2
+	msgbox RustboroCity_PokemonSchool_Text_214604, MSGBOX_NPC
 	end
 
 RustboroCity_PokemonSchool_EventScript_213F7A:: @ 8213F7A
-	msgbox RustboroCity_PokemonSchool_Text_214669, 2
+	msgbox RustboroCity_PokemonSchool_Text_214669, MSGBOX_NPC
 	end
 
 RustboroCity_PokemonSchool_EventScript_213F83:: @ 8213F83
-	msgbox RustboroCity_PokemonSchool_Text_214719, 2
+	msgbox RustboroCity_PokemonSchool_Text_214719, MSGBOX_NPC
 	end
 
 RustboroCity_PokemonSchool_EventScript_213F8C:: @ 8213F8C
-	msgbox RustboroCity_PokemonSchool_Text_2147A2, 3
+	msgbox RustboroCity_PokemonSchool_Text_2147A2, MSGBOX_SIGN
 	end
 
 RustboroCity_PokemonSchool_EventScript_213F95:: @ 8213F95
@@ -83,7 +83,7 @@ RustboroCity_PokemonSchool_EventScript_213F95:: @ 8213F95
 	call_if 1, RustboroCity_PokemonSchool_EventScript_213FE5
 	compare VAR_FACING, 3
 	call_if 1, RustboroCity_PokemonSchool_EventScript_213FF0
-	msgbox RustboroCity_PokemonSchool_Text_214433, 4
+	msgbox RustboroCity_PokemonSchool_Text_214433, MSGBOX_DEFAULT
 	giveitem_std ITEM_QUICK_CLAW
 	compare VAR_RESULT, 0
 	goto_eq RustboroCity_PokemonSchool_EventScript_272054
@@ -105,7 +105,7 @@ RustboroCity_PokemonSchool_EventScript_213FF0:: @ 8213FF0
 	return
 
 RustboroCity_PokemonSchool_EventScript_213FFB:: @ 8213FFB
-	msgbox RustboroCity_PokemonSchool_Text_2144C8, 4
+	msgbox RustboroCity_PokemonSchool_Text_2144C8, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, RustboroCity_PokemonSchool_Movement_2725AA
 	waitmovement 0
@@ -173,7 +173,7 @@ RustboroCity_PokemonSchool_EventScript_214040:: @ 8214040
 	goto_eq RustboroCity_PokemonSchool_EventScript_21406F
 	checkflag FLAG_BADGE01_GET
 	goto_eq RustboroCity_PokemonSchool_EventScript_214082
-	msgbox RustboroCity_PokemonSchool_Text_2148C0, 4
+	msgbox RustboroCity_PokemonSchool_Text_2148C0, MSGBOX_DEFAULT
 	addvar VAR_0x40D1, 1
 	setflag FLAG_0x136
 	release
@@ -182,17 +182,17 @@ RustboroCity_PokemonSchool_EventScript_214040:: @ 8214040
 RustboroCity_PokemonSchool_EventScript_21406F:: @ 821406F
 	checkflag FLAG_BADGE01_GET
 	goto_eq RustboroCity_PokemonSchool_EventScript_214090
-	msgbox RustboroCity_PokemonSchool_Text_214A5F, 4
+	msgbox RustboroCity_PokemonSchool_Text_214A5F, MSGBOX_DEFAULT
 	release
 	end
 
 RustboroCity_PokemonSchool_EventScript_214082:: @ 8214082
-	msgbox RustboroCity_PokemonSchool_Text_214B8A, 4
+	msgbox RustboroCity_PokemonSchool_Text_214B8A, MSGBOX_DEFAULT
 	goto RustboroCity_PokemonSchool_EventScript_21409E
 	end
 
 RustboroCity_PokemonSchool_EventScript_214090:: @ 8214090
-	msgbox RustboroCity_PokemonSchool_Text_214AB6, 4
+	msgbox RustboroCity_PokemonSchool_Text_214AB6, MSGBOX_DEFAULT
 	goto RustboroCity_PokemonSchool_EventScript_21409E
 	end
 
@@ -203,7 +203,7 @@ RustboroCity_PokemonSchool_EventScript_21409E:: @ 821409E
 	end
 
 RustboroCity_PokemonSchool_EventScript_2140A8:: @ 82140A8
-	msgbox RustboroCity_PokemonSchool_Text_214A5F, 4
+	msgbox RustboroCity_PokemonSchool_Text_214A5F, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/RusturfTunnel/scripts.inc
+++ b/data/maps/RusturfTunnel/scripts.inc
@@ -21,7 +21,7 @@ RusturfTunnel_EventScript_22CE50:: @ 822CE50
 RusturfTunnel_EventScript_22CE5F:: @ 822CE5F
 	lock
 	faceplayer
-	msgbox RusturfTunnel_Text_22D7A3, 4
+	msgbox RusturfTunnel_Text_22D7A3, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, RusturfTunnel_Movement_2725A2
 	waitmovement 0
@@ -34,7 +34,7 @@ RusturfTunnel_EventScript_22CE76:: @ 822CE76
 	checkflag FLAG_TEMP_1
 	goto_eq RusturfTunnel_EventScript_22CE99
 	setflag FLAG_TEMP_1
-	msgbox RusturfTunnel_Text_22D510, 4
+	msgbox RusturfTunnel_Text_22D510, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, RusturfTunnel_Movement_2725A2
 	waitmovement 0
@@ -42,7 +42,7 @@ RusturfTunnel_EventScript_22CE76:: @ 822CE76
 	end
 
 RusturfTunnel_EventScript_22CE99:: @ 822CE99
-	msgbox RusturfTunnel_Text_22D5F3, 4
+	msgbox RusturfTunnel_Text_22D5F3, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, RusturfTunnel_Movement_2725A2
 	waitmovement 0
@@ -58,14 +58,14 @@ RusturfTunnel_EventScript_22CEAE:: @ 822CEAE
 	compare VAR_TEMP_1, 3
 	call_if 1, RusturfTunnel_EventScript_22CFC7
 	call RusturfTunnel_EventScript_22CFFF
-	msgbox RusturfTunnel_Text_22D65C, 4
+	msgbox RusturfTunnel_Text_22D65C, MSGBOX_DEFAULT
 	compare VAR_TEMP_1, 2
 	call_if 1, RusturfTunnel_EventScript_22CFC8
 	compare VAR_TEMP_1, 3
 	call_if 1, RusturfTunnel_EventScript_22CFC8
 	giveitem_std ITEM_HM04
 	setflag FLAG_0x06A
-	msgbox RusturfTunnel_Text_22D6D2, 4
+	msgbox RusturfTunnel_Text_22D6D2, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_TEMP_1, 1
 	call_if 1, RusturfTunnel_EventScript_22CF5D
@@ -73,7 +73,7 @@ RusturfTunnel_EventScript_22CEAE:: @ 822CEAE
 	call_if 1, RusturfTunnel_EventScript_22CF6F
 	compare VAR_TEMP_1, 3
 	call_if 1, RusturfTunnel_EventScript_22CF8B
-	msgbox RusturfTunnel_Text_22D745, 4
+	msgbox RusturfTunnel_Text_22D745, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_TEMP_1, 1
 	call_if 1, RusturfTunnel_EventScript_22CFD4
@@ -281,7 +281,7 @@ RusturfTunnel_EventScript_22D07D:: @ 822D07D
 
 RusturfTunnel_EventScript_22D083:: @ 822D083
 	lockall
-	msgbox RusturfTunnel_Text_22D1C8, 4
+	msgbox RusturfTunnel_Text_22D1C8, MSGBOX_DEFAULT
 	closemessage
 	applymovement 6, RusturfTunnel_Movement_22D0AB
 	applymovement 7, RusturfTunnel_Movement_22D0AB
@@ -303,7 +303,7 @@ RusturfTunnel_EventScript_22D0AF:: @ 822D0AF
 	faceplayer
 	waitse
 	playmoncry SPECIES_WINGULL, 0
-	msgbox RusturfTunnel_Text_22D1F7, 4
+	msgbox RusturfTunnel_Text_22D1F7, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
@@ -312,9 +312,9 @@ RusturfTunnel_EventScript_22D0C2:: @ 822D0C2
 	lock
 	faceplayer
 	playbgm MUS_AQA_0, 0
-	msgbox RusturfTunnel_Text_22D20A, 4
+	msgbox RusturfTunnel_Text_22D20A, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_GRUNT_10, 0, RusturfTunnel_Text_22D2B0
-	msgbox RusturfTunnel_Text_22D2E1, 4
+	msgbox RusturfTunnel_Text_22D2E1, MSGBOX_DEFAULT
 	giveitem_std ITEM_DEVON_GOODS
 	closemessage
 	applymovement 255, RusturfTunnel_Movement_22D178
@@ -328,7 +328,7 @@ RusturfTunnel_EventScript_22D0C2:: @ 822D0C2
 	applymovement 255, RusturfTunnel_Movement_22D17E
 	applymovement 5, RusturfTunnel_Movement_22D1A4
 	waitmovement 0
-	msgbox RusturfTunnel_Text_22D395, 4
+	msgbox RusturfTunnel_Text_22D395, MSGBOX_DEFAULT
 	applymovement 5, RusturfTunnel_Movement_27259E
 	waitmovement 0
 	message RusturfTunnel_Text_22D3BA
@@ -427,7 +427,7 @@ RusturfTunnel_Movement_22D1A7: @ 822D1A7
 
 RusturfTunnel_EventScript_22D1B1:: @ 822D1B1
 	trainerbattle 0, TRAINER_MIKE_2, 0, RusturfTunnel_Text_22D84D, RusturfTunnel_Text_22D8DB
-	msgbox RusturfTunnel_Text_22D8F9, 6
+	msgbox RusturfTunnel_Text_22D8F9, MSGBOX_AUTOCLOSE
 	end
 
 RusturfTunnel_Text_22D1C8: @ 822D1C8

--- a/data/maps/SSTidalCorridor/scripts.inc
+++ b/data/maps/SSTidalCorridor/scripts.inc
@@ -15,7 +15,7 @@ SSTidalCorridor_EventScript_23BFFF:: @ 823BFFF
 	setvar VAR_PORTHOLE_STATE, 2
 	lockall
 	playse SE_PINPON
-	msgbox SSTidalCorridor_Text_23C462, 4
+	msgbox SSTidalCorridor_Text_23C462, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -23,7 +23,7 @@ SSTidalCorridor_EventScript_23C015:: @ 823C015
 	setvar VAR_PORTHOLE_STATE, 6
 	lockall
 	playse SE_PINPON
-	msgbox SSTidalCorridor_Text_23C4E3, 4
+	msgbox SSTidalCorridor_Text_23C4E3, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -31,14 +31,14 @@ SSTidalRooms_EventScript_23C028:: @ 823C028
 	special SetSSTidalFlag
 	setvar VAR_PORTHOLE_STATE, 7
 	playse SE_PINPON
-	msgbox SSTidalRooms_Text_23C462, 4
+	msgbox SSTidalRooms_Text_23C462, MSGBOX_DEFAULT
 	return
 
 SSTidalRooms_EventScript_23C03C:: @ 823C03C
 	special ResetSSTidalFlag
 	setvar VAR_PORTHOLE_STATE, 4
 	playse SE_PINPON
-	msgbox SSTidalRooms_Text_23C553, 4
+	msgbox SSTidalRooms_Text_23C553, MSGBOX_DEFAULT
 	return
 
 SSTidalCorridor_EventScript_23C050:: @ 823C050
@@ -53,7 +53,7 @@ SSTidalCorridor_EventScript_23C067:: @ 823C067
 	setvar VAR_PORTHOLE_STATE, 3
 	lockall
 	playse SE_PINPON
-	msgbox SSTidalCorridor_Text_23C4E3, 4
+	msgbox SSTidalCorridor_Text_23C4E3, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -62,7 +62,7 @@ SSTidalCorridor_EventScript_23C07D:: @ 823C07D
 	setvar VAR_PORTHOLE_STATE, 8
 	lockall
 	playse SE_PINPON
-	msgbox SSTidalCorridor_Text_23C50F, 4
+	msgbox SSTidalCorridor_Text_23C50F, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -70,7 +70,7 @@ SSTidalRooms_EventScript_23C093:: @ 823C093
 	special ResetSSTidalFlag
 	setvar VAR_PORTHOLE_STATE, 8
 	playse SE_PINPON
-	msgbox SSTidalRooms_Text_23C50F, 4
+	msgbox SSTidalRooms_Text_23C50F, MSGBOX_DEFAULT
 	return
 
 SSTidalRooms_EventScript_23C0A7:: @ 823C0A7
@@ -82,7 +82,7 @@ SSTidalRooms_EventScript_23C0A7:: @ 823C0A7
 	return
 
 SSTidalCorridor_EventScript_23C0D9:: @ 823C0D9
-	msgbox SSTidalCorridor_Text_23C6EC, 2
+	msgbox SSTidalCorridor_Text_23C6EC, MSGBOX_NPC
 	end
 
 SSTidalCorridor_EventScript_23C0E2:: @ 823C0E2
@@ -90,25 +90,25 @@ SSTidalCorridor_EventScript_23C0E2:: @ 823C0E2
 	faceplayer
 	waitse
 	playmoncry SPECIES_WINGULL, 0
-	msgbox SSTidalCorridor_Text_23C7E1, 4
+	msgbox SSTidalCorridor_Text_23C7E1, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
 
 SSTidalCorridor_EventScript_23C0F5:: @ 823C0F5
-	msgbox SSTidalCorridor_Text_23C7F8, 3
+	msgbox SSTidalCorridor_Text_23C7F8, MSGBOX_SIGN
 	end
 
 SSTidalCorridor_EventScript_23C0FE:: @ 823C0FE
-	msgbox SSTidalCorridor_Text_23C800, 3
+	msgbox SSTidalCorridor_Text_23C800, MSGBOX_SIGN
 	end
 
 SSTidalCorridor_EventScript_23C107:: @ 823C107
-	msgbox SSTidalCorridor_Text_23C808, 3
+	msgbox SSTidalCorridor_Text_23C808, MSGBOX_SIGN
 	end
 
 SSTidalCorridor_EventScript_23C110:: @ 823C110
-	msgbox SSTidalCorridor_Text_23C810, 3
+	msgbox SSTidalCorridor_Text_23C810, MSGBOX_SIGN
 	end
 
 SSTidalCorridor_EventScript_23C119:: @ 823C119
@@ -118,13 +118,13 @@ SSTidalCorridor_EventScript_23C119:: @ 823C119
 	goto_eq SSTidalCorridor_EventScript_23C13B
 	compare VAR_PORTHOLE_STATE, 8
 	goto_eq SSTidalCorridor_EventScript_23C15A
-	msgbox SSTidalCorridor_Text_23C596, 4
+	msgbox SSTidalCorridor_Text_23C596, MSGBOX_DEFAULT
 	release
 	end
 
 SSTidalCorridor_EventScript_23C13B:: @ 823C13B
 	setrespawn HEAL_LOCATION_LILYCOVE_CITY
-	msgbox SSTidalCorridor_Text_23C64F, 4
+	msgbox SSTidalCorridor_Text_23C64F, MSGBOX_DEFAULT
 	checkflag FLAG_0x104
 	call_if 1, SSTidalCorridor_EventScript_23C179
 	warp MAP_LILYCOVE_CITY_HARBOR, 255, 8, 11
@@ -134,7 +134,7 @@ SSTidalCorridor_EventScript_23C13B:: @ 823C13B
 
 SSTidalCorridor_EventScript_23C15A:: @ 823C15A
 	setrespawn HEAL_LOCATION_SLATEPORT_CITY
-	msgbox SSTidalCorridor_Text_23C64F, 4
+	msgbox SSTidalCorridor_Text_23C64F, MSGBOX_DEFAULT
 	checkflag FLAG_0x104
 	call_if 1, SSTidalCorridor_EventScript_23C179
 	warp MAP_SLATEPORT_CITY_HARBOR, 255, 8, 11
@@ -152,7 +152,7 @@ SSTidalCorridor_EventScript_23C17D:: @ 823C17D
 	goto_eq SSTidalCorridor_EventScript_23C19E
 	compare VAR_PORTHOLE_STATE, 7
 	goto_eq SSTidalCorridor_EventScript_23C19E
-	msgbox SSTidalCorridor_Text_23C6C3, 4
+	msgbox SSTidalCorridor_Text_23C6C3, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -167,12 +167,12 @@ SSTidalCorridor_EventScript_23C1A3:: @ 823C1A3
 	checkflag FLAG_0x0F7
 	goto_eq SSTidalCorridor_EventScript_23C1BD
 	call SSTidalCorridor_EventScript_23C1C7
-	msgbox SSTidalCorridor_Text_23C65E, 4
+	msgbox SSTidalCorridor_Text_23C65E, MSGBOX_DEFAULT
 	release
 	end
 
 SSTidalCorridor_EventScript_23C1BD:: @ 823C1BD
-	msgbox SSTidalCorridor_Text_23C6B0, 4
+	msgbox SSTidalCorridor_Text_23C6B0, MSGBOX_DEFAULT
 	release
 	end
 
@@ -206,7 +206,7 @@ SSTidalCorridor_EventScript_23C219:: @ 823C219
 	waitmovement 0
 	applymovement 255, SSTidalCorridor_Movement_2725A8
 	waitmovement 0
-	msgbox SSTidalCorridor_Text_23C28F, 4
+	msgbox SSTidalCorridor_Text_23C28F, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, SSTidalCorridor_Movement_23C27D
 	applymovement 1, SSTidalCorridor_Movement_23C284

--- a/data/maps/SSTidalLowerDeck/scripts.inc
+++ b/data/maps/SSTidalLowerDeck/scripts.inc
@@ -3,12 +3,12 @@ SSTidalLowerDeck_MapScripts:: @ 823C818
 
 SSTidalLowerDeck_EventScript_23C819:: @ 823C819
 	trainerbattle 0, TRAINER_PHILLIP, 0, SSTidalLowerDeck_Text_23C847, SSTidalLowerDeck_Text_23C8A0
-	msgbox SSTidalLowerDeck_Text_23C8B4, 6
+	msgbox SSTidalLowerDeck_Text_23C8B4, MSGBOX_AUTOCLOSE
 	end
 
 SSTidalLowerDeck_EventScript_23C830:: @ 823C830
 	trainerbattle 0, TRAINER_LEONARD, 0, SSTidalLowerDeck_Text_23C917, SSTidalLowerDeck_Text_23C97D
-	msgbox SSTidalLowerDeck_Text_23C98E, 6
+	msgbox SSTidalLowerDeck_Text_23C98E, MSGBOX_AUTOCLOSE
 	end
 
 SSTidalLowerDeck_Text_23C847: @ 823C847

--- a/data/maps/SSTidalRooms/scripts.inc
+++ b/data/maps/SSTidalRooms/scripts.inc
@@ -6,23 +6,23 @@ SSTidalRooms_EventScript_23C9F2:: @ 823C9F2
 	faceplayer
 	checkflag FLAG_0x104
 	goto_eq SSTidalRooms_EventScript_23CA29
-	msgbox SSTidalRooms_Text_23D098, 4
+	msgbox SSTidalRooms_Text_23D098, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM49
 	compare VAR_RESULT, 0
 	goto_eq SSTidalRooms_EventScript_272054
 	setflag FLAG_0x104
-	msgbox SSTidalRooms_Text_23D145, 4
+	msgbox SSTidalRooms_Text_23D145, MSGBOX_DEFAULT
 	release
 	end
 
 SSTidalRooms_EventScript_23CA29:: @ 823CA29
-	msgbox SSTidalRooms_Text_23D145, 4
+	msgbox SSTidalRooms_Text_23D145, MSGBOX_DEFAULT
 	release
 	end
 
 SSTidalRooms_EventScript_23CA33:: @ 823CA33
 	lockall
-	msgbox SSTidalRooms_Text_23CAF2, 4
+	msgbox SSTidalRooms_Text_23CAF2, MSGBOX_DEFAULT
 	closemessage
 	call SSTidalRooms_EventScript_272083
 	call SSTidalRooms_EventScript_23C0A7
@@ -31,37 +31,37 @@ SSTidalRooms_EventScript_23CA33:: @ 823CA33
 
 SSTidalRooms_EventScript_23CA49:: @ 823CA49
 	trainerbattle 0, TRAINER_COLTON, 0, SSTidalRooms_Text_23CB14, SSTidalRooms_Text_23CB58
-	msgbox SSTidalRooms_Text_23CB75, 6
+	msgbox SSTidalRooms_Text_23CB75, MSGBOX_AUTOCLOSE
 	end
 
 SSTidalRooms_EventScript_23CA60:: @ 823CA60
 	trainerbattle 0, TRAINER_MICAH, 0, SSTidalRooms_Text_23CBEB, SSTidalRooms_Text_23CC04
-	msgbox SSTidalRooms_Text_23CC26, 6
+	msgbox SSTidalRooms_Text_23CC26, MSGBOX_AUTOCLOSE
 	end
 
 SSTidalRooms_EventScript_23CA77:: @ 823CA77
 	trainerbattle 0, TRAINER_THOMAS, 0, SSTidalRooms_Text_23CC68, SSTidalRooms_Text_23CC8A
-	msgbox SSTidalRooms_Text_23CCBB, 6
+	msgbox SSTidalRooms_Text_23CCBB, MSGBOX_AUTOCLOSE
 	end
 
 SSTidalRooms_EventScript_23CA8E:: @ 823CA8E
 	trainerbattle 4, TRAINER_LEA_AND_JED, 0, SSTidalRooms_Text_23CD04, SSTidalRooms_Text_23CD54, SSTidalRooms_Text_23CDC6
-	msgbox SSTidalRooms_Text_23CD5F, 6
+	msgbox SSTidalRooms_Text_23CD5F, MSGBOX_AUTOCLOSE
 	end
 
 SSTidalRooms_EventScript_23CAA9:: @ 823CAA9
 	trainerbattle 4, TRAINER_LEA_AND_JED, 0, SSTidalRooms_Text_23CE04, SSTidalRooms_Text_23CE4B, SSTidalRooms_Text_23CEB0
-	msgbox SSTidalRooms_Text_23CE59, 6
+	msgbox SSTidalRooms_Text_23CE59, MSGBOX_AUTOCLOSE
 	end
 
 SSTidalRooms_EventScript_23CAC4:: @ 823CAC4
 	trainerbattle 0, TRAINER_GARRET, 0, SSTidalRooms_Text_23CEEE, SSTidalRooms_Text_23CF36
-	msgbox SSTidalRooms_Text_23CF45, 6
+	msgbox SSTidalRooms_Text_23CF45, MSGBOX_AUTOCLOSE
 	end
 
 SSTidalRooms_EventScript_23CADB:: @ 823CADB
 	trainerbattle 0, TRAINER_NAOMI, 0, SSTidalRooms_Text_23CF97, SSTidalRooms_Text_23CFF4
-	msgbox SSTidalRooms_Text_23D013, 6
+	msgbox SSTidalRooms_Text_23D013, MSGBOX_AUTOCLOSE
 	end
 
 SSTidalRooms_Text_23CAF2: @ 823CAF2

--- a/data/maps/SafariZone_North/scripts.inc
+++ b/data/maps/SafariZone_North/scripts.inc
@@ -2,10 +2,10 @@ SafariZone_North_MapScripts:: @ 823D253
 	.byte 0
 
 SafariZone_North_EventScript_23D254:: @ 823D254
-	msgbox SafariZone_North_Text_2A5489, 2
+	msgbox SafariZone_North_Text_2A5489, MSGBOX_NPC
 	end
 
 SafariZone_North_EventScript_23D25D:: @ 823D25D
-	msgbox SafariZone_North_Text_2A54F0, 2
+	msgbox SafariZone_North_Text_2A54F0, MSGBOX_NPC
 	end
 

--- a/data/maps/SafariZone_Northwest/scripts.inc
+++ b/data/maps/SafariZone_Northwest/scripts.inc
@@ -2,6 +2,6 @@ SafariZone_Northwest_MapScripts:: @ 823D249
 	.byte 0
 
 SafariZone_Northwest_EventScript_23D24A:: @ 823D24A
-	msgbox SafariZone_Northwest_Text_2A542C, 2
+	msgbox SafariZone_Northwest_Text_2A542C, MSGBOX_NPC
 	end
 

--- a/data/maps/SafariZone_RestHouse/scripts.inc
+++ b/data/maps/SafariZone_RestHouse/scripts.inc
@@ -2,14 +2,14 @@ SafariZone_RestHouse_MapScripts:: @ 8242BE6
 	.byte 0
 
 SafariZone_RestHouse_EventScript_242BE7:: @ 8242BE7
-	msgbox SafariZone_RestHouse_Text_2A5639, 2
+	msgbox SafariZone_RestHouse_Text_2A5639, MSGBOX_NPC
 	end
 
 SafariZone_RestHouse_EventScript_242BF0:: @ 8242BF0
-	msgbox SafariZone_RestHouse_Text_2A56E1, 2
+	msgbox SafariZone_RestHouse_Text_2A56E1, MSGBOX_NPC
 	end
 
 SafariZone_RestHouse_EventScript_242BF9:: @ 8242BF9
-	msgbox SafariZone_RestHouse_Text_2A5764, 2
+	msgbox SafariZone_RestHouse_Text_2A5764, MSGBOX_NPC
 	end
 

--- a/data/maps/SafariZone_South/scripts.inc
+++ b/data/maps/SafariZone_South/scripts.inc
@@ -37,15 +37,15 @@ SafariZone_South_Movement_23D2C7: @ 823D2C7
 	step_end
 
 SafariZone_South_EventScript_23D2CA:: @ 823D2CA
-	msgbox SafariZone_South_Text_2A52EF, 2
+	msgbox SafariZone_South_Text_2A52EF, MSGBOX_NPC
 	end
 
 SafariZone_South_EventScript_23D2D3:: @ 823D2D3
-	msgbox SafariZone_South_Text_2A533B, 2
+	msgbox SafariZone_South_Text_2A533B, MSGBOX_NPC
 	end
 
 SafariZone_South_EventScript_23D2DC:: @ 823D2DC
-	msgbox SafariZone_South_Text_2A553E, 2
+	msgbox SafariZone_South_Text_2A553E, MSGBOX_NPC
 	end
 
 SafariZone_South_EventScript_23D2E5:: @ 823D2E5
@@ -53,21 +53,21 @@ SafariZone_South_EventScript_23D2E5:: @ 823D2E5
 	faceplayer
 	checkflag FLAG_0x05D
 	goto_if 0, SafariZone_South_EventScript_23D30D
-	msgbox SafariZone_South_Text_2A51D4, 5
+	msgbox SafariZone_South_Text_2A51D4, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq SafariZone_South_EventScript_23D31A
-	msgbox SafariZone_South_Text_2A521A, 4
+	msgbox SafariZone_South_Text_2A521A, MSGBOX_DEFAULT
 	release
 	end
 
 SafariZone_South_EventScript_23D30D:: @ 823D30D
 	setflag FLAG_0x05D
-	msgbox SafariZone_South_Text_2A52AB, 4
+	msgbox SafariZone_South_Text_2A52AB, MSGBOX_DEFAULT
 	release
 	end
 
 SafariZone_South_EventScript_23D31A:: @ 823D31A
-	msgbox SafariZone_South_Text_2A5248, 4
+	msgbox SafariZone_South_Text_2A5248, MSGBOX_DEFAULT
 	closemessage
 	switch VAR_FACING
 	case 2, SafariZone_South_EventScript_23D33F
@@ -117,38 +117,38 @@ SafariZone_South_Movement_23D38D: @ 823D38D
 	step_end
 
 SafariZone_South_EventScript_23D390:: @ 823D390
-	msgbox SafariZone_South_Text_2A57EE, 2
+	msgbox SafariZone_South_Text_2A57EE, MSGBOX_NPC
 	end
 
 SafariZone_Southeast_EventScript_23D399:: @ 823D399
-	msgbox SafariZone_Southeast_Text_2A582D, 2
+	msgbox SafariZone_Southeast_Text_2A582D, MSGBOX_NPC
 	end
 
 SafariZone_South_EventScript_23D3A2:: @ 823D3A2
-	msgbox SafariZone_South_Text_2A5887, 2
+	msgbox SafariZone_South_Text_2A5887, MSGBOX_NPC
 	end
 
 SafariZone_Southeast_EventScript_23D3AB:: @ 823D3AB
-	msgbox SafariZone_Southeast_Text_2A58C6, 2
+	msgbox SafariZone_Southeast_Text_2A58C6, MSGBOX_NPC
 	end
 
 SafariZone_Southeast_EventScript_23D3B4:: @ 823D3B4
-	msgbox SafariZone_Southeast_Text_2A58FD, 2
+	msgbox SafariZone_Southeast_Text_2A58FD, MSGBOX_NPC
 	end
 
 SafariZone_Southeast_EventScript_23D3BD:: @ 823D3BD
-	msgbox SafariZone_Southeast_Text_2A5960, 2
+	msgbox SafariZone_Southeast_Text_2A5960, MSGBOX_NPC
 	end
 
 SafariZone_Northeast_EventScript_23D3C6:: @ 823D3C6
-	msgbox SafariZone_Northeast_Text_2A59A4, 2
+	msgbox SafariZone_Northeast_Text_2A59A4, MSGBOX_NPC
 	end
 
 SafariZone_Northeast_EventScript_23D3CF:: @ 823D3CF
-	msgbox SafariZone_Northeast_Text_2A5A09, 2
+	msgbox SafariZone_Northeast_Text_2A5A09, MSGBOX_NPC
 	end
 
 SafariZone_Northeast_EventScript_23D3D8:: @ 823D3D8
-	msgbox SafariZone_Northeast_Text_2A5A44, 2
+	msgbox SafariZone_Northeast_Text_2A5A44, MSGBOX_NPC
 	end
 

--- a/data/maps/SafariZone_Southwest/scripts.inc
+++ b/data/maps/SafariZone_Southwest/scripts.inc
@@ -2,10 +2,10 @@ SafariZone_Southwest_MapScripts:: @ 823D266
 	.byte 0
 
 SafariZone_Southwest_EventScript_23D267:: @ 823D267
-	msgbox SafariZone_Southwest_Text_2A53B7, 2
+	msgbox SafariZone_Southwest_Text_2A53B7, MSGBOX_NPC
 	end
 
 SafariZone_Southwest_EventScript_23D270:: @ 823D270
-	msgbox SafariZone_Southwest_Text_2A5613, 3
+	msgbox SafariZone_Southwest_Text_2A5613, MSGBOX_SIGN
 	end
 

--- a/data/maps/SeafloorCavern_Entrance/scripts.inc
+++ b/data/maps/SeafloorCavern_Entrance/scripts.inc
@@ -27,7 +27,7 @@ SeafloorCavern_Entrance_EventScript_234485:: @ 8234485
 	delay 30
 	setvar VAR_0x40D9, 1
 	moveobjectoffscreen 1
-	msgbox SeafloorCavern_Entrance_Text_234544, 4
+	msgbox SeafloorCavern_Entrance_Text_234544, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, SeafloorCavern_Entrance_Movement_2725A6
 	waitmovement 0
@@ -41,7 +41,7 @@ SeafloorCavern_Entrance_EventScript_2344ED:: @ 82344ED
 	call_if 1, SeafloorCavern_Entrance_EventScript_234523
 	compare VAR_FACING, 2
 	call_if 1, SeafloorCavern_Entrance_EventScript_234539
-	msgbox SeafloorCavern_Entrance_Text_2346C8, 4
+	msgbox SeafloorCavern_Entrance_Text_2346C8, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, SeafloorCavern_Entrance_Movement_2725A6
 	waitmovement 0

--- a/data/maps/SeafloorCavern_Room1/scripts.inc
+++ b/data/maps/SeafloorCavern_Room1/scripts.inc
@@ -3,12 +3,12 @@ SeafloorCavern_Room1_MapScripts:: @ 82347EB
 
 SeafloorCavern_Room1_EventScript_2347EC:: @ 82347EC
 	trainerbattle 0, TRAINER_GRUNT_5, 0, SeafloorCavern_Room1_Text_23481A, SeafloorCavern_Room1_Text_23484A
-	msgbox SeafloorCavern_Room1_Text_23485D, 6
+	msgbox SeafloorCavern_Room1_Text_23485D, MSGBOX_AUTOCLOSE
 	end
 
 SeafloorCavern_Room1_EventScript_234803:: @ 8234803
 	trainerbattle 0, TRAINER_GRUNT_6, 0, SeafloorCavern_Room1_Text_234898, SeafloorCavern_Room1_Text_2348CD
-	msgbox SeafloorCavern_Room1_Text_2348E3, 6
+	msgbox SeafloorCavern_Room1_Text_2348E3, MSGBOX_AUTOCLOSE
 	end
 
 SeafloorCavern_Room1_Text_23481A: @ 823481A

--- a/data/maps/SeafloorCavern_Room3/scripts.inc
+++ b/data/maps/SeafloorCavern_Room3/scripts.inc
@@ -3,12 +3,12 @@ SeafloorCavern_Room3_MapScripts:: @ 8234937
 
 SeafloorCavern_Room3_EventScript_234938:: @ 8234938
 	trainerbattle 0, TRAINER_SHELLY_2, 0, SeafloorCavern_Room3_Text_234966, SeafloorCavern_Room3_Text_234A79
-	msgbox SeafloorCavern_Room3_Text_234A8A, 6
+	msgbox SeafloorCavern_Room3_Text_234A8A, MSGBOX_AUTOCLOSE
 	end
 
 SeafloorCavern_Room3_EventScript_23494F:: @ 823494F
 	trainerbattle 0, TRAINER_GRUNT_27, 0, SeafloorCavern_Room3_Text_234B3A, SeafloorCavern_Room3_Text_234BFE
-	msgbox SeafloorCavern_Room3_Text_234C04, 6
+	msgbox SeafloorCavern_Room3_Text_234C04, MSGBOX_AUTOCLOSE
 	end
 
 SeafloorCavern_Room3_Text_234966: @ 8234966

--- a/data/maps/SeafloorCavern_Room4/scripts.inc
+++ b/data/maps/SeafloorCavern_Room4/scripts.inc
@@ -3,12 +3,12 @@ SeafloorCavern_Room4_MapScripts:: @ 8234C9B
 
 SeafloorCavern_Room4_EventScript_234C9C:: @ 8234C9C
 	trainerbattle 0, TRAINER_GRUNT_7, 0, SeafloorCavern_Room4_Text_234CCA, SeafloorCavern_Room4_Text_234CF3
-	msgbox SeafloorCavern_Room4_Text_234CFC, 6
+	msgbox SeafloorCavern_Room4_Text_234CFC, MSGBOX_AUTOCLOSE
 	end
 
 SeafloorCavern_Room4_EventScript_234CB3:: @ 8234CB3
 	trainerbattle 0, TRAINER_GRUNT_9, 0, SeafloorCavern_Room4_Text_234D3A, SeafloorCavern_Room4_Text_234D68
-	msgbox SeafloorCavern_Room4_Text_234D79, 6
+	msgbox SeafloorCavern_Room4_Text_234D79, MSGBOX_AUTOCLOSE
 	end
 
 SeafloorCavern_Room4_Text_234CCA: @ 8234CCA

--- a/data/maps/SeafloorCavern_Room9/scripts.inc
+++ b/data/maps/SeafloorCavern_Room9/scripts.inc
@@ -12,27 +12,27 @@ SeafloorCavern_Room9_EventScript_234DC9:: @ 8234DC9
 	applymovement 255, SeafloorCavern_Room9_Movement_23505C
 	waitmovement 0
 	playbgm MUS_AQA_0, 0
-	msgbox SeafloorCavern_Room9_Text_23505F, 4
+	msgbox SeafloorCavern_Room9_Text_23505F, MSGBOX_DEFAULT
 	closemessage
 	addobject VAR_0x8004
 	applymovement 255, SeafloorCavern_Room9_Movement_2725A4
 	waitmovement 0
 	applymovement VAR_0x8004, SeafloorCavern_Room9_Movement_23502A
 	waitmovement 0
-	msgbox SeafloorCavern_Room9_Text_23507C, 4
+	msgbox SeafloorCavern_Room9_Text_23507C, MSGBOX_DEFAULT
 	applymovement VAR_0x8004, SeafloorCavern_Room9_Movement_2725A6
 	waitmovement 0
-	msgbox SeafloorCavern_Room9_Text_2350A6, 4
+	msgbox SeafloorCavern_Room9_Text_2350A6, MSGBOX_DEFAULT
 	applymovement VAR_0x8004, SeafloorCavern_Room9_Movement_27259E
 	waitmovement 0
-	msgbox SeafloorCavern_Room9_Text_23512C, 4
+	msgbox SeafloorCavern_Room9_Text_23512C, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_ARCHIE, 0, SeafloorCavern_Room9_Text_2351BC
-	msgbox SeafloorCavern_Room9_Text_2351E5, 4
+	msgbox SeafloorCavern_Room9_Text_2351E5, MSGBOX_DEFAULT
 	setweather 0
 	doweather
 	special sub_80B05B4
 	waitstate
-	msgbox SeafloorCavern_Room9_Text_235279, 4
+	msgbox SeafloorCavern_Room9_Text_235279, MSGBOX_DEFAULT
 	special WaitWeather
 	waitstate
 	setvar VAR_RESULT, 1
@@ -80,21 +80,21 @@ SeafloorCavern_Room9_EventScript_234DC9:: @ 8234DC9
 	setvar VAR_0x8005, 3
 	setvar VAR_0x8006, 4
 	setvar VAR_0x8007, 5
-	msgbox SeafloorCavern_Room9_Text_2352A7, 4
+	msgbox SeafloorCavern_Room9_Text_2352A7, MSGBOX_DEFAULT
 	playse SE_PC_LOGIN
 	applymovement 255, SeafloorCavern_Room9_Movement_2725A4
 	waitmovement 0
-	msgbox SeafloorCavern_Room9_Text_2352F6, 4
+	msgbox SeafloorCavern_Room9_Text_2352F6, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_0x8004, SeafloorCavern_Room9_Movement_235035
 	waitmovement 0
-	msgbox SeafloorCavern_Room9_Text_23532B, 4
+	msgbox SeafloorCavern_Room9_Text_23532B, MSGBOX_DEFAULT
 	closemessage
 	playse SE_PC_OFF
 	delay 20
 	applymovement VAR_0x8004, SeafloorCavern_Room9_Movement_2725AA
 	waitmovement 0
-	msgbox SeafloorCavern_Room9_Text_23546F, 4
+	msgbox SeafloorCavern_Room9_Text_23546F, MSGBOX_DEFAULT
 	closemessage
 	addobject VAR_0x8005
 	addobject VAR_0x8006
@@ -105,19 +105,19 @@ SeafloorCavern_Room9_EventScript_234DC9:: @ 8234DC9
 	waitmovement 0
 	applymovement VAR_0x8004, SeafloorCavern_Room9_Movement_2725A4
 	waitmovement 0
-	msgbox SeafloorCavern_Room9_Text_2354F0, 4
+	msgbox SeafloorCavern_Room9_Text_2354F0, MSGBOX_DEFAULT
 	playse SE_PIN
 	applymovement VAR_0x8004, SeafloorCavern_Room9_Movement_272598
 	waitmovement 0
 	applymovement VAR_0x8004, SeafloorCavern_Room9_Movement_27259A
 	waitmovement 0
-	msgbox SeafloorCavern_Room9_Text_2355C2, 4
-	msgbox SeafloorCavern_Room9_Text_235692, 4
+	msgbox SeafloorCavern_Room9_Text_2355C2, MSGBOX_DEFAULT
+	msgbox SeafloorCavern_Room9_Text_235692, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_0x8005, SeafloorCavern_Room9_Movement_235054
 	applymovement VAR_0x8004, SeafloorCavern_Room9_Movement_23503A
 	waitmovement 0
-	msgbox SeafloorCavern_Room9_Text_235723, 4
+	msgbox SeafloorCavern_Room9_Text_235723, MSGBOX_DEFAULT
 	setvar VAR_0x407B, 1
 	setvar VAR_0x405E, 1
 	clearflag FLAG_HIDE_SOOTOPOLIS_CITY_STEVEN

--- a/data/maps/SealedChamber_InnerRoom/scripts.inc
+++ b/data/maps/SealedChamber_InnerRoom/scripts.inc
@@ -28,7 +28,7 @@ SealedChamber_InnerRoom_EventScript_2391F8:: @ 82391F8
 	waitstate
 	playse SE_DOOR
 	delay 40
-	msgbox gUnknown_0827301B, 4
+	msgbox gUnknown_0827301B, MSGBOX_DEFAULT
 	closemessage
 	fadeinbgm 0
 	setflag FLAG_0x0E4

--- a/data/maps/SealedChamber_OuterRoom/scripts.inc
+++ b/data/maps/SealedChamber_OuterRoom/scripts.inc
@@ -118,7 +118,7 @@ SealedChamber_OuterRoom_EventScript_2391D0:: @ 82391D0
 	end
 
 SealedChamber_OuterRoom_EventScript_2391E3:: @ 82391E3
-	msgbox gUnknown_0827304E, 4
+	msgbox gUnknown_0827304E, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/ShoalCave_LowTideEntranceRoom/scripts.inc
+++ b/data/maps/ShoalCave_LowTideEntranceRoom/scripts.inc
@@ -28,7 +28,7 @@ ShoalCave_LowTideEntranceRoom_EventScript_236DD9:: @ 8236DD9
 	checkitem ITEM_SHOAL_SHELL, 4
 	compare VAR_RESULT, 0
 	goto_eq ShoalCave_LowTideEntranceRoom_EventScript_236E9B
-	msgbox ShoalCave_LowTideEntranceRoom_Text_2A7F37, 5
+	msgbox ShoalCave_LowTideEntranceRoom_Text_2A7F37, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq ShoalCave_LowTideEntranceRoom_EventScript_236ECF
 	checkitemspace ITEM_SHELL_BELL, 1
@@ -36,13 +36,13 @@ ShoalCave_LowTideEntranceRoom_EventScript_236DD9:: @ 8236DD9
 	call_if 1, ShoalCave_LowTideEntranceRoom_EventScript_236E69
 	compare VAR_RESULT, 2
 	goto_eq ShoalCave_LowTideEntranceRoom_EventScript_236E91
-	msgbox ShoalCave_LowTideEntranceRoom_Text_2A7FAC, 4
+	msgbox ShoalCave_LowTideEntranceRoom_Text_2A7FAC, MSGBOX_DEFAULT
 	takeitem ITEM_SHOAL_SALT, 4
 	takeitem ITEM_SHOAL_SHELL, 4
 	giveitem_std ITEM_SHELL_BELL
 	compare VAR_RESULT, 0
 	goto_eq ShoalCave_LowTideEntranceRoom_EventScript_272054
-	msgbox ShoalCave_LowTideEntranceRoom_Text_2A8012, 4
+	msgbox ShoalCave_LowTideEntranceRoom_Text_2A8012, MSGBOX_DEFAULT
 	setflag FLAG_TEMP_2
 	release
 	end
@@ -64,7 +64,7 @@ ShoalCave_LowTideEntranceRoom_EventScript_236E8B:: @ 8236E8B
 	return
 
 ShoalCave_LowTideEntranceRoom_EventScript_236E91:: @ 8236E91
-	msgbox ShoalCave_LowTideEntranceRoom_Text_2A80F5, 4
+	msgbox ShoalCave_LowTideEntranceRoom_Text_2A80F5, MSGBOX_DEFAULT
 	release
 	end
 
@@ -75,17 +75,17 @@ ShoalCave_LowTideEntranceRoom_EventScript_236E9B:: @ 8236E9B
 	checkitem ITEM_SHOAL_SHELL, 1
 	compare VAR_RESULT, 1
 	goto_eq ShoalCave_LowTideEntranceRoom_EventScript_236EC5
-	msgbox ShoalCave_LowTideEntranceRoom_Text_2A7E0E, 4
+	msgbox ShoalCave_LowTideEntranceRoom_Text_2A7E0E, MSGBOX_DEFAULT
 	release
 	end
 
 ShoalCave_LowTideEntranceRoom_EventScript_236EC5:: @ 8236EC5
-	msgbox ShoalCave_LowTideEntranceRoom_Text_2A7EB3, 4
+	msgbox ShoalCave_LowTideEntranceRoom_Text_2A7EB3, MSGBOX_DEFAULT
 	release
 	end
 
 ShoalCave_LowTideEntranceRoom_EventScript_236ECF:: @ 8236ECF
-	msgbox ShoalCave_LowTideEntranceRoom_Text_2A80C6, 4
+	msgbox ShoalCave_LowTideEntranceRoom_Text_2A80C6, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/ShoalCave_LowTideInnerRoom/scripts.inc
+++ b/data/maps/ShoalCave_LowTideInnerRoom/scripts.inc
@@ -82,7 +82,7 @@ ShoalCave_LowTideInnerRoom_EventScript_236FBA:: @ 8236FBA
 	end
 
 ShoalCave_LowTideInnerRoom_EventScript_236FEC:: @ 8236FEC
-	msgbox ShoalCave_LowTideInnerRoom_Text_2A81A8, 4
+	msgbox ShoalCave_LowTideInnerRoom_Text_2A81A8, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -139,7 +139,7 @@ ShoalCave_LowTideInnerRoom_EventScript_23708C:: @ 823708C
 	end
 
 ShoalCave_LowTideInnerRoom_EventScript_2370BE:: @ 82370BE
-	msgbox ShoalCave_LowTideInnerRoom_Text_2A8169, 4
+	msgbox ShoalCave_LowTideInnerRoom_Text_2A8169, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/ShoalCave_LowTideLowerRoom/scripts.inc
+++ b/data/maps/ShoalCave_LowTideLowerRoom/scripts.inc
@@ -29,7 +29,7 @@ ShoalCave_LowTideLowerRoom_EventScript_237176:: @ 8237176
 	end
 
 ShoalCave_LowTideLowerRoom_EventScript_2371A8:: @ 82371A8
-	msgbox ShoalCave_LowTideLowerRoom_Text_2A8169, 4
+	msgbox ShoalCave_LowTideLowerRoom_Text_2A8169, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -38,7 +38,7 @@ ShoalCave_LowTideLowerRoom_EventScript_2371B2:: @ 82371B2
 	faceplayer
 	checkflag FLAG_0x11B
 	goto_eq ShoalCave_LowTideLowerRoom_EventScript_2371E1
-	msgbox ShoalCave_LowTideLowerRoom_Text_2371EB, 4
+	msgbox ShoalCave_LowTideLowerRoom_Text_2371EB, MSGBOX_DEFAULT
 	giveitem_std ITEM_FOCUS_BAND
 	compare VAR_RESULT, 0
 	goto_eq ShoalCave_LowTideLowerRoom_EventScript_272054
@@ -47,7 +47,7 @@ ShoalCave_LowTideLowerRoom_EventScript_2371B2:: @ 82371B2
 	end
 
 ShoalCave_LowTideLowerRoom_EventScript_2371E1:: @ 82371E1
-	msgbox ShoalCave_LowTideLowerRoom_Text_23728D, 4
+	msgbox ShoalCave_LowTideLowerRoom_Text_23728D, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/ShoalCave_LowTideStairsRoom/scripts.inc
+++ b/data/maps/ShoalCave_LowTideStairsRoom/scripts.inc
@@ -29,7 +29,7 @@ ShoalCave_LowTideStairsRoom_EventScript_23711A:: @ 823711A
 	end
 
 ShoalCave_LowTideStairsRoom_EventScript_23714C:: @ 823714C
-	msgbox ShoalCave_LowTideStairsRoom_Text_2A8169, 4
+	msgbox ShoalCave_LowTideStairsRoom_Text_2A8169, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/SkyPillar_Outside/scripts.inc
+++ b/data/maps/SkyPillar_Outside/scripts.inc
@@ -40,7 +40,7 @@ SkyPillar_Outside_EventScript_239304:: @ 8239304
 	waitmovement 0
 	applymovement 255, SkyPillar_Outside_Movement_2725A4
 	waitmovement 0
-	msgbox SkyPillar_Outside_Text_239416, 4
+	msgbox SkyPillar_Outside_Text_239416, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	setvar VAR_0x8004, 1
@@ -50,7 +50,7 @@ SkyPillar_Outside_EventScript_239304:: @ 8239304
 	special sub_8139560
 	waitstate
 	delay 40
-	msgbox SkyPillar_Outside_Text_2394BC, 4
+	msgbox SkyPillar_Outside_Text_2394BC, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, SkyPillar_Outside_Movement_2393EB
 	applymovement 1, SkyPillar_Outside_Movement_2393DE
@@ -71,7 +71,7 @@ SkyPillar_Outside_EventScript_239304:: @ 8239304
 	applymovement 1, SkyPillar_Outside_Movement_2725AA
 	waitmovement 0
 	delay 30
-	msgbox SkyPillar_Outside_Text_23950C, 4
+	msgbox SkyPillar_Outside_Text_23950C, MSGBOX_DEFAULT
 	closemessage
 	setflag FLAG_SYS_WEATHER_CTRL
 	setweather 15
@@ -79,7 +79,7 @@ SkyPillar_Outside_EventScript_239304:: @ 8239304
 	special WaitWeather
 	waitstate
 	delay 30
-	msgbox SkyPillar_Outside_Text_23953A, 4
+	msgbox SkyPillar_Outside_Text_23953A, MSGBOX_DEFAULT
 	closemessage
 	playse SE_KAIDAN
 	fadescreenswapbuffers 1
@@ -138,7 +138,7 @@ SkyPillar_Outside_EventScript_2393F8:: @ 82393F8
 	end
 
 SkyPillar_Outside_EventScript_2393F9:: @ 82393F9
-	msgbox SkyPillar_Outside_Text_239402, 3
+	msgbox SkyPillar_Outside_Text_239402, MSGBOX_SIGN
 	end
 
 SkyPillar_Outside_Text_239402: @ 8239402

--- a/data/maps/SkyPillar_Top/scripts.inc
+++ b/data/maps/SkyPillar_Top/scripts.inc
@@ -89,7 +89,7 @@ SkyPillar_Top_EventScript_239785:: @ 8239785
 	removeobject VAR_LAST_TALKED
 	fadescreenswapbuffers 0
 	bufferspeciesname 0, VAR_0x8004
-	msgbox gUnknown_08273204, 4
+	msgbox gUnknown_08273204, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -124,7 +124,7 @@ SkyPillar_Top_EventScript_23979A:: @ 823979A
 	applymovement 1, SkyPillar_Top_Movement_23984B
 	waitmovement 0
 	removeobject 1
-	msgbox SkyPillar_Top_Text_239860, 4
+	msgbox SkyPillar_Top_Text_239860, MSGBOX_DEFAULT
 	closemessage
 	delay 20
 	fadeinbgm 1

--- a/data/maps/SlateportCity/scripts.inc
+++ b/data/maps/SlateportCity/scripts.inc
@@ -59,24 +59,24 @@ SlateportCity_EventScript_1DCD1C:: @ 81DCD1C
 	applymovement 255, SlateportCity_Movement_1DCDA8
 	applymovement 35, SlateportCity_Movement_1DCDAC
 	waitmovement 0
-	msgbox SlateportCity_Text_1DF032, 4
+	msgbox SlateportCity_Text_1DF032, MSGBOX_DEFAULT
 	closemessage
 	applymovement 35, SlateportCity_Movement_2725A4
 	waitmovement 0
 	delay 60
-	msgbox SlateportCity_Text_1DF0FE, 4
+	msgbox SlateportCity_Text_1DF0FE, MSGBOX_DEFAULT
 	applymovement 35, SlateportCity_Movement_2725A8
 	waitmovement 0
-	msgbox SlateportCity_Text_1DF12B, 4
+	msgbox SlateportCity_Text_1DF12B, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox SlateportCity_Text_1DF1A6, 4
+	msgbox SlateportCity_Text_1DF1A6, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
 	setflag FLAG_0x0D7
-	msgbox SlateportCity_Text_1DF1D3, 4
+	msgbox SlateportCity_Text_1DF1D3, MSGBOX_DEFAULT
 	closemessage
 	applymovement 35, SlateportCity_Movement_1DCDB4
 	waitmovement 0
@@ -122,7 +122,7 @@ SlateportCity_EventScript_1DCDBD:: @ 81DCDBD
 	message SlateportCity_Text_1DD64A
 	waitmessage
 	pokemart SlateportCity_Pokemart_1DCDD4
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -141,29 +141,29 @@ SlateportCity_EventScript_1DCDE4:: @ 81DCDE4
 	lock
 	faceplayer
 	bufferleadmonspeciesname 0
-	msgbox SlateportCity_Text_1DD68A, 4
+	msgbox SlateportCity_Text_1DD68A, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, LeadMonHasEffortRibbon
 	compare VAR_RESULT, 1
 	call_if 1, SlateportCity_EventScript_1DCE38
 	specialvar VAR_RESULT, Special_AreLeadMonEVsMaxedOut
 	compare VAR_RESULT, 0
 	call_if 1, SlateportCity_EventScript_1DCE2E
-	msgbox SlateportCity_Text_1DD697, 4
+	msgbox SlateportCity_Text_1DD697, MSGBOX_DEFAULT
 	playfanfare MUS_FANFA4
 	message SlateportCity_Text_1DD6E3
 	waitfanfare
-	msgbox SlateportCity_Text_1DD702, 4
+	msgbox SlateportCity_Text_1DD702, MSGBOX_DEFAULT
 	special GiveLeadMonEffortRibbon
 	release
 	end
 
 SlateportCity_EventScript_1DCE2E:: @ 81DCE2E
-	msgbox SlateportCity_Text_1DD722, 4
+	msgbox SlateportCity_Text_1DD722, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_EventScript_1DCE38:: @ 81DCE38
-	msgbox SlateportCity_Text_1DD77B, 4
+	msgbox SlateportCity_Text_1DD77B, MSGBOX_DEFAULT
 	release
 	end
 
@@ -172,12 +172,12 @@ SlateportCity_EventScript_1DCE42:: @ 81DCE42
 	faceplayer
 	compare VAR_0x4058, 1
 	call_if 1, SlateportCity_EventScript_1DCE59
-	msgbox SlateportCity_Text_1DD81A, 4
+	msgbox SlateportCity_Text_1DD81A, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_EventScript_1DCE59:: @ 81DCE59
-	msgbox SlateportCity_Text_1DE3E2, 4
+	msgbox SlateportCity_Text_1DE3E2, MSGBOX_DEFAULT
 	release
 	end
 
@@ -186,12 +186,12 @@ SlateportCity_EventScript_1DCE63:: @ 81DCE63
 	faceplayer
 	compare VAR_0x4058, 1
 	call_if 1, SlateportCity_EventScript_1DCE7A
-	msgbox SlateportCity_Text_1DD8A6, 4
+	msgbox SlateportCity_Text_1DD8A6, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_EventScript_1DCE7A:: @ 81DCE7A
-	msgbox SlateportCity_Text_1DE28E, 4
+	msgbox SlateportCity_Text_1DE28E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -202,17 +202,17 @@ SlateportCity_EventScript_1DCE84:: @ 81DCE84
 	call_if 1, SlateportCity_EventScript_1DCEA4
 	checkflag FLAG_0x060
 	goto_eq SlateportCity_EventScript_1DCEAE
-	msgbox SlateportCity_Text_1DD93D, 4
+	msgbox SlateportCity_Text_1DD93D, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_EventScript_1DCEA4:: @ 81DCEA4
-	msgbox SlateportCity_Text_1DE30C, 4
+	msgbox SlateportCity_Text_1DE30C, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_EventScript_1DCEAE:: @ 81DCEAE
-	msgbox SlateportCity_Text_1DD999, 4
+	msgbox SlateportCity_Text_1DD999, MSGBOX_DEFAULT
 	release
 	end
 
@@ -221,23 +221,23 @@ SlateportCity_EventScript_1DCEB8:: @ 81DCEB8
 	faceplayer
 	compare VAR_0x4058, 1
 	call_if 1, SlateportCity_EventScript_1DCECF
-	msgbox SlateportCity_Text_1DDA34, 4
+	msgbox SlateportCity_Text_1DDA34, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_EventScript_1DCECF:: @ 81DCECF
-	msgbox SlateportCity_Text_1DE376, 4
+	msgbox SlateportCity_Text_1DE376, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_EventScript_1DCED9:: @ 81DCED9
 	compare VAR_0x4058, 1
 	goto_eq SlateportCity_EventScript_1DCEED
-	msgbox SlateportCity_Text_1DDA9A, 2
+	msgbox SlateportCity_Text_1DDA9A, MSGBOX_NPC
 	end
 
 SlateportCity_EventScript_1DCEED:: @ 81DCEED
-	msgbox SlateportCity_Text_1DE43D, 3
+	msgbox SlateportCity_Text_1DE43D, MSGBOX_SIGN
 	end
 
 SlateportCity_EventScript_1DCEF6:: @ 81DCEF6
@@ -245,12 +245,12 @@ SlateportCity_EventScript_1DCEF6:: @ 81DCEF6
 	faceplayer
 	compare VAR_0x4058, 1
 	call_if 1, SlateportCity_EventScript_1DCF0D
-	msgbox SlateportCity_Text_1DDB21, 4
+	msgbox SlateportCity_Text_1DDB21, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_EventScript_1DCF0D:: @ 81DCF0D
-	msgbox SlateportCity_Text_1DE460, 4
+	msgbox SlateportCity_Text_1DE460, MSGBOX_DEFAULT
 	release
 	end
 
@@ -259,17 +259,17 @@ SlateportCity_EventScript_1DCF17:: @ 81DCF17
 	faceplayer
 	checkflag FLAG_0x094
 	goto_eq SlateportCity_EventScript_1DCF2C
-	msgbox SlateportCity_Text_1DDBAC, 4
+	msgbox SlateportCity_Text_1DDBAC, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_EventScript_1DCF2C:: @ 81DCF2C
-	msgbox SlateportCity_Text_1DDBD5, 4
+	msgbox SlateportCity_Text_1DDBD5, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_EventScript_1DCF36:: @ 81DCF36
-	msgbox SlateportCity_Text_1DE8BC, 3
+	msgbox SlateportCity_Text_1DE8BC, MSGBOX_SIGN
 	end
 
 SlateportCity_EventScript_1DCF3F:: @ 81DCF3F
@@ -278,51 +278,51 @@ SlateportCity_EventScript_1DCF3F:: @ 81DCF3F
 	goto_eq SlateportCity_EventScript_1DCF66
 	checkflag FLAG_BADGE07_GET
 	goto_eq SlateportCity_EventScript_1DCF5C
-	msgbox SlateportCity_Text_1DE8F8, 4
+	msgbox SlateportCity_Text_1DE8F8, MSGBOX_DEFAULT
 	releaseall
 	end
 
 SlateportCity_EventScript_1DCF5C:: @ 81DCF5C
-	msgbox SlateportCity_Text_1DE940, 4
+	msgbox SlateportCity_Text_1DE940, MSGBOX_DEFAULT
 	releaseall
 	end
 
 SlateportCity_EventScript_1DCF66:: @ 81DCF66
-	msgbox SlateportCity_Text_1DE9AA, 4
+	msgbox SlateportCity_Text_1DE9AA, MSGBOX_DEFAULT
 	releaseall
 	end
 
 SlateportCity_EventScript_1DCF70:: @ 81DCF70
-	msgbox SlateportCity_Text_1DEA0B, 3
+	msgbox SlateportCity_Text_1DEA0B, MSGBOX_SIGN
 	end
 
 SlateportCity_EventScript_1DCF79:: @ 81DCF79
-	msgbox SlateportCity_Text_1DEA3B, 3
+	msgbox SlateportCity_Text_1DEA3B, MSGBOX_SIGN
 	end
 
 SlateportCity_EventScript_1DCF82:: @ 81DCF82
-	msgbox SlateportCity_Text_1DEA6F, 3
+	msgbox SlateportCity_Text_1DEA6F, MSGBOX_SIGN
 	end
 
 SlateportCity_EventScript_1DCF8B:: @ 81DCF8B
-	msgbox SlateportCity_Text_1DEAAF, 3
+	msgbox SlateportCity_Text_1DEAAF, MSGBOX_SIGN
 	end
 
 SlateportCity_EventScript_1DCF94:: @ 81DCF94
 	lockall
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_eq SlateportCity_EventScript_1DCFA8
-	msgbox SlateportCity_Text_1DEAE3, 4
+	msgbox SlateportCity_Text_1DEAE3, MSGBOX_DEFAULT
 	releaseall
 	end
 
 SlateportCity_EventScript_1DCFA8:: @ 81DCFA8
-	msgbox SlateportCity_Text_1DEB5A, 4
+	msgbox SlateportCity_Text_1DEB5A, MSGBOX_DEFAULT
 	releaseall
 	end
 
 SlateportCity_EventScript_1DCFB2:: @ 81DCFB2
-	msgbox SlateportCity_Text_1DEBA0, 3
+	msgbox SlateportCity_Text_1DEBA0, MSGBOX_SIGN
 	end
 
 SlateportCity_EventScript_1DCFBB:: @ 81DCFBB
@@ -330,39 +330,39 @@ SlateportCity_EventScript_1DCFBB:: @ 81DCFBB
 	faceplayer
 	compare VAR_0x4058, 1
 	call_if 1, SlateportCity_EventScript_1DCFD2
-	msgbox SlateportCity_Text_1DE10E, 4
+	msgbox SlateportCity_Text_1DE10E, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_EventScript_1DCFD2:: @ 81DCFD2
-	msgbox SlateportCity_Text_1DE10E, 4
+	msgbox SlateportCity_Text_1DE10E, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_EventScript_1DCFDC:: @ 81DCFDC
-	msgbox SlateportCity_Text_1DE16C, 2
+	msgbox SlateportCity_Text_1DE16C, MSGBOX_NPC
 	end
 
 SlateportCity_EventScript_1DCFE5:: @ 81DCFE5
-	msgbox SlateportCity_Text_1DDFF7, 2
+	msgbox SlateportCity_Text_1DDFF7, MSGBOX_NPC
 	end
 
 SlateportCity_EventScript_1DCFEE:: @ 81DCFEE
-	msgbox SlateportCity_Text_1DE04B, 2
+	msgbox SlateportCity_Text_1DE04B, MSGBOX_NPC
 	end
 
 SlateportCity_EventScript_1DCFF7:: @ 81DCFF7
-	msgbox SlateportCity_Text_1DE0D2, 2
+	msgbox SlateportCity_Text_1DE0D2, MSGBOX_NPC
 	end
 
 SlateportCity_EventScript_1DD000:: @ 81DD000
-	msgbox SlateportCity_Text_1DE1EC, 2
+	msgbox SlateportCity_Text_1DE1EC, MSGBOX_NPC
 	end
 
 SlateportCity_EventScript_1DD009:: @ 81DD009
 	lock
 	faceplayer
-	msgbox SlateportCity_Text_1DDC4F, 4
+	msgbox SlateportCity_Text_1DDC4F, MSGBOX_DEFAULT
 	closemessage
 	applymovement 5, SlateportCity_Movement_2725A2
 	waitmovement 0
@@ -372,7 +372,7 @@ SlateportCity_EventScript_1DD009:: @ 81DD009
 SlateportCity_EventScript_1DD020:: @ 81DD020
 	lock
 	faceplayer
-	msgbox SlateportCity_Text_1DDC8A, 4
+	msgbox SlateportCity_Text_1DDC8A, MSGBOX_DEFAULT
 	closemessage
 	applymovement 18, SlateportCity_Movement_2725A2
 	waitmovement 0
@@ -382,7 +382,7 @@ SlateportCity_EventScript_1DD020:: @ 81DD020
 SlateportCity_EventScript_1DD037:: @ 81DD037
 	lock
 	faceplayer
-	msgbox SlateportCity_Text_1DDCD5, 4
+	msgbox SlateportCity_Text_1DDCD5, MSGBOX_DEFAULT
 	closemessage
 	applymovement 19, SlateportCity_Movement_2725A2
 	waitmovement 0
@@ -392,7 +392,7 @@ SlateportCity_EventScript_1DD037:: @ 81DD037
 SlateportCity_EventScript_1DD04E:: @ 81DD04E
 	lock
 	faceplayer
-	msgbox SlateportCity_Text_1DDD18, 4
+	msgbox SlateportCity_Text_1DDD18, MSGBOX_DEFAULT
 	closemessage
 	applymovement 26, SlateportCity_Movement_2725A2
 	waitmovement 0
@@ -402,7 +402,7 @@ SlateportCity_EventScript_1DD04E:: @ 81DD04E
 SlateportCity_EventScript_1DD065:: @ 81DD065
 	lock
 	faceplayer
-	msgbox SlateportCity_Text_1DDD7D, 4
+	msgbox SlateportCity_Text_1DDD7D, MSGBOX_DEFAULT
 	closemessage
 	applymovement 27, SlateportCity_Movement_2725A2
 	waitmovement 0
@@ -412,7 +412,7 @@ SlateportCity_EventScript_1DD065:: @ 81DD065
 SlateportCity_EventScript_1DD07C:: @ 81DD07C
 	lock
 	faceplayer
-	msgbox SlateportCity_Text_1DDDC0, 4
+	msgbox SlateportCity_Text_1DDDC0, MSGBOX_DEFAULT
 	closemessage
 	applymovement 28, SlateportCity_Movement_2725A2
 	waitmovement 0
@@ -422,7 +422,7 @@ SlateportCity_EventScript_1DD07C:: @ 81DD07C
 SlateportCity_EventScript_1DD093:: @ 81DD093
 	lock
 	faceplayer
-	msgbox SlateportCity_Text_1DDDDF, 4
+	msgbox SlateportCity_Text_1DDDDF, MSGBOX_DEFAULT
 	closemessage
 	applymovement 29, SlateportCity_Movement_2725A2
 	waitmovement 0
@@ -432,7 +432,7 @@ SlateportCity_EventScript_1DD093:: @ 81DD093
 SlateportCity_EventScript_1DD0AA:: @ 81DD0AA
 	lock
 	faceplayer
-	msgbox SlateportCity_Text_1DDE2F, 4
+	msgbox SlateportCity_Text_1DDE2F, MSGBOX_DEFAULT
 	closemessage
 	applymovement 30, SlateportCity_Movement_2725A2
 	waitmovement 0
@@ -447,7 +447,7 @@ SlateportCity_EventScript_1DD0C1:: @ 81DD0C1
 	waitmovement 0
 	applymovement 31, SlateportCity_Movement_27259A
 	waitmovement 0
-	msgbox SlateportCity_Text_1DDE6E, 4
+	msgbox SlateportCity_Text_1DDE6E, MSGBOX_DEFAULT
 	closemessage
 	applymovement 31, SlateportCity_Movement_2725A2
 	waitmovement 0
@@ -455,13 +455,13 @@ SlateportCity_EventScript_1DD0C1:: @ 81DD0C1
 	waitmovement 0
 	applymovement 31, SlateportCity_Movement_27259E
 	waitmovement 0
-	msgbox SlateportCity_Text_1DDE86, 4
+	msgbox SlateportCity_Text_1DDE86, MSGBOX_DEFAULT
 	closemessage
 	applymovement 31, SlateportCity_Movement_2725A2
 	waitmovement 0
 	applymovement 31, SlateportCity_Movement_1DD147
 	waitmovement 0
-	msgbox SlateportCity_Text_1DDEB8, 4
+	msgbox SlateportCity_Text_1DDEB8, MSGBOX_DEFAULT
 	closemessage
 	applymovement 31, SlateportCity_Movement_27259E
 	waitmovement 0
@@ -478,13 +478,13 @@ SlateportCity_Movement_1DD147: @ 81DD147
 	step_end
 
 SlateportCity_EventScript_1DD14A:: @ 81DD14A
-	msgbox SlateportCity_Text_1DDF32, 3
+	msgbox SlateportCity_Text_1DDF32, MSGBOX_SIGN
 	end
 
 SlateportCity_EventScript_1DD153:: @ 81DD153
 	lock
 	faceplayer
-	msgbox SlateportCity_Text_1DDF8D, 4
+	msgbox SlateportCity_Text_1DDF8D, MSGBOX_DEFAULT
 	closemessage
 	applymovement 33, SlateportCity_Movement_2725A2
 	waitmovement 0
@@ -497,7 +497,7 @@ SlateportCity_EventScript_1DD16A:: @ 81DD16A
 	message gUnknown_08272A21
 	waitmessage
 	pokemartdecoration SlateportCity_PokemartDecor_1DD184
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -511,7 +511,7 @@ SlateportCity_PokemartDecor_1DD184: @ 81DD184
 	end
 
 SlateportCity_EventScript_1DD18E:: @ 81DD18E
-	msgbox gUnknown_08272E30, 4
+	msgbox gUnknown_08272E30, MSGBOX_DEFAULT
 	release
 	end
 
@@ -523,7 +523,7 @@ SlateportCity_EventScript_1DD198:: @ 81DD198
 	message gUnknown_08272A21
 	waitmessage
 	pokemartdecoration SlateportCity_PokemartDecor_1DD1B8
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -552,7 +552,7 @@ SlateportCity_EventScript_1DD1D8:: @ 81DD1D8
 	message gUnknown_08272A21
 	waitmessage
 	pokemart SlateportCity_Pokemart_1DD1F0
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -566,8 +566,8 @@ SlateportCity_Pokemart_1DD1F0: @ 81DD1F0
 
 SlateportCity_EventScript_1DD1F8:: @ 81DD1F8
 	lockall
-	msgbox SlateportCity_Text_1DE502, 4
-	msgbox SlateportCity_Text_1DE54A, 4
+	msgbox SlateportCity_Text_1DE502, MSGBOX_DEFAULT
+	msgbox SlateportCity_Text_1DE54A, MSGBOX_DEFAULT
 	closemessage
 	applymovement 10, SlateportCity_Movement_2725A8
 	waitmovement 0
@@ -582,12 +582,12 @@ SlateportCity_EventScript_1DD1F8:: @ 81DD1F8
 	waitmovement 0
 	removeobject 10
 	removeobject 9
-	msgbox SlateportCity_Text_1DE5F7, 4
+	msgbox SlateportCity_Text_1DE5F7, MSGBOX_DEFAULT
 	applymovement 11, SlateportCity_Movement_2725A6
 	waitmovement 0
-	msgbox SlateportCity_Text_1DE64F, 4
+	msgbox SlateportCity_Text_1DE64F, MSGBOX_DEFAULT
 	playbgm MUS_AQA_0, 0
-	msgbox SlateportCity_Text_1DE724, 4
+	msgbox SlateportCity_Text_1DE724, MSGBOX_DEFAULT
 	applymovement 6, SlateportCity_Movement_2725A4
 	applymovement 1, SlateportCity_Movement_2725A4
 	applymovement 7, SlateportCity_Movement_1DD309
@@ -596,7 +596,7 @@ SlateportCity_EventScript_1DD1F8:: @ 81DD1F8
 	waitmovement 0
 	applymovement 11, SlateportCity_Movement_2725AA
 	waitmovement 0
-	msgbox SlateportCity_Text_1DE7F7, 4
+	msgbox SlateportCity_Text_1DE7F7, MSGBOX_DEFAULT
 	playse SE_PIN
 	applymovement 11, SlateportCity_Movement_272598
 	waitmovement 0
@@ -604,8 +604,8 @@ SlateportCity_EventScript_1DD1F8:: @ 81DD1F8
 	waitmovement 0
 	applymovement 11, SlateportCity_Movement_2725A6
 	waitmovement 0
-	msgbox SlateportCity_Text_1DE860, 4
-	msgbox SlateportCity_Text_1DE8A0, 4
+	msgbox SlateportCity_Text_1DE860, MSGBOX_DEFAULT
+	msgbox SlateportCity_Text_1DE8A0, MSGBOX_DEFAULT
 	closemessage
 	applymovement 11, SlateportCity_Movement_1DD337
 	applymovement 255, SlateportCity_Movement_1DD344
@@ -714,15 +714,15 @@ SlateportCity_Movement_1DD34A: @ 81DD34A
 	step_end
 
 SlateportCity_EventScript_1DD353:: @ 81DD353
-	msgbox SlateportCity_Text_1DE491, 3
+	msgbox SlateportCity_Text_1DE491, MSGBOX_SIGN
 	end
 
 SlateportCity_EventScript_1DD35C:: @ 81DD35C
-	msgbox SlateportCity_Text_1DE4C4, 3
+	msgbox SlateportCity_Text_1DE4C4, MSGBOX_SIGN
 	end
 
 SlateportCity_EventScript_1DD365:: @ 81DD365
-	msgbox SlateportCity_Text_1DD7AD, 2
+	msgbox SlateportCity_Text_1DD7AD, MSGBOX_NPC
 	end
 
 SlateportCity_EventScript_1DD36E:: @ 81DD36E
@@ -730,10 +730,10 @@ SlateportCity_EventScript_1DD36E:: @ 81DD36E
 	faceplayer
 	checkflag FLAG_0x151
 	goto_eq SlateportCity_EventScript_1DD39A
-	msgbox SlateportCity_Text_1DEBCE, 4
+	msgbox SlateportCity_Text_1DEBCE, MSGBOX_DEFAULT
 	giveitem_std ITEM_POWDER_JAR
 	setflag FLAG_0x151
-	msgbox SlateportCity_Text_1DED27, 4
+	msgbox SlateportCity_Text_1DED27, MSGBOX_DEFAULT
 	release
 	end
 
@@ -742,13 +742,13 @@ SlateportCity_EventScript_1DD39A:: @ 81DD39A
 	specialvar VAR_RESULT, sub_80246D4
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_EventScript_1DD3C0
-	msgbox SlateportCity_Text_1DEE40, 4
+	msgbox SlateportCity_Text_1DEE40, MSGBOX_DEFAULT
 	special sub_80248B0
 	goto SlateportCity_EventScript_1DD3CA
 	end
 
 SlateportCity_EventScript_1DD3C0:: @ 81DD3C0
-	msgbox SlateportCity_Text_1DED27, 4
+	msgbox SlateportCity_Text_1DED27, MSGBOX_DEFAULT
 	release
 	end
 
@@ -852,13 +852,13 @@ SlateportCity_EventScript_1DD536:: @ 81DD536
 	end
 
 SlateportCity_EventScript_1DD54A:: @ 81DD54A
-	msgbox SlateportCity_Text_1DEFBC, 4
+	msgbox SlateportCity_Text_1DEFBC, MSGBOX_DEFAULT
 	special sub_8024918
 	release
 	end
 
 SlateportCity_EventScript_1DD557:: @ 81DD557
-	msgbox SlateportCity_Text_1DEE90, 5
+	msgbox SlateportCity_Text_1DEE90, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_EventScript_1DD3CA
 	copyvar VAR_0x8004, VAR_0x8009
@@ -871,22 +871,22 @@ SlateportCity_EventScript_1DD557:: @ 81DD557
 	copyvar VAR_0x8004, VAR_0x8009
 	special sub_802477C
 	special sub_802488C
-	msgbox SlateportCity_Text_1DEEF7, 5
+	msgbox SlateportCity_Text_1DEEF7, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq SlateportCity_EventScript_1DD3CA
-	msgbox SlateportCity_Text_1DEF79, 4
+	msgbox SlateportCity_Text_1DEF79, MSGBOX_DEFAULT
 	special sub_8024918
 	release
 	end
 
 SlateportCity_EventScript_1DD5C1:: @ 81DD5C1
-	msgbox gUnknown_08272A89, 4
+	msgbox gUnknown_08272A89, MSGBOX_DEFAULT
 	special sub_8024918
 	release
 	end
 
 SlateportCity_EventScript_1DD5CE:: @ 81DD5CE
-	msgbox SlateportCity_Text_1DEEC9, 4
+	msgbox SlateportCity_Text_1DEEC9, MSGBOX_DEFAULT
 	goto SlateportCity_EventScript_1DD3CA
 	end
 
@@ -902,7 +902,7 @@ SlateportCity_EventScript_1DD5DC:: @ 81DD5DC
 	waitmovement 0
 	closedoor 10, 12
 	waitdooranim
-	msgbox SlateportCity_Text_1DF28C, 4
+	msgbox SlateportCity_Text_1DF28C, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, SlateportCity_Movement_1DD634
 	applymovement 35, SlateportCity_Movement_1DD63A

--- a/data/maps/SlateportCity_BattleTentBattleRoom/scripts.inc
+++ b/data/maps/SlateportCity_BattleTentBattleRoom/scripts.inc
@@ -51,7 +51,7 @@ SlateportCity_BattleTentBattleRoom_EventScript_2099BE:: @ 82099BE
 	setvar VAR_0x8004, 4
 	special sub_81B99B4
 	lockall
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	waitmessage
 	closemessage
 	special HealPlayerParty

--- a/data/maps/SlateportCity_BattleTentCorridor/scripts.inc
+++ b/data/maps/SlateportCity_BattleTentCorridor/scripts.inc
@@ -35,14 +35,14 @@ SlateportCity_BattleTentCorridor_EventScript_208E65:: @ 8208E65
 	special sub_81B9D08
 	setvar VAR_0x8004, 8
 	special sub_81B9D08
-	msgbox SlateportCity_BattleTentCorridor_Text_25A1C8, 4
+	msgbox SlateportCity_BattleTentCorridor_Text_25A1C8, MSGBOX_DEFAULT
 	fadescreen 1
 	setvar VAR_0x8004, 6
 	special sub_81B9D08
 	waitstate
 
 SlateportCity_BattleTentCorridor_EventScript_208EB4:: @ 8208EB4
-	msgbox SlateportCity_BattleTentCorridor_Text_25AB96, 4
+	msgbox SlateportCity_BattleTentCorridor_Text_25AB96, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, SlateportCity_BattleTentCorridor_Movement_2725A6
 	waitmovement 0
@@ -62,7 +62,7 @@ SlateportCity_BattleTentCorridor_EventScript_208EEE:: @ 8208EEE
 	special CallBattleFactoryFunction
 	setvar VAR_0x8004, 16
 	special CallBattleFactoryFunction
-	msgbox SlateportCity_BattleTentCorridor_Text_25A22D, 4
+	msgbox SlateportCity_BattleTentCorridor_Text_25A22D, MSGBOX_DEFAULT
 	playfanfare MUS_ME_ASA
 	waitfanfare
 	special HealPlayerParty
@@ -82,7 +82,7 @@ SlateportCity_BattleTentCorridor_EventScript_208F0D:: @ 8208F0D
 	case 2, SlateportCity_BattleTentCorridor_EventScript_208F89
 
 SlateportCity_BattleTentCorridor_EventScript_208F5B:: @ 8208F5B
-	msgbox SlateportCity_BattleTentCorridor_Text_25A350, 5
+	msgbox SlateportCity_BattleTentCorridor_Text_25A350, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, SlateportCity_BattleTentCorridor_EventScript_208F0D
 	case 1, SlateportCity_BattleTentCorridor_EventScript_209022
@@ -100,7 +100,7 @@ SlateportCity_BattleTentCorridor_EventScript_208F89:: @ 8208F89
 SlateportCity_BattleTentCorridor_EventScript_208FBB:: @ 8208FBB
 	setvar VAR_0x8004, 8
 	special sub_81B9D08
-	msgbox SlateportCity_BattleTentCorridor_Text_25AB2E, 5
+	msgbox SlateportCity_BattleTentCorridor_Text_25AB2E, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, SlateportCity_BattleTentCorridor_EventScript_208EB4
 	case 1, SlateportCity_BattleTentCorridor_EventScript_208FF1
@@ -113,7 +113,7 @@ SlateportCity_BattleTentCorridor_EventScript_208FF1:: @ 8208FF1
 	waitstate
 	compare VAR_RESULT, 1
 	goto_eq SlateportCity_BattleTentCorridor_EventScript_208EB4
-	msgbox SlateportCity_BattleTentCorridor_Text_25AB6C, 4
+	msgbox SlateportCity_BattleTentCorridor_Text_25AB6C, MSGBOX_DEFAULT
 	goto SlateportCity_BattleTentCorridor_EventScript_208EB4
 
 SlateportCity_BattleTentCorridor_EventScript_209014:: @ 8209014

--- a/data/maps/SlateportCity_BattleTentLobby/scripts.inc
+++ b/data/maps/SlateportCity_BattleTentLobby/scripts.inc
@@ -27,7 +27,7 @@ SlateportCity_BattleTentLobby_EventScript_208779:: @ 8208779
 
 SlateportCity_BattleTentLobby_EventScript_208782:: @ 8208782
 	lockall
-	msgbox SlateportCity_BattleTentLobby_Text_2C5DFA, 4
+	msgbox SlateportCity_BattleTentLobby_Text_2C5DFA, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 0
@@ -58,7 +58,7 @@ SlateportCity_BattleTentLobby_EventScript_2087B7:: @ 82087B7
 	waitse
 
 SlateportCity_BattleTentLobby_EventScript_2087E9:: @ 82087E9
-	msgbox SlateportCity_BattleTentLobby_Text_2C5D14, 4
+	msgbox SlateportCity_BattleTentLobby_Text_2C5D14, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 5
 	special sub_81B9D08
 	switch VAR_RESULT
@@ -74,7 +74,7 @@ SlateportCity_BattleTentLobby_EventScript_2087E9:: @ 82087E9
 	goto SlateportCity_BattleTentLobby_EventScript_208861
 
 SlateportCity_BattleTentLobby_EventScript_20882A:: @ 820882A
-	msgbox SlateportCity_BattleTentLobby_Text_2C5D52, 4
+	msgbox SlateportCity_BattleTentLobby_Text_2C5D52, MSGBOX_DEFAULT
 	goto SlateportCity_BattleTentLobby_EventScript_208861
 
 SlateportCity_BattleTentLobby_EventScript_208837:: @ 8208837
@@ -92,7 +92,7 @@ SlateportCity_BattleTentLobby_EventScript_208837:: @ 8208837
 	waitse
 
 SlateportCity_BattleTentLobby_EventScript_208861:: @ 8208861
-	msgbox SlateportCity_BattleTentLobby_Text_2C5AA5, 4
+	msgbox SlateportCity_BattleTentLobby_Text_2C5AA5, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
@@ -123,7 +123,7 @@ SlateportCity_BattleTentLobby_EventScript_2088AA:: @ 82088AA
 	compare VAR_RESULT, 0
 	goto_if 5, SlateportCity_BattleTentLobby_EventScript_2087E9
 	special SavePlayerParty
-	msgbox SlateportCity_BattleTentLobby_Text_2C5810, 4
+	msgbox SlateportCity_BattleTentLobby_Text_2C5810, MSGBOX_DEFAULT
 
 SlateportCity_BattleTentLobby_EventScript_2088CA:: @ 82088CA
 	message SlateportCity_BattleTentLobby_Text_2C586A
@@ -142,7 +142,7 @@ SlateportCity_BattleTentLobby_EventScript_208906:: @ 8208906
 	setvar VAR_0x8005, 1
 	setvar VAR_0x8006, 2
 	special CallFrontierUtilFunc
-	msgbox SlateportCity_BattleTentLobby_Text_2C5B06, 5
+	msgbox SlateportCity_BattleTentLobby_Text_2C5B06, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, SlateportCity_BattleTentLobby_EventScript_208A2B
 	case 1, SlateportCity_BattleTentLobby_EventScript_208950
@@ -172,7 +172,7 @@ SlateportCity_BattleTentLobby_EventScript_208950:: @ 8208950
 	setvar VAR_0x8006, 0
 
 SlateportCity_BattleTentLobby_EventScript_2089AC:: @ 82089AC
-	msgbox SlateportCity_BattleTentLobby_Text_2C5B8C, 4
+	msgbox SlateportCity_BattleTentLobby_Text_2C5B8C, MSGBOX_DEFAULT
 	closemessage
 	call SlateportCity_BattleTentLobby_EventScript_2089C9
 	warp MAP_SLATEPORT_CITY_BATTLE_TENT_CORRIDOR, 255, 2, 7
@@ -217,7 +217,7 @@ SlateportCity_BattleTentLobby_Movement_208A03: @ 8208A03
 	step_end
 
 SlateportCity_BattleTentLobby_EventScript_208A07:: @ 8208A07
-	msgbox SlateportCity_BattleTentLobby_Text_2C589C, 4
+	msgbox SlateportCity_BattleTentLobby_Text_2C589C, MSGBOX_DEFAULT
 	goto SlateportCity_BattleTentLobby_EventScript_2088CA
 
 SlateportCity_BattleTentLobby_EventScript_208A14:: @ 8208A14
@@ -231,7 +231,7 @@ SlateportCity_BattleTentLobby_EventScript_208A2B:: @ 8208A2B
 	special LoadPlayerParty
 
 SlateportCity_BattleTentLobby_EventScript_208A2E:: @ 8208A2E
-	msgbox SlateportCity_BattleTentLobby_Text_2C5AA5, 4
+	msgbox SlateportCity_BattleTentLobby_Text_2C5AA5, MSGBOX_DEFAULT
 	release
 	end
 
@@ -247,35 +247,35 @@ SlateportCity_BattleTentLobby_EventScript_208A3D:: @ 8208A3D
 	faceplayer
 	checkflag FLAG_0x109
 	goto_eq SlateportCity_BattleTentLobby_EventScript_208A74
-	msgbox SlateportCity_BattleTentLobby_Text_208B4E, 4
+	msgbox SlateportCity_BattleTentLobby_Text_208B4E, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM41
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_BattleTentLobby_EventScript_272054
 	setflag FLAG_0x109
-	msgbox SlateportCity_BattleTentLobby_Text_208C5C, 4
+	msgbox SlateportCity_BattleTentLobby_Text_208C5C, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_BattleTentLobby_EventScript_208A74:: @ 8208A74
-	msgbox SlateportCity_BattleTentLobby_Text_208C5C, 4
+	msgbox SlateportCity_BattleTentLobby_Text_208C5C, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_BattleTentLobby_EventScript_208A7E:: @ 8208A7E
-	msgbox SlateportCity_BattleTentLobby_Text_208D27, 2
+	msgbox SlateportCity_BattleTentLobby_Text_208D27, MSGBOX_NPC
 	end
 
 SlateportCity_BattleTentLobby_EventScript_208A87:: @ 8208A87
-	msgbox SlateportCity_BattleTentLobby_Text_208DA6, 2
+	msgbox SlateportCity_BattleTentLobby_Text_208DA6, MSGBOX_NPC
 	end
 
 SlateportCity_BattleTentLobby_EventScript_208A90:: @ 8208A90
-	msgbox SlateportCity_BattleTentLobby_Text_208DF1, 2
+	msgbox SlateportCity_BattleTentLobby_Text_208DF1, MSGBOX_NPC
 	end
 
 SlateportCity_BattleTentLobby_EventScript_208A99:: @ 8208A99
 	lockall
-	msgbox SlateportCity_BattleTentLobby_Text_259721, 4
+	msgbox SlateportCity_BattleTentLobby_Text_259721, MSGBOX_DEFAULT
 	goto SlateportCity_BattleTentLobby_EventScript_208AA8
 	end
 
@@ -294,27 +294,27 @@ SlateportCity_BattleTentLobby_EventScript_208AA8:: @ 8208AA8
 	end
 
 SlateportCity_BattleTentLobby_EventScript_208B06:: @ 8208B06
-	msgbox SlateportCity_BattleTentLobby_Text_2C5F08, 4
+	msgbox SlateportCity_BattleTentLobby_Text_2C5F08, MSGBOX_DEFAULT
 	goto SlateportCity_BattleTentLobby_EventScript_208AA8
 	end
 
 SlateportCity_BattleTentLobby_EventScript_208B14:: @ 8208B14
-	msgbox SlateportCity_BattleTentLobby_Text_2C5F9D, 4
+	msgbox SlateportCity_BattleTentLobby_Text_2C5F9D, MSGBOX_DEFAULT
 	goto SlateportCity_BattleTentLobby_EventScript_208AA8
 	end
 
 SlateportCity_BattleTentLobby_EventScript_208B22:: @ 8208B22
-	msgbox SlateportCity_BattleTentLobby_Text_2C6020, 4
+	msgbox SlateportCity_BattleTentLobby_Text_2C6020, MSGBOX_DEFAULT
 	goto SlateportCity_BattleTentLobby_EventScript_208AA8
 	end
 
 SlateportCity_BattleTentLobby_EventScript_208B30:: @ 8208B30
-	msgbox SlateportCity_BattleTentLobby_Text_2C60C0, 4
+	msgbox SlateportCity_BattleTentLobby_Text_2C60C0, MSGBOX_DEFAULT
 	goto SlateportCity_BattleTentLobby_EventScript_208AA8
 	end
 
 SlateportCity_BattleTentLobby_EventScript_208B3E:: @ 8208B3E
-	msgbox SlateportCity_BattleTentLobby_Text_2C61FE, 4
+	msgbox SlateportCity_BattleTentLobby_Text_2C61FE, MSGBOX_DEFAULT
 	goto SlateportCity_BattleTentLobby_EventScript_208AA8
 	end
 

--- a/data/maps/SlateportCity_Harbor/scripts.inc
+++ b/data/maps/SlateportCity_Harbor/scripts.inc
@@ -54,7 +54,7 @@ SlateportCity_Harbor_EventScript_20C9F5:: @ 820C9F5
 	applymovement 6, SlateportCity_Harbor_Movement_2725AA
 	applymovement 255, SlateportCity_Harbor_Movement_2725A6
 	waitmovement 0
-	msgbox SlateportCity_Harbor_Text_20D291, 4
+	msgbox SlateportCity_Harbor_Text_20D291, MSGBOX_DEFAULT
 	closemessage
 	applymovement 6, SlateportCity_Harbor_Movement_20CAC8
 	applymovement 7, SlateportCity_Harbor_Movement_20CAC8
@@ -74,7 +74,7 @@ SlateportCity_Harbor_EventScript_20C9F5:: @ 820C9F5
 	call_if 1, SlateportCity_Harbor_EventScript_20CAB3
 	compare VAR_0x8008, 3
 	call_if 1, SlateportCity_Harbor_EventScript_20CAB3
-	msgbox SlateportCity_Harbor_Text_20D35A, 4
+	msgbox SlateportCity_Harbor_Text_20D35A, MSGBOX_DEFAULT
 	closemessage
 	setflag FLAG_HIDE_AQUA_HIDEOUT_1F_GRUNT_1_BLOCKING_ENTRANCE
 	setflag FLAG_HIDE_AQUA_HIDEOUT_1F_GRUNT_2_BLOCKING_ENTRANCE
@@ -164,12 +164,12 @@ SlateportCity_Harbor_EventScript_20CAF1:: @ 820CAF1
 	faceplayer
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_eq SlateportCity_Harbor_EventScript_20CB06
-	msgbox SlateportCity_Harbor_Text_20CE20, 4
+	msgbox SlateportCity_Harbor_Text_20CE20, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_Harbor_EventScript_20CB06:: @ 820CB06
-	msgbox SlateportCity_Harbor_Text_20CE87, 4
+	msgbox SlateportCity_Harbor_Text_20CE87, MSGBOX_DEFAULT
 	message SlateportCity_Harbor_Text_20CF1C
 	waitmessage
 	goto SlateportCity_Harbor_EventScript_20CB1A
@@ -195,12 +195,12 @@ SlateportCity_Harbor_EventScript_20CB50:: @ 820CB50
 	end
 
 SlateportCity_Harbor_EventScript_20CB88:: @ 820CB88
-	msgbox SlateportCity_Harbor_Text_20CEC1, 4
+	msgbox SlateportCity_Harbor_Text_20CEC1, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_Harbor_EventScript_20CB92:: @ 820CB92
-	msgbox SlateportCity_Harbor_Text_20CF93, 5
+	msgbox SlateportCity_Harbor_Text_20CF93, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_Harbor_EventScript_20CBDD
 	setvar VAR_PORTHOLE_STATE, 1
@@ -211,7 +211,7 @@ SlateportCity_Harbor_EventScript_20CB92:: @ 820CB92
 	end
 
 SlateportCity_Harbor_EventScript_20CBBA:: @ 820CBBA
-	msgbox SlateportCity_Harbor_Text_20CFAE, 5
+	msgbox SlateportCity_Harbor_Text_20CFAE, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_Harbor_EventScript_20CBDD
 	call SlateportCity_Harbor_EventScript_20CBE9
@@ -227,7 +227,7 @@ SlateportCity_Harbor_EventScript_20CBDD:: @ 820CBDD
 	end
 
 SlateportCity_Harbor_EventScript_20CBE9:: @ 820CBE9
-	msgbox SlateportCity_Harbor_Text_20CFCB, 4
+	msgbox SlateportCity_Harbor_Text_20CFCB, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, SlateportCity_Harbor_Movement_2725A6
 	waitmovement 0
@@ -244,7 +244,7 @@ SlateportCity_Harbor_EventScript_20CBE9:: @ 820CBE9
 	return
 
 SlateportCity_Harbor_EventScript_20CC2D:: @ 820CC2D
-	msgbox SlateportCity_Harbor_Text_20CF71, 4
+	msgbox SlateportCity_Harbor_Text_20CF71, MSGBOX_DEFAULT
 	release
 	end
 
@@ -279,12 +279,12 @@ SlateportCity_Harbor_EventScript_20CC52:: @ 820CC52
 	call_if 1, SlateportCity_Harbor_EventScript_20CC93
 	compare VAR_0x8004, 2
 	goto_eq SlateportCity_Harbor_EventScript_20CC89
-	msgbox SlateportCity_Harbor_Text_20D08E, 4
+	msgbox SlateportCity_Harbor_Text_20D08E, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_Harbor_EventScript_20CC89:: @ 820CC89
-	msgbox SlateportCity_Harbor_Text_20D01C, 4
+	msgbox SlateportCity_Harbor_Text_20D01C, MSGBOX_DEFAULT
 	release
 	end
 
@@ -293,7 +293,7 @@ SlateportCity_Harbor_EventScript_20CC93:: @ 820CC93
 	return
 
 SlateportCity_Harbor_EventScript_20CC99:: @ 820CC99
-	msgbox SlateportCity_Harbor_Text_20D194, 2
+	msgbox SlateportCity_Harbor_Text_20D194, MSGBOX_NPC
 	end
 
 SlateportCity_Harbor_EventScript_20CCA2:: @ 820CCA2
@@ -307,7 +307,7 @@ SlateportCity_Harbor_EventScript_20CCA2:: @ 820CCA2
 	goto_eq SlateportCity_Harbor_EventScript_20CCE9
 	compare VAR_0x40A0, 2
 	goto_eq SlateportCity_Harbor_EventScript_20CCDF
-	msgbox SlateportCity_Harbor_Text_20D232, 4
+	msgbox SlateportCity_Harbor_Text_20D232, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, SlateportCity_Harbor_Movement_2725A2
 	waitmovement 0
@@ -315,18 +315,18 @@ SlateportCity_Harbor_EventScript_20CCA2:: @ 820CCA2
 	end
 
 SlateportCity_Harbor_EventScript_20CCDF:: @ 820CCDF
-	msgbox SlateportCity_Harbor_Text_20D35A, 4
+	msgbox SlateportCity_Harbor_Text_20D35A, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_Harbor_EventScript_20CCE9:: @ 820CCE9
 	setflag FLAG_0x10F
-	msgbox SlateportCity_Harbor_Text_20D42B, 4
+	msgbox SlateportCity_Harbor_Text_20D42B, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_Harbor_EventScript_20CCF6:: @ 820CCF6
-	msgbox SlateportCity_Harbor_Text_20D58A, 4
+	msgbox SlateportCity_Harbor_Text_20D58A, MSGBOX_DEFAULT
 	release
 	end
 
@@ -338,12 +338,12 @@ SlateportCity_Harbor_EventScript_20CD00:: @ 820CD00
 	goto_eq SlateportCity_Harbor_EventScript_20CD38
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_eq SlateportCity_Harbor_EventScript_20CD2E
-	msgbox SlateportCity_Harbor_Text_20D65C, 4
+	msgbox SlateportCity_Harbor_Text_20D65C, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_Harbor_EventScript_20CD2E:: @ 820CD2E
-	msgbox SlateportCity_Harbor_Text_20D6CB, 4
+	msgbox SlateportCity_Harbor_Text_20D6CB, MSGBOX_DEFAULT
 	release
 	end
 
@@ -363,33 +363,33 @@ SlateportCity_Harbor_EventScript_20CD44:: @ 820CD44
 	end
 
 SlateportCity_Harbor_EventScript_20CD7B:: @ 820CD7B
-	msgbox SlateportCity_Harbor_Text_20D8BC, 5
+	msgbox SlateportCity_Harbor_Text_20D8BC, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_Harbor_EventScript_20CE05
 	giveitem_std ITEM_DEEP_SEA_TOOTH
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_Harbor_EventScript_272054
 	takeitem ITEM_SCANNER, 1
-	msgbox SlateportCity_Harbor_Text_20D94A, 4
+	msgbox SlateportCity_Harbor_Text_20D94A, MSGBOX_DEFAULT
 	setflag FLAG_TRADED_SCANNER_TO_STERN
 	goto SlateportCity_Harbor_EventScript_20CE11
 	end
 
 SlateportCity_Harbor_EventScript_20CDBB:: @ 820CDBB
-	msgbox SlateportCity_Harbor_Text_20D8F1, 5
+	msgbox SlateportCity_Harbor_Text_20D8F1, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_Harbor_EventScript_20CE05
 	giveitem_std ITEM_DEEP_SEA_SCALE
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_Harbor_EventScript_272054
 	takeitem ITEM_SCANNER, 1
-	msgbox SlateportCity_Harbor_Text_20D94A, 4
+	msgbox SlateportCity_Harbor_Text_20D94A, MSGBOX_DEFAULT
 	setflag FLAG_TRADED_SCANNER_TO_STERN
 	goto SlateportCity_Harbor_EventScript_20CE11
 	end
 
 SlateportCity_Harbor_EventScript_20CDFB:: @ 820CDFB
-	msgbox SlateportCity_Harbor_Text_20D841, 4
+	msgbox SlateportCity_Harbor_Text_20D841, MSGBOX_DEFAULT
 	release
 	end
 
@@ -401,7 +401,7 @@ SlateportCity_Harbor_EventScript_20CE05:: @ 820CE05
 
 SlateportCity_Harbor_EventScript_20CE11:: @ 820CE11
 	setvar VAR_TEMP_1, 1
-	msgbox SlateportCity_Harbor_Text_20D970, 4
+	msgbox SlateportCity_Harbor_Text_20D970, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/SlateportCity_House1/scripts.inc
+++ b/data/maps/SlateportCity_House1/scripts.inc
@@ -4,7 +4,7 @@ SlateportCity_House1_MapScripts:: @ 8209AA4
 SlateportCity_House1_EventScript_209AA5:: @ 8209AA5
 	lock
 	faceplayer
-	msgbox SlateportCity_House1_Text_209B8E, 5
+	msgbox SlateportCity_House1_Text_209B8E, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq SlateportCity_House1_EventScript_209AC6
 	compare VAR_RESULT, 0
@@ -12,7 +12,7 @@ SlateportCity_House1_EventScript_209AA5:: @ 8209AA5
 	end
 
 SlateportCity_House1_EventScript_209AC6:: @ 8209AC6
-	msgbox SlateportCity_House1_Text_209BFF, 4
+	msgbox SlateportCity_House1_Text_209BFF, MSGBOX_DEFAULT
 	special sub_81B94B0
 	waitstate
 	compare VAR_0x8004, 255
@@ -22,7 +22,7 @@ SlateportCity_House1_EventScript_209AC6:: @ 8209AC6
 	end
 
 SlateportCity_House1_EventScript_209AE9:: @ 8209AE9
-	msgbox SlateportCity_House1_Text_209D42, 4
+	msgbox SlateportCity_House1_Text_209D42, MSGBOX_DEFAULT
 	release
 	end
 
@@ -38,7 +38,7 @@ SlateportCity_House1_EventScript_209AF3:: @ 8209AF3
 	special TV_CopyNicknameToStringVar1AndEnsureTerminated
 	compare VAR_RESULT, 1
 	goto_eq SlateportCity_House1_EventScript_209B50
-	msgbox SlateportCity_House1_Text_209C2B, 5
+	msgbox SlateportCity_House1_Text_209C2B, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq SlateportCity_House1_EventScript_209B5A
 	compare VAR_RESULT, 0
@@ -46,28 +46,28 @@ SlateportCity_House1_EventScript_209AF3:: @ 8209AF3
 	end
 
 SlateportCity_House1_EventScript_209B46:: @ 8209B46
-	msgbox SlateportCity_House1_Text_209E74, 4
+	msgbox SlateportCity_House1_Text_209E74, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_House1_EventScript_209B50:: @ 8209B50
-	msgbox SlateportCity_House1_Text_209DF0, 4
+	msgbox SlateportCity_House1_Text_209DF0, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_House1_EventScript_209B5A:: @ 8209B5A
-	msgbox SlateportCity_House1_Text_209CA4, 4
+	msgbox SlateportCity_House1_Text_209CA4, MSGBOX_DEFAULT
 	call SlateportCity_House1_EventScript_2723DD
 	specialvar VAR_RESULT, TV_PutNameRaterShowOnTheAirIfNicnkameChanged
 	special TV_CopyNicknameToStringVar1AndEnsureTerminated
 	compare VAR_RESULT, 1
 	goto_eq SlateportCity_House1_EventScript_209B84
-	msgbox SlateportCity_House1_Text_209D5E, 4
+	msgbox SlateportCity_House1_Text_209D5E, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_House1_EventScript_209B84:: @ 8209B84
-	msgbox SlateportCity_House1_Text_209CD4, 4
+	msgbox SlateportCity_House1_Text_209CD4, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/SlateportCity_House2/scripts.inc
+++ b/data/maps/SlateportCity_House2/scripts.inc
@@ -2,11 +2,11 @@ SlateportCity_House2_MapScripts:: @ 820D9AE
 	.byte 0
 
 SlateportCity_House2_EventScript_20D9AF:: @ 820D9AF
-	msgbox SlateportCity_House2_Text_20D9C1, 2
+	msgbox SlateportCity_House2_Text_20D9C1, MSGBOX_NPC
 	end
 
 SlateportCity_House2_EventScript_20D9B8:: @ 820D9B8
-	msgbox SlateportCity_House2_Text_20DA59, 2
+	msgbox SlateportCity_House2_Text_20DA59, MSGBOX_NPC
 	end
 
 SlateportCity_House2_Text_20D9C1: @ 820D9C1

--- a/data/maps/SlateportCity_Mart/scripts.inc
+++ b/data/maps/SlateportCity_Mart/scripts.inc
@@ -7,7 +7,7 @@ SlateportCity_Mart_EventScript_20DC49:: @ 820DC49
 	message gUnknown_08272A21
 	waitmessage
 	pokemart SlateportCity_Mart_Pokemart_20DC60
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -26,11 +26,11 @@ SlateportCity_Mart_Pokemart_20DC60: @ 820DC60
 	end
 
 SlateportCity_Mart_EventScript_20DC76:: @ 820DC76
-	msgbox SlateportCity_Mart_Text_20DC88, 2
+	msgbox SlateportCity_Mart_Text_20DC88, MSGBOX_NPC
 	end
 
 SlateportCity_Mart_EventScript_20DC7F:: @ 820DC7F
-	msgbox SlateportCity_Mart_Text_20DCF8, 2
+	msgbox SlateportCity_Mart_Text_20DCF8, MSGBOX_NPC
 	end
 
 SlateportCity_Mart_Text_20DC88: @ 820DC88

--- a/data/maps/SlateportCity_OceanicMuseum_1F/scripts.inc
+++ b/data/maps/SlateportCity_OceanicMuseum_1F/scripts.inc
@@ -2,7 +2,7 @@ SlateportCity_OceanicMuseum_1F_MapScripts:: @ 820AD95
 	.byte 0
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AD96:: @ 820AD96
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B026, 2
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B026, MSGBOX_NPC
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AD9F:: @ 820AD9F
@@ -21,7 +21,7 @@ SlateportCity_OceanicMuseum_1F_EventScript_20ADB0:: @ 820ADB0
 
 SlateportCity_OceanicMuseum_1F_EventScript_20ADC1:: @ 820ADC1
 	showmoneybox 0, 0, 0
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20AFD5, 5
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20AFD5, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq SlateportCity_OceanicMuseum_1F_EventScript_20ADE8
 	closemessage
@@ -41,7 +41,7 @@ SlateportCity_OceanicMuseum_1F_EventScript_20ADE8:: @ 820ADE8
 	takemoney 0x32, 0
 	updatemoneybox 0, 0
 	nop
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B026, 4
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B026, MSGBOX_DEFAULT
 	setvar VAR_0x40AA, 1
 	hidemoneybox
 	nop
@@ -52,7 +52,7 @@ SlateportCity_OceanicMuseum_1F_EventScript_20ADE8:: @ 820ADE8
 SlateportCity_OceanicMuseum_1F_EventScript_20AE18:: @ 820AE18
 	checkflag FLAG_0x095
 	goto_if 0, SlateportCity_OceanicMuseum_1F_EventScript_20AE39
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B03D, 4
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B03D, MSGBOX_DEFAULT
 	closemessage
 	hidemoneybox
 	nop
@@ -63,7 +63,7 @@ SlateportCity_OceanicMuseum_1F_EventScript_20AE18:: @ 820AE18
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AE39:: @ 820AE39
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B075, 4
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B075, MSGBOX_DEFAULT
 	setvar VAR_0x40AA, 1
 	hidemoneybox
 	nop
@@ -76,79 +76,79 @@ SlateportCity_OceanicMuseum_1F_Movement_20AE4B: @ 820AE4B
 	step_end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AE4D:: @ 820AE4D
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B0E8, 2
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B0E8, MSGBOX_NPC
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AE56:: @ 820AE56
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B112, 2
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B112, MSGBOX_NPC
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AE5F:: @ 820AE5F
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B165, 2
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B165, MSGBOX_NPC
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AE68:: @ 820AE68
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B19C, 3
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B19C, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AE71:: @ 820AE71
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B1D4, 2
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B1D4, MSGBOX_NPC
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AE7A:: @ 820AE7A
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B218, 2
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B218, MSGBOX_NPC
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AE83:: @ 820AE83
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B4CF, 3
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B4CF, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AE8C:: @ 820AE8C
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B547, 3
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B547, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AE95:: @ 820AE95
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B5CA, 3
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B5CA, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AE9E:: @ 820AE9E
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B699, 3
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B699, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AEA7:: @ 820AEA7
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B74B, 3
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B74B, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AEB0:: @ 820AEB0
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B81F, 3
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B81F, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AEB9:: @ 820AEB9
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B912, 3
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B912, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AEC2:: @ 820AEC2
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B9C0, 3
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B9C0, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AECB:: @ 820AECB
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20BA9C, 3
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20BA9C, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AED4:: @ 820AED4
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B25F, 2
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B25F, MSGBOX_NPC
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AEDD:: @ 820AEDD
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B2A2, 2
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B2A2, MSGBOX_NPC
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AEE6:: @ 820AEE6
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B302, 2
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B302, MSGBOX_NPC
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AEEF:: @ 820AEEF
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B369, 2
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B369, MSGBOX_NPC
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AEF8:: @ 820AEF8
@@ -160,12 +160,12 @@ SlateportCity_OceanicMuseum_1F_EventScript_20AEF8:: @ 820AEF8
 	waitmovement 0
 	applymovement 13, SlateportCity_OceanicMuseum_1F_Movement_27259A
 	waitmovement 0
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B3AB, 4
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B3AB, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM46
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_OceanicMuseum_1F_EventScript_20AFB5
 	setflag FLAG_0x10D
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B449, 4
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B449, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_FACING, 2
 	goto_eq SlateportCity_OceanicMuseum_1F_EventScript_20AF6C
@@ -205,7 +205,7 @@ SlateportCity_OceanicMuseum_1F_EventScript_20AFAA:: @ 820AFAA
 	end
 
 SlateportCity_OceanicMuseum_1F_EventScript_20AFB5:: @ 820AFB5
-	msgbox SlateportCity_OceanicMuseum_1F_Text_20B49B, 4
+	msgbox SlateportCity_OceanicMuseum_1F_Text_20B49B, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/SlateportCity_OceanicMuseum_2F/scripts.inc
+++ b/data/maps/SlateportCity_OceanicMuseum_2F/scripts.inc
@@ -4,7 +4,7 @@ SlateportCity_OceanicMuseum_2F_MapScripts:: @ 820BAFF
 SlateportCity_OceanicMuseum_2F_EventScript_20BB00:: @ 820BB00
 	lock
 	faceplayer
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20BD8D, 4
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20BD8D, MSGBOX_DEFAULT
 	closemessage
 	playbgm MUS_AQA_0, 1
 	addobject 3
@@ -20,11 +20,11 @@ SlateportCity_OceanicMuseum_2F_EventScript_20BB00:: @ 820BB00
 	call_if 1, SlateportCity_OceanicMuseum_2F_EventScript_20BC92
 	compare VAR_FACING, 4
 	call_if 1, SlateportCity_OceanicMuseum_2F_EventScript_20BC92
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20BE40, 4
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20BE40, MSGBOX_DEFAULT
 	compare VAR_FACING, 4
 	call_if 5, SlateportCity_OceanicMuseum_2F_EventScript_20BC9D
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20BE69, 4
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20BE93, 4
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20BE69, MSGBOX_DEFAULT
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20BE93, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, SlateportCity_OceanicMuseum_2F_Movement_20BCE2
 	waitmovement 0
@@ -33,31 +33,31 @@ SlateportCity_OceanicMuseum_2F_EventScript_20BB00:: @ 820BB00
 	compare VAR_FACING, 3
 	call_if 1, SlateportCity_OceanicMuseum_2F_EventScript_20BCB3
 	trainerbattle 3, TRAINER_GRUNT_14, 0, SlateportCity_OceanicMuseum_2F_Text_20BEE2
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20BEFA, 4
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20BEFA, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, SlateportCity_OceanicMuseum_2F_Movement_20BCEF
 	waitmovement 0
 	applymovement 3, SlateportCity_OceanicMuseum_2F_Movement_20BCE2
 	waitmovement 0
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20BF35, 4
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20BF35, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_GRUNT_15, 0, SlateportCity_OceanicMuseum_2F_Text_20BF66
 	applymovement 3, SlateportCity_OceanicMuseum_2F_Movement_20BCEF
 	waitmovement 0
 	applymovement 3, SlateportCity_OceanicMuseum_2F_Movement_2725AA
 	applymovement 4, SlateportCity_OceanicMuseum_2F_Movement_2725A6
 	waitmovement 0
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20BF7A, 4
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20BF7A, MSGBOX_DEFAULT
 	closemessage
 	delay 35
 	addobject 2
 	applymovement 2, SlateportCity_OceanicMuseum_2F_Movement_20BCD8
 	applymovement 4, SlateportCity_OceanicMuseum_2F_Movement_20BCFE
 	waitmovement 0
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20BFF2, 4
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20BFF2, MSGBOX_DEFAULT
 	closemessage
 	applymovement 2, SlateportCity_OceanicMuseum_2F_Movement_20BCD6
 	waitmovement 0
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C059, 4
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C059, MSGBOX_DEFAULT
 	closemessage
 	savebgm MUS_DUMMY
 	fadedefaultbgm
@@ -70,10 +70,10 @@ SlateportCity_OceanicMuseum_2F_EventScript_20BB00:: @ 820BB00
 	setflag FLAG_HIDE_SLATEPORT_CITY_OCEANIC_MUSEUM_AQUA_GRUNTS
 	applymovement 255, SlateportCity_OceanicMuseum_2F_Movement_2725A8
 	waitmovement 0
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C2BE, 4
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C2BE, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 269
 	call SlateportCity_OceanicMuseum_2F_EventScript_2723E4
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C36C, 4
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C36C, MSGBOX_DEFAULT
 	closemessage
 	fadescreen 1
 	playfanfare MUS_ME_ASA
@@ -216,57 +216,57 @@ SlateportCity_OceanicMuseum_2F_Movement_20BCFE: @ 820BCFE
 	step_end
 
 SlateportCity_OceanicMuseum_2F_EventScript_20BD0A:: @ 820BD0A
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C4F9, 3
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C4F9, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_2F_EventScript_20BD13:: @ 820BD13
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C566, 3
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C566, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_2F_EventScript_20BD1C:: @ 820BD1C
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C5C6, 3
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C5C6, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_2F_EventScript_20BD25:: @ 820BD25
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C6C7, 3
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C6C7, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_2F_EventScript_20BD2E:: @ 820BD2E
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C72F, 3
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C72F, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_2F_EventScript_20BD37:: @ 820BD37
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C7C1, 3
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C7C1, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_2F_EventScript_20BD40:: @ 820BD40
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C82F, 3
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C82F, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_2F_EventScript_20BD49:: @ 820BD49
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C88B, 3
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C88B, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_2F_EventScript_20BD52:: @ 820BD52
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C8E8, 3
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C8E8, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_2F_EventScript_20BD5B:: @ 820BD5B
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C93A, 3
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C93A, MSGBOX_SIGN
 	end
 
 SlateportCity_OceanicMuseum_2F_EventScript_20BD64:: @ 820BD64
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C43F, 2
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C43F, MSGBOX_NPC
 	end
 
 SlateportCity_OceanicMuseum_2F_EventScript_20BD6D:: @ 820BD6D
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C495, 2
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C495, MSGBOX_NPC
 	end
 
 SlateportCity_OceanicMuseum_2F_EventScript_20BD76:: @ 820BD76
 	lock
 	faceplayer
-	msgbox SlateportCity_OceanicMuseum_2F_Text_20C4C2, 4
+	msgbox SlateportCity_OceanicMuseum_2F_Text_20C4C2, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, SlateportCity_OceanicMuseum_2F_Movement_2725A2
 	waitmovement 0

--- a/data/maps/SlateportCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/SlateportCity_PokemonCenter_1F/scripts.inc
@@ -17,11 +17,11 @@ SlateportCity_PokemonCenter_1F_EventScript_20DAD3:: @ 820DAD3
 	end
 
 SlateportCity_PokemonCenter_1F_EventScript_20DAE1:: @ 820DAE1
-	msgbox SlateportCity_PokemonCenter_1F_Text_20DAF3, 2
+	msgbox SlateportCity_PokemonCenter_1F_Text_20DAF3, MSGBOX_NPC
 	end
 
 SlateportCity_PokemonCenter_1F_EventScript_20DAEA:: @ 820DAEA
-	msgbox SlateportCity_PokemonCenter_1F_Text_20DBBC, 2
+	msgbox SlateportCity_PokemonCenter_1F_Text_20DBBC, MSGBOX_NPC
 	end
 
 SlateportCity_PokemonCenter_1F_Text_20DAF3: @ 820DAF3

--- a/data/maps/SlateportCity_PokemonFanClub/scripts.inc
+++ b/data/maps/SlateportCity_PokemonFanClub/scripts.inc
@@ -17,7 +17,7 @@ SlateportCity_PokemonFanClub_EventScript_209E96:: @ 8209E96
 
 SlateportCity_PokemonFanClub_EventScript_209ED2:: @ 8209ED2
 	setvar VAR_0x40B7, 1
-	msgbox SlateportCity_PokemonFanClub_Text_20A445, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A445, MSGBOX_DEFAULT
 	goto SlateportCity_PokemonFanClub_EventScript_209F45
 	end
 
@@ -37,17 +37,17 @@ SlateportCity_PokemonFanClub_EventScript_209EE5:: @ 8209EE5
 	call_if 1, SlateportCity_PokemonFanClub_EventScript_209FCA
 	compare VAR_0x40B7, 2
 	goto_eq SlateportCity_PokemonFanClub_EventScript_209F3B
-	msgbox SlateportCity_PokemonFanClub_Text_20A62A, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A62A, MSGBOX_DEFAULT
 	goto SlateportCity_PokemonFanClub_EventScript_209F45
 	end
 
 SlateportCity_PokemonFanClub_EventScript_209F3B:: @ 8209F3B
-	msgbox SlateportCity_PokemonFanClub_Text_20A9E1, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A9E1, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_PokemonFanClub_EventScript_209F45:: @ 8209F45
-	msgbox SlateportCity_PokemonFanClub_Text_20A65F, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A65F, MSGBOX_DEFAULT
 	setvar VAR_TEMP_1, 0
 	checkflag FLAG_0x0CC
 	call_if 0, SlateportCity_PokemonFanClub_EventScript_20A13B
@@ -79,7 +79,7 @@ SlateportCity_PokemonFanClub_EventScript_209FD0:: @ 8209FD0
 	return
 
 SlateportCity_PokemonFanClub_EventScript_209FD6:: @ 8209FD6
-	msgbox SlateportCity_PokemonFanClub_Text_20A66E, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A66E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -87,10 +87,10 @@ SlateportCity_PokemonFanClub_EventScript_209FE0:: @ 8209FE0
 	checkitemspace ITEM_RED_SCARF, 1
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_PokemonFanClub_EventScript_20A0D5
-	msgbox SlateportCity_PokemonFanClub_Text_20A795, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A795, MSGBOX_DEFAULT
 	setflag FLAG_0x0C8
 	giveitem_std ITEM_RED_SCARF
-	msgbox SlateportCity_PokemonFanClub_Text_20A827, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A827, MSGBOX_DEFAULT
 	release
 	end
 
@@ -98,10 +98,10 @@ SlateportCity_PokemonFanClub_EventScript_20A011:: @ 820A011
 	checkitemspace ITEM_BLUE_SCARF, 1
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_PokemonFanClub_EventScript_20A0D5
-	msgbox SlateportCity_PokemonFanClub_Text_20A795, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A795, MSGBOX_DEFAULT
 	setflag FLAG_0x0C9
 	giveitem_std ITEM_BLUE_SCARF
-	msgbox SlateportCity_PokemonFanClub_Text_20A880, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A880, MSGBOX_DEFAULT
 	release
 	end
 
@@ -109,10 +109,10 @@ SlateportCity_PokemonFanClub_EventScript_20A042:: @ 820A042
 	checkitemspace ITEM_PINK_SCARF, 1
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_PokemonFanClub_EventScript_20A0D5
-	msgbox SlateportCity_PokemonFanClub_Text_20A795, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A795, MSGBOX_DEFAULT
 	setflag FLAG_0x0CA
 	giveitem_std ITEM_PINK_SCARF
-	msgbox SlateportCity_PokemonFanClub_Text_20A8D7, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A8D7, MSGBOX_DEFAULT
 	release
 	end
 
@@ -120,10 +120,10 @@ SlateportCity_PokemonFanClub_EventScript_20A073:: @ 820A073
 	checkitemspace ITEM_GREEN_SCARF, 1
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_PokemonFanClub_EventScript_20A0D5
-	msgbox SlateportCity_PokemonFanClub_Text_20A795, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A795, MSGBOX_DEFAULT
 	setflag FLAG_0x0CB
 	giveitem_std ITEM_GREEN_SCARF
-	msgbox SlateportCity_PokemonFanClub_Text_20A933, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A933, MSGBOX_DEFAULT
 	release
 	end
 
@@ -131,15 +131,15 @@ SlateportCity_PokemonFanClub_EventScript_20A0A4:: @ 820A0A4
 	checkitemspace ITEM_YELLOW_SCARF, 1
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_PokemonFanClub_EventScript_20A0D5
-	msgbox SlateportCity_PokemonFanClub_Text_20A795, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A795, MSGBOX_DEFAULT
 	setflag FLAG_0x0CC
 	giveitem_std ITEM_YELLOW_SCARF
-	msgbox SlateportCity_PokemonFanClub_Text_20A984, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A984, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_PokemonFanClub_EventScript_20A0D5:: @ 820A0D5
-	msgbox SlateportCity_PokemonFanClub_Text_20A719, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A719, MSGBOX_DEFAULT
 	release
 	end
 
@@ -196,18 +196,18 @@ SlateportCity_PokemonFanClub_EventScript_20A14C:: @ 820A14C
 SlateportCity_PokemonFanClub_EventScript_20A152:: @ 820A152
 	checkflag FLAG_0x156
 	goto_eq SlateportCity_PokemonFanClub_EventScript_20A168
-	msgbox SlateportCity_PokemonFanClub_Text_20A233, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A233, MSGBOX_DEFAULT
 	setflag FLAG_0x156
 	release
 	end
 
 SlateportCity_PokemonFanClub_EventScript_20A168:: @ 820A168
-	msgbox SlateportCity_PokemonFanClub_Text_20A3EE, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A3EE, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_PokemonFanClub_EventScript_20A172:: @ 820A172
-	msgbox SlateportCity_PokemonFanClub_Text_20A233, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20A233, MSGBOX_DEFAULT
 	setflag FLAG_0x156
 	return
 
@@ -216,7 +216,7 @@ SlateportCity_PokemonFanClub_EventScript_20A17E:: @ 820A17E
 	faceplayer
 	checkflag FLAG_0x116
 	goto_eq SlateportCity_PokemonFanClub_EventScript_20A1DE
-	msgbox SlateportCity_PokemonFanClub_Text_20AA77, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20AA77, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, GetLeadMonFriendshipScore
 	compare VAR_RESULT, 4
 	goto_if 4, SlateportCity_PokemonFanClub_EventScript_20A1A3
@@ -229,7 +229,7 @@ SlateportCity_PokemonFanClub_EventScript_20A1A3:: @ 820A1A3
 	waitmovement 0
 	applymovement VAR_LAST_TALKED, SlateportCity_PokemonFanClub_Movement_27259A
 	waitmovement 0
-	msgbox SlateportCity_PokemonFanClub_Text_20AB63, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20AB63, MSGBOX_DEFAULT
 	giveitem_std ITEM_SOOTHE_BELL
 	compare VAR_RESULT, 0
 	goto_eq SlateportCity_PokemonFanClub_EventScript_272054
@@ -238,16 +238,16 @@ SlateportCity_PokemonFanClub_EventScript_20A1A3:: @ 820A1A3
 	end
 
 SlateportCity_PokemonFanClub_EventScript_20A1DE:: @ 820A1DE
-	msgbox SlateportCity_PokemonFanClub_Text_20ABC4, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20ABC4, MSGBOX_DEFAULT
 	release
 	end
 
 SlateportCity_PokemonFanClub_EventScript_20A1E8:: @ 820A1E8
-	msgbox SlateportCity_PokemonFanClub_Text_20AC47, 2
+	msgbox SlateportCity_PokemonFanClub_Text_20AC47, MSGBOX_NPC
 	end
 
 SlateportCity_PokemonFanClub_EventScript_20A1F1:: @ 820A1F1
-	msgbox SlateportCity_PokemonFanClub_Text_20ACF9, 2
+	msgbox SlateportCity_PokemonFanClub_Text_20ACF9, MSGBOX_NPC
 	end
 
 SlateportCity_PokemonFanClub_EventScript_20A1FA:: @ 820A1FA
@@ -255,7 +255,7 @@ SlateportCity_PokemonFanClub_EventScript_20A1FA:: @ 820A1FA
 	faceplayer
 	waitse
 	playmoncry SPECIES_SKITTY, 0
-	msgbox SlateportCity_PokemonFanClub_Text_20AD5A, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20AD5A, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
@@ -265,7 +265,7 @@ SlateportCity_PokemonFanClub_EventScript_20A20D:: @ 820A20D
 	faceplayer
 	waitse
 	playmoncry SPECIES_ZIGZAGOON, 0
-	msgbox SlateportCity_PokemonFanClub_Text_20AD6E, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20AD6E, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
@@ -275,7 +275,7 @@ SlateportCity_PokemonFanClub_EventScript_20A220:: @ 820A220
 	faceplayer
 	waitse
 	playmoncry SPECIES_AZUMARILL, 0
-	msgbox SlateportCity_PokemonFanClub_Text_20AD80, 4
+	msgbox SlateportCity_PokemonFanClub_Text_20AD80, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/SlateportCity_SternsShipyard_1F/scripts.inc
+++ b/data/maps/SlateportCity_SternsShipyard_1F/scripts.inc
@@ -11,10 +11,10 @@ SlateportCity_SternsShipyard_1F_EventScript_207F40:: @ 8207F40
 	goto_eq SlateportCity_SternsShipyard_1F_EventScript_207FD9
 	checkflag FLAG_0x094
 	goto_eq SlateportCity_SternsShipyard_1F_EventScript_207FBA
-	msgbox SlateportCity_SternsShipyard_1F_Text_208008, 4
+	msgbox SlateportCity_SternsShipyard_1F_Text_208008, MSGBOX_DEFAULT
 	applymovement 1, SlateportCity_SternsShipyard_1F_Movement_27259E
 	waitmovement 0
-	msgbox SlateportCity_SternsShipyard_1F_Text_2080A5, 4
+	msgbox SlateportCity_SternsShipyard_1F_Text_2080A5, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, SlateportCity_SternsShipyard_1F_Movement_2725A2
 	waitmovement 0
@@ -26,21 +26,21 @@ SlateportCity_SternsShipyard_1F_EventScript_207F40:: @ 8207F40
 SlateportCity_SternsShipyard_1F_EventScript_207F92:: @ 8207F92
 	applymovement 1, SlateportCity_SternsShipyard_1F_Movement_27259E
 	waitmovement 0
-	msgbox SlateportCity_SternsShipyard_1F_Text_208323, 4
+	msgbox SlateportCity_SternsShipyard_1F_Text_208323, MSGBOX_DEFAULT
 	releaseall
 	end
 
 SlateportCity_SternsShipyard_1F_EventScript_207FA6:: @ 8207FA6
 	applymovement 1, SlateportCity_SternsShipyard_1F_Movement_27259E
 	waitmovement 0
-	msgbox SlateportCity_SternsShipyard_1F_Text_2082A8, 4
+	msgbox SlateportCity_SternsShipyard_1F_Text_2082A8, MSGBOX_DEFAULT
 	releaseall
 	end
 
 SlateportCity_SternsShipyard_1F_EventScript_207FBA:: @ 8207FBA
 	applymovement 1, SlateportCity_SternsShipyard_1F_Movement_27259E
 	waitmovement 0
-	msgbox SlateportCity_SternsShipyard_1F_Text_2081A5, 4
+	msgbox SlateportCity_SternsShipyard_1F_Text_2081A5, MSGBOX_DEFAULT
 	closemessage
 	applymovement 1, SlateportCity_SternsShipyard_1F_Movement_2725A2
 	waitmovement 0
@@ -50,20 +50,20 @@ SlateportCity_SternsShipyard_1F_EventScript_207FBA:: @ 8207FBA
 SlateportCity_SternsShipyard_1F_EventScript_207FD9:: @ 8207FD9
 	applymovement 1, SlateportCity_SternsShipyard_1F_Movement_27259E
 	waitmovement 0
-	msgbox SlateportCity_SternsShipyard_1F_Text_208213, 4
+	msgbox SlateportCity_SternsShipyard_1F_Text_208213, MSGBOX_DEFAULT
 	releaseall
 	end
 
 SlateportCity_SternsShipyard_1F_EventScript_207FED:: @ 8207FED
-	msgbox SlateportCity_SternsShipyard_1F_Text_208558, 2
+	msgbox SlateportCity_SternsShipyard_1F_Text_208558, MSGBOX_NPC
 	end
 
 SlateportCity_SternsShipyard_1F_EventScript_207FF6:: @ 8207FF6
-	msgbox SlateportCity_SternsShipyard_1F_Text_2085FF, 2
+	msgbox SlateportCity_SternsShipyard_1F_Text_2085FF, MSGBOX_NPC
 	end
 
 SlateportCity_SternsShipyard_1F_EventScript_207FFF:: @ 8207FFF
-	msgbox SlateportCity_SternsShipyard_1F_Text_2083EE, 2
+	msgbox SlateportCity_SternsShipyard_1F_Text_2083EE, MSGBOX_NPC
 	end
 
 SlateportCity_SternsShipyard_1F_Text_208008: @ 8208008

--- a/data/maps/SlateportCity_SternsShipyard_2F/scripts.inc
+++ b/data/maps/SlateportCity_SternsShipyard_2F/scripts.inc
@@ -2,11 +2,11 @@ SlateportCity_SternsShipyard_2F_MapScripts:: @ 820863D
 	.byte 0
 
 SlateportCity_SternsShipyard_2F_EventScript_20863E:: @ 820863E
-	msgbox SlateportCity_SternsShipyard_2F_Text_208650, 2
+	msgbox SlateportCity_SternsShipyard_2F_Text_208650, MSGBOX_NPC
 	end
 
 SlateportCity_SternsShipyard_2F_EventScript_208647:: @ 8208647
-	msgbox SlateportCity_SternsShipyard_2F_Text_2086BA, 2
+	msgbox SlateportCity_SternsShipyard_2F_Text_2086BA, MSGBOX_NPC
 	end
 
 SlateportCity_SternsShipyard_2F_Text_208650: @ 8208650

--- a/data/maps/SootopolisCity/scripts.inc
+++ b/data/maps/SootopolisCity/scripts.inc
@@ -704,22 +704,22 @@ SootopolisCity_EventScript_1E5E8D:: @ 81E5E8D
 	goto_eq SootopolisCity_EventScript_1E5ECE
 	compare VAR_0x405E, 2
 	goto_if 4, SootopolisCity_EventScript_1E5EBA
-	msgbox SootopolisCity_Text_1E6D77, 4
+	msgbox SootopolisCity_Text_1E6D77, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_EventScript_1E5EBA:: @ 81E5EBA
-	msgbox SootopolisCity_Text_1E6DFE, 4
+	msgbox SootopolisCity_Text_1E6DFE, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_EventScript_1E5EC4:: @ 81E5EC4
-	msgbox SootopolisCity_Text_1E6F38, 4
+	msgbox SootopolisCity_Text_1E6F38, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_EventScript_1E5ECE:: @ 81E5ECE
-	msgbox SootopolisCity_Text_1E6ED4, 4
+	msgbox SootopolisCity_Text_1E6ED4, MSGBOX_DEFAULT
 	release
 	end
 
@@ -732,7 +732,7 @@ SootopolisCity_EventScript_1E5ED8:: @ 81E5ED8
 	goto_if 4, SootopolisCity_EventScript_1E5F1B
 	compare VAR_0x405E, 5
 	goto_eq SootopolisCity_EventScript_1E5F10
-	msgbox SootopolisCity_Text_1E6BFF, 4
+	msgbox SootopolisCity_Text_1E6BFF, MSGBOX_DEFAULT
 	closemessage
 	applymovement 3, SootopolisCity_Movement_2725A2
 	waitmovement 0
@@ -740,7 +740,7 @@ SootopolisCity_EventScript_1E5ED8:: @ 81E5ED8
 	end
 
 SootopolisCity_EventScript_1E5F10:: @ 81E5F10
-	msgbox SootopolisCity_Text_1E6C53, 4
+	msgbox SootopolisCity_Text_1E6C53, MSGBOX_DEFAULT
 	closemessage
 	release
 	end
@@ -750,7 +750,7 @@ SootopolisCity_EventScript_1E5F1B:: @ 81E5F1B
 	special GetPlayerBigGuyGirlString
 	checkflag FLAG_0x932
 	goto_eq SootopolisCity_EventScript_1E5FBB
-	msgbox SootopolisCity_Text_2A7BB0, 4
+	msgbox SootopolisCity_Text_2A7BB0, MSGBOX_DEFAULT
 	random 10
 	addvar VAR_RESULT, 20
 	addvar VAR_RESULT, 133
@@ -758,7 +758,7 @@ SootopolisCity_EventScript_1E5F1B:: @ 81E5F1B
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_EventScript_272054
 	setflag FLAG_0x932
-	msgbox SootopolisCity_Text_2A7C7C, 4
+	msgbox SootopolisCity_Text_2A7C7C, MSGBOX_DEFAULT
 	random 2
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_EventScript_1E5F79
@@ -770,7 +770,7 @@ SootopolisCity_EventScript_1E5F79:: @ 81E5F79
 	giveitem_std ITEM_FIGY_BERRY
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_EventScript_272054
-	msgbox SootopolisCity_Text_2A7CB7, 4
+	msgbox SootopolisCity_Text_2A7CB7, MSGBOX_DEFAULT
 	release
 	end
 
@@ -778,20 +778,20 @@ SootopolisCity_EventScript_1E5F9A:: @ 81E5F9A
 	giveitem_std ITEM_IAPAPA_BERRY
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_EventScript_272054
-	msgbox SootopolisCity_Text_2A7CB7, 4
+	msgbox SootopolisCity_Text_2A7CB7, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_EventScript_1E5FBB:: @ 81E5FBB
-	msgbox SootopolisCity_Text_2A7CEC, 5
+	msgbox SootopolisCity_Text_2A7CEC, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq SootopolisCity_EventScript_1E5FD8
-	msgbox SootopolisCity_Text_2A7DD2, 4
+	msgbox SootopolisCity_Text_2A7DD2, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_EventScript_1E5FD8:: @ 81E5FD8
-	msgbox SootopolisCity_Text_2A7D80, 4
+	msgbox SootopolisCity_Text_2A7D80, MSGBOX_DEFAULT
 	release
 	end
 
@@ -801,7 +801,7 @@ SootopolisCity_EventScript_1E5FE2:: @ 81E5FE2
 	waitmovement 0
 	compare VAR_0x405E, 5
 	goto_eq SootopolisCity_EventScript_1E600D
-	msgbox SootopolisCity_Text_1E71A1, 4
+	msgbox SootopolisCity_Text_1E71A1, MSGBOX_DEFAULT
 	closemessage
 	applymovement 2, SootopolisCity_Movement_2725A2
 	waitmovement 0
@@ -809,7 +809,7 @@ SootopolisCity_EventScript_1E5FE2:: @ 81E5FE2
 	end
 
 SootopolisCity_EventScript_1E600D:: @ 81E600D
-	msgbox SootopolisCity_Text_1E728C, 4
+	msgbox SootopolisCity_Text_1E728C, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -818,12 +818,12 @@ SootopolisCity_EventScript_1E6017:: @ 81E6017
 	faceplayer
 	compare VAR_0x405E, 6
 	goto_if 4, SootopolisCity_EventScript_1E602E
-	msgbox SootopolisCity_Text_1E6CCA, 4
+	msgbox SootopolisCity_Text_1E6CCA, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_EventScript_1E602E:: @ 81E602E
-	msgbox SootopolisCity_Text_1E6D57, 4
+	msgbox SootopolisCity_Text_1E6D57, MSGBOX_DEFAULT
 	release
 	end
 
@@ -836,12 +836,12 @@ SootopolisCity_EventScript_1E6038:: @ 81E6038
 	goto_eq SootopolisCity_EventScript_1E6084
 	compare VAR_0x405E, 2
 	goto_if 4, SootopolisCity_EventScript_1E6065
-	msgbox SootopolisCity_Text_1E6F90, 4
+	msgbox SootopolisCity_Text_1E6F90, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_EventScript_1E6065:: @ 81E6065
-	msgbox SootopolisCity_Text_1E7078, 4
+	msgbox SootopolisCity_Text_1E7078, MSGBOX_DEFAULT
 	closemessage
 	applymovement 8, SootopolisCity_Movement_2725A2
 	waitmovement 0
@@ -849,12 +849,12 @@ SootopolisCity_EventScript_1E6065:: @ 81E6065
 	end
 
 SootopolisCity_EventScript_1E607A:: @ 81E607A
-	msgbox SootopolisCity_Text_1E710B, 4
+	msgbox SootopolisCity_Text_1E710B, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_EventScript_1E6084:: @ 81E6084
-	msgbox SootopolisCity_Text_1E70D4, 4
+	msgbox SootopolisCity_Text_1E70D4, MSGBOX_DEFAULT
 	release
 	end
 
@@ -868,7 +868,7 @@ SootopolisCity_EventScript_1E608E:: @ 81E608E
 	goto_if 4, SootopolisCity_EventScript_1E60CF
 	compare VAR_0x405E, 1
 	goto_if 3, SootopolisCity_EventScript_1E60CF
-	msgbox SootopolisCity_Text_1E690B, 4
+	msgbox SootopolisCity_Text_1E690B, MSGBOX_DEFAULT
 	closemessage
 	applymovement 4, SootopolisCity_Movement_2725A2
 	waitmovement 0
@@ -876,12 +876,12 @@ SootopolisCity_EventScript_1E608E:: @ 81E608E
 	end
 
 SootopolisCity_EventScript_1E60CF:: @ 81E60CF
-	msgbox SootopolisCity_Text_1E68A1, 4
+	msgbox SootopolisCity_Text_1E68A1, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_EventScript_1E60D9:: @ 81E60D9
-	msgbox SootopolisCity_Text_1E6920, 4
+	msgbox SootopolisCity_Text_1E6920, MSGBOX_DEFAULT
 	release
 	end
 
@@ -897,7 +897,7 @@ SootopolisCity_EventScript_1E60E3:: @ 81E60E3
 	goto_if 4, SootopolisCity_EventScript_1E6141
 	compare VAR_0x405E, 1
 	goto_if 3, SootopolisCity_EventScript_1E6141
-	msgbox SootopolisCity_Text_1E6692, 4
+	msgbox SootopolisCity_Text_1E6692, MSGBOX_DEFAULT
 	closemessage
 	applymovement 5, SootopolisCity_Movement_2725A2
 	waitmovement 0
@@ -905,30 +905,30 @@ SootopolisCity_EventScript_1E60E3:: @ 81E60E3
 	end
 
 SootopolisCity_EventScript_1E612D:: @ 81E612D
-	msgbox SootopolisCity_Text_1E6750, 4
+	msgbox SootopolisCity_Text_1E6750, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_EventScript_1E6137:: @ 81E6137
-	msgbox SootopolisCity_Text_1E677F, 4
+	msgbox SootopolisCity_Text_1E677F, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_EventScript_1E6141:: @ 81E6141
-	msgbox SootopolisCity_Text_1E6618, 4
+	msgbox SootopolisCity_Text_1E6618, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_EventScript_1E614B:: @ 81E614B
-	msgbox SootopolisCity_Text_1E656F, 3
+	msgbox SootopolisCity_Text_1E656F, MSGBOX_SIGN
 	end
 
 SootopolisCity_EventScript_1E6154:: @ 81E6154
-	msgbox SootopolisCity_Text_1E65C8, 3
+	msgbox SootopolisCity_Text_1E65C8, MSGBOX_SIGN
 	end
 
 EventScript_ClosedSootopolisDoor:: @ 81E615D
-	msgbox SootopolisCity_Text_1E6604, 3
+	msgbox SootopolisCity_Text_1E6604, MSGBOX_SIGN
 	end
 
 SootopolisCity_EventScript_1E6166:: @ 81E6166
@@ -945,33 +945,33 @@ SootopolisCity_EventScript_1E6166:: @ 81E6166
 	goto_eq SootopolisCity_EventScript_1E61C2
 	checkflag FLAG_0x09E
 	goto_eq SootopolisCity_EventScript_1E61B8
-	msgbox SootopolisCity_Text_1E78E5, 4
+	msgbox SootopolisCity_Text_1E78E5, MSGBOX_DEFAULT
 	releaseall
 	end
 
 SootopolisCity_EventScript_1E61AE:: @ 81E61AE
-	msgbox SootopolisCity_Text_1E7866, 4
+	msgbox SootopolisCity_Text_1E7866, MSGBOX_DEFAULT
 	releaseall
 	end
 
 SootopolisCity_EventScript_1E61B8:: @ 81E61B8
-	msgbox SootopolisCity_Text_1E794B, 4
+	msgbox SootopolisCity_Text_1E794B, MSGBOX_DEFAULT
 	releaseall
 	end
 
 SootopolisCity_EventScript_1E61C2:: @ 81E61C2
-	msgbox SootopolisCity_Text_1E789A, 4
+	msgbox SootopolisCity_Text_1E789A, MSGBOX_DEFAULT
 	releaseall
 	end
 
 SootopolisCity_EventScript_1E61CC:: @ 81E61CC
-	msgbox SootopolisCity_Text_1E75CB, 4
+	msgbox SootopolisCity_Text_1E75CB, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_FACING, 3
 	call_if 1, SootopolisCity_EventScript_1E6243
 	compare VAR_FACING, 2
 	call_if 1, SootopolisCity_EventScript_1E6255
-	msgbox SootopolisCity_Text_1E7737, 4
+	msgbox SootopolisCity_Text_1E7737, MSGBOX_DEFAULT
 	closemessage
 	applymovement 7, SootopolisCity_Movement_1E62D4
 	applymovement 255, SootopolisCity_Movement_1E630E
@@ -982,7 +982,7 @@ SootopolisCity_EventScript_1E61CC:: @ 81E61CC
 	applymovement 7, SootopolisCity_Movement_1E6344
 	applymovement 255, SootopolisCity_Movement_1E634F
 	waitmovement 0
-	msgbox SootopolisCity_Text_1E77F0, 4
+	msgbox SootopolisCity_Text_1E77F0, MSGBOX_DEFAULT
 	closemessage
 	setflag FLAG_0x133
 	applymovement 255, SootopolisCity_Movement_1E635A
@@ -1273,7 +1273,7 @@ SootopolisCity_EventScript_1E635D:: @ 81E635D
 	waitmovement 0
 	compare VAR_0x405E, 5
 	goto_eq SootopolisCity_EventScript_1E6388
-	msgbox SootopolisCity_Text_1E67DC, 4
+	msgbox SootopolisCity_Text_1E67DC, MSGBOX_DEFAULT
 	closemessage
 	applymovement 15, SootopolisCity_Movement_2725A2
 	waitmovement 0
@@ -1281,7 +1281,7 @@ SootopolisCity_EventScript_1E635D:: @ 81E635D
 	end
 
 SootopolisCity_EventScript_1E6388:: @ 81E6388
-	msgbox SootopolisCity_Text_1E6853, 4
+	msgbox SootopolisCity_Text_1E6853, MSGBOX_DEFAULT
 	closemessage
 	releaseall
 	end
@@ -1290,11 +1290,11 @@ SootopolisCity_EventScript_1E6393:: @ 81E6393
 	lockall
 	compare VAR_0x405E, 5
 	goto_eq SootopolisCity_EventScript_1E63C7
-	msgbox SootopolisCity_Text_1E6936, 4
+	msgbox SootopolisCity_Text_1E6936, MSGBOX_DEFAULT
 	closemessage
 	applymovement 14, SootopolisCity_Movement_27259E
 	waitmovement 0
-	msgbox SootopolisCity_Text_1E696C, 4
+	msgbox SootopolisCity_Text_1E696C, MSGBOX_DEFAULT
 	closemessage
 	applymovement 14, SootopolisCity_Movement_2725A2
 	waitmovement 0
@@ -1304,7 +1304,7 @@ SootopolisCity_EventScript_1E6393:: @ 81E6393
 SootopolisCity_EventScript_1E63C7:: @ 81E63C7
 	applymovement 14, SootopolisCity_Movement_27259E
 	waitmovement 0
-	msgbox SootopolisCity_Text_1E69B8, 4
+	msgbox SootopolisCity_Text_1E69B8, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -1314,7 +1314,7 @@ SootopolisCity_EventScript_1E63DB:: @ 81E63DB
 	waitmovement 0
 	compare VAR_0x405E, 5
 	goto_eq SootopolisCity_EventScript_1E6406
-	msgbox SootopolisCity_Text_1E6C7C, 4
+	msgbox SootopolisCity_Text_1E6C7C, MSGBOX_DEFAULT
 	closemessage
 	applymovement 13, SootopolisCity_Movement_2725A2
 	waitmovement 0
@@ -1322,7 +1322,7 @@ SootopolisCity_EventScript_1E63DB:: @ 81E63DB
 	end
 
 SootopolisCity_EventScript_1E6406:: @ 81E6406
-	msgbox SootopolisCity_Text_1E6CA6, 4
+	msgbox SootopolisCity_Text_1E6CA6, MSGBOX_DEFAULT
 	closemessage
 	releaseall
 	end
@@ -1333,7 +1333,7 @@ SootopolisCity_EventScript_1E6411:: @ 81E6411
 	waitmovement 0
 	compare VAR_0x405E, 5
 	goto_eq SootopolisCity_EventScript_1E643C
-	msgbox SootopolisCity_Text_1E6A50, 4
+	msgbox SootopolisCity_Text_1E6A50, MSGBOX_DEFAULT
 	closemessage
 	applymovement 12, SootopolisCity_Movement_2725A2
 	waitmovement 0
@@ -1341,7 +1341,7 @@ SootopolisCity_EventScript_1E6411:: @ 81E6411
 	end
 
 SootopolisCity_EventScript_1E643C:: @ 81E643C
-	msgbox SootopolisCity_Text_1E6B2A, 4
+	msgbox SootopolisCity_Text_1E6B2A, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -1354,15 +1354,15 @@ SootopolisCity_EventScript_1E6446:: @ 81E6446
 	goto_eq SootopolisCity_EventScript_1E64E2
 	checkflag FLAG_0x09E
 	goto_eq SootopolisCity_EventScript_1E646F
-	msgbox SootopolisCity_Text_1E7A3E, 4
+	msgbox SootopolisCity_Text_1E7A3E, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_EventScript_1E646F:: @ 81E646F
-	msgbox SootopolisCity_Text_1E7ACF, 4
+	msgbox SootopolisCity_Text_1E7ACF, MSGBOX_DEFAULT
 	giveitem_std ITEM_HM07
 	setflag FLAG_0x138
-	msgbox SootopolisCity_Text_1E7B86, 4
+	msgbox SootopolisCity_Text_1E7B86, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_FACING, 2
 	call_if 1, SootopolisCity_EventScript_1E64B2
@@ -1388,12 +1388,12 @@ SootopolisCity_EventScript_1E64C5:: @ 81E64C5
 	return
 
 SootopolisCity_EventScript_1E64D8:: @ 81E64D8
-	msgbox SootopolisCity_Text_1E79C8, 4
+	msgbox SootopolisCity_Text_1E79C8, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_EventScript_1E64E2:: @ 81E64E2
-	msgbox SootopolisCity_Text_1E7CBC, 4
+	msgbox SootopolisCity_Text_1E7CBC, MSGBOX_DEFAULT
 	release
 	end
 
@@ -1411,13 +1411,13 @@ SootopolisCity_EventScript_1E64F2:: @ 81E64F2
 	lockall
 	compare VAR_0x405E, 5
 	goto_eq SootopolisCity_EventScript_1E6509
-	msgbox SootopolisCity_Text_1E72DB, 4
+	msgbox SootopolisCity_Text_1E72DB, MSGBOX_DEFAULT
 	closemessage
 	releaseall
 	end
 
 SootopolisCity_EventScript_1E6509:: @ 81E6509
-	msgbox SootopolisCity_Text_1E737E, 4
+	msgbox SootopolisCity_Text_1E737E, MSGBOX_DEFAULT
 	setflag FLAG_0x135
 	checkflag FLAG_0x134
 	goto_eq SootopolisCity_EventScript_1E654C
@@ -1428,13 +1428,13 @@ SootopolisCity_EventScript_1E651F:: @ 81E651F
 	lockall
 	compare VAR_0x405E, 5
 	goto_eq SootopolisCity_EventScript_1E6536
-	msgbox SootopolisCity_Text_1E7460, 4
+	msgbox SootopolisCity_Text_1E7460, MSGBOX_DEFAULT
 	closemessage
 	releaseall
 	end
 
 SootopolisCity_EventScript_1E6536:: @ 81E6536
-	msgbox SootopolisCity_Text_1E74F6, 4
+	msgbox SootopolisCity_Text_1E74F6, MSGBOX_DEFAULT
 	setflag FLAG_0x134
 	checkflag FLAG_0x135
 	goto_eq SootopolisCity_EventScript_1E654C

--- a/data/maps/SootopolisCity_Gym_1F/scripts.inc
+++ b/data/maps/SootopolisCity_Gym_1F/scripts.inc
@@ -94,7 +94,7 @@ SootopolisCity_Gym_1F_EventScript_224F44:: @ 8224F44
 	goto_if 0, SootopolisCity_Gym_1F_EventScript_224FF7
 	checkflag FLAG_BADGE06_GET
 	goto_if 0, SootopolisCity_Gym_1F_EventScript_22501B
-	msgbox SootopolisCity_Gym_1F_Text_225778, 4
+	msgbox SootopolisCity_Gym_1F_Text_225778, MSGBOX_DEFAULT
 	release
 	end
 
@@ -102,7 +102,7 @@ SootopolisCity_Gym_1F_EventScript_224F82:: @ 8224F82
 	message SootopolisCity_Gym_1F_Text_225598
 	waitmessage
 	call SootopolisCity_Gym_1F_EventScript_27207E
-	msgbox SootopolisCity_Gym_1F_Text_2255BE, 4
+	msgbox SootopolisCity_Gym_1F_Text_2255BE, MSGBOX_DEFAULT
 	setflag FLAG_0x4F7
 	setflag FLAG_BADGE08_GET
 	setflag FLAG_HIDE_SOOTOPOLIS_CITY_RESIDENTS
@@ -116,7 +116,7 @@ SootopolisCity_Gym_1F_EventScript_224F82:: @ 8224F82
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox SootopolisCity_Gym_1F_Text_22574D, 4
+	msgbox SootopolisCity_Gym_1F_Text_22574D, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
@@ -128,7 +128,7 @@ SootopolisCity_Gym_1F_EventScript_224FD4:: @ 8224FD4
 	giveitem_std ITEM_TM03
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_Gym_1F_EventScript_27205E
-	msgbox SootopolisCity_Gym_1F_Text_2256C1, 4
+	msgbox SootopolisCity_Gym_1F_Text_2256C1, MSGBOX_DEFAULT
 	setflag FLAG_0x0AC
 	return
 
@@ -136,19 +136,19 @@ SootopolisCity_Gym_1F_EventScript_224FF7:: @ 8224FF7
 	giveitem_std ITEM_TM03
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_Gym_1F_EventScript_272054
-	msgbox SootopolisCity_Gym_1F_Text_2256C1, 4
+	msgbox SootopolisCity_Gym_1F_Text_2256C1, MSGBOX_DEFAULT
 	setflag FLAG_0x0AC
 	release
 	end
 
 SootopolisCity_Gym_1F_EventScript_22501B:: @ 822501B
-	msgbox SootopolisCity_Gym_1F_Text_225865, 4
+	msgbox SootopolisCity_Gym_1F_Text_225865, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_Gym_1F_EventScript_225025:: @ 8225025
 	trainerbattle 7, TRAINER_JUAN_1, 0, SootopolisCity_Gym_1F_Text_225950, SootopolisCity_Gym_1F_Text_225A2E, SootopolisCity_Gym_1F_Text_225B48
-	msgbox SootopolisCity_Gym_1F_Text_225A67, 6
+	msgbox SootopolisCity_Gym_1F_Text_225A67, MSGBOX_AUTOCLOSE
 	end
 
 SootopolisCity_Gym_1F_EventScript_225040:: @ 8225040
@@ -156,12 +156,12 @@ SootopolisCity_Gym_1F_EventScript_225040:: @ 8225040
 	faceplayer
 	checkflag FLAG_0x4F7
 	goto_eq SootopolisCity_Gym_1F_EventScript_225055
-	msgbox SootopolisCity_Gym_1F_Text_225093, 4
+	msgbox SootopolisCity_Gym_1F_Text_225093, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_Gym_1F_EventScript_225055:: @ 8225055
-	msgbox SootopolisCity_Gym_1F_Text_2251AF, 4
+	msgbox SootopolisCity_Gym_1F_Text_2251AF, MSGBOX_DEFAULT
 	release
 	end
 
@@ -180,12 +180,12 @@ SootopolisCity_Gym_1F_EventScript_22506F:: @ 822506F
 	end
 
 SootopolisCity_Gym_1F_EventScript_22507F:: @ 822507F
-	msgbox SootopolisCity_Gym_1F_Text_225916, 4
+	msgbox SootopolisCity_Gym_1F_Text_225916, MSGBOX_DEFAULT
 	releaseall
 	end
 
 SootopolisCity_Gym_1F_EventScript_225089:: @ 8225089
-	msgbox SootopolisCity_Gym_1F_Text_2258FA, 4
+	msgbox SootopolisCity_Gym_1F_Text_2258FA, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/SootopolisCity_Gym_B1F/scripts.inc
+++ b/data/maps/SootopolisCity_Gym_B1F/scripts.inc
@@ -3,52 +3,52 @@ SootopolisCity_Gym_B1F_MapScripts:: @ 8225C8A
 
 SootopolisCity_Gym_B1F_EventScript_225C8B:: @ 8225C8B
 	trainerbattle 0, TRAINER_ANDREA, 0, SootopolisCity_Gym_B1F_Text_225D71, SootopolisCity_Gym_B1F_Text_225DB6
-	msgbox SootopolisCity_Gym_B1F_Text_225DCF, 6
+	msgbox SootopolisCity_Gym_B1F_Text_225DCF, MSGBOX_AUTOCLOSE
 	end
 
 SootopolisCity_Gym_B1F_EventScript_225CA2:: @ 8225CA2
 	trainerbattle 0, TRAINER_CRISSY, 0, SootopolisCity_Gym_B1F_Text_225E04, SootopolisCity_Gym_B1F_Text_225E60
-	msgbox SootopolisCity_Gym_B1F_Text_225E90, 6
+	msgbox SootopolisCity_Gym_B1F_Text_225E90, MSGBOX_AUTOCLOSE
 	end
 
 SootopolisCity_Gym_B1F_EventScript_225CB9:: @ 8225CB9
 	trainerbattle 0, TRAINER_BRIANNA, 0, SootopolisCity_Gym_B1F_Text_22646E, SootopolisCity_Gym_B1F_Text_226495
-	msgbox SootopolisCity_Gym_B1F_Text_2264BC, 6
+	msgbox SootopolisCity_Gym_B1F_Text_2264BC, MSGBOX_AUTOCLOSE
 	end
 
 SootopolisCity_Gym_B1F_EventScript_225CD0:: @ 8225CD0
 	trainerbattle 0, TRAINER_CONNIE, 0, SootopolisCity_Gym_B1F_Text_225FBE, SootopolisCity_Gym_B1F_Text_225FEB
-	msgbox SootopolisCity_Gym_B1F_Text_225FFE, 6
+	msgbox SootopolisCity_Gym_B1F_Text_225FFE, MSGBOX_AUTOCLOSE
 	end
 
 SootopolisCity_Gym_B1F_EventScript_225CE7:: @ 8225CE7
 	trainerbattle 0, TRAINER_BRIDGET, 0, SootopolisCity_Gym_B1F_Text_226061, SootopolisCity_Gym_B1F_Text_2260B6
-	msgbox SootopolisCity_Gym_B1F_Text_2260D1, 6
+	msgbox SootopolisCity_Gym_B1F_Text_2260D1, MSGBOX_AUTOCLOSE
 	end
 
 SootopolisCity_Gym_B1F_EventScript_225CFE:: @ 8225CFE
 	trainerbattle 0, TRAINER_OLIVIA, 0, SootopolisCity_Gym_B1F_Text_226164, SootopolisCity_Gym_B1F_Text_2261A7
-	msgbox SootopolisCity_Gym_B1F_Text_2261B5, 6
+	msgbox SootopolisCity_Gym_B1F_Text_2261B5, MSGBOX_AUTOCLOSE
 	end
 
 SootopolisCity_Gym_B1F_EventScript_225D15:: @ 8225D15
 	trainerbattle 0, TRAINER_TIFFANY, 0, SootopolisCity_Gym_B1F_Text_2261F7, SootopolisCity_Gym_B1F_Text_226274
-	msgbox SootopolisCity_Gym_B1F_Text_226286, 6
+	msgbox SootopolisCity_Gym_B1F_Text_226286, MSGBOX_AUTOCLOSE
 	end
 
 SootopolisCity_Gym_B1F_EventScript_225D2C:: @ 8225D2C
 	trainerbattle 0, TRAINER_BETHANY, 0, SootopolisCity_Gym_B1F_Text_2262F3, SootopolisCity_Gym_B1F_Text_22633B
-	msgbox SootopolisCity_Gym_B1F_Text_226341, 6
+	msgbox SootopolisCity_Gym_B1F_Text_226341, MSGBOX_AUTOCLOSE
 	end
 
 SootopolisCity_Gym_B1F_EventScript_225D43:: @ 8225D43
 	trainerbattle 0, TRAINER_ANNIKA, 0, SootopolisCity_Gym_B1F_Text_226388, SootopolisCity_Gym_B1F_Text_2263BD
-	msgbox SootopolisCity_Gym_B1F_Text_2263F4, 6
+	msgbox SootopolisCity_Gym_B1F_Text_2263F4, MSGBOX_AUTOCLOSE
 	end
 
 SootopolisCity_Gym_B1F_EventScript_225D5A:: @ 8225D5A
 	trainerbattle 0, TRAINER_DAPHNE, 0, SootopolisCity_Gym_B1F_Text_225ED6, SootopolisCity_Gym_B1F_Text_225F35
-	msgbox SootopolisCity_Gym_B1F_Text_225F67, 6
+	msgbox SootopolisCity_Gym_B1F_Text_225F67, MSGBOX_AUTOCLOSE
 	end
 
 SootopolisCity_Gym_B1F_Text_225D71: @ 8225D71

--- a/data/maps/SootopolisCity_House1/scripts.inc
+++ b/data/maps/SootopolisCity_House1/scripts.inc
@@ -6,17 +6,17 @@ SootopolisCity_House1_EventScript_22694D:: @ 822694D
 	faceplayer
 	checkflag FLAG_0x079
 	goto_eq SootopolisCity_House1_EventScript_226984
-	msgbox SootopolisCity_House1_Text_2269A1, 4
+	msgbox SootopolisCity_House1_Text_2269A1, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM31
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_House1_EventScript_272054
 	setflag FLAG_0x079
-	msgbox SootopolisCity_House1_Text_226A13, 4
+	msgbox SootopolisCity_House1_Text_226A13, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_House1_EventScript_226984:: @ 8226984
-	msgbox SootopolisCity_House1_Text_226A13, 4
+	msgbox SootopolisCity_House1_Text_226A13, MSGBOX_DEFAULT
 	release
 	end
 
@@ -25,7 +25,7 @@ SootopolisCity_House1_EventScript_22698E:: @ 822698E
 	faceplayer
 	waitse
 	playmoncry SPECIES_KECLEON, 0
-	msgbox SootopolisCity_House1_Text_226A60, 4
+	msgbox SootopolisCity_House1_Text_226A60, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/SootopolisCity_House2/scripts.inc
+++ b/data/maps/SootopolisCity_House2/scripts.inc
@@ -4,7 +4,7 @@ SootopolisCity_House2_MapScripts:: @ 8226A76
 SootopolisCity_House2_EventScript_226A77:: @ 8226A77
 	lock
 	faceplayer
-	msgbox SootopolisCity_House2_Text_226AAB, 5
+	msgbox SootopolisCity_House2_Text_226AAB, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	call_if 1, SootopolisCity_House2_EventScript_226A99
 	compare VAR_RESULT, 0
@@ -13,11 +13,11 @@ SootopolisCity_House2_EventScript_226A77:: @ 8226A77
 	end
 
 SootopolisCity_House2_EventScript_226A99:: @ 8226A99
-	msgbox SootopolisCity_House2_Text_226AF1, 4
+	msgbox SootopolisCity_House2_Text_226AF1, MSGBOX_DEFAULT
 	return
 
 SootopolisCity_House2_EventScript_226AA2:: @ 8226AA2
-	msgbox SootopolisCity_House2_Text_226B41, 4
+	msgbox SootopolisCity_House2_Text_226B41, MSGBOX_DEFAULT
 	return
 
 SootopolisCity_House2_Text_226AAB: @ 8226AAB

--- a/data/maps/SootopolisCity_House3/scripts.inc
+++ b/data/maps/SootopolisCity_House3/scripts.inc
@@ -4,20 +4,20 @@ SootopolisCity_House3_MapScripts:: @ 8226B71
 SootopolisCity_House3_EventScript_226B72:: @ 8226B72
 	lock
 	faceplayer
-	msgbox SootopolisCity_House3_Text_226BA4, 5
+	msgbox SootopolisCity_House3_Text_226BA4, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq SootopolisCity_House3_EventScript_226B91
-	msgbox SootopolisCity_House3_Text_226C44, 4
+	msgbox SootopolisCity_House3_Text_226C44, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_House3_EventScript_226B91:: @ 8226B91
-	msgbox SootopolisCity_House3_Text_226C20, 4
+	msgbox SootopolisCity_House3_Text_226C20, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_House3_EventScript_226B9B:: @ 8226B9B
-	msgbox SootopolisCity_House3_Text_226C9C, 2
+	msgbox SootopolisCity_House3_Text_226C9C, MSGBOX_NPC
 	end
 
 SootopolisCity_House3_Text_226BA4: @ 8226BA4

--- a/data/maps/SootopolisCity_House4/scripts.inc
+++ b/data/maps/SootopolisCity_House4/scripts.inc
@@ -2,11 +2,11 @@ SootopolisCity_House4_MapScripts:: @ 8226D15
 	.byte 0
 
 SootopolisCity_House4_EventScript_226D16:: @ 8226D16
-	msgbox SootopolisCity_House4_Text_226D3B, 2
+	msgbox SootopolisCity_House4_Text_226D3B, MSGBOX_NPC
 	end
 
 SootopolisCity_House4_EventScript_226D1F:: @ 8226D1F
-	msgbox SootopolisCity_House4_Text_226DEA, 2
+	msgbox SootopolisCity_House4_Text_226DEA, MSGBOX_NPC
 	end
 
 SootopolisCity_House4_EventScript_226D28:: @ 8226D28
@@ -14,7 +14,7 @@ SootopolisCity_House4_EventScript_226D28:: @ 8226D28
 	faceplayer
 	waitse
 	playmoncry SPECIES_AZUMARILL, 0
-	msgbox SootopolisCity_House4_Text_226E7F, 4
+	msgbox SootopolisCity_House4_Text_226E7F, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/SootopolisCity_House5/scripts.inc
+++ b/data/maps/SootopolisCity_House5/scripts.inc
@@ -2,11 +2,11 @@ SootopolisCity_House5_MapScripts:: @ 8226E93
 	.byte 0
 
 SootopolisCity_House5_EventScript_226E94:: @ 8226E94
-	msgbox SootopolisCity_House5_Text_226EA6, 2
+	msgbox SootopolisCity_House5_Text_226EA6, MSGBOX_NPC
 	end
 
 SootopolisCity_House5_EventScript_226E9D:: @ 8226E9D
-	msgbox SootopolisCity_House5_Text_226F35, 2
+	msgbox SootopolisCity_House5_Text_226F35, MSGBOX_NPC
 	end
 
 SootopolisCity_House5_Text_226EA6: @ 8226EA6

--- a/data/maps/SootopolisCity_House6/scripts.inc
+++ b/data/maps/SootopolisCity_House6/scripts.inc
@@ -6,10 +6,10 @@ SootopolisCity_House6_EventScript_226F5C:: @ 8226F5C
 	faceplayer
 	checkflag FLAG_0x0F5
 	goto_eq SootopolisCity_House6_EventScript_226FA3
-	msgbox SootopolisCity_House6_Text_226FC3, 5
+	msgbox SootopolisCity_House6_Text_226FC3, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	call_if 1, SootopolisCity_House6_EventScript_226F99
-	msgbox SootopolisCity_House6_Text_227034, 4
+	msgbox SootopolisCity_House6_Text_227034, MSGBOX_DEFAULT
 	givedecoration_std 117
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_House6_EventScript_226FAD
@@ -18,19 +18,19 @@ SootopolisCity_House6_EventScript_226F5C:: @ 8226F5C
 	end
 
 SootopolisCity_House6_EventScript_226F99:: @ 8226F99
-	msgbox SootopolisCity_House6_Text_22708F, 4
+	msgbox SootopolisCity_House6_Text_22708F, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_House6_EventScript_226FA3:: @ 8226FA3
-	msgbox SootopolisCity_House6_Text_2270B7, 4
+	msgbox SootopolisCity_House6_Text_2270B7, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_House6_EventScript_226FAD:: @ 8226FAD
 	bufferdecorationname 1, 117
-	msgbox gUnknown_08272B1A, 4
-	msgbox SootopolisCity_House6_Text_22704A, 4
+	msgbox gUnknown_08272B1A, MSGBOX_DEFAULT
+	msgbox SootopolisCity_House6_Text_22704A, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/SootopolisCity_House7/scripts.inc
+++ b/data/maps/SootopolisCity_House7/scripts.inc
@@ -2,11 +2,11 @@ SootopolisCity_House7_MapScripts:: @ 82270CB
 	.byte 0
 
 SootopolisCity_House7_EventScript_2270CC:: @ 82270CC
-	msgbox SootopolisCity_House7_Text_2270DE, 2
+	msgbox SootopolisCity_House7_Text_2270DE, MSGBOX_NPC
 	end
 
 SootopolisCity_House7_EventScript_2270D5:: @ 82270D5
-	msgbox SootopolisCity_House7_Text_227190, 2
+	msgbox SootopolisCity_House7_Text_227190, MSGBOX_NPC
 	end
 
 SootopolisCity_House7_Text_2270DE: @ 82270DE

--- a/data/maps/SootopolisCity_LotadAndSeedotHouse/scripts.inc
+++ b/data/maps/SootopolisCity_LotadAndSeedotHouse/scripts.inc
@@ -5,7 +5,7 @@ SootopolisCity_LotadAndSeedotHouse_EventScript_22722B:: @ 822722B
 	special GetSeedotSizeRecordInfo
 	lock
 	faceplayer
-	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227369, 4
+	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227369, MSGBOX_DEFAULT
 	special sub_81B94B0
 	waitstate
 	copyvar VAR_RESULT, VAR_0x8004
@@ -22,22 +22,22 @@ SootopolisCity_LotadAndSeedotHouse_EventScript_22722B:: @ 822722B
 	end
 
 SootopolisCity_LotadAndSeedotHouse_EventScript_227272:: @ 8227272
-	msgbox SootopolisCity_LotadAndSeedotHouse_Text_2275BC, 4
+	msgbox SootopolisCity_LotadAndSeedotHouse_Text_2275BC, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_LotadAndSeedotHouse_EventScript_22727C:: @ 822727C
-	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227584, 4
+	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227584, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_LotadAndSeedotHouse_EventScript_227286:: @ 8227286
-	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227544, 4
+	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227544, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_LotadAndSeedotHouse_EventScript_227290:: @ 8227290
-	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227480, 4
+	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227480, MSGBOX_DEFAULT
 	giveitem_std ITEM_ELIXIR
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_LotadAndSeedotHouse_EventScript_2272B2
@@ -46,7 +46,7 @@ SootopolisCity_LotadAndSeedotHouse_EventScript_227290:: @ 8227290
 	end
 
 SootopolisCity_LotadAndSeedotHouse_EventScript_2272B2:: @ 82272B2
-	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227524, 4
+	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227524, MSGBOX_DEFAULT
 	release
 	end
 
@@ -54,7 +54,7 @@ SootopolisCity_LotadAndSeedotHouse_EventScript_2272BC:: @ 82272BC
 	special GetLotadSizeRecordInfo
 	lock
 	faceplayer
-	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227676, 4
+	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227676, MSGBOX_DEFAULT
 	special sub_81B94B0
 	waitstate
 	copyvar VAR_RESULT, VAR_0x8004
@@ -71,22 +71,22 @@ SootopolisCity_LotadAndSeedotHouse_EventScript_2272BC:: @ 82272BC
 	end
 
 SootopolisCity_LotadAndSeedotHouse_EventScript_227303:: @ 8227303
-	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227896, 4
+	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227896, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_LotadAndSeedotHouse_EventScript_22730D:: @ 822730D
-	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227867, 4
+	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227867, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_LotadAndSeedotHouse_EventScript_227317:: @ 8227317
-	msgbox SootopolisCity_LotadAndSeedotHouse_Text_22782A, 4
+	msgbox SootopolisCity_LotadAndSeedotHouse_Text_22782A, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_LotadAndSeedotHouse_EventScript_227321:: @ 8227321
-	msgbox SootopolisCity_LotadAndSeedotHouse_Text_22776C, 4
+	msgbox SootopolisCity_LotadAndSeedotHouse_Text_22776C, MSGBOX_DEFAULT
 	giveitem_std ITEM_ELIXIR
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_LotadAndSeedotHouse_EventScript_227343
@@ -95,21 +95,21 @@ SootopolisCity_LotadAndSeedotHouse_EventScript_227321:: @ 8227321
 	end
 
 SootopolisCity_LotadAndSeedotHouse_EventScript_227343:: @ 8227343
-	msgbox SootopolisCity_LotadAndSeedotHouse_Text_22780A, 4
+	msgbox SootopolisCity_LotadAndSeedotHouse_Text_22780A, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_LotadAndSeedotHouse_EventScript_22734D:: @ 822734D
 	special GetSeedotSizeRecordInfo
 	lockall
-	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227617, 4
+	msgbox SootopolisCity_LotadAndSeedotHouse_Text_227617, MSGBOX_DEFAULT
 	releaseall
 	end
 
 SootopolisCity_LotadAndSeedotHouse_EventScript_22735B:: @ 822735B
 	special GetLotadSizeRecordInfo
 	lockall
-	msgbox SootopolisCity_LotadAndSeedotHouse_Text_2278F2, 4
+	msgbox SootopolisCity_LotadAndSeedotHouse_Text_2278F2, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/SootopolisCity_Mart/scripts.inc
+++ b/data/maps/SootopolisCity_Mart/scripts.inc
@@ -7,7 +7,7 @@ SootopolisCity_Mart_EventScript_226795:: @ 8226795
 	message gUnknown_08272A21
 	waitmessage
 	pokemart SootopolisCity_Mart_Pokemart_2267AC
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -32,12 +32,12 @@ SootopolisCity_Mart_EventScript_2267C2:: @ 82267C2
 	goto_if 4, SootopolisCity_Mart_EventScript_2267E2
 	checkflag FLAG_0x081
 	goto_if 0, SootopolisCity_Mart_EventScript_2267E2
-	msgbox SootopolisCity_Mart_Text_22685D, 4
+	msgbox SootopolisCity_Mart_Text_22685D, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_Mart_EventScript_2267E2:: @ 82267E2
-	msgbox SootopolisCity_Mart_Text_226816, 4
+	msgbox SootopolisCity_Mart_Text_226816, MSGBOX_DEFAULT
 	release
 	end
 
@@ -48,12 +48,12 @@ SootopolisCity_Mart_EventScript_2267EC:: @ 82267EC
 	goto_if 4, SootopolisCity_Mart_EventScript_22680C
 	checkflag FLAG_0x081
 	goto_if 0, SootopolisCity_Mart_EventScript_22680C
-	msgbox SootopolisCity_Mart_Text_226928, 4
+	msgbox SootopolisCity_Mart_Text_226928, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_Mart_EventScript_22680C:: @ 822680C
-	msgbox SootopolisCity_Mart_Text_2268AF, 4
+	msgbox SootopolisCity_Mart_Text_2268AF, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/SootopolisCity_MysteryEventsHouse_1F/scripts.inc
+++ b/data/maps/SootopolisCity_MysteryEventsHouse_1F/scripts.inc
@@ -51,15 +51,15 @@ SootopolisCity_MysteryEventsHouse_1F_EventScript_2279B7:: @ 82279B7
 	end
 
 SootopolisCity_MysteryEventsHouse_1F_EventScript_227A04:: @ 8227A04
-	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227DB8, 4
+	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227DB8, MSGBOX_DEFAULT
 	return
 
 SootopolisCity_MysteryEventsHouse_1F_EventScript_227A0D:: @ 8227A0D
-	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227E03, 4
+	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227E03, MSGBOX_DEFAULT
 	return
 
 SootopolisCity_MysteryEventsHouse_1F_EventScript_227A16:: @ 8227A16
-	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227D5B, 4
+	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227D5B, MSGBOX_DEFAULT
 	return
 
 SootopolisCity_MysteryEventsHouse_1F_Movement_227A1F: @ 8227A1F
@@ -80,25 +80,25 @@ SootopolisCity_MysteryEventsHouse_1F_EventScript_227A24:: @ 8227A24
 	goto_eq SootopolisCity_MysteryEventsHouse_1F_EventScript_227A4E
 	compare VAR_TEMP_1, 1
 	goto_eq SootopolisCity_MysteryEventsHouse_1F_EventScript_227A58
-	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227B46, 4
+	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227B46, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_MysteryEventsHouse_1F_EventScript_227A4E:: @ 8227A4E
-	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227B46, 4
+	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227B46, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_MysteryEventsHouse_1F_EventScript_227A58:: @ 8227A58
 	special SavePlayerParty
 	special BufferEReaderTrainerName
-	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227BFC, 5
+	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227BFC, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_MysteryEventsHouse_1F_EventScript_227AE2
 	call SootopolisCity_MysteryEventsHouse_1F_EventScript_227AEF
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_MysteryEventsHouse_1F_EventScript_227AE2
-	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227CEB, 5
+	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227CEB, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SootopolisCity_MysteryEventsHouse_1F_EventScript_227AE2
 	special LoadPlayerParty
@@ -107,7 +107,7 @@ SootopolisCity_MysteryEventsHouse_1F_EventScript_227A58:: @ 8227A58
 	goto_eq SootopolisCity_MysteryEventsHouse_1F_EventScript_227AE2
 	special SavePlayerParty
 	special ReducePlayerPartyToSelectedMons
-	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227D21, 4
+	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227D21, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_FACING, 2
 	call_if 1, SootopolisCity_MysteryEventsHouse_1F_EventScript_227AFE
@@ -122,12 +122,12 @@ SootopolisCity_MysteryEventsHouse_1F_EventScript_227A58:: @ 8227A58
 
 SootopolisCity_MysteryEventsHouse_1F_EventScript_227AE2:: @ 8227AE2
 	special LoadPlayerParty
-	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227C44, 4
+	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227C44, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_MysteryEventsHouse_1F_EventScript_227AEF:: @ 8227AEF
-	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227C84, 4
+	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_227C84, MSGBOX_DEFAULT
 	fadescreen 1
 	special sub_80F9438
 	waitstate

--- a/data/maps/SootopolisCity_MysteryEventsHouse_B1F/scripts.inc
+++ b/data/maps/SootopolisCity_MysteryEventsHouse_B1F/scripts.inc
@@ -16,7 +16,7 @@ SootopolisCity_MysteryEventsHouse_B1F_EventScript_227E68:: @ 8227E68
 	applymovement 255, SootopolisCity_MysteryEventsHouse_B1F_Movement_227EF3
 	waitmovement 0
 	special CopyEReaderTrainerGreeting
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, SPECIAL_BATTLE_EREADER
 	setvar VAR_0x8005, 0
@@ -41,7 +41,7 @@ SootopolisCity_MysteryEventsHouse_B1F_EventScript_227E68:: @ 8227E68
 
 SootopolisCity_MysteryEventsHouse_B1F_EventScript_227ECF:: @ 8227ECF
 	setvar VAR_0x40C0, 3
-	msgbox SootopolisCity_MysteryEventsHouse_B1F_Text_227D40, 4
+	msgbox SootopolisCity_MysteryEventsHouse_B1F_Text_227D40, MSGBOX_DEFAULT
 	return
 
 SootopolisCity_MysteryEventsHouse_B1F_EventScript_227EDD:: @ 8227EDD

--- a/data/maps/SootopolisCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/SootopolisCity_PokemonCenter_1F/scripts.inc
@@ -22,12 +22,12 @@ SootopolisCity_PokemonCenter_1F_EventScript_22650E:: @ 822650E
 	goto_if 4, SootopolisCity_PokemonCenter_1F_EventScript_22652E
 	checkflag FLAG_0x081
 	goto_if 0, SootopolisCity_PokemonCenter_1F_EventScript_22652E
-	msgbox SootopolisCity_PokemonCenter_1F_Text_22664B, 4
+	msgbox SootopolisCity_PokemonCenter_1F_Text_22664B, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_PokemonCenter_1F_EventScript_22652E:: @ 822652E
-	msgbox SootopolisCity_PokemonCenter_1F_Text_226562, 4
+	msgbox SootopolisCity_PokemonCenter_1F_Text_226562, MSGBOX_DEFAULT
 	release
 	end
 
@@ -38,12 +38,12 @@ SootopolisCity_PokemonCenter_1F_EventScript_226538:: @ 8226538
 	goto_if 4, SootopolisCity_PokemonCenter_1F_EventScript_226558
 	checkflag FLAG_0x081
 	goto_if 0, SootopolisCity_PokemonCenter_1F_EventScript_226558
-	msgbox SootopolisCity_PokemonCenter_1F_Text_22672F, 4
+	msgbox SootopolisCity_PokemonCenter_1F_Text_22672F, MSGBOX_DEFAULT
 	release
 	end
 
 SootopolisCity_PokemonCenter_1F_EventScript_226558:: @ 8226558
-	msgbox SootopolisCity_PokemonCenter_1F_Text_2266B9, 4
+	msgbox SootopolisCity_PokemonCenter_1F_Text_2266B9, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/SouthernIsland_Exterior/scripts.inc
+++ b/data/maps/SouthernIsland_Exterior/scripts.inc
@@ -9,10 +9,10 @@ SouthernIsland_Exterior_MapScript1_2429CE: @ 82429CE
 SouthernIsland_Exterior_EventScript_2429D2:: @ 82429D2
 	lock
 	faceplayer
-	msgbox SouthernIsland_Exterior_Text_2A69F1, 5
+	msgbox SouthernIsland_Exterior_Text_2A69F1, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq SouthernIsland_Exterior_EventScript_242A17
-	msgbox SouthernIsland_Exterior_Text_2A6A5D, 4
+	msgbox SouthernIsland_Exterior_Text_2A6A5D, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_LAST_TALKED, SouthernIsland_Exterior_Movement_2725AA
 	waitmovement 0
@@ -26,7 +26,7 @@ SouthernIsland_Exterior_EventScript_2429D2:: @ 82429D2
 	end
 
 SouthernIsland_Exterior_EventScript_242A17:: @ 8242A17
-	msgbox SouthernIsland_Exterior_Text_2A6A82, 4
+	msgbox SouthernIsland_Exterior_Text_2A6A82, MSGBOX_DEFAULT
 	release
 	end
 
@@ -50,6 +50,6 @@ BattleFrontier_OutsideWest_Movement_242A39: @ 8242A39
 	step_end
 
 SouthernIsland_Exterior_EventScript_242A3C:: @ 8242A3C
-	msgbox SouthernIsland_Exterior_Text_2A6AD5, 3
+	msgbox SouthernIsland_Exterior_Text_2A6AD5, MSGBOX_SIGN
 	end
 

--- a/data/maps/SouthernIsland_Interior/scripts.inc
+++ b/data/maps/SouthernIsland_Interior/scripts.inc
@@ -113,7 +113,7 @@ SouthernIsland_Interior_EventScript_242B8F:: @ 8242B8F
 	end
 
 SouthernIsland_Interior_EventScript_242B9A:: @ 8242B9A
-	msgbox SouthernIsland_Interior_Text_2A6AA1, 4
+	msgbox SouthernIsland_Interior_Text_2A6AA1, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/maps/TrainerHill_Elevator/scripts.inc
+++ b/data/maps/TrainerHill_Elevator/scripts.inc
@@ -23,7 +23,7 @@ TrainerHill_Elevator_EventScript_269375:: @ 8269375
 	applymovement 1, TrainerHill_Elevator_Movement_2693EE
 	waitmovement 0
 	lockall
-	msgbox TrainerHill_Elevator_Text_268F3E, 5
+	msgbox TrainerHill_Elevator_Text_268F3E, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq TrainerHill_Elevator_EventScript_269360
 	releaseall

--- a/data/maps/TrainerHill_Entrance/scripts.inc
+++ b/data/maps/TrainerHill_Entrance/scripts.inc
@@ -84,13 +84,13 @@ TrainerHill_Entrance_EventScript_268182:: @ 8268182
 TrainerHill_Entrance_EventScript_2681B5:: @ 82681B5
 	lockall
 	applymovement 255, TrainerHill_Entrance_Movement_26837F
-	msgbox TrainerHill_Entrance_Text_268689, 4
+	msgbox TrainerHill_Entrance_Text_268689, MSGBOX_DEFAULT
 	goto TrainerHill_Entrance_EventScript_2681DA
 
 TrainerHill_Entrance_EventScript_2681CA:: @ 82681CA
 	lockall
 	applymovement 255, TrainerHill_Entrance_Movement_26837F
-	msgbox TrainerHill_Entrance_Text_268712, 4
+	msgbox TrainerHill_Entrance_Text_268712, MSGBOX_DEFAULT
 
 TrainerHill_Entrance_EventScript_2681DA:: @ 82681DA
 	closemessage
@@ -118,11 +118,11 @@ TrainerHill_Entrance_EventScript_2681FD:: @ 82681FD
 	special sp194_trainer_tower
 	compare VAR_RESULT, 0
 	goto_eq TrainerHill_Entrance_EventScript_26821F
-	msgbox TrainerHill_Entrance_Text_2686F4, 4
+	msgbox TrainerHill_Entrance_Text_2686F4, MSGBOX_DEFAULT
 	goto TrainerHill_Entrance_EventScript_268227
 
 TrainerHill_Entrance_EventScript_26821F:: @ 826821F
-	msgbox TrainerHill_Entrance_Text_2687AC, 4
+	msgbox TrainerHill_Entrance_Text_2687AC, MSGBOX_DEFAULT
 
 TrainerHill_Entrance_EventScript_268227:: @ 8268227
 	release
@@ -133,7 +133,7 @@ TrainerHill_Entrance_EventScript_268229:: @ 8268229
 	applymovement 255, TrainerHill_Entrance_Movement_26837F
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_if 0, TrainerHill_Entrance_EventScript_26836A
-	msgbox TrainerHill_Entrance_Text_2684C6, 4
+	msgbox TrainerHill_Entrance_Text_2684C6, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 13
 	special sp194_trainer_tower
 	compare VAR_RESULT, 0
@@ -142,11 +142,11 @@ TrainerHill_Entrance_EventScript_268229:: @ 8268229
 	special sp194_trainer_tower
 	compare VAR_RESULT, 1
 	goto_eq TrainerHill_Entrance_EventScript_268275
-	msgbox TrainerHill_Entrance_Text_268564, 4
+	msgbox TrainerHill_Entrance_Text_268564, MSGBOX_DEFAULT
 	goto TrainerHill_Entrance_EventScript_26827D
 
 TrainerHill_Entrance_EventScript_268275:: @ 8268275
-	msgbox TrainerHill_Entrance_Text_26859E, 4
+	msgbox TrainerHill_Entrance_Text_26859E, MSGBOX_DEFAULT
 
 TrainerHill_Entrance_EventScript_26827D:: @ 826827D
 	message TrainerHill_Entrance_Text_2685F8
@@ -160,7 +160,7 @@ TrainerHill_Entrance_EventScript_26827D:: @ 826827D
 	end
 
 TrainerHill_Entrance_EventScript_2682BA:: @ 82682BA
-	msgbox TrainerHill_Entrance_Text_2687C3, 4
+	msgbox TrainerHill_Entrance_Text_2687C3, MSGBOX_DEFAULT
 	goto TrainerHill_Entrance_EventScript_26827D
 	end
 
@@ -175,7 +175,7 @@ TrainerHill_Entrance_EventScript_2682C8:: @ 82682C8
 	setvar VAR_0x40D6, 1
 	setvar VAR_TEMP_5, 0
 	special HealPlayerParty
-	msgbox TrainerHill_Entrance_Text_26862A, 4
+	msgbox TrainerHill_Entrance_Text_26862A, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 0
 	special sp194_trainer_tower
 	releaseall
@@ -183,7 +183,7 @@ TrainerHill_Entrance_EventScript_2682C8:: @ 82682C8
 
 TrainerHill_Entrance_EventScript_268314:: @ 8268314
 	setvar VAR_TEMP_5, 0
-	msgbox TrainerHill_Entrance_Text_26866F, 4
+	msgbox TrainerHill_Entrance_Text_26866F, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, TrainerHill_Entrance_Movement_268381
 	waitmovement 0
@@ -191,7 +191,7 @@ TrainerHill_Entrance_EventScript_268314:: @ 8268314
 	end
 
 TrainerHill_Entrance_EventScript_26832E:: @ 826832E
-	msgbox TrainerHill_Entrance_Text_26851C, 4
+	msgbox TrainerHill_Entrance_Text_26851C, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 14
 	special sp194_trainer_tower
 	setvar VAR_TEMP_5, 1
@@ -209,7 +209,7 @@ TrainerHill_Entrance_EventScript_26835C:: @ 826835C
 	end
 
 TrainerHill_Entrance_EventScript_26836A:: @ 826836A
-	msgbox TrainerHill_Entrance_Text_268430, 4
+	msgbox TrainerHill_Entrance_Text_268430, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, TrainerHill_Entrance_Movement_268381
 	waitmovement 0
@@ -244,21 +244,21 @@ TrainerHill_Entrance_EventScript_268388:: @ 8268388
 TrainerHill_Entrance_EventScript_268391:: @ 8268391
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_if 0, TrainerHill_Entrance_EventScript_2683A3
-	msgbox TrainerHill_Entrance_Text_268D5A, 2
+	msgbox TrainerHill_Entrance_Text_268D5A, MSGBOX_NPC
 	end
 
 TrainerHill_Entrance_EventScript_2683A3:: @ 82683A3
-	msgbox TrainerHill_Entrance_Text_268DDA, 2
+	msgbox TrainerHill_Entrance_Text_268DDA, MSGBOX_NPC
 	end
 
 TrainerHill_Entrance_EventScript_2683AC:: @ 82683AC
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_if 0, TrainerHill_Entrance_EventScript_2683BE
-	msgbox TrainerHill_Entrance_Text_268E6A, 2
+	msgbox TrainerHill_Entrance_Text_268E6A, MSGBOX_NPC
 	end
 
 TrainerHill_Entrance_EventScript_2683BE:: @ 82683BE
-	msgbox TrainerHill_Entrance_Text_268EDC, 2
+	msgbox TrainerHill_Entrance_Text_268EDC, MSGBOX_NPC
 	end
 
 TrainerHill_Entrance_EventScript_2683C7:: @ 82683C7
@@ -269,7 +269,7 @@ TrainerHill_Entrance_EventScript_2683C7:: @ 82683C7
 	checkflag FLAG_SYS_GAME_CLEAR
 	goto_eq TrainerHill_Entrance_EventScript_268402
 	pokemart TrainerHill_Entrance_Pokemart_2683E8
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -292,7 +292,7 @@ TrainerHill_Entrance_Pokemart_2683E8: @ 82683E8
 
 TrainerHill_Entrance_EventScript_268402:: @ 8268402
 	pokemart TrainerHill_Entrance_Pokemart_268414
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/TrainerHill_Roof/scripts.inc
+++ b/data/maps/TrainerHill_Roof/scripts.inc
@@ -16,7 +16,7 @@ TrainerHill_Roof_EventScript_268FB2:: @ 8268FB2
 	case 2, TrainerHill_Roof_EventScript_2690A8
 
 TrainerHill_Roof_EventScript_268FEA:: @ 8268FEA
-	msgbox TrainerHill_Roof_Text_268986, 4
+	msgbox TrainerHill_Roof_Text_268986, MSGBOX_DEFAULT
 
 TrainerHill_Roof_EventScript_268FF2:: @ 8268FF2
 	setvar VAR_0x8004, 2
@@ -27,7 +27,7 @@ TrainerHill_Roof_EventScript_268FF2:: @ 8268FF2
 	case 2, TrainerHill_Roof_EventScript_269054
 
 TrainerHill_Roof_EventScript_269020:: @ 8269020
-	msgbox TrainerHill_Roof_Text_268AC5, 4
+	msgbox TrainerHill_Roof_Text_268AC5, MSGBOX_DEFAULT
 	playfanfare MUS_FANFA1
 	message gUnknown_08272A78
 	waitfanfare
@@ -35,9 +35,9 @@ TrainerHill_Roof_EventScript_269020:: @ 8269020
 	goto TrainerHill_Roof_EventScript_269054
 
 TrainerHill_Roof_EventScript_269037:: @ 8269037
-	msgbox TrainerHill_Roof_Text_268AC5, 4
-	msgbox gUnknown_08272A89, 4
-	msgbox TrainerHill_Roof_Text_268B07, 4
+	msgbox TrainerHill_Roof_Text_268AC5, MSGBOX_DEFAULT
+	msgbox gUnknown_08272A89, MSGBOX_DEFAULT
+	msgbox TrainerHill_Roof_Text_268B07, MSGBOX_DEFAULT
 	goto TrainerHill_Roof_EventScript_269054
 
 TrainerHill_Roof_EventScript_269054:: @ 8269054
@@ -49,22 +49,22 @@ TrainerHill_Roof_EventScript_269054:: @ 8269054
 	case 2, TrainerHill_Roof_EventScript_26909E
 
 TrainerHill_Roof_EventScript_269082:: @ 8269082
-	msgbox TrainerHill_Roof_Text_268B43, 4
+	msgbox TrainerHill_Roof_Text_268B43, MSGBOX_DEFAULT
 	goto TrainerHill_Roof_EventScript_26909E
 	end
 
 TrainerHill_Roof_EventScript_269090:: @ 8269090
-	msgbox TrainerHill_Roof_Text_268C03, 4
+	msgbox TrainerHill_Roof_Text_268C03, MSGBOX_DEFAULT
 	goto TrainerHill_Roof_EventScript_26909E
 	end
 
 TrainerHill_Roof_EventScript_26909E:: @ 826909E
-	msgbox TrainerHill_Roof_Text_268C31, 4
+	msgbox TrainerHill_Roof_Text_268C31, MSGBOX_DEFAULT
 	release
 	end
 
 TrainerHill_Roof_EventScript_2690A8:: @ 82690A8
-	msgbox TrainerHill_Roof_Text_268C31, 4
+	msgbox TrainerHill_Roof_Text_268C31, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/Underwater_SeafloorCavern/scripts.inc
+++ b/data/maps/Underwater_SeafloorCavern/scripts.inc
@@ -39,7 +39,7 @@ Underwater_SeafloorCavern_MapScript1_2343D3: @ 82343D3
 	end
 
 Underwater_SeafloorCavern_EventScript_2343DC:: @ 82343DC
-	msgbox Underwater_SeafloorCavern_Text_2343E5, 3
+	msgbox Underwater_SeafloorCavern_Text_2343E5, MSGBOX_SIGN
 	end
 
 Underwater_SeafloorCavern_Text_2343E5: @ 82343E5

--- a/data/maps/VerdanturfTown/scripts.inc
+++ b/data/maps/VerdanturfTown/scripts.inc
@@ -12,25 +12,25 @@ VerdanturfTown_EventScript_1EB575:: @ 81EB575
 	faceplayer
 	checkflag FLAG_RUSTURF_TUNNEL_OPENED
 	goto_eq VerdanturfTown_EventScript_1EB594
-	msgbox VerdanturfTown_Text_1EB5FD, 4
+	msgbox VerdanturfTown_Text_1EB5FD, MSGBOX_DEFAULT
 	applymovement 2, VerdanturfTown_Movement_2725A2
 	waitmovement 0
 	release
 	end
 
 VerdanturfTown_EventScript_1EB594:: @ 81EB594
-	msgbox VerdanturfTown_Text_1EB6E0, 4
+	msgbox VerdanturfTown_Text_1EB6E0, MSGBOX_DEFAULT
 	applymovement 2, VerdanturfTown_Movement_2725A2
 	waitmovement 0
 	release
 	end
 
 VerdanturfTown_EventScript_1EB5A8:: @ 81EB5A8
-	msgbox VerdanturfTown_Text_1EB736, 2
+	msgbox VerdanturfTown_Text_1EB736, MSGBOX_NPC
 	end
 
 VerdanturfTown_EventScript_1EB5B1:: @ 81EB5B1
-	msgbox VerdanturfTown_Text_1EB7E2, 2
+	msgbox VerdanturfTown_Text_1EB7E2, MSGBOX_NPC
 	end
 
 VerdanturfTown_EventScript_1EB5BA:: @ 81EB5BA
@@ -38,29 +38,29 @@ VerdanturfTown_EventScript_1EB5BA:: @ 81EB5BA
 	faceplayer
 	checkflag FLAG_RUSTURF_TUNNEL_OPENED
 	goto_eq VerdanturfTown_EventScript_1EB5CF
-	msgbox VerdanturfTown_Text_1EB854, 4
+	msgbox VerdanturfTown_Text_1EB854, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_EventScript_1EB5CF:: @ 81EB5CF
-	msgbox VerdanturfTown_Text_1EB935, 4
+	msgbox VerdanturfTown_Text_1EB935, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_EventScript_1EB5D9:: @ 81EB5D9
-	msgbox VerdanturfTown_Text_1EB9C4, 3
+	msgbox VerdanturfTown_Text_1EB9C4, MSGBOX_SIGN
 	end
 
 VerdanturfTown_EventScript_1EB5E2:: @ 81EB5E2
-	msgbox VerdanturfTown_Text_1EBA11, 3
+	msgbox VerdanturfTown_Text_1EBA11, MSGBOX_SIGN
 	end
 
 VerdanturfTown_EventScript_1EB5EB:: @ 81EB5EB
-	msgbox VerdanturfTown_Text_1EBA1F, 3
+	msgbox VerdanturfTown_Text_1EBA1F, MSGBOX_SIGN
 	end
 
 VerdanturfTown_EventScript_1EB5F4:: @ 81EB5F4
-	msgbox VerdanturfTown_Text_1EBA59, 3
+	msgbox VerdanturfTown_Text_1EBA59, MSGBOX_SIGN
 	end
 
 VerdanturfTown_Text_1EB5FD: @ 81EB5FD

--- a/data/maps/VerdanturfTown_BattleTentBattleRoom/scripts.inc
+++ b/data/maps/VerdanturfTown_BattleTentBattleRoom/scripts.inc
@@ -48,7 +48,7 @@ VerdanturfTown_BattleTentBattleRoom_EventScript_20236F:: @ 820236F
 	waitmovement 0
 	setvar VAR_0x8004, 4
 	special sub_81B99B4
-	msgbox gStringVar4, 4
+	msgbox gStringVar4, MSGBOX_DEFAULT
 	waitmessage
 	call VerdanturfTown_BattleTentBattleRoom_EventScript_24FDF7
 	switch VAR_RESULT
@@ -80,7 +80,7 @@ VerdanturfTown_BattleTentBattleRoom_EventScript_2023C8:: @ 82023C8
 	applymovement 3, VerdanturfTown_BattleTentBattleRoom_Movement_2725AA
 	applymovement 1, VerdanturfTown_BattleTentBattleRoom_Movement_2725A6
 	waitmovement 0
-	msgbox VerdanturfTown_BattleTentBattleRoom_Text_24FF00, 4
+	msgbox VerdanturfTown_BattleTentBattleRoom_Text_24FF00, MSGBOX_DEFAULT
 	special LoadPlayerParty
 	special SavePlayerParty
 	setvar VAR_0x8004, 3
@@ -105,7 +105,7 @@ VerdanturfTown_BattleTentBattleRoom_EventScript_20243C:: @ 820243C
 	case 2, VerdanturfTown_BattleTentBattleRoom_EventScript_2024B8
 
 VerdanturfTown_BattleTentBattleRoom_EventScript_20248A:: @ 820248A
-	msgbox VerdanturfTown_BattleTentBattleRoom_Text_250030, 5
+	msgbox VerdanturfTown_BattleTentBattleRoom_Text_250030, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, VerdanturfTown_BattleTentBattleRoom_EventScript_20243C
 	case 1, VerdanturfTown_BattleTentBattleRoom_EventScript_20251F

--- a/data/maps/VerdanturfTown_BattleTentLobby/scripts.inc
+++ b/data/maps/VerdanturfTown_BattleTentLobby/scripts.inc
@@ -27,7 +27,7 @@ VerdanturfTown_BattleTentLobby_EventScript_201719:: @ 8201719
 
 VerdanturfTown_BattleTentLobby_EventScript_201722:: @ 8201722
 	lockall
-	msgbox VerdanturfTown_BattleTentLobby_Text_24E636, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_24E636, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, 0
@@ -43,7 +43,7 @@ VerdanturfTown_BattleTentLobby_EventScript_201722:: @ 8201722
 
 VerdanturfTown_BattleTentLobby_EventScript_201757:: @ 8201757
 	lockall
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C5731, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C5731, MSGBOX_DEFAULT
 	message VerdanturfTown_BattleTentLobby_Text_2C5791
 	waitmessage
 	setvar VAR_0x8004, 6
@@ -59,7 +59,7 @@ VerdanturfTown_BattleTentLobby_EventScript_201757:: @ 8201757
 	waitse
 
 VerdanturfTown_BattleTentLobby_EventScript_201791:: @ 8201791
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C57CD, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C57CD, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 7
 	special sub_81B99B4
 	switch VAR_RESULT
@@ -72,14 +72,14 @@ VerdanturfTown_BattleTentLobby_EventScript_201791:: @ 8201791
 	waitmessage
 	playfanfare MUS_FANFA4
 	waitfanfare
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C539A, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C539A, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
 	end
 
 VerdanturfTown_BattleTentLobby_EventScript_2017DD:: @ 82017DD
-	msgbox VerdanturfTown_BattleTentLobby_Text_24E57B, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_24E57B, MSGBOX_DEFAULT
 	waitmessage
 	closemessage
 	setvar VAR_TEMP_0, 255
@@ -88,7 +88,7 @@ VerdanturfTown_BattleTentLobby_EventScript_2017DD:: @ 82017DD
 
 VerdanturfTown_BattleTentLobby_EventScript_2017EE:: @ 82017EE
 	lockall
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C5731, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C5731, MSGBOX_DEFAULT
 	goto VerdanturfTown_BattleTentLobby_EventScript_201791
 	end
 
@@ -105,7 +105,7 @@ VerdanturfTown_BattleTentLobby_EventScript_2017FD:: @ 82017FD
 	special sub_81B99B4
 	playse SE_SAVE
 	waitse
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C539A, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C539A, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_0, 255
 	releaseall
@@ -113,7 +113,7 @@ VerdanturfTown_BattleTentLobby_EventScript_2017FD:: @ 82017FD
 
 VerdanturfTown_BattleTentLobby_EventScript_201837:: @ 8201837
 	lockall
-	msgbox VerdanturfTown_BattleTentLobby_Text_24E5D8, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_24E5D8, MSGBOX_DEFAULT
 	message VerdanturfTown_BattleTentLobby_Text_24E5F6
 	waitmessage
 	setvar VAR_0x8004, 5
@@ -136,7 +136,7 @@ VerdanturfTown_BattleTentLobby_EventScript_201873:: @ 8201873
 	compare VAR_RESULT, 0
 	goto_if 5, VerdanturfTown_BattleTentLobby_EventScript_2017EE
 	special SavePlayerParty
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C50C3, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C50C3, MSGBOX_DEFAULT
 
 VerdanturfTown_BattleTentLobby_EventScript_201893:: @ 8201893
 	message VerdanturfTown_BattleTentLobby_Text_2C5129
@@ -160,7 +160,7 @@ VerdanturfTown_BattleTentLobby_EventScript_2018CF:: @ 82018CF
 	setvar VAR_0x8005, 1
 	setvar VAR_0x8006, 2
 	special CallFrontierUtilFunc
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C5633, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C5633, MSGBOX_DEFAULT
 	fadescreen 1
 	setvar VAR_0x8004, 1
 	setvar VAR_0x8005, 3
@@ -168,7 +168,7 @@ VerdanturfTown_BattleTentLobby_EventScript_2018CF:: @ 82018CF
 	waitstate
 	compare VAR_RESULT, 0
 	goto_eq VerdanturfTown_BattleTentLobby_EventScript_201A34
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C5662, 5
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C5662, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, VerdanturfTown_BattleTentLobby_EventScript_201A34
 	case 1, VerdanturfTown_BattleTentLobby_EventScript_201954
@@ -202,7 +202,7 @@ VerdanturfTown_BattleTentLobby_EventScript_2019AE:: @ 82019AE
 	setvar VAR_0x8004, 3
 	setvar VAR_0x8005, 3
 	special CallFrontierUtilFunc
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C56A2, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C56A2, MSGBOX_DEFAULT
 	closemessage
 	call VerdanturfTown_BattleTentLobby_EventScript_201A41
 	warp MAP_VERDANTURF_TOWN_BATTLE_TENT_CORRIDOR, 255, 2, 7
@@ -211,7 +211,7 @@ VerdanturfTown_BattleTentLobby_EventScript_2019AE:: @ 82019AE
 	end
 
 VerdanturfTown_BattleTentLobby_EventScript_2019DB:: @ 82019DB
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C5163, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C5163, MSGBOX_DEFAULT
 	goto VerdanturfTown_BattleTentLobby_EventScript_201893
 
 VerdanturfTown_BattleTentLobby_EventScript_2019E8:: @ 82019E8
@@ -220,11 +220,11 @@ VerdanturfTown_BattleTentLobby_EventScript_2019E8:: @ 82019E8
 	case 1, VerdanturfTown_BattleTentLobby_EventScript_201A10
 
 VerdanturfTown_BattleTentLobby_EventScript_201A03:: @ 8201A03
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C543D, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C543D, MSGBOX_DEFAULT
 	goto VerdanturfTown_BattleTentLobby_EventScript_201A3F
 
 VerdanturfTown_BattleTentLobby_EventScript_201A10:: @ 8201A10
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C5538, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C5538, MSGBOX_DEFAULT
 	goto VerdanturfTown_BattleTentLobby_EventScript_201A3F
 
 VerdanturfTown_BattleTentLobby_EventScript_201A1D:: @ 8201A1D
@@ -238,7 +238,7 @@ VerdanturfTown_BattleTentLobby_EventScript_201A34:: @ 8201A34
 	special LoadPlayerParty
 
 VerdanturfTown_BattleTentLobby_EventScript_201A37:: @ 8201A37
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C539A, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C539A, MSGBOX_DEFAULT
 
 VerdanturfTown_BattleTentLobby_EventScript_201A3F:: @ 8201A3F
 	release
@@ -279,27 +279,27 @@ VerdanturfTown_BattleTentLobby_EventScript_201A7B:: @ 8201A7B
 	faceplayer
 	checkflag FLAG_0x0EB
 	goto_eq VerdanturfTown_BattleTentLobby_EventScript_201AB2
-	msgbox VerdanturfTown_BattleTentLobby_Text_201D9E, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_201D9E, MSGBOX_DEFAULT
 	giveitem_std ITEM_TM45
 	compare VAR_RESULT, 0
 	goto_eq VerdanturfTown_BattleTentLobby_EventScript_272054
 	setflag FLAG_0x0EB
-	msgbox VerdanturfTown_BattleTentLobby_Text_201E43, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_201E43, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_BattleTentLobby_EventScript_201AB2:: @ 8201AB2
-	msgbox VerdanturfTown_BattleTentLobby_Text_201E43, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_201E43, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_BattleTentLobby_EventScript_201ABC:: @ 8201ABC
-	msgbox VerdanturfTown_BattleTentLobby_Text_201EB1, 2
+	msgbox VerdanturfTown_BattleTentLobby_Text_201EB1, MSGBOX_NPC
 	end
 
 VerdanturfTown_BattleTentLobby_EventScript_201AC5:: @ 8201AC5
 	lock
-	msgbox VerdanturfTown_BattleTentLobby_Text_201BD4, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_201BD4, MSGBOX_DEFAULT
 	release
 	end
 
@@ -308,26 +308,26 @@ VerdanturfTown_BattleTentLobby_EventScript_201AD0:: @ 8201AD0
 	faceplayer
 	checkflag FLAG_0x1CC
 	goto_eq VerdanturfTown_BattleTentLobby_EventScript_201AED
-	msgbox VerdanturfTown_BattleTentLobby_Text_201F3F, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_201F3F, MSGBOX_DEFAULT
 	addvar VAR_0x40D1, 1
 	setflag FLAG_0x1CC
 	release
 	end
 
 VerdanturfTown_BattleTentLobby_EventScript_201AED:: @ 8201AED
-	msgbox VerdanturfTown_BattleTentLobby_Text_202025, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_202025, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_BattleTentLobby_EventScript_201AF7:: @ 8201AF7
 	lock
-	msgbox VerdanturfTown_BattleTentLobby_Text_201D11, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_201D11, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_BattleTentLobby_EventScript_201B02:: @ 8201B02
 	lockall
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C6878, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C6878, MSGBOX_DEFAULT
 	goto VerdanturfTown_BattleTentLobby_EventScript_201B11
 	end
 
@@ -349,32 +349,32 @@ VerdanturfTown_BattleTentLobby_EventScript_201B11:: @ 8201B11
 	end
 
 VerdanturfTown_BattleTentLobby_EventScript_201B7E:: @ 8201B7E
-	msgbox VerdanturfTown_BattleTentLobby_Text_2C67CD, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_2C67CD, MSGBOX_DEFAULT
 	goto VerdanturfTown_BattleTentLobby_EventScript_201B11
 	end
 
 VerdanturfTown_BattleTentLobby_EventScript_201B8C:: @ 8201B8C
-	msgbox VerdanturfTown_BattleTentLobby_Text_24EFAB, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_24EFAB, MSGBOX_DEFAULT
 	goto VerdanturfTown_BattleTentLobby_EventScript_201B11
 	end
 
 VerdanturfTown_BattleTentLobby_EventScript_201B9A:: @ 8201B9A
-	msgbox VerdanturfTown_BattleTentLobby_Text_24F049, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_24F049, MSGBOX_DEFAULT
 	goto VerdanturfTown_BattleTentLobby_EventScript_201B11
 	end
 
 VerdanturfTown_BattleTentLobby_EventScript_201BA8:: @ 8201BA8
-	msgbox VerdanturfTown_BattleTentLobby_Text_24F190, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_24F190, MSGBOX_DEFAULT
 	goto VerdanturfTown_BattleTentLobby_EventScript_201B11
 	end
 
 VerdanturfTown_BattleTentLobby_EventScript_201BB6:: @ 8201BB6
-	msgbox VerdanturfTown_BattleTentLobby_Text_24F2E8, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_24F2E8, MSGBOX_DEFAULT
 	goto VerdanturfTown_BattleTentLobby_EventScript_201B11
 	end
 
 VerdanturfTown_BattleTentLobby_EventScript_201BC4:: @ 8201BC4
-	msgbox VerdanturfTown_BattleTentLobby_Text_24F3F4, 4
+	msgbox VerdanturfTown_BattleTentLobby_Text_24F3F4, MSGBOX_DEFAULT
 	goto VerdanturfTown_BattleTentLobby_EventScript_201B11
 	end
 

--- a/data/maps/VerdanturfTown_FriendshipRatersHouse/scripts.inc
+++ b/data/maps/VerdanturfTown_FriendshipRatersHouse/scripts.inc
@@ -4,7 +4,7 @@ VerdanturfTown_FriendshipRatersHouse_MapScripts:: @ 8203030
 VerdanturfTown_FriendshipRatersHouse_EventScript_203031:: @ 8203031
 	lock
 	faceplayer
-	msgbox VerdanturfTown_FriendshipRatersHouse_Text_2030ED, 4
+	msgbox VerdanturfTown_FriendshipRatersHouse_Text_2030ED, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, GetLeadMonFriendshipScore
 	switch VAR_RESULT
 	case 0, VerdanturfTown_FriendshipRatersHouse_EventScript_203094
@@ -18,37 +18,37 @@ VerdanturfTown_FriendshipRatersHouse_EventScript_203031:: @ 8203031
 	end
 
 VerdanturfTown_FriendshipRatersHouse_EventScript_203094:: @ 8203094
-	msgbox VerdanturfTown_FriendshipRatersHouse_Text_2032DF, 4
+	msgbox VerdanturfTown_FriendshipRatersHouse_Text_2032DF, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_FriendshipRatersHouse_EventScript_20309E:: @ 820309E
-	msgbox VerdanturfTown_FriendshipRatersHouse_Text_203288, 4
+	msgbox VerdanturfTown_FriendshipRatersHouse_Text_203288, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_FriendshipRatersHouse_EventScript_2030A8:: @ 82030A8
-	msgbox VerdanturfTown_FriendshipRatersHouse_Text_203249, 4
+	msgbox VerdanturfTown_FriendshipRatersHouse_Text_203249, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_FriendshipRatersHouse_EventScript_2030B2:: @ 82030B2
-	msgbox VerdanturfTown_FriendshipRatersHouse_Text_203213, 4
+	msgbox VerdanturfTown_FriendshipRatersHouse_Text_203213, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_FriendshipRatersHouse_EventScript_2030BC:: @ 82030BC
-	msgbox VerdanturfTown_FriendshipRatersHouse_Text_2031D1, 4
+	msgbox VerdanturfTown_FriendshipRatersHouse_Text_2031D1, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_FriendshipRatersHouse_EventScript_2030C6:: @ 82030C6
-	msgbox VerdanturfTown_FriendshipRatersHouse_Text_203192, 4
+	msgbox VerdanturfTown_FriendshipRatersHouse_Text_203192, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_FriendshipRatersHouse_EventScript_2030D0:: @ 82030D0
-	msgbox VerdanturfTown_FriendshipRatersHouse_Text_203141, 4
+	msgbox VerdanturfTown_FriendshipRatersHouse_Text_203141, MSGBOX_DEFAULT
 	release
 	end
 
@@ -57,7 +57,7 @@ VerdanturfTown_FriendshipRatersHouse_EventScript_2030DA:: @ 82030DA
 	faceplayer
 	waitse
 	playmoncry SPECIES_PIKACHU, 0
-	msgbox VerdanturfTown_FriendshipRatersHouse_Text_20334A, 4
+	msgbox VerdanturfTown_FriendshipRatersHouse_Text_20334A, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end

--- a/data/maps/VerdanturfTown_House/scripts.inc
+++ b/data/maps/VerdanturfTown_House/scripts.inc
@@ -2,11 +2,11 @@ VerdanturfTown_House_MapScripts:: @ 820335E
 	.byte 0
 
 VerdanturfTown_House_EventScript_20335F:: @ 820335F
-	msgbox VerdanturfTown_House_Text_203371, 2
+	msgbox VerdanturfTown_House_Text_203371, MSGBOX_NPC
 	end
 
 VerdanturfTown_House_EventScript_203368:: @ 8203368
-	msgbox VerdanturfTown_House_Text_2033EE, 2
+	msgbox VerdanturfTown_House_Text_2033EE, MSGBOX_NPC
 	end
 
 VerdanturfTown_House_Text_203371: @ 8203371

--- a/data/maps/VerdanturfTown_Mart/scripts.inc
+++ b/data/maps/VerdanturfTown_Mart/scripts.inc
@@ -7,7 +7,7 @@ VerdanturfTown_Mart_EventScript_202587:: @ 8202587
 	message gUnknown_08272A21
 	waitmessage
 	pokemart VerdanturfTown_Mart_Pokemart_2025A0
-	msgbox gUnknown_08272A3F, 4
+	msgbox gUnknown_08272A3F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -29,15 +29,15 @@ VerdanturfTown_Mart_Pokemart_2025A0: @ 82025A0
 	end
 
 VerdanturfTown_Mart_EventScript_2025BA:: @ 82025BA
-	msgbox VerdanturfTown_Mart_Text_2025D5, 2
+	msgbox VerdanturfTown_Mart_Text_2025D5, MSGBOX_NPC
 	end
 
 VerdanturfTown_Mart_EventScript_2025C3:: @ 82025C3
-	msgbox VerdanturfTown_Mart_Text_20264C, 2
+	msgbox VerdanturfTown_Mart_Text_20264C, MSGBOX_NPC
 	end
 
 VerdanturfTown_Mart_EventScript_2025CC:: @ 82025CC
-	msgbox VerdanturfTown_Mart_Text_2026C9, 2
+	msgbox VerdanturfTown_Mart_Text_2026C9, MSGBOX_NPC
 	end
 
 VerdanturfTown_Mart_Text_2025D5: @ 82025D5

--- a/data/maps/VerdanturfTown_PokemonCenter_1F/scripts.inc
+++ b/data/maps/VerdanturfTown_PokemonCenter_1F/scripts.inc
@@ -17,11 +17,11 @@ VerdanturfTown_PokemonCenter_1F_EventScript_20273A:: @ 820273A
 	end
 
 VerdanturfTown_PokemonCenter_1F_EventScript_202748:: @ 8202748
-	msgbox VerdanturfTown_PokemonCenter_1F_Text_20275A, 2
+	msgbox VerdanturfTown_PokemonCenter_1F_Text_20275A, MSGBOX_NPC
 	end
 
 VerdanturfTown_PokemonCenter_1F_EventScript_202751:: @ 8202751
-	msgbox VerdanturfTown_PokemonCenter_1F_Text_20280B, 2
+	msgbox VerdanturfTown_PokemonCenter_1F_Text_20280B, MSGBOX_NPC
 	end
 
 VerdanturfTown_PokemonCenter_1F_Text_20275A: @ 820275A

--- a/data/maps/VerdanturfTown_WandasHouse/scripts.inc
+++ b/data/maps/VerdanturfTown_WandasHouse/scripts.inc
@@ -6,13 +6,13 @@ VerdanturfTown_WandasHouse_EventScript_2028BF:: @ 82028BF
 	faceplayer
 	checkflag FLAG_0x0C1
 	goto_eq VerdanturfTown_WandasHouse_EventScript_2028D7
-	msgbox VerdanturfTown_WandasHouse_Text_202993, 4
+	msgbox VerdanturfTown_WandasHouse_Text_202993, MSGBOX_DEFAULT
 	setflag FLAG_0x0C1
 	release
 	end
 
 VerdanturfTown_WandasHouse_EventScript_2028D7:: @ 82028D7
-	msgbox VerdanturfTown_WandasHouse_Text_202ABE, 4
+	msgbox VerdanturfTown_WandasHouse_Text_202ABE, MSGBOX_DEFAULT
 	release
 	end
 
@@ -23,22 +23,22 @@ VerdanturfTown_WandasHouse_EventScript_2028E1:: @ 82028E1
 	goto_eq VerdanturfTown_WandasHouse_EventScript_202909
 	checkflag FLAG_0x4F3
 	goto_eq VerdanturfTown_WandasHouse_EventScript_2028FF
-	msgbox VerdanturfTown_WandasHouse_Text_202B37, 4
+	msgbox VerdanturfTown_WandasHouse_Text_202B37, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_WandasHouse_EventScript_2028FF:: @ 82028FF
-	msgbox VerdanturfTown_WandasHouse_Text_202C20, 4
+	msgbox VerdanturfTown_WandasHouse_Text_202C20, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_WandasHouse_EventScript_202909:: @ 8202909
-	msgbox VerdanturfTown_WandasHouse_Text_202C4E, 4
+	msgbox VerdanturfTown_WandasHouse_Text_202C4E, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_WandasHouse_EventScript_202913:: @ 8202913
-	msgbox VerdanturfTown_WandasHouse_Text_202E00, 2
+	msgbox VerdanturfTown_WandasHouse_Text_202E00, MSGBOX_NPC
 	end
 
 VerdanturfTown_WandasHouse_EventScript_20291C:: @ 820291C
@@ -48,17 +48,17 @@ VerdanturfTown_WandasHouse_EventScript_20291C:: @ 820291C
 	goto_eq VerdanturfTown_WandasHouse_EventScript_202944
 	checkflag FLAG_0x0BE
 	goto_eq VerdanturfTown_WandasHouse_EventScript_20293A
-	msgbox VerdanturfTown_WandasHouse_Text_202D91, 4
+	msgbox VerdanturfTown_WandasHouse_Text_202D91, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_WandasHouse_EventScript_20293A:: @ 820293A
-	msgbox VerdanturfTown_WandasHouse_Text_202CCF, 4
+	msgbox VerdanturfTown_WandasHouse_Text_202CCF, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_WandasHouse_EventScript_202944:: @ 8202944
-	msgbox VerdanturfTown_WandasHouse_Text_202D91, 4
+	msgbox VerdanturfTown_WandasHouse_Text_202D91, MSGBOX_DEFAULT
 	release
 	end
 
@@ -71,22 +71,22 @@ VerdanturfTown_WandasHouse_EventScript_20294E:: @ 820294E
 	goto_eq VerdanturfTown_WandasHouse_EventScript_20297F
 	checkflag FLAG_RUSTURF_TUNNEL_OPENED
 	goto_eq VerdanturfTown_WandasHouse_EventScript_202975
-	msgbox VerdanturfTown_WandasHouse_Text_202E47, 4
+	msgbox VerdanturfTown_WandasHouse_Text_202E47, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_WandasHouse_EventScript_202975:: @ 8202975
-	msgbox VerdanturfTown_WandasHouse_Text_202F19, 4
+	msgbox VerdanturfTown_WandasHouse_Text_202F19, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_WandasHouse_EventScript_20297F:: @ 820297F
-	msgbox VerdanturfTown_WandasHouse_Text_202F73, 4
+	msgbox VerdanturfTown_WandasHouse_Text_202F73, MSGBOX_DEFAULT
 	release
 	end
 
 VerdanturfTown_WandasHouse_EventScript_202989:: @ 8202989
-	msgbox VerdanturfTown_WandasHouse_Text_202FDB, 4
+	msgbox VerdanturfTown_WandasHouse_Text_202FDB, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/maps/VictoryRoad_1F/scripts.inc
+++ b/data/maps/VictoryRoad_1F/scripts.inc
@@ -40,9 +40,9 @@ VictoryRoad_1F_EventScript_235DC8:: @ 8235DC8
 VictoryRoad_1F_EventScript_235DE1:: @ 8235DE1
 	applymovement 255, VictoryRoad_1F_Movement_2725AA
 	waitmovement 0
-	msgbox VictoryRoad_1F_Text_235EE6, 4
+	msgbox VictoryRoad_1F_Text_235EE6, MSGBOX_DEFAULT
 	trainerbattle 3, TRAINER_WALLY_1, 0, VictoryRoad_1F_Text_235FFC
-	msgbox VictoryRoad_1F_Text_236020, 4
+	msgbox VictoryRoad_1F_Text_236020, MSGBOX_DEFAULT
 	clearflag FLAG_HIDE_VICTORY_ROAD_ENTRANCE_WALLY
 	moveobjectoffscreen 4
 	setflag FLAG_0x07E
@@ -78,7 +78,7 @@ VictoryRoad_1F_Movement_235E21: @ 8235E21
 	step_end
 
 VictoryRoad_1F_EventScript_235E2C:: @ 8235E2C
-	msgbox VictoryRoad_1F_Text_236020, 2
+	msgbox VictoryRoad_1F_Text_236020, MSGBOX_NPC
 	end
 
 VictoryRoad_1F_EventScript_235E35:: @ 8235E35
@@ -86,37 +86,37 @@ VictoryRoad_1F_EventScript_235E35:: @ 8235E35
 	specialvar VAR_RESULT, ShouldTryRematchBattle
 	compare VAR_RESULT, 1
 	goto_eq VictoryRoad_1F_EventScript_235E5C
-	msgbox VictoryRoad_1F_Text_2360FE, 6
+	msgbox VictoryRoad_1F_Text_2360FE, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_1F_EventScript_235E5C:: @ 8235E5C
 	trainerbattle 5, TRAINER_WALLY_3, 0, VictoryRoad_1F_Text_236073, VictoryRoad_1F_Text_2360DA
-	msgbox VictoryRoad_1F_Text_2360FE, 6
+	msgbox VictoryRoad_1F_Text_2360FE, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_1F_EventScript_235E73:: @ 8235E73
 	trainerbattle 0, TRAINER_EDGAR, 0, VictoryRoad_1F_Text_236184, VictoryRoad_1F_Text_2361CB
-	msgbox VictoryRoad_1F_Text_2361E5, 6
+	msgbox VictoryRoad_1F_Text_2361E5, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_1F_EventScript_235E8A:: @ 8235E8A
 	trainerbattle 0, TRAINER_ALBERT, 0, VictoryRoad_1F_Text_236248, VictoryRoad_1F_Text_236290
-	msgbox VictoryRoad_1F_Text_2362A4, 6
+	msgbox VictoryRoad_1F_Text_2362A4, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_1F_EventScript_235EA1:: @ 8235EA1
 	trainerbattle 0, TRAINER_HOPE, 0, VictoryRoad_1F_Text_2362EE, VictoryRoad_1F_Text_236336
-	msgbox VictoryRoad_1F_Text_236356, 6
+	msgbox VictoryRoad_1F_Text_236356, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_1F_EventScript_235EB8:: @ 8235EB8
 	trainerbattle 0, TRAINER_QUINCY, 0, VictoryRoad_1F_Text_236390, VictoryRoad_1F_Text_2363C4
-	msgbox VictoryRoad_1F_Text_2363D5, 6
+	msgbox VictoryRoad_1F_Text_2363D5, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_1F_EventScript_235ECF:: @ 8235ECF
 	trainerbattle 0, TRAINER_KATELYNN, 0, VictoryRoad_1F_Text_236468, VictoryRoad_1F_Text_2364A7
-	msgbox VictoryRoad_1F_Text_2364BB, 6
+	msgbox VictoryRoad_1F_Text_2364BB, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_1F_Text_235EE6: @ 8235EE6

--- a/data/maps/VictoryRoad_B1F/scripts.inc
+++ b/data/maps/VictoryRoad_B1F/scripts.inc
@@ -3,27 +3,27 @@ VictoryRoad_B1F_MapScripts:: @ 82364E4
 
 VictoryRoad_B1F_EventScript_2364E5:: @ 82364E5
 	trainerbattle 0, TRAINER_SAMUEL, 0, VictoryRoad_B1F_Text_236558, VictoryRoad_B1F_Text_2365AD
-	msgbox VictoryRoad_B1F_Text_2365C4, 6
+	msgbox VictoryRoad_B1F_Text_2365C4, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_B1F_EventScript_2364FC:: @ 82364FC
 	trainerbattle 0, TRAINER_SHANNON, 0, VictoryRoad_B1F_Text_2365FD, VictoryRoad_B1F_Text_23664D
-	msgbox VictoryRoad_B1F_Text_236678, 6
+	msgbox VictoryRoad_B1F_Text_236678, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_B1F_EventScript_236513:: @ 8236513
 	trainerbattle 0, TRAINER_MICHELLE, 0, VictoryRoad_B1F_Text_2366C2, VictoryRoad_B1F_Text_23670B
-	msgbox VictoryRoad_B1F_Text_23671B, 6
+	msgbox VictoryRoad_B1F_Text_23671B, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_B1F_EventScript_23652A:: @ 823652A
 	trainerbattle 0, TRAINER_MITCHELL, 0, VictoryRoad_B1F_Text_236757, VictoryRoad_B1F_Text_236780
-	msgbox VictoryRoad_B1F_Text_2367A7, 6
+	msgbox VictoryRoad_B1F_Text_2367A7, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_B1F_EventScript_236541:: @ 8236541
 	trainerbattle 0, TRAINER_HALLE, 0, VictoryRoad_B1F_Text_2367FD, VictoryRoad_B1F_Text_23683B
-	msgbox VictoryRoad_B1F_Text_23684C, 6
+	msgbox VictoryRoad_B1F_Text_23684C, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_B1F_Text_236558: @ 8236558

--- a/data/maps/VictoryRoad_B2F/scripts.inc
+++ b/data/maps/VictoryRoad_B2F/scripts.inc
@@ -3,32 +3,32 @@ VictoryRoad_B2F_MapScripts:: @ 82368D4
 
 VictoryRoad_B2F_EventScript_2368D5:: @ 82368D5
 	trainerbattle 0, TRAINER_VITO, 0, VictoryRoad_B2F_Text_23695F, VictoryRoad_B2F_Text_2369B3
-	msgbox VictoryRoad_B2F_Text_2369DE, 6
+	msgbox VictoryRoad_B2F_Text_2369DE, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_B2F_EventScript_2368EC:: @ 82368EC
 	trainerbattle 0, TRAINER_OWEN, 0, VictoryRoad_B2F_Text_236A4C, VictoryRoad_B2F_Text_236A92
-	msgbox VictoryRoad_B2F_Text_236AAE, 6
+	msgbox VictoryRoad_B2F_Text_236AAE, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_B2F_EventScript_236903:: @ 8236903
 	trainerbattle 0, TRAINER_CAROLINE, 0, VictoryRoad_B2F_Text_236AF0, VictoryRoad_B2F_Text_236B14
-	msgbox VictoryRoad_B2F_Text_236B2F, 6
+	msgbox VictoryRoad_B2F_Text_236B2F, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_B2F_EventScript_23691A:: @ 823691A
 	trainerbattle 0, TRAINER_JULIE, 0, VictoryRoad_B2F_Text_236B88, VictoryRoad_B2F_Text_236C0A
-	msgbox VictoryRoad_B2F_Text_236C21, 6
+	msgbox VictoryRoad_B2F_Text_236C21, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_B2F_EventScript_236931:: @ 8236931
 	trainerbattle 0, TRAINER_FELIX, 0, VictoryRoad_B2F_Text_236C67, VictoryRoad_B2F_Text_236CAB
-	msgbox VictoryRoad_B2F_Text_236CBA, 6
+	msgbox VictoryRoad_B2F_Text_236CBA, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_B2F_EventScript_236948:: @ 8236948
 	trainerbattle 0, TRAINER_DIANNE, 0, VictoryRoad_B2F_Text_236D27, VictoryRoad_B2F_Text_236D6E
-	msgbox VictoryRoad_B2F_Text_236D8C, 6
+	msgbox VictoryRoad_B2F_Text_236D8C, MSGBOX_AUTOCLOSE
 	end
 
 VictoryRoad_B2F_Text_23695F: @ 823695F

--- a/data/scripts/berry_tree.inc
+++ b/data/scripts/berry_tree.inc
@@ -31,7 +31,7 @@ Route102_EventScript_274359:: @ 8274359
 	end
 
 Route102_EventScript_274374:: @ 8274374
-	msgbox Route102_Text_274507, 5
+	msgbox Route102_Text_274507, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route102_EventScript_274393
 	compare VAR_RESULT, 0
@@ -106,7 +106,7 @@ Route102_EventScript_274421:: @ 8274421
 	lock
 	faceplayer
 	special EventObjectInteractionGetBerryCountString
-	msgbox Route102_Text_2745EE, 5
+	msgbox Route102_Text_2745EE, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route102_EventScript_274448
 	compare VAR_RESULT, 0
@@ -155,7 +155,7 @@ Route102_EventScript_27448D:: @ 827448D
 	compare VAR_RESULT, 0
 	goto_eq Route102_EventScript_2744BE
 	special EventObjectInteractionGetBerryName
-	msgbox Route102_Text_2746E4, 5
+	msgbox Route102_Text_2746E4, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route102_EventScript_2744C4
 	compare VAR_RESULT, 0

--- a/data/scripts/cable_club.inc
+++ b/data/scripts/cable_club.inc
@@ -63,7 +63,7 @@ OldaleTown_PokemonCenter_2F_EventScript_276B19:: @ 8276B19
 	execram
 
 OldaleTown_PokemonCenter_2F_EventScript_276B1A:: @ 8276B1A
-	msgbox gUnknown_08273178, 2
+	msgbox gUnknown_08273178, MSGBOX_NPC
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_276B23:: @ 8276B23
@@ -72,16 +72,16 @@ OldaleTown_PokemonCenter_2F_EventScript_276B23:: @ 8276B23
 	goto_eq OldaleTown_PokemonCenter_2F_EventScript_276B19
 	checkflag FLAG_SYS_HAS_EON_TICKET
 	goto_eq OldaleTown_PokemonCenter_2F_EventScript_276B19
-	msgbox gUnknown_08273594, 4
+	msgbox gUnknown_08273594, MSGBOX_DEFAULT
 	giveitem_std ITEM_EON_TICKET
 	setflag FLAG_SYS_HAS_EON_TICKET
 	setvar VAR_0x403F, 0
-	msgbox gUnknown_082735F2, 4
+	msgbox gUnknown_082735F2, MSGBOX_DEFAULT
 	release
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_276B62:: @ 8276B62
-	msgbox gUnknown_08273178, 4
+	msgbox gUnknown_08273178, MSGBOX_DEFAULT
 	release
 	end
 
@@ -331,12 +331,12 @@ OldaleTown_PokemonCenter_2F_EventScript_276DE0:: @ 8276DE0
 	lockall
 	applymovement 255, OldaleTown_PokemonCenter_2F_Movement_2725A6
 	waitmovement 0
-	msgbox OldaleTown_PokemonCenter_2F_Text_27964A, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_27964A, MSGBOX_DEFAULT
 	closemessage
 	applymovement 255, OldaleTown_PokemonCenter_2F_Movement_276E10
 	waitmovement 0
 	delay 30
-	msgbox OldaleTown_PokemonCenter_2F_Text_279718, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_279718, MSGBOX_DEFAULT
 	setvar VAR_0x40CD, 2
 	releaseall
 	end
@@ -354,7 +354,7 @@ OldaleTown_PokemonCenter_2F_EventScript_276E13:: @ 8276E13
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_276E22:: @ 8276E22
-	msgbox OldaleTown_PokemonCenter_2F_Text_277EF1, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_277EF1, MSGBOX_DEFAULT
 	goto OldaleTown_PokemonCenter_2F_EventScript_276E30
 	end
 
@@ -399,7 +399,7 @@ OldaleTown_PokemonCenter_2F_EventScript_276EC2:: @ 8276EC2
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_276F15:: @ 8276F15
-	msgbox OldaleTown_PokemonCenter_2F_Text_279142, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_279142, MSGBOX_DEFAULT
 	goto OldaleTown_PokemonCenter_2F_EventScript_276EC2
 	end
 
@@ -417,7 +417,7 @@ OldaleTown_PokemonCenter_2F_EventScript_276F2E:: @ 8276F2E
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_276F47:: @ 8276F47
-	msgbox OldaleTown_PokemonCenter_2F_Text_277FEE, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_277FEE, MSGBOX_DEFAULT
 	goto OldaleTown_PokemonCenter_2F_EventScript_276EC2
 	end
 
@@ -502,25 +502,25 @@ OldaleTown_PokemonCenter_2F_EventScript_277046:: @ 8277046
 
 OldaleTown_PokemonCenter_2F_EventScript_277072:: @ 8277072
 	special CloseLink
-	msgbox OldaleTown_PokemonCenter_2F_Text_27833D, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_27833D, MSGBOX_DEFAULT
 	goto OldaleTown_PokemonCenter_2F_EventScript_2770A5
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_277083:: @ 8277083
 	special CloseLink
-	msgbox OldaleTown_PokemonCenter_2F_Text_278307, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_278307, MSGBOX_DEFAULT
 	goto OldaleTown_PokemonCenter_2F_EventScript_2770A5
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_277094:: @ 8277094
 	special CloseLink
-	msgbox OldaleTown_PokemonCenter_2F_Text_2782D1, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_2782D1, MSGBOX_DEFAULT
 	goto OldaleTown_PokemonCenter_2F_EventScript_2770A5
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_2770A5:: @ 82770A5
 	special CloseLink
-	msgbox OldaleTown_PokemonCenter_2F_Text_278372, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_278372, MSGBOX_DEFAULT
 	release
 	end
 
@@ -593,12 +593,12 @@ OldaleTown_PokemonCenter_2F_EventScript_277199:: @ 8277199
 	return
 
 OldaleTown_PokemonCenter_2F_EventScript_2771BF:: @ 82771BF
-	msgbox OldaleTown_PokemonCenter_2F_Text_278027, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_278027, MSGBOX_DEFAULT
 	setvar VAR_RESULT, 0
 	return
 
 OldaleTown_PokemonCenter_2F_EventScript_2771CD:: @ 82771CD
-	msgbox OldaleTown_PokemonCenter_2F_Text_278061, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_278061, MSGBOX_DEFAULT
 	setvar VAR_RESULT, 0
 	return
 
@@ -659,45 +659,45 @@ OldaleTown_PokemonCenter_2F_EventScript_27724C:: @ 827724C
 
 OldaleTown_PokemonCenter_2F_EventScript_2772AB:: @ 82772AB
 	special CloseLink
-	msgbox OldaleTown_PokemonCenter_2F_Text_278565, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_278565, MSGBOX_DEFAULT
 	release
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_2772B8:: @ 82772B8
 	special CloseLink
-	msgbox OldaleTown_PokemonCenter_2F_Text_2785C9, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_2785C9, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_2772C5:: @ 82772C5
 OldaleTown_PokemonCenter_2F_EventScript_2772C5:: @ 82772C5
 	special CloseLink
-	msgbox OldaleTown_PokemonCenter_2F_Text_27821C, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_27821C, MSGBOX_DEFAULT
 	release
 	end
 
 BattleFrontier_BattleTowerLobby_EventScript_2772D2:: @ 82772D2
 OldaleTown_PokemonCenter_2F_EventScript_2772D2:: @ 82772D2
 	special CloseLink
-	msgbox OldaleTown_PokemonCenter_2F_Text_2781C7, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_2781C7, MSGBOX_DEFAULT
 	release
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_2772DF:: @ 82772DF
 	special CloseLink
-	msgbox OldaleTown_PokemonCenter_2F_Text_278255, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_278255, MSGBOX_DEFAULT
 	release
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_2772EC:: @ 82772EC
 	special CloseLink
-	msgbox OldaleTown_PokemonCenter_2F_Text_278291, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_278291, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_GameCorner_1F_EventScript_2772F9:: @ 82772F9
 	special CloseLink
-	msgbox MossdeepCity_GameCorner_1F_Text_278D51, 4
+	msgbox MossdeepCity_GameCorner_1F_Text_278D51, MSGBOX_DEFAULT
 	release
 	end
 
@@ -709,29 +709,29 @@ OldaleTown_PokemonCenter_2F_EventScript_277306:: @ 8277306
 
 OldaleTown_PokemonCenter_2F_EventScript_27730E:: @ 827730E
 	special CloseLink
-	msgbox OldaleTown_PokemonCenter_2F_Text_2782A8, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_2782A8, MSGBOX_DEFAULT
 	release
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_27731B:: @ 827731B
 	special CloseLink
-	msgbox OldaleTown_PokemonCenter_2F_Text_2785E9, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_2785E9, MSGBOX_DEFAULT
 	release
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_277328:: @ 8277328
 	special CloseLink
-	msgbox OldaleTown_PokemonCenter_2F_Text_278651, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_278651, MSGBOX_DEFAULT
 	release
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_277335:: @ 8277335
-	msgbox gUnknown_0827306F, 4
+	msgbox gUnknown_0827306F, MSGBOX_DEFAULT
 	release
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_27733F:: @ 827733F
-	msgbox gUnknown_082730BC, 4
+	msgbox gUnknown_082730BC, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -917,34 +917,34 @@ RecordCorner_EventScript_277471:: @ 8277471
 	end
 
 EventScript_TradeRoom_ReadTrainerCard1:: @ 827747E
-	msgbox Text_278452, 4
+	msgbox Text_278452, MSGBOX_DEFAULT
 	fadescreen 1
 	special sp02A_crash_sound
 	waitstate
 	end
 
 EventScript_TradeRoom_ReadTrainerCard2:: @ 827748D
-	msgbox Text_27847B, 4
+	msgbox Text_27847B, MSGBOX_DEFAULT
 	fadescreen 1
 	special sp02A_crash_sound
 	waitstate
 	end
 
 EventScript_TradeRoom_TooBusyToNotice:: @ 827749C
-	msgbox Text_27842E, 4
+	msgbox Text_27842E, MSGBOX_DEFAULT
 	closemessage
 	end
 
 SingleBattleColosseum_EventScript_2774A6:: @ 82774A6
 	special sub_8098574
-	msgbox SingleBattleColosseum_Text_2784B4, 4
+	msgbox SingleBattleColosseum_Text_2784B4, MSGBOX_DEFAULT
 	special sub_809859C
 	closemessage
 	end
 
 TradeCenter_EventScript_2774B6:: @ 82774B6
 	special sub_8098574
-	msgbox TradeCenter_Text_2784E2, 4
+	msgbox TradeCenter_Text_2784E2, MSGBOX_DEFAULT
 	special sub_809859C
 	closemessage
 	end
@@ -970,7 +970,7 @@ RecordCorner_EventScript_2774E0:: @ 82774E0
 	end
 
 gUnknown_082774EF:: @ 82774EF
-	msgbox Text_2783A8, 5
+	msgbox Text_2783A8, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq gUnknown_08277509
 	erasebox 0, 0, 29, 19
@@ -1029,7 +1029,7 @@ OldaleTown_PokemonCenter_2F_EventScript_27759F:: @ 827759F
 	call OldaleTown_PokemonCenter_2F_EventScript_27134F
 	compare VAR_RESULT, 0
 	goto_eq OldaleTown_PokemonCenter_2F_EventScript_2772EC
-	msgbox OldaleTown_PokemonCenter_2F_Text_27961C, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_27961C, MSGBOX_DEFAULT
 	closemessage
 	special HealPlayerParty
 	setvar VAR_0x8004, 6
@@ -1068,17 +1068,17 @@ OldaleTown_PokemonCenter_2F_EventScript_277626:: @ 8277626
 	return
 
 OldaleTown_PokemonCenter_2F_EventScript_27764C:: @ 827764C
-	msgbox OldaleTown_PokemonCenter_2F_Text_27893E, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_27893E, MSGBOX_DEFAULT
 	goto OldaleTown_PokemonCenter_2F_EventScript_273755
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_27765A:: @ 827765A
-	msgbox OldaleTown_PokemonCenter_2F_Text_27897B, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_27897B, MSGBOX_DEFAULT
 	goto OldaleTown_PokemonCenter_2F_EventScript_273755
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_277668:: @ 8277668
-	msgbox OldaleTown_PokemonCenter_2F_Text_2789B5, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_2789B5, MSGBOX_DEFAULT
 	release
 	return
 
@@ -1087,15 +1087,15 @@ OldaleTown_PokemonCenter_2F_EventScript_277672:: @ 8277672
 	faceplayer
 	checkflag FLAG_SYS_POKEDEX_GET
 	goto_if 0, OldaleTown_PokemonCenter_2F_EventScript_277335
-	msgbox OldaleTown_PokemonCenter_2F_Text_279937, 5
+	msgbox OldaleTown_PokemonCenter_2F_Text_279937, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq OldaleTown_PokemonCenter_2F_EventScript_27769A
-	msgbox OldaleTown_PokemonCenter_2F_Text_2799AA, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_2799AA, MSGBOX_DEFAULT
 	release
 	return
 
 OldaleTown_PokemonCenter_2F_EventScript_27769A:: @ 827769A
-	msgbox OldaleTown_PokemonCenter_2F_Text_279C91, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_279C91, MSGBOX_DEFAULT
 	release
 	return
 
@@ -1165,7 +1165,7 @@ OldaleTown_PokemonCenter_2F_EventScript_2777CB:: @ 82777CB
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_27780D:: @ 827780D
-	msgbox OldaleTown_PokemonCenter_2F_Text_27909D, 5
+	msgbox OldaleTown_PokemonCenter_2F_Text_27909D, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq OldaleTown_PokemonCenter_2F_EventScript_2772EC
 	call OldaleTown_PokemonCenter_2F_EventScript_277199
@@ -1202,7 +1202,7 @@ OldaleTown_PokemonCenter_2F_EventScript_277899:: @ 8277899
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_2778B2:: @ 82778B2
-	msgbox OldaleTown_PokemonCenter_2F_Text_277FEE, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_277FEE, MSGBOX_DEFAULT
 	goto OldaleTown_PokemonCenter_2F_EventScript_27783B
 	end
 
@@ -1212,12 +1212,12 @@ OldaleTown_PokemonCenter_2F_EventScript_2778C0:: @ 82778C0
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_2778CB:: @ 82778CB
-	msgbox OldaleTown_PokemonCenter_2F_Text_279142, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_279142, MSGBOX_DEFAULT
 	goto OldaleTown_PokemonCenter_2F_EventScript_27783B
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_2778D9:: @ 82778D9
-	msgbox OldaleTown_PokemonCenter_2F_Text_2790E8, 5
+	msgbox OldaleTown_PokemonCenter_2F_Text_2790E8, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq OldaleTown_PokemonCenter_2F_EventScript_2772EC
 	setvar VAR_0x8004, 12
@@ -1225,7 +1225,7 @@ OldaleTown_PokemonCenter_2F_EventScript_2778D9:: @ 82778D9
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_2778F7:: @ 82778F7
-	msgbox OldaleTown_PokemonCenter_2F_Text_279114, 5
+	msgbox OldaleTown_PokemonCenter_2F_Text_279114, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq OldaleTown_PokemonCenter_2F_EventScript_2772EC
 	special HasAtLeastOneBerry
@@ -1236,7 +1236,7 @@ OldaleTown_PokemonCenter_2F_EventScript_2778F7:: @ 82778F7
 	end
 
 OldaleTown_PokemonCenter_2F_EventScript_277923:: @ 8277923
-	msgbox OldaleTown_PokemonCenter_2F_Text_2788FC, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_2788FC, MSGBOX_DEFAULT
 	goto OldaleTown_PokemonCenter_2F_EventScript_2776E3
 	end
 
@@ -1402,12 +1402,12 @@ EventScript_WirelessBoxResults:: @ 8277B8A
 	fadescreen 1
 	special sub_801A42C
 	waitstate
-	msgbox OldaleTown_PokemonCenter_2F_Text_27874F, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_27874F, MSGBOX_DEFAULT
 	releaseall
 	end
 
 EventScript_277BB4:: @ 8277BB4
-	msgbox OldaleTown_PokemonCenter_2F_Text_27871F, 4
+	msgbox OldaleTown_PokemonCenter_2F_Text_27871F, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -1476,17 +1476,17 @@ MossdeepCity_GameCorner_1F_EventScript_277C34:: @ 8277C34
 	end
 
 MossdeepCity_GameCorner_1F_EventScript_277C73:: @ 8277C73
-	msgbox MossdeepCity_GameCorner_1F_Text_278ACB, 4
+	msgbox MossdeepCity_GameCorner_1F_Text_278ACB, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_GameCorner_1F_EventScript_277C7D:: @ 8277C7D
-	msgbox MossdeepCity_GameCorner_1F_Text_278BF1, 4
+	msgbox MossdeepCity_GameCorner_1F_Text_278BF1, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_GameCorner_1F_EventScript_277C87:: @ 8277C87
-	msgbox MossdeepCity_GameCorner_1F_Text_278CAC, 4
+	msgbox MossdeepCity_GameCorner_1F_Text_278CAC, MSGBOX_DEFAULT
 	release
 	end
 
@@ -1514,7 +1514,7 @@ MossdeepCity_GameCorner_1F_EventScript_277CE9:: @ 8277CE9
 	special sub_802C920
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_GameCorner_1F_EventScript_277E55
-	msgbox MossdeepCity_GameCorner_1F_Text_278DD9, 4
+	msgbox MossdeepCity_GameCorner_1F_Text_278DD9, MSGBOX_DEFAULT
 	fadescreen 1
 	setvar VAR_0x8005, 0
 	special sub_81B8958
@@ -1533,7 +1533,7 @@ MossdeepCity_GameCorner_1F_EventScript_277D35:: @ 8277D35
 	special sub_8027A5C
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_GameCorner_1F_EventScript_277E55
-	msgbox MossdeepCity_GameCorner_1F_Text_278DD9, 4
+	msgbox MossdeepCity_GameCorner_1F_Text_278DD9, MSGBOX_DEFAULT
 	fadescreen 1
 	setvar VAR_0x8005, 1
 	special sub_81B8958
@@ -1602,12 +1602,12 @@ MossdeepCity_GameCorner_1F_EventScript_277E0E:: @ 8277E0E
 
 MossdeepCity_GameCorner_1F_EventScript_277E48:: @ 8277E48
 	delay 60
-	msgbox MossdeepCity_GameCorner_1F_Text_278D68, 4
+	msgbox MossdeepCity_GameCorner_1F_Text_278D68, MSGBOX_DEFAULT
 	release
 	end
 
 MossdeepCity_GameCorner_1F_EventScript_277E55:: @ 8277E55
-	msgbox MossdeepCity_GameCorner_1F_Text_278E60, 5
+	msgbox MossdeepCity_GameCorner_1F_Text_278E60, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MossdeepCity_GameCorner_1F_EventScript_2772F9
 	compare VAR_0x8005, 0
@@ -1618,11 +1618,11 @@ MossdeepCity_GameCorner_1F_EventScript_277E55:: @ 8277E55
 	end
 
 MossdeepCity_GameCorner_1F_EventScript_277E84:: @ 8277E84
-	msgbox MossdeepCity_GameCorner_1F_Text_278EDC, 4
+	msgbox MossdeepCity_GameCorner_1F_Text_278EDC, MSGBOX_DEFAULT
 	return
 
 MossdeepCity_GameCorner_1F_EventScript_277E8D:: @ 8277E8D
-	msgbox MossdeepCity_GameCorner_1F_Text_278FA4, 4
+	msgbox MossdeepCity_GameCorner_1F_Text_278FA4, MSGBOX_DEFAULT
 	return
 
 MossdeepCity_GameCorner_1F_EventScript_277E96:: @ 8277E96

--- a/data/scripts/contest_hall.inc
+++ b/data/scripts/contest_hall.inc
@@ -11,18 +11,18 @@ LilycoveCity_ContestLobby_EventScript_279CC5:: @ 8279CC5
 	end
 
 LilycoveCity_ContestLobby_EventScript_279CEA:: @ 8279CEA
-	msgbox LilycoveCity_ContestLobby_Text_27AEA8, 4
+	msgbox LilycoveCity_ContestLobby_Text_27AEA8, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_ContestLobby_EventScript_279CF3:: @ 8279CF3
-	msgbox LilycoveCity_ContestLobby_Text_27ADA7, 4
+	msgbox LilycoveCity_ContestLobby_Text_27ADA7, MSGBOX_DEFAULT
 	giveitem_std ITEM_POKEBLOCK_CASE
 	setflag FLAG_0x05F
-	msgbox LilycoveCity_ContestLobby_Text_27AE47, 4
+	msgbox LilycoveCity_ContestLobby_Text_27AE47, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_ContestLobby_EventScript_279D13:: @ 8279D13
-	msgbox LilycoveCity_ContestLobby_Text_27B67B, 4
+	msgbox LilycoveCity_ContestLobby_Text_27B67B, MSGBOX_DEFAULT
 	switch VAR_0x408A
 	case 4, LilycoveCity_ContestLobby_EventScript_279D2C
 	end
@@ -38,7 +38,7 @@ LilycoveCity_ContestLobby_EventScript_279D2C:: @ 8279D2C
 
 LilycoveCity_ContestLobby_EventScript_279D4B:: @ 8279D4B
 	call LilycoveCity_ContestLobby_EventScript_27205E
-	msgbox LilycoveCity_ContestLobby_Text_27B6E7, 4
+	msgbox LilycoveCity_ContestLobby_Text_27B6E7, MSGBOX_DEFAULT
 	release
 	end
 
@@ -66,27 +66,27 @@ LilycoveCity_ContestLobby_EventScript_279D97:: @ 8279D97
 	end
 
 LilycoveCity_ContestLobby_EventScript_279DDF:: @ 8279DDF
-	msgbox LilycoveCity_ContestLobby_Text_27AF7A, 4
+	msgbox LilycoveCity_ContestLobby_Text_27AF7A, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_279D97
 	end
 
 LilycoveCity_ContestLobby_EventScript_279DED:: @ 8279DED
-	msgbox LilycoveCity_ContestLobby_Text_27B17D, 4
+	msgbox LilycoveCity_ContestLobby_Text_27B17D, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_279D97
 	end
 
 LilycoveCity_ContestLobby_EventScript_279DFB:: @ 8279DFB
-	msgbox LilycoveCity_ContestLobby_Text_27B221, 4
+	msgbox LilycoveCity_ContestLobby_Text_27B221, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_279D97
 	end
 
 LilycoveCity_ContestLobby_EventScript_279E09:: @ 8279E09
-	msgbox LilycoveCity_ContestLobby_Text_27BD4F, 4
+	msgbox LilycoveCity_ContestLobby_Text_27BD4F, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_279E13:: @ 8279E13
-	msgbox LilycoveCity_ContestLobby_Text_27B44A, 4
+	msgbox LilycoveCity_ContestLobby_Text_27B44A, MSGBOX_DEFAULT
 	choosecontestmon
 	compare VAR_0x8004, 255
 	goto_eq LilycoveCity_ContestLobby_EventScript_279E09
@@ -148,39 +148,39 @@ LilycoveCity_ContestLobby_EventScript_279EE1:: @ 8279EE1
 	end
 
 LilycoveCity_ContestLobby_EventScript_279F12:: @ 8279F12
-	msgbox LilycoveCity_ContestLobby_Text_27B471, 4
+	msgbox LilycoveCity_ContestLobby_Text_27B471, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_279E13
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_279F21:: @ 8279F21
-	msgbox LilycoveCity_ContestLobby_Text_27B5C4, 5
+	msgbox LilycoveCity_ContestLobby_Text_27B5C4, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, LilycoveCity_ContestLobby_EventScript_279E13
 	case 1, LilycoveCity_ContestLobby_EventScript_279F87
 	end
 
 LilycoveCity_ContestLobby_EventScript_279F45:: @ 8279F45
-	msgbox LilycoveCity_ContestLobby_Text_27B547, 5
+	msgbox LilycoveCity_ContestLobby_Text_27B547, MSGBOX_YESNO
 	switch VAR_RESULT
 	case 0, LilycoveCity_ContestLobby_EventScript_279E13
 	case 1, LilycoveCity_ContestLobby_EventScript_279F87
 	end
 
 LilycoveCity_ContestLobby_EventScript_279F69:: @ 8279F69
-	msgbox LilycoveCity_ContestLobby_Text_27B4C4, 4
+	msgbox LilycoveCity_ContestLobby_Text_27B4C4, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_279E13
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_279F78:: @ 8279F78
-	msgbox LilycoveCity_ContestLobby_Text_27B501, 4
+	msgbox LilycoveCity_ContestLobby_Text_27B501, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_279E13
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_279F87:: @ 8279F87
-	msgbox LilycoveCity_ContestLobby_Text_27B5E2, 4
+	msgbox LilycoveCity_ContestLobby_Text_27B5E2, MSGBOX_DEFAULT
 	closemessage
 	releaseall
 	setvar VAR_0x4086, 1
@@ -276,7 +276,7 @@ LinkContestRoom1_EventScript_27A0B1:: @ 827A0B1
 	compare VAR_0x4088, 5
 	goto_eq LinkContestRoom1_EventScript_27A0C7
 	lockall
-	msgbox LinkContestRoom1_Text_27B711, 4
+	msgbox LinkContestRoom1_Text_27B711, MSGBOX_DEFAULT
 	releaseall
 	return
 
@@ -423,7 +423,7 @@ LinkContestRoom1_EventScript_27A230:: @ 827A230
 LinkContestRoom1_EventScript_27A26C:: @ 827A26C
 	compare VAR_0x4088, 5
 	goto_eq LinkContestRoom1_EventScript_27A280
-	msgbox LinkContestRoom1_Text_27B830, 4
+	msgbox LinkContestRoom1_Text_27B830, MSGBOX_DEFAULT
 	return
 
 LinkContestRoom1_EventScript_27A280:: @ 827A280
@@ -847,7 +847,7 @@ LinkContestRoom1_EventScript_27A801:: @ 827A801
 LinkContestRoom1_EventScript_27A853:: @ 827A853
 	compare VAR_0x4088, 5
 	goto_eq LinkContestRoom1_EventScript_27A867
-	msgbox LinkContestRoom1_Text_27B904, 4
+	msgbox LinkContestRoom1_Text_27B904, MSGBOX_DEFAULT
 	return
 
 LinkContestRoom1_EventScript_27A867:: @ 827A867
@@ -897,7 +897,7 @@ LinkContestRoom1_EventScript_27A8A5:: @ 827A8A5
 LinkContestRoom1_EventScript_27A8FB:: @ 827A8FB
 	compare VAR_0x4088, 5
 	goto_eq LinkContestRoom1_EventScript_27A90F
-	msgbox LinkContestRoom1_Text_27BA15, 4
+	msgbox LinkContestRoom1_Text_27BA15, MSGBOX_DEFAULT
 	return
 
 LinkContestRoom1_EventScript_27A90F:: @ 827A90F
@@ -910,7 +910,7 @@ LinkContestRoom1_EventScript_27A90F:: @ 827A90F
 LinkContestRoom1_EventScript_27A91E:: @ 827A91E
 	compare VAR_0x4088, 5
 	goto_eq LinkContestRoom1_EventScript_27A932
-	msgbox LinkContestRoom1_Text_27BA30, 4
+	msgbox LinkContestRoom1_Text_27BA30, MSGBOX_DEFAULT
 	return
 
 LinkContestRoom1_EventScript_27A932:: @ 827A932
@@ -923,7 +923,7 @@ LinkContestRoom1_EventScript_27A932:: @ 827A932
 LinkContestRoom1_EventScript_27A941:: @ 827A941
 	compare VAR_0x4088, 5
 	goto_eq LinkContestRoom1_EventScript_27A955
-	msgbox LinkContestRoom1_Text_27BAAC, 4
+	msgbox LinkContestRoom1_Text_27BAAC, MSGBOX_DEFAULT
 	return
 
 LinkContestRoom1_EventScript_27A955:: @ 827A955
@@ -936,7 +936,7 @@ LinkContestRoom1_EventScript_27A955:: @ 827A955
 LinkContestRoom1_EventScript_27A964:: @ 827A964
 	compare VAR_0x4088, 5
 	goto_eq LinkContestRoom1_EventScript_27A978
-	msgbox LinkContestRoom1_Text_27BB25, 4
+	msgbox LinkContestRoom1_Text_27BB25, MSGBOX_DEFAULT
 	return
 
 LinkContestRoom1_EventScript_27A978:: @ 827A978
@@ -987,7 +987,7 @@ LinkContestRoom1_EventScript_27A9D4:: @ 827A9D4
 LinkContestRoom1_EventScript_27AA00:: @ 827AA00
 	compare VAR_0x4088, 5
 	goto_eq LinkContestRoom1_EventScript_27AA14
-	msgbox LinkContestRoom1_Text_27BB4C, 4
+	msgbox LinkContestRoom1_Text_27BB4C, MSGBOX_DEFAULT
 	return
 
 LinkContestRoom1_EventScript_27AA14:: @ 827AA14
@@ -1089,7 +1089,7 @@ LinkContestRoom1_EventScript_27AB36:: @ 827AB36
 	checkflag FLAG_TEMP_2
 	goto_eq LinkContestRoom1_EventScript_27AB82
 	lockall
-	msgbox LinkContestRoom1_Text_27BBA8, 4
+	msgbox LinkContestRoom1_Text_27BBA8, MSGBOX_DEFAULT
 	releaseall
 	call LinkContestRoom1_EventScript_27ABF8
 	call LinkContestRoom1_EventScript_27AC5E
@@ -1104,7 +1104,7 @@ LinkContestRoom1_EventScript_27AB36:: @ 827AB36
 
 LinkContestRoom1_EventScript_27AB82:: @ 827AB82
 	lockall
-	msgbox LinkContestRoom1_Text_27BB7A, 4
+	msgbox LinkContestRoom1_Text_27BB7A, MSGBOX_DEFAULT
 	releaseall
 	delay 90
 	special sub_80F88E8
@@ -1199,7 +1199,7 @@ LinkContestRoom1_EventScript_27AC5E:: @ 827AC5E
 	compare VAR_0x8005, 3
 	goto_eq LinkContestRoom1_EventScript_27AC77
 	lockall
-	msgbox LinkContestRoom1_Text_27BB7A, 4
+	msgbox LinkContestRoom1_Text_27BB7A, MSGBOX_DEFAULT
 	releaseall
 	return
 
@@ -1212,14 +1212,14 @@ LinkContestRoom1_EventScript_27AC77:: @ 827AC77
 	compare VAR_CONTEST_RANK, 3
 	goto_eq LinkContestRoom1_EventScript_27ACBD
 	lockall
-	msgbox LinkContestRoom1_Text_27BB7A, 4
+	msgbox LinkContestRoom1_Text_27BB7A, MSGBOX_DEFAULT
 	releaseall
 	return
 
 LinkContestRoom1_EventScript_27ACA8:: @ 827ACA8
 	lockall
 	call LinkContestRoom1_EventScript_27205E
-	msgbox LinkContestRoom1_Text_27BC2F, 4
+	msgbox LinkContestRoom1_Text_27BC2F, MSGBOX_DEFAULT
 	releaseall
 	setvar VAR_0x408A, 4
 	return
@@ -1229,7 +1229,7 @@ LinkContestRoom1_EventScript_27ACBD:: @ 827ACBD
 	compare VAR_RESULT, 0
 	goto_eq LinkContestRoom1_EventScript_27ACA8
 	lockall
-	msgbox LinkContestRoom1_Text_27BB7A, 4
+	msgbox LinkContestRoom1_Text_27BB7A, MSGBOX_DEFAULT
 	releaseall
 	return
 
@@ -1238,12 +1238,12 @@ LinkContestRoom1_EventScript_27ACDF:: @ 827ACDF
 	incrementgamestat 42
 	setflag FLAG_SYS_RIBBON_GET
 	lockall
-	msgbox LinkContestRoom1_Text_27BBD4, 4
+	msgbox LinkContestRoom1_Text_27BBD4, MSGBOX_DEFAULT
 	playfanfare MUS_FANFA4
-	msgbox LinkContestRoom1_Text_27BC00, 4
+	msgbox LinkContestRoom1_Text_27BC00, MSGBOX_DEFAULT
 	waitfanfare
 	special sub_80F8390
-	msgbox LinkContestRoom1_Text_27BC16, 4
+	msgbox LinkContestRoom1_Text_27BC16, MSGBOX_DEFAULT
 	releaseall
 	return
 

--- a/data/scripts/day_care.inc
+++ b/data/scripts/day_care.inc
@@ -9,18 +9,18 @@ Route117_EventScript_291C18:: @ 8291C18
 	goto_eq Route117_EventScript_291CD1
 	compare VAR_RESULT, 3
 	goto_eq Route117_EventScript_291CE8
-	msgbox Route117_Text_291FCF, 4
+	msgbox Route117_Text_291FCF, MSGBOX_DEFAULT
 	release
 	end
 
 Route117_EventScript_291C4D:: @ 8291C4D
-	msgbox Route117_Text_29205D, 5
+	msgbox Route117_Text_29205D, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route117_EventScript_291C83
-	msgbox Route117_Text_2922C6, 5
+	msgbox Route117_Text_2922C6, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route117_EventScript_291C83
-	msgbox Route117_Text_292149, 4
+	msgbox Route117_Text_292149, MSGBOX_DEFAULT
 	clearflag FLAG_PENDING_DAYCARE_EGG
 	special RejectEggFromDayCare
 	release
@@ -30,7 +30,7 @@ Route117_EventScript_291C83:: @ 8291C83
 	specialvar VAR_RESULT, CalculatePlayerPartyCount
 	compare VAR_RESULT, 6
 	goto_if 5, Route117_EventScript_291C9D
-	msgbox Route117_Text_29216A, 4
+	msgbox Route117_Text_29216A, MSGBOX_DEFAULT
 	release
 	end
 
@@ -39,7 +39,7 @@ Route117_EventScript_291C9D:: @ 8291C9D
 	playfanfare MUS_FANFA1
 	waitfanfare
 	waitbuttonpress
-	msgbox Route117_Text_2921CF, 4
+	msgbox Route117_Text_2921CF, MSGBOX_DEFAULT
 	special GiveEggFromDaycare
 	clearflag FLAG_PENDING_DAYCARE_EGG
 	release
@@ -52,12 +52,12 @@ Route117_EventScript_291CB7:: @ 8291CB7
 	return
 
 Route117_EventScript_291CC8:: @ 8291CC8
-	msgbox Route117_Text_2921E5, 4
+	msgbox Route117_Text_2921E5, MSGBOX_DEFAULT
 	return
 
 Route117_EventScript_291CD1:: @ 8291CD1
 	special GetDaycareMonNicknames
-	msgbox Route117_Text_292114, 4
+	msgbox Route117_Text_292114, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 0
 	call Route117_EventScript_291CB7
 	release
@@ -65,7 +65,7 @@ Route117_EventScript_291CD1:: @ 8291CD1
 
 Route117_EventScript_291CE8:: @ 8291CE8
 	special GetDaycareMonNicknames
-	msgbox Route117_Text_292299, 4
+	msgbox Route117_Text_292299, MSGBOX_DEFAULT
 	special SetDaycareCompatibilityString
 	special ShowFieldMessageStringVar4
 	waitmessage
@@ -87,10 +87,10 @@ Route117_PokemonDayCare_EventScript_291D11:: @ 8291D11
 	goto_eq Route117_PokemonDayCare_EventScript_291E2F
 	compare VAR_RESULT, 3
 	goto_eq Route117_PokemonDayCare_EventScript_291F5C
-	msgbox Route117_PokemonDayCare_Text_2922F4, 5
+	msgbox Route117_PokemonDayCare_Text_2922F4, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route117_PokemonDayCare_EventScript_291D56
-	msgbox Route117_PokemonDayCare_Text_292416, 4
+	msgbox Route117_PokemonDayCare_Text_292416, MSGBOX_DEFAULT
 	release
 	end
 
@@ -101,7 +101,7 @@ Route117_PokemonDayCare_EventScript_291D56:: @ 8291D56
 	specialvar VAR_RESULT, sub_80722E0
 	compare VAR_RESULT, 2
 	goto_eq Route117_PokemonDayCare_EventScript_291E01
-	msgbox Route117_PokemonDayCare_Text_292349, 4
+	msgbox Route117_PokemonDayCare_Text_292349, MSGBOX_DEFAULT
 	fadescreen 1
 	special ChooseSendDaycareMon
 	waitstate
@@ -113,7 +113,7 @@ Route117_PokemonDayCare_EventScript_291D56:: @ 8291D56
 	specialvar VAR_0x8005, GetSelectedMonNickAndSpecies
 	waitse
 	playmoncry VAR_0x8005, 0
-	msgbox Route117_PokemonDayCare_Text_292370, 4
+	msgbox Route117_PokemonDayCare_Text_292370, MSGBOX_DEFAULT
 	waitmoncry
 	special StoreSelectedPokemonInDaycare
 	incrementgamestat 47
@@ -124,39 +124,39 @@ Route117_PokemonDayCare_EventScript_291D56:: @ 8291D56
 	end
 
 Route117_PokemonDayCare_EventScript_291DCA:: @ 8291DCA
-	msgbox Route117_PokemonDayCare_Text_292476, 4
+	msgbox Route117_PokemonDayCare_Text_292476, MSGBOX_DEFAULT
 	release
 	end
 
 Route117_PokemonDayCare_EventScript_291DD4:: @ 8291DD4
-	msgbox Route117_PokemonDayCare_Text_2923AF, 5
+	msgbox Route117_PokemonDayCare_Text_2923AF, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route117_PokemonDayCare_EventScript_291D56
 	goto Route117_PokemonDayCare_EventScript_291DCA
 	end
 
 Route117_PokemonDayCare_EventScript_291DED:: @ 8291DED
-	msgbox Route117_PokemonDayCare_Text_2925BB, 4
+	msgbox Route117_PokemonDayCare_Text_2925BB, MSGBOX_DEFAULT
 	release
 	end
 
 Route117_PokemonDayCare_EventScript_291DF7:: @ 8291DF7
-	msgbox Route117_PokemonDayCare_Text_292617, 4
+	msgbox Route117_PokemonDayCare_Text_292617, MSGBOX_DEFAULT
 	release
 	end
 
 Route117_PokemonDayCare_EventScript_291E01:: @ 8291E01
-	msgbox Route117_PokemonDayCare_Text_29266D, 4
+	msgbox Route117_PokemonDayCare_Text_29266D, MSGBOX_DEFAULT
 	release
 	end
 
 Route117_PokemonDayCare_EventScript_291E0B:: @ 8291E0B
-	msgbox Route117_PokemonDayCare_Text_2923F6, 4
+	msgbox Route117_PokemonDayCare_Text_2923F6, MSGBOX_DEFAULT
 	release
 	end
 
 Route117_PokemonDayCare_EventScript_291E15:: @ 8291E15
-	msgbox Route117_PokemonDayCare_Text_2924CC, 4
+	msgbox Route117_PokemonDayCare_Text_2924CC, MSGBOX_DEFAULT
 	return
 
 Route117_PokemonDayCare_EventScript_291E1E:: @ 8291E1E
@@ -166,13 +166,13 @@ Route117_PokemonDayCare_EventScript_291E1E:: @ 8291E1E
 	return
 
 Route117_PokemonDayCare_EventScript_291E2F:: @ 8291E2F
-	msgbox Route117_PokemonDayCare_Text_292488, 4
+	msgbox Route117_PokemonDayCare_Text_292488, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 0
 	call Route117_PokemonDayCare_EventScript_291E1E
-	msgbox Route117_PokemonDayCare_Text_2923AF, 5
+	msgbox Route117_PokemonDayCare_Text_2923AF, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route117_PokemonDayCare_EventScript_291D56
-	msgbox Route117_PokemonDayCare_Text_2925F6, 5
+	msgbox Route117_PokemonDayCare_Text_2925F6, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route117_PokemonDayCare_EventScript_291E6D
 	goto Route117_PokemonDayCare_EventScript_291DCA
@@ -196,7 +196,7 @@ Route117_PokemonDayCare_EventScript_291E6D:: @ 8291E6D
 
 Route117_PokemonDayCare_EventScript_291EAC:: @ 8291EAC
 	special GetDaycareCost
-	msgbox Route117_PokemonDayCare_Text_292549, 5
+	msgbox Route117_PokemonDayCare_Text_292549, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route117_PokemonDayCare_EventScript_291EC8
 	goto Route117_PokemonDayCare_EventScript_291DCA
@@ -206,7 +206,7 @@ Route117_PokemonDayCare_EventScript_291EC8:: @ 8291EC8
 	specialvar VAR_RESULT, IsEnoughForCostInVar0x8005
 	compare VAR_RESULT, 1
 	goto_eq Route117_PokemonDayCare_EventScript_291EE2
-	msgbox Route117_PokemonDayCare_Text_292432, 4
+	msgbox Route117_PokemonDayCare_Text_292432, MSGBOX_DEFAULT
 	release
 	end
 
@@ -216,10 +216,10 @@ Route117_PokemonDayCare_EventScript_291EE2:: @ 8291EE2
 	specialvar VAR_RESULT, TakePokemonFromDaycare
 	special SubtractMoneyFromVar0x8005
 	playse SE_REGI
-	msgbox Route117_PokemonDayCare_Text_292575, 4
+	msgbox Route117_PokemonDayCare_Text_292575, MSGBOX_DEFAULT
 	waitse
 	playmoncry VAR_RESULT, 0
-	msgbox Route117_PokemonDayCare_Text_292593, 4
+	msgbox Route117_PokemonDayCare_Text_292593, MSGBOX_DEFAULT
 	waitmoncry
 	specialvar VAR_RESULT, GetDaycareState
 	compare VAR_RESULT, 2
@@ -228,14 +228,14 @@ Route117_PokemonDayCare_EventScript_291EE2:: @ 8291EE2
 	end
 
 Route117_PokemonDayCare_EventScript_291F24:: @ 8291F24
-	msgbox Route117_PokemonDayCare_Text_29244F, 5
+	msgbox Route117_PokemonDayCare_Text_29244F, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route117_PokemonDayCare_EventScript_291E6D
 	goto Route117_PokemonDayCare_EventScript_291DCA
 	end
 
 Route117_PokemonDayCare_EventScript_291F3D:: @ 8291F3D
-	msgbox Route117_PokemonDayCare_Text_2924EF, 4
+	msgbox Route117_PokemonDayCare_Text_2924EF, MSGBOX_DEFAULT
 	release
 	end
 
@@ -265,15 +265,15 @@ Route117_PokemonDayCare_EventScript_291F5B:: @ 8291F5B
 	end
 
 Route117_PokemonDayCare_EventScript_291F5C:: @ 8291F5C
-	msgbox Route117_PokemonDayCare_Text_292488, 4
+	msgbox Route117_PokemonDayCare_Text_292488, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 0
 	call Route117_PokemonDayCare_EventScript_291E1E
 	setvar VAR_0x8004, 1
 	call Route117_PokemonDayCare_EventScript_291E1E
-	msgbox Route117_PokemonDayCare_Text_2925F6, 5
+	msgbox Route117_PokemonDayCare_Text_2925F6, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route117_PokemonDayCare_EventScript_291E6D
-	msgbox Route117_PokemonDayCare_Text_292476, 4
+	msgbox Route117_PokemonDayCare_Text_292476, MSGBOX_DEFAULT
 	release
 	end
 
@@ -284,14 +284,14 @@ Route117_PokemonDayCare_EventScript_291F95:: @ 8291F95
 	goto_eq Route117_PokemonDayCare_EventScript_291DCA
 	copyvar VAR_0x8004, VAR_RESULT
 	specialvar VAR_RESULT, TakePokemonFromDaycare
-	msgbox Route117_PokemonDayCare_Text_292575, 4
-	msgbox Route117_PokemonDayCare_Text_292476, 4
+	msgbox Route117_PokemonDayCare_Text_292575, MSGBOX_DEFAULT
+	msgbox Route117_PokemonDayCare_Text_292476, MSGBOX_DEFAULT
 	release
 	end
 
 EventScript_EggHatch:: @ 8291FC0
 	lockall
-	msgbox Text_292668, 4
+	msgbox Text_292668, MSGBOX_DEFAULT
 	special EggHatch
 	waitstate
 	releaseall

--- a/data/scripts/field_move_scripts.inc
+++ b/data/scripts/field_move_scripts.inc
@@ -18,10 +18,10 @@ Route123_EventScript_2906BB:: @ 82906BB
 	setfieldeffectargument 0, VAR_RESULT
 	bufferpartymonnick 0, VAR_RESULT
 	buffermovename 1, MOVE_CUT
-	msgbox Route103_Text_29072E, 5
+	msgbox Route103_Text_29072E, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route103_EventScript_29072B
-	msgbox Route103_Text_290771, 4
+	msgbox Route103_Text_290771, MSGBOX_DEFAULT
 	closemessage
 	dofieldeffect 2
 	waitstate
@@ -47,7 +47,7 @@ Route103_Movement_29071F: @ 829071F
 	step_end
 
 Route103_EventScript_290721:: @ 8290721
-	msgbox Route103_Text_29077D, 4
+	msgbox Route103_Text_29077D, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -92,10 +92,10 @@ VictoryRoad_B1F_EventScript_2907A6:: @ 82907A6
 	setfieldeffectargument 0, VAR_RESULT
 	bufferpartymonnick 0, VAR_RESULT
 	buffermovename 1, MOVE_ROCK_SMASH
-	msgbox Route111_Text_29083A, 5
+	msgbox Route111_Text_29083A, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq Route111_EventScript_290837
-	msgbox Route111_Text_290771, 4
+	msgbox Route111_Text_290771, MSGBOX_DEFAULT
 	closemessage
 	dofieldeffect 37
 	waitstate
@@ -132,7 +132,7 @@ Route111_Movement_29082B: @ 829082B
 	step_end
 
 Route111_EventScript_29082D:: @ 829082D
-	msgbox Route111_Text_29087F, 4
+	msgbox Route111_Text_29087F, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -168,7 +168,7 @@ VictoryRoad_B1F_EventScript_2908BA:: @ 82908BA
 	compare VAR_RESULT, 6
 	goto_eq FieryPath_EventScript_290915
 	setfieldeffectargument 0, VAR_RESULT
-	msgbox FieryPath_Text_29092C, 5
+	msgbox FieryPath_Text_29092C, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq FieryPath_EventScript_290929
 	closemessage
@@ -186,17 +186,17 @@ FieryPath_EventScript_2908FD:: @ 82908FD
 
 FieryPath_EventScript_290908:: @ 8290908
 	setflag FLAG_SYS_USE_STRENGTH
-	msgbox FieryPath_Text_29098C, 4
+	msgbox FieryPath_Text_29098C, MSGBOX_DEFAULT
 	releaseall
 	end
 
 FieryPath_EventScript_290915:: @ 8290915
-	msgbox FieryPath_Text_2909D6, 4
+	msgbox FieryPath_Text_2909D6, MSGBOX_DEFAULT
 	releaseall
 	end
 
 FieryPath_EventScript_29091F:: @ 829091F
-	msgbox FieryPath_Text_290A16, 4
+	msgbox FieryPath_Text_290A16, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -230,10 +230,10 @@ EventScript_UseWaterfall:: @ 8290A49
 	goto_eq EventScript_290A84
 	bufferpartymonnick 0, VAR_RESULT
 	setfieldeffectargument 0, VAR_RESULT
-	msgbox Text_290AC3, 5
+	msgbox Text_290AC3, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq EventScript_290A8C
-	msgbox Text_290AFC, 4
+	msgbox Text_290AFC, MSGBOX_DEFAULT
 	dofieldeffect 43
 	goto EventScript_290A8C
 
@@ -241,7 +241,7 @@ EventScript_CannotUseWaterfall:: @ 8290A83
 	lockall
 
 EventScript_290A84:: @ 8290A84
-	msgbox Text_290A8E, 4
+	msgbox Text_290A8E, MSGBOX_DEFAULT
 
 EventScript_290A8C:: @ 8290A8C
 	releaseall
@@ -266,16 +266,16 @@ EventScript_UseDive:: @ 8290B0F
 	bufferpartymonnick 0, VAR_RESULT
 	setfieldeffectargument 0, VAR_RESULT
 	setfieldeffectargument 1, 1
-	msgbox Text_290BE8, 5
+	msgbox Text_290BE8, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq EventScript_290B58
-	msgbox Text_290C1A, 4
+	msgbox Text_290C1A, MSGBOX_DEFAULT
 	dofieldeffect 44
 	goto EventScript_290B58
 	end
 
 EventScript_290B4E:: @ 8290B4E
-	msgbox Text_290BAA, 4
+	msgbox Text_290BAA, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -291,17 +291,17 @@ EventScript_UseDiveUnderwater:: @ 8290B5A
 	bufferpartymonnick 0, VAR_RESULT
 	setfieldeffectargument 0, VAR_RESULT
 	setfieldeffectargument 1, 1
-	msgbox Text_290C6E, 5
+	msgbox Text_290C6E, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq EventScript_290BA8
-	msgbox Text_290C1A, 4
+	msgbox Text_290C1A, MSGBOX_DEFAULT
 	dofieldeffect 44
 	goto EventScript_290BA8
 	end
 
 EventScript_290B99:: @ 8290B99
 	lockall
-	msgbox Text_290C28, 4
+	msgbox Text_290C28, MSGBOX_DEFAULT
 	goto EventScript_290BA8
 	end
 
@@ -329,7 +329,7 @@ Text_290C6E: @ 8290C6E
 	.string "Would you like to use DIVE?$"
 
 EventScript_290CAE:: @ 8290CAE
-	msgbox Text_290CB7, 3
+	msgbox Text_290CB7, MSGBOX_SIGN
 	end
 
 Text_290CB7: @ 8290CB7

--- a/data/scripts/gabby_and_ty.inc
+++ b/data/scripts/gabby_and_ty.inc
@@ -137,61 +137,61 @@ Route111_EventScript_28CDD2:: @ 828CDD2
 
 Route111_EventScript_28CDD6:: @ 828CDD6
 	trainerbattle 6, TRAINER_GABBY_AND_TY_1, 0, Route111_Text_28AF05, Route111_Text_28B000, Route111_Text_28B5EC, Route111_EventScript_28CF56
-	msgbox Route111_Text_28B5C0, 4
+	msgbox Route111_Text_28B5C0, MSGBOX_DEFAULT
 	release
 	end
 
 Route111_EventScript_28CDF6:: @ 828CDF6
 	trainerbattle 6, TRAINER_GABBY_AND_TY_1, 0, Route111_Text_28B75C, Route111_Text_28B8B1, Route111_Text_28B841, Route111_EventScript_28CF56
-	msgbox Route111_Text_28B805, 4
+	msgbox Route111_Text_28B805, MSGBOX_DEFAULT
 	release
 	end
 
 Route118_EventScript_28CE16:: @ 828CE16
 	trainerbattle 6, TRAINER_GABBY_AND_TY_2, 0, Route118_Text_28AF7D, Route118_Text_28B719, Route118_Text_28B5EC, Route118_EventScript_28CFC3
-	msgbox Route118_Text_28B5C0, 4
+	msgbox Route118_Text_28B5C0, MSGBOX_DEFAULT
 	release
 	end
 
 Route118_EventScript_28CE36:: @ 828CE36
 	trainerbattle 6, TRAINER_GABBY_AND_TY_2, 0, Route118_Text_28B7B1, Route118_Text_28B8F6, Route118_Text_28B841, Route118_EventScript_28CFC3
-	msgbox Route118_Text_28B805, 4
+	msgbox Route118_Text_28B805, MSGBOX_DEFAULT
 	release
 	end
 
 Route120_EventScript_28CE56:: @ 828CE56
 	trainerbattle 6, TRAINER_GABBY_AND_TY_3, 0, Route120_Text_28AF7D, Route120_Text_28B719, Route120_Text_28B5EC, Route120_EventScript_28CFC3
-	msgbox Route120_Text_28B5C0, 4
+	msgbox Route120_Text_28B5C0, MSGBOX_DEFAULT
 	release
 	end
 
 Route120_EventScript_28CE76:: @ 828CE76
 	trainerbattle 6, TRAINER_GABBY_AND_TY_3, 0, Route120_Text_28B7B1, Route120_Text_28B8F6, Route120_Text_28B841, Route120_EventScript_28CFC3
-	msgbox Route120_Text_28B805, 4
+	msgbox Route120_Text_28B805, MSGBOX_DEFAULT
 	release
 	end
 
 Route111_EventScript_28CE96:: @ 828CE96
 	trainerbattle 6, TRAINER_GABBY_AND_TY_4, 0, Route111_Text_28AF7D, Route111_Text_28B719, Route111_Text_28B5EC, Route111_EventScript_28CFC3
-	msgbox Route111_Text_28B5C0, 4
+	msgbox Route111_Text_28B5C0, MSGBOX_DEFAULT
 	release
 	end
 
 Route111_EventScript_28CEB6:: @ 828CEB6
 	trainerbattle 6, TRAINER_GABBY_AND_TY_4, 0, Route111_Text_28B7B1, Route111_Text_28B8F6, Route111_Text_28B841, Route111_EventScript_28CFC3
-	msgbox Route111_Text_28B805, 4
+	msgbox Route111_Text_28B805, MSGBOX_DEFAULT
 	release
 	end
 
 Route118_EventScript_28CED6:: @ 828CED6
 	trainerbattle 6, TRAINER_GABBY_AND_TY_5, 0, Route118_Text_28AF7D, Route118_Text_28B719, Route118_Text_28B5EC, Route118_EventScript_28CFC3
-	msgbox Route118_Text_28B5C0, 4
+	msgbox Route118_Text_28B5C0, MSGBOX_DEFAULT
 	release
 	end
 
 Route118_EventScript_28CEF6:: @ 828CEF6
 	trainerbattle 6, TRAINER_GABBY_AND_TY_5, 0, Route118_Text_28B7B1, Route118_Text_28B8F6, Route118_Text_28B841, Route118_EventScript_28CFC3
-	msgbox Route118_Text_28B805, 4
+	msgbox Route118_Text_28B805, MSGBOX_DEFAULT
 	release
 	end
 
@@ -199,7 +199,7 @@ Route111_EventScript_28CF16:: @ 828CF16
 Route118_EventScript_28CF16:: @ 828CF16
 Route120_EventScript_28CF16:: @ 828CF16
 	trainerbattle 6, TRAINER_GABBY_AND_TY_6, 0, Route111_Text_28AF7D, Route111_Text_28B719, Route111_Text_28B5EC, Route111_EventScript_28CFC3
-	msgbox Route111_Text_28B5C0, 4
+	msgbox Route111_Text_28B5C0, MSGBOX_DEFAULT
 	release
 	end
 
@@ -207,7 +207,7 @@ Route111_EventScript_28CF36:: @ 828CF36
 Route118_EventScript_28CF36:: @ 828CF36
 Route120_EventScript_28CF36:: @ 828CF36
 	trainerbattle 6, TRAINER_GABBY_AND_TY_6, 0, Route111_Text_28B7B1, Route111_Text_28B8F6, Route111_Text_28B841, Route111_EventScript_28CFC3
-	msgbox Route111_Text_28B805, 4
+	msgbox Route111_Text_28B805, MSGBOX_DEFAULT
 	release
 	end
 
@@ -222,7 +222,7 @@ Route111_EventScript_28CF56:: @ 828CF56
 	call_if 1, Route111_EventScript_28CFB1
 	checkflag FLAG_TEMP_1
 	goto_eq Route111_EventScript_28D0EE
-	msgbox Route111_Text_28B042, 5
+	msgbox Route111_Text_28B042, MSGBOX_YESNO
 	goto Route111_EventScript_28D0A7
 	end
 
@@ -259,7 +259,7 @@ Route120_EventScript_28CFC3:: @ 828CFC3
 	specialvar VAR_RESULT, GabbyAndTyGetLastQuote
 	compare VAR_RESULT, 0
 	goto_eq Route111_EventScript_28D053
-	msgbox Route111_Text_28B137, 4
+	msgbox Route111_Text_28B137, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, GabbyAndTyGetLastBattleTrivia
 	switch VAR_RESULT
 	case 0, Route111_EventScript_28D061
@@ -282,58 +282,58 @@ Route111_Movement_28D051: @ 828D051
 	step_end
 
 Route111_EventScript_28D053:: @ 828D053
-	msgbox Route111_Text_28B62D, 5
+	msgbox Route111_Text_28B62D, MSGBOX_YESNO
 	goto Route111_EventScript_28D0A7
 	end
 
 Route111_EventScript_28D061:: @ 828D061
-	msgbox Route111_Text_28B3F3, 5
+	msgbox Route111_Text_28B3F3, MSGBOX_YESNO
 	goto Route111_EventScript_28D0A7
 	end
 
 Route111_EventScript_28D06F:: @ 828D06F
-	msgbox Route111_Text_28B1B3, 5
+	msgbox Route111_Text_28B1B3, MSGBOX_YESNO
 	goto Route111_EventScript_28D0A7
 	end
 
 Route111_EventScript_28D07D:: @ 828D07D
-	msgbox Route111_Text_28B23D, 5
+	msgbox Route111_Text_28B23D, MSGBOX_YESNO
 	goto Route111_EventScript_28D0A7
 	end
 
 Route111_EventScript_28D08B:: @ 828D08B
-	msgbox Route111_Text_28B2FA, 5
+	msgbox Route111_Text_28B2FA, MSGBOX_YESNO
 	goto Route111_EventScript_28D0A7
 	end
 
 Route111_EventScript_28D099:: @ 828D099
-	msgbox Route111_Text_28B379, 5
+	msgbox Route111_Text_28B379, MSGBOX_YESNO
 	goto Route111_EventScript_28D0A7
 	end
 
 Route111_EventScript_28D0A7:: @ 828D0A7
 	compare VAR_RESULT, 0
 	goto_eq Route111_EventScript_28D0E1
-	msgbox Route111_Text_28B433, 4
+	msgbox Route111_Text_28B433, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 10
 	call Route111_EventScript_271E7C
 	lock
 	faceplayer
 	compare VAR_RESULT, 0
 	goto_eq Route111_EventScript_28D0E1
-	msgbox Route111_Text_28B4AB, 4
+	msgbox Route111_Text_28B4AB, MSGBOX_DEFAULT
 	special GabbyAndTyAfterInterview
 	setflag FLAG_TEMP_1
 	release
 	end
 
 Route111_EventScript_28D0E1:: @ 828D0E1
-	msgbox Route111_Text_28B577, 4
+	msgbox Route111_Text_28B577, MSGBOX_DEFAULT
 	setflag FLAG_TEMP_1
 	release
 	end
 
 Route111_EventScript_28D0EE:: @ 828D0EE
-	msgbox Route111_Text_28B5C0, 4
+	msgbox Route111_Text_28B5C0, MSGBOX_DEFAULT
 	release
 	end

--- a/data/scripts/mauville_man.inc
+++ b/data/scripts/mauville_man.inc
@@ -11,7 +11,7 @@ MauvilleCity_PokemonCenter_1F_EventScript_28E066:: @ 828E066
 MauvilleCity_PokemonCenter_1F_EventScript_28E0A6:: @ 828E0A6
 	lock
 	faceplayer
-	msgbox MauvilleCity_PokemonCenter_1F_Text_29038E, 5
+	msgbox MauvilleCity_PokemonCenter_1F_Text_29038E, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_28E0C7
 	compare VAR_RESULT, 0
@@ -25,17 +25,17 @@ MauvilleCity_PokemonCenter_1F_EventScript_28E0C7:: @ 828E0C7
 	special ScrSpecial_HasBardSongBeenChanged
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_28E0F4
-	msgbox MauvilleCity_PokemonCenter_1F_Text_2903E6, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_2903E6, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_28E0EA:: @ 828E0EA
-	msgbox MauvilleCity_PokemonCenter_1F_Text_2903C0, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_2903C0, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_28E0F4:: @ 828E0F4
-	msgbox MauvilleCity_PokemonCenter_1F_Text_290421, 5
+	msgbox MauvilleCity_PokemonCenter_1F_Text_290421, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_28E113
 	compare VAR_RESULT, 0
@@ -49,20 +49,20 @@ MauvilleCity_PokemonCenter_1F_EventScript_28E113:: @ 828E113
 	faceplayer
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_28E15D
-	msgbox MauvilleCity_PokemonCenter_1F_Text_2904C1, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_2904C1, MSGBOX_DEFAULT
 	setvar VAR_0x8004, 1
 	special ScrSpecial_PlayBardSong
 	delay 60
-	msgbox MauvilleCity_PokemonCenter_1F_Text_2904EB, 5
+	msgbox MauvilleCity_PokemonCenter_1F_Text_2904EB, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_28E113
 	special ScrSpecial_SaveBardSongLyrics
-	msgbox MauvilleCity_PokemonCenter_1F_Text_290514, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_290514, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_28E15D:: @ 828E15D
-	msgbox MauvilleCity_PokemonCenter_1F_Text_29049B, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_29049B, MSGBOX_DEFAULT
 	release
 	end
 
@@ -70,11 +70,11 @@ MauvilleCity_PokemonCenter_1F_EventScript_28E167:: @ 828E167
 	lock
 	faceplayer
 	setflag FLAG_SYS_HIPSTER_MEET
-	msgbox MauvilleCity_PokemonCenter_1F_Text_29054C, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_29054C, MSGBOX_DEFAULT
 	special ScrSpecial_GetHipsterSpokenFlag
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_28E18C
-	msgbox MauvilleCity_PokemonCenter_1F_Text_290598, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_290598, MSGBOX_DEFAULT
 	release
 	end
 
@@ -82,12 +82,12 @@ MauvilleCity_PokemonCenter_1F_EventScript_28E18C:: @ 828E18C
 	special ScrSpecial_HipsterTeachWord
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_28E1A4
-	msgbox MauvilleCity_PokemonCenter_1F_Text_290602, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_290602, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_28E1A4:: @ 828E1A4
-	msgbox MauvilleCity_PokemonCenter_1F_Text_290666, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_290666, MSGBOX_DEFAULT
 	special ScrSpecial_SetHipsterSpokenFlag
 	release
 	end
@@ -154,7 +154,7 @@ MauvilleCity_PokemonCenter_1F_Text_28E45A: @ 828E45A
 MauvilleCity_PokemonCenter_1F_EventScript_28E4D4:: @ 828E4D4
 	lock
 	faceplayer
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E1B1, 5
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E1B1, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_28E503
 	special ScrSpecial_GetTraderTradedFlag
@@ -166,12 +166,12 @@ MauvilleCity_PokemonCenter_1F_EventScript_28E4D4:: @ 828E4D4
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_28E503:: @ 828E503
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E1E8, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E1E8, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_28E50D:: @ 828E50D
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E20E, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E20E, MSGBOX_DEFAULT
 	release
 	end
 
@@ -182,7 +182,7 @@ MauvilleCity_PokemonCenter_1F_EventScript_28E517:: @ 828E517
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_28E558
 	compare VAR_0x8004, 65535
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_28E562
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E2A9, 5
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E2A9, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_28E56E
 	special ScrSpecial_DoesPlayerHaveNoDecorations
@@ -192,7 +192,7 @@ MauvilleCity_PokemonCenter_1F_EventScript_28E517:: @ 828E517
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_28E558:: @ 828E558
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E27F, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E27F, MSGBOX_DEFAULT
 	release
 	end
 
@@ -209,12 +209,12 @@ MauvilleCity_PokemonCenter_1F_EventScript_28E56E:: @ 828E56E
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_28E57A:: @ 828E57A
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E2E3, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E2E3, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_28E584:: @ 828E584
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E323, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E323, MSGBOX_DEFAULT
 	special ScrSpecial_TraderMenuGiveDecoration
 	waitstate
 	compare VAR_0x8006, 0
@@ -224,26 +224,26 @@ MauvilleCity_PokemonCenter_1F_EventScript_28E584:: @ 828E584
 	special ScrSpecial_IsDecorationFull
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_28E5EC
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E3C4, 5
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E3C4, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_28E584
 	special ScrSpecial_TraderDoDecorationTrade
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E424, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E424, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_28E5D4:: @ 828E5D4
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E356, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E356, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_28E5DE:: @ 828E5DE
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E3EC, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E3EC, MSGBOX_DEFAULT
 	goto MauvilleCity_PokemonCenter_1F_EventScript_28E584
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_28E5EC:: @ 828E5EC
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E380, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E380, MSGBOX_DEFAULT
 	release
 	end
 
@@ -810,7 +810,7 @@ MauvilleCity_PokemonCenter_1F_EventScript_29014A:: @ 829014A
 	setvar VAR_0x8009, 0
 	setvar VAR_0x800A, 0
 	setvar VAR_0x800B, 0
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E5F6, 5
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E5F6, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_290219
 	specialvar VAR_RESULT, ScrSpecial_StorytellerGetFreeStorySlot
@@ -836,38 +836,38 @@ MauvilleCity_PokemonCenter_1F_EventScript_2901B7:: @ 82901B7
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_2901BD:: @ 82901BD
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E78A, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E78A, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, ScrSpecial_HasStorytellerAlreadyRecorded
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_29022D
 	goto MauvilleCity_PokemonCenter_1F_EventScript_2901E2
 
 MauvilleCity_PokemonCenter_1F_EventScript_2901DA:: @ 82901DA
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E6AE, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E6AE, MSGBOX_DEFAULT
 
 MauvilleCity_PokemonCenter_1F_EventScript_2901E2:: @ 82901E2
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E7EE, 5
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E7EE, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_290219
 	specialvar VAR_RESULT, ScrSpecial_StorytellerInitializeRandomStat
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_29020F
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E881, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E881, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_29020F:: @ 829020F
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E726, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E726, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_290219:: @ 8290219
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E64D, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E64D, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_290223:: @ 8290223
-	msgbox MauvilleCity_PokemonCenter_1F_Text_28E8D9, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_28E8D9, MSGBOX_DEFAULT
 	release
 	end
 
@@ -895,7 +895,7 @@ MauvilleCity_PokemonCenter_1F_Text_2902BD: @ 82902BD
 MauvilleCity_PokemonCenter_1F_EventScript_2902F6:: @ 82902F6
 	lock
 	faceplayer
-	msgbox MauvilleCity_PokemonCenter_1F_Text_29022F, 5
+	msgbox MauvilleCity_PokemonCenter_1F_Text_29022F, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq MauvilleCity_PokemonCenter_1F_EventScript_290317
 	compare VAR_RESULT, 0
@@ -919,7 +919,7 @@ MauvilleCity_PokemonCenter_1F_EventScript_290331:: @ 8290331
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_29034B:: @ 829034B
-	msgbox MauvilleCity_PokemonCenter_1F_Text_2902A7, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_2902A7, MSGBOX_DEFAULT
 	goto MauvilleCity_PokemonCenter_1F_EventScript_290359
 	end
 
@@ -935,12 +935,12 @@ MauvilleCity_PokemonCenter_1F_EventScript_290359:: @ 8290359
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_29037A:: @ 829037A
-	msgbox MauvilleCity_PokemonCenter_1F_Text_290281, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_290281, MSGBOX_DEFAULT
 	release
 	end
 
 MauvilleCity_PokemonCenter_1F_EventScript_290384:: @ 8290384
-	msgbox MauvilleCity_PokemonCenter_1F_Text_2902BD, 4
+	msgbox MauvilleCity_PokemonCenter_1F_Text_2902BD, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/scripts/mystery_event_club.inc
+++ b/data/scripts/mystery_event_club.inc
@@ -3,12 +3,12 @@ PetalburgCity_PokemonCenter_1F_EventScript_291539:: @ 8291539
 	faceplayer
 	checkflag FLAG_SYS_CHAT_USED
 	goto_eq PetalburgCity_PokemonCenter_1F_EventScript_2915F5
-	msgbox PetalburgCity_PokemonCenter_1F_Text_291687, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_291687, MSGBOX_DEFAULT
 	goto PetalburgCity_PokemonCenter_1F_EventScript_291552
 	end
 
 PetalburgCity_PokemonCenter_1F_EventScript_291552:: @ 8291552
-	msgbox PetalburgCity_PokemonCenter_1F_Text_2916FF, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_2916FF, MSGBOX_DEFAULT
 	multichoice 17, 6, 20, 0
 	switch VAR_RESULT
 	case 0, PetalburgCity_PokemonCenter_1F_EventScript_29159F
@@ -18,12 +18,12 @@ PetalburgCity_PokemonCenter_1F_EventScript_291552:: @ 8291552
 	end
 
 PetalburgCity_PokemonCenter_1F_EventScript_291591:: @ 8291591
-	msgbox PetalburgCity_PokemonCenter_1F_Text_291729, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_291729, MSGBOX_DEFAULT
 	goto PetalburgCity_PokemonCenter_1F_EventScript_291552
 	end
 
 PetalburgCity_PokemonCenter_1F_EventScript_29159F:: @ 829159F
-	msgbox PetalburgCity_PokemonCenter_1F_Text_291969, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_291969, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 0
 	call PetalburgCity_PokemonCenter_1F_EventScript_271E7C
@@ -36,7 +36,7 @@ PetalburgCity_PokemonCenter_1F_EventScript_29159F:: @ 829159F
 	end
 
 PetalburgCity_PokemonCenter_1F_EventScript_2915CB:: @ 82915CB
-	msgbox PetalburgCity_PokemonCenter_1F_Text_2919DC, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_2919DC, MSGBOX_DEFAULT
 	release
 	end
 
@@ -45,22 +45,22 @@ PetalburgCity_PokemonCenter_1F_EventScript_2915D5:: @ 82915D5
 	special sub_811EECC
 	waitmessage
 	delay 80
-	msgbox PetalburgCity_PokemonCenter_1F_Text_291B22, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_291B22, MSGBOX_DEFAULT
 	release
 	end
 
 PetalburgCity_PokemonCenter_1F_EventScript_2915EB:: @ 82915EB
-	msgbox PetalburgCity_PokemonCenter_1F_Text_291991, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_291991, MSGBOX_DEFAULT
 	release
 	end
 
 PetalburgCity_PokemonCenter_1F_EventScript_2915F5:: @ 82915F5
-	msgbox PetalburgCity_PokemonCenter_1F_Text_291A1B, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_291A1B, MSGBOX_DEFAULT
 	goto PetalburgCity_PokemonCenter_1F_EventScript_291603
 	end
 
 PetalburgCity_PokemonCenter_1F_EventScript_291603:: @ 8291603
-	msgbox PetalburgCity_PokemonCenter_1F_Text_291A4F, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_291A4F, MSGBOX_DEFAULT
 	multichoice 17, 6, 20, 0
 	switch VAR_RESULT
 	case 0, PetalburgCity_PokemonCenter_1F_EventScript_291650
@@ -70,12 +70,12 @@ PetalburgCity_PokemonCenter_1F_EventScript_291603:: @ 8291603
 	end
 
 PetalburgCity_PokemonCenter_1F_EventScript_291642:: @ 8291642
-	msgbox PetalburgCity_PokemonCenter_1F_Text_291729, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_291729, MSGBOX_DEFAULT
 	goto PetalburgCity_PokemonCenter_1F_EventScript_291603
 	end
 
 PetalburgCity_PokemonCenter_1F_EventScript_291650:: @ 8291650
-	msgbox PetalburgCity_PokemonCenter_1F_Text_291A6B, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_291A6B, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x8004, 0
 	call PetalburgCity_PokemonCenter_1F_EventScript_271E7C
@@ -88,7 +88,7 @@ PetalburgCity_PokemonCenter_1F_EventScript_291650:: @ 8291650
 	end
 
 PetalburgCity_PokemonCenter_1F_EventScript_29167C:: @ 829167C
-	msgbox PetalburgCity_PokemonCenter_1F_Text_291ABA, 4
+	msgbox PetalburgCity_PokemonCenter_1F_Text_291ABA, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -5,14 +5,14 @@ LittlerootTown_MaysHouse_2F_EventScript_2926FE:: @ 82926FE
 
 LittlerootTown_BrendansHouse_1F_EventScript_292704:: @ 8292704
 LittlerootTown_MaysHouse_1F_EventScript_292704:: @ 8292704
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7A1C, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7A1C, MSGBOX_DEFAULT
 	applymovement VAR_0x8004, LittlerootTown_BrendansHouse_1F_Movement_27259E
 	waitmovement 0
 	compare VAR_0x8005, 0
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_29274D
 	compare VAR_0x8005, 1
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_292758
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7A46, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7A46, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x4092, 4
 	applymovement 255, LittlerootTown_BrendansHouse_1F_Movement_292763
@@ -37,7 +37,7 @@ LittlerootTown_BrendansHouse_1F_Movement_292763: @ 8292763
 
 LittlerootTown_BrendansHouse_1F_EventScript_292765:: @ 8292765
 LittlerootTown_MaysHouse_1F_EventScript_292765:: @ 8292765
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7B24, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7B24, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_0x8004, LittlerootTown_BrendansHouse_1F_Movement_2725A6
 	applymovement 255, LittlerootTown_BrendansHouse_1F_Movement_292AF0
@@ -61,7 +61,7 @@ LittlerootTown_BrendansHouse_2F_EventScript_292799:: @ 8292799
 LittlerootTown_MaysHouse_2F_EventScript_292799:: @ 8292799
 	checkflag FLAG_0x051
 	goto_eq LittlerootTown_BrendansHouse_2F_EventScript_29283F
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F8668, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F8668, MSGBOX_DEFAULT
 	call LittlerootTown_BrendansHouse_2F_EventScript_292849
 	delay 30
 	setvar VAR_0x4092, 6
@@ -85,7 +85,7 @@ LittlerootTown_BrendansHouse_2F_EventScript_2927DF:: @ 82927DF
 	waitmovement 0
 	applymovement 255, LittlerootTown_BrendansHouse_2F_Movement_2725A8
 	waitmovement 0
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F869A, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F869A, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_0x8008, LittlerootTown_BrendansHouse_2F_Movement_292857
 	waitmovement 0
@@ -98,7 +98,7 @@ LittlerootTown_BrendansHouse_2F_EventScript_29280F:: @ 829280F
 	waitmovement 0
 	applymovement 255, LittlerootTown_BrendansHouse_2F_Movement_2725A4
 	waitmovement 0
-	msgbox LittlerootTown_BrendansHouse_2F_Text_1F869A, 4
+	msgbox LittlerootTown_BrendansHouse_2F_Text_1F869A, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_0x8008, LittlerootTown_BrendansHouse_2F_Movement_292862
 	waitmovement 0
@@ -161,7 +161,7 @@ LittlerootTown_BrendansHouse_1F_EventScript_29286D:: @ 829286D
 	applymovement 255, LittlerootTown_BrendansHouse_1F_Movement_292AE0
 	waitmovement 0
 	playbgm MUS_INTER_V, 0
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7BBC, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7BBC, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_0x8005, LittlerootTown_BrendansHouse_1F_Movement_2929B7
 	waitmovement 0
@@ -170,8 +170,8 @@ LittlerootTown_BrendansHouse_1F_EventScript_29286D:: @ 829286D
 	call LittlerootTown_BrendansHouse_1F_EventScript_29296C
 	applymovement 255, LittlerootTown_BrendansHouse_1F_Movement_2725A4
 	waitmovement 0
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7BF1, 4
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7C35, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7BF1, MSGBOX_DEFAULT
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7C35, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_1, 1
 	applymovement VAR_0x8005, LittlerootTown_BrendansHouse_1F_Movement_2929BD
@@ -186,7 +186,7 @@ LittlerootTown_MaysHouse_1F_EventScript_2928DC:: @ 82928DC
 	applymovement 255, LittlerootTown_MaysHouse_1F_Movement_292AE8
 	waitmovement 0
 	playbgm MUS_INTER_V, 0
-	msgbox LittlerootTown_MaysHouse_1F_Text_1F7BBC, 4
+	msgbox LittlerootTown_MaysHouse_1F_Text_1F7BBC, MSGBOX_DEFAULT
 	closemessage
 	applymovement VAR_0x8005, LittlerootTown_MaysHouse_1F_Movement_2929BA
 	waitmovement 0
@@ -195,8 +195,8 @@ LittlerootTown_MaysHouse_1F_EventScript_2928DC:: @ 82928DC
 	call LittlerootTown_MaysHouse_1F_EventScript_29296C
 	applymovement 255, LittlerootTown_MaysHouse_1F_Movement_2725A8
 	waitmovement 0
-	msgbox LittlerootTown_MaysHouse_1F_Text_1F7BF1, 4
-	msgbox LittlerootTown_MaysHouse_1F_Text_1F7C35, 4
+	msgbox LittlerootTown_MaysHouse_1F_Text_1F7BF1, MSGBOX_DEFAULT
+	msgbox LittlerootTown_MaysHouse_1F_Text_1F7C35, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_TEMP_1, 1
 	applymovement VAR_0x8005, LittlerootTown_MaysHouse_1F_Movement_2929C1
@@ -211,7 +211,7 @@ LittlerootTown_MaysHouse_1F_EventScript_29294B:: @ 829294B
 	waitmovement 0
 	applymovement VAR_0x8005, LittlerootTown_BrendansHouse_1F_Movement_27259A
 	waitmovement 0
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7B96, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7B96, MSGBOX_DEFAULT
 	closemessage
 	return
 
@@ -219,7 +219,7 @@ LittlerootTown_BrendansHouse_1F_EventScript_29296C:: @ 829296C
 LittlerootTown_MaysHouse_1F_EventScript_29296C:: @ 829296C
 	applymovement 255, LittlerootTown_BrendansHouse_1F_Movement_2725A6
 	waitmovement 0
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7EC6, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7EC6, MSGBOX_DEFAULT
 	fadedefaultbgm
 	special TurnOffTVScreen
 	setflag FLAG_SYS_TV_HOME
@@ -326,23 +326,23 @@ LittlerootTown_MaysHouse_1F_EventScript_2929C5:: @ 82929C5
 	goto_eq LittlerootTown_BrendansHouse_1F_EventScript_292A94
 	compare VAR_0x4092, 7
 	goto_eq LittlerootTown_BrendansHouse_1F_EventScript_292AB0
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7A1C, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7A1C, MSGBOX_DEFAULT
 	release
 	end
 
 LittlerootTown_BrendansHouse_1F_EventScript_292A0F:: @ 8292A0F
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7DBE, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7DBE, MSGBOX_DEFAULT
 	release
 	end
 
 LittlerootTown_BrendansHouse_1F_EventScript_292A19:: @ 8292A19
 	checkflag FLAG_0x0D8
 	goto_eq LittlerootTown_BrendansHouse_1F_EventScript_292A43
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7E0E, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7E0E, MSGBOX_DEFAULT
 	closemessage
 	delay 30
 	playfanfare MUS_ME_TORE_EYE
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7E89, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7E89, MSGBOX_DEFAULT
 	waitfanfare
 	closemessage
 	delay 30
@@ -358,22 +358,22 @@ LittlerootTown_BrendansHouse_1F_EventScript_292A43:: @ 8292A43
 LittlerootTown_BrendansHouse_1F_EventScript_292A51:: @ 8292A51
 	checkflag FLAG_0x085
 	goto_eq LittlerootTown_BrendansHouse_1F_EventScript_292A86
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7D73, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7D73, MSGBOX_DEFAULT
 	giveitem_std ITEM_AMULET_COIN
 	compare VAR_RESULT, 0
 	goto_eq LittlerootTown_BrendansHouse_1F_EventScript_272054
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7DBE, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7DBE, MSGBOX_DEFAULT
 	setflag FLAG_0x085
 	release
 	end
 
 LittlerootTown_BrendansHouse_1F_EventScript_292A86:: @ 8292A86
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7D08, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7D08, MSGBOX_DEFAULT
 	goto LittlerootTown_BrendansHouse_1F_EventScript_292A9E
 	end
 
 LittlerootTown_BrendansHouse_1F_EventScript_292A94:: @ 8292A94
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7CC3, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7CC3, MSGBOX_DEFAULT
 	release
 	end
 
@@ -381,12 +381,12 @@ LittlerootTown_BrendansHouse_1F_EventScript_292A9E:: @ 8292A9E
 	closemessage
 	call LittlerootTown_BrendansHouse_1F_EventScript_272083
 	incrementgamestat 16
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7D5C, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7D5C, MSGBOX_DEFAULT
 	release
 	end
 
 LittlerootTown_BrendansHouse_1F_EventScript_292AB0:: @ 8292AB0
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7CD8, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7CD8, MSGBOX_DEFAULT
 	release
 	end
 
@@ -396,7 +396,7 @@ LittlerootTown_MaysHouse_1F_EventScript_292ABA:: @ 8292ABA
 	faceplayer
 	waitse
 	playmoncry SPECIES_VIGOROTH, 0
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7EA8, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7EA8, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
@@ -407,7 +407,7 @@ LittlerootTown_MaysHouse_1F_EventScript_292ACD:: @ 8292ACD
 	faceplayer
 	waitse
 	playmoncry SPECIES_VIGOROTH, 0
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7EB3, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7EB3, MSGBOX_DEFAULT
 	waitmoncry
 	release
 	end
@@ -464,16 +464,16 @@ LittlerootTown_MaysHouse_1F_EventScript_292AF2:: @ 8292AF2
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_292C96
 	compare VAR_0x8008, 1
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_292CA1
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F800E, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F800E, MSGBOX_DEFAULT
 	giveitem_std ITEM_SS_TICKET
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F80FE, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F80FE, MSGBOX_DEFAULT
 	closemessage
 	delay 20
 	compare VAR_0x8008, 0
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_292CAC
 	compare VAR_0x8008, 1
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_292CC1
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F815B, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F815B, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_0x8008, 0
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_292CD6
@@ -488,7 +488,7 @@ LittlerootTown_MaysHouse_1F_EventScript_292AF2:: @ 8292AF2
 	compare VAR_0x8008, 1
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_292D5D
 	delay 20
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F81B9, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F81B9, MSGBOX_DEFAULT
 	closemessage
 	setflag FLAG_SYS_TV_LATI
 	special TurnOnTVScreen
@@ -497,13 +497,13 @@ LittlerootTown_MaysHouse_1F_EventScript_292AF2:: @ 8292AF2
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_292D72
 	compare VAR_0x8008, 1
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_292D7D
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F824B, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F824B, MSGBOX_DEFAULT
 	closemessage
 	compare VAR_0x8008, 0
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_292D1E
 	compare VAR_0x8008, 1
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_292D33
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F826F, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F826F, MSGBOX_DEFAULT
 	closemessage
 	clearflag FLAG_SYS_TV_LATI
 	setflag FLAG_0x0FF
@@ -512,12 +512,12 @@ LittlerootTown_MaysHouse_1F_EventScript_292AF2:: @ 8292AF2
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_292D88
 	compare VAR_0x8008, 1
 	call_if 1, LittlerootTown_BrendansHouse_1F_EventScript_292D9D
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F8351, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F8351, MSGBOX_DEFAULT
 	multichoice 22, 8, 108, 1
 	copyvar VAR_0x8004, VAR_RESULT
 	special InitRoamer
 	copyvar VAR_0x40D5, VAR_RESULT
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F83A1, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F83A1, MSGBOX_DEFAULT
 	closemessage
 	setvar VAR_0x4082, 4
 	setvar VAR_0x408C, 4

--- a/data/scripts/pokeblocks.inc
+++ b/data/scripts/pokeblocks.inc
@@ -252,19 +252,19 @@ EventScript_Pblock1_Ask:: @ 8293C3E
 	setvar VAR_0x8009, 1
 	applymovement 16, LilycoveCity_ContestLobby_Movement_294053
 	waitmovement 0
-	msgbox Text_Pblock1_Ask, 5
+	msgbox Text_Pblock1_Ask, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq EventScript_Pblock1_Yes
 	goto EventScript_Pblock1_No
 	end
 
 EventScript_Pblock1_No: @ 8293C70
-	msgbox Text_Pblock1_No, 4
+	msgbox Text_Pblock1_No, MSGBOX_DEFAULT
 	releaseall
 	end
 
 EventScript_Pblock1_NoBerries: @ 8293C7A
-	msgbox Text_Pblock1_NoBerries, 4
+	msgbox Text_Pblock1_NoBerries, MSGBOX_DEFAULT
 	dodailyevents
 	checkflag FLAG_0x921
 	goto_eq LilycoveCity_ContestLobby_EventScript_293C92
@@ -272,31 +272,31 @@ EventScript_Pblock1_NoBerries: @ 8293C7A
 	end
 
 LilycoveCity_ContestLobby_EventScript_293C92: @ 8293C92
-	msgbox LilycoveCity_ContestLobby_Text_29307D, 4
+	msgbox LilycoveCity_ContestLobby_Text_29307D, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_ContestLobby_EventScript_293C9C: @ 8293C9C
-	msgbox LilycoveCity_ContestLobby_Text_292FD1, 4
+	msgbox LilycoveCity_ContestLobby_Text_292FD1, MSGBOX_DEFAULT
 	giveitem_std ITEM_PECHA_BERRY
 	setflag FLAG_0x921
 	goto EventScript_Pblock1_KnowHow
 	end
 
 EventScript_Pblock1_KnowHow: @ 8293CB9
-	msgbox Text_Pblock1_KnowHow, 5
+	msgbox Text_Pblock1_KnowHow, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq EventScript_Pblock1_Start
 	goto EventScript_Pblock1_Explain
 	end
 
 EventScript_Pblock1_Start: @ 8293CD2
-	msgbox Text_Pblock1_Start, 4
+	msgbox Text_Pblock1_Start, MSGBOX_DEFAULT
 	goto EventScript_StartBlending
 	end
 
 EventScript_Pblock1_Explain: @ 8293CE0
-	msgbox Text_Pblock1_Explain, 4
+	msgbox Text_Pblock1_Explain, MSGBOX_DEFAULT
 	goto EventScript_Pblock1_Start
 	end
 
@@ -310,7 +310,7 @@ EventScript_Pblock1_Yes: @ 8293CEE
 	specialvar VAR_RESULT, PlayerHasBerries
 	compare VAR_RESULT, 0
 	goto_eq EventScript_Pblock1_NoBerries
-	msgbox Text_Pblock1_Yes, 4
+	msgbox Text_Pblock1_Yes, MSGBOX_DEFAULT
 	goto EventScript_Pblock1_KnowHow
 	end
 
@@ -323,12 +323,12 @@ EventScript_StartBlending: @ 8293D2C
 	end
 
 EventScript_Pblock1_FullPokeblock: @ 8293D39
-	msgbox Text_Pblock1_FullPokeblock, 4
+	msgbox Text_Pblock1_FullPokeblock, MSGBOX_DEFAULT
 	releaseall
 	end
 
 EventScript_Pblock1_NoPokeblock: @ 8293D43
-	msgbox Text_Pblock1_NoPokeblock, 4
+	msgbox Text_Pblock1_NoPokeblock, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -338,36 +338,36 @@ LilycoveCity_ContestLobby_EventScript_293D4D:: @ 8293D4D
 	applymovement 10, LilycoveCity_ContestLobby_Movement_2725A2
 	applymovement 3, LilycoveCity_ContestLobby_Movement_294053
 	waitmovement 0
-	msgbox LilycoveCity_ContestLobby_Text_293201, 5
+	msgbox LilycoveCity_ContestLobby_Text_293201, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_ContestLobby_EventScript_293DC6
 	goto LilycoveCity_ContestLobby_EventScript_293D7D
 	end
 
 LilycoveCity_ContestLobby_EventScript_293D7D: @ 8293D7D
-	msgbox LilycoveCity_ContestLobby_Text_29323D, 4
+	msgbox LilycoveCity_ContestLobby_Text_29323D, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_ContestLobby_EventScript_293D87: @ 8293D87
-	msgbox LilycoveCity_ContestLobby_Text_293394, 4
+	msgbox LilycoveCity_ContestLobby_Text_293394, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_293D91: @ 8293D91
-	msgbox LilycoveCity_ContestLobby_Text_29328C, 5
+	msgbox LilycoveCity_ContestLobby_Text_29328C, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_ContestLobby_EventScript_293DAA
 	goto LilycoveCity_ContestLobby_EventScript_293DB8
 	end
 
 LilycoveCity_ContestLobby_EventScript_293DAA: @ 8293DAA
-	msgbox LilycoveCity_ContestLobby_Text_2932C3, 4
+	msgbox LilycoveCity_ContestLobby_Text_2932C3, MSGBOX_DEFAULT
 	goto EventScript_StartBlending
 	end
 
 LilycoveCity_ContestLobby_EventScript_293DB8: @ 8293DB8
-	msgbox LilycoveCity_ContestLobby_Text_2932F1, 4
+	msgbox LilycoveCity_ContestLobby_Text_2932F1, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_293DAA
 	end
 
@@ -378,7 +378,7 @@ LilycoveCity_ContestLobby_EventScript_293DC6: @ 8293DC6
 	checkitem ITEM_POKEBLOCK_CASE, 1
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_ContestLobby_EventScript_293E14
-	msgbox LilycoveCity_ContestLobby_Text_293237, 4
+	msgbox LilycoveCity_ContestLobby_Text_293237, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, GetFirstFreePokeblockSlot
 	compare VAR_RESULT, 65535
 	goto_if 5, LilycoveCity_ContestLobby_EventScript_293D91
@@ -387,12 +387,12 @@ LilycoveCity_ContestLobby_EventScript_293DC6: @ 8293DC6
 	end
 
 LilycoveCity_ContestLobby_EventScript_293E0A: @ 8293E0A
-	msgbox LilycoveCity_ContestLobby_Text_29343E, 4
+	msgbox LilycoveCity_ContestLobby_Text_29343E, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_ContestLobby_EventScript_293E14: @ 8293E14
-	msgbox LilycoveCity_ContestLobby_Text_2934A2, 4
+	msgbox LilycoveCity_ContestLobby_Text_2934A2, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -404,36 +404,36 @@ LilycoveCity_ContestLobby_EventScript_293E1E:: @ 8293E1E
 	applymovement 17, LilycoveCity_ContestLobby_Movement_2725A2
 	applymovement VAR_0x8008, LilycoveCity_ContestLobby_Movement_294053
 	waitmovement 0
-	msgbox LilycoveCity_ContestLobby_Text_293842, 5
+	msgbox LilycoveCity_ContestLobby_Text_293842, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_ContestLobby_EventScript_293EA3
 	goto LilycoveCity_ContestLobby_EventScript_293E5A
 	end
 
 LilycoveCity_ContestLobby_EventScript_293E5A: @ 8293E5A
-	msgbox LilycoveCity_ContestLobby_Text_293558, 4
+	msgbox LilycoveCity_ContestLobby_Text_293558, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_ContestLobby_EventScript_293E64: @ 8293E64
-	msgbox LilycoveCity_ContestLobby_Text_29367D, 4
+	msgbox LilycoveCity_ContestLobby_Text_29367D, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_293E6E: @ 8293E6E
-	msgbox LilycoveCity_ContestLobby_Text_29357E, 5
+	msgbox LilycoveCity_ContestLobby_Text_29357E, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_ContestLobby_EventScript_293E87
 	goto LilycoveCity_ContestLobby_EventScript_293E95
 	end
 
 LilycoveCity_ContestLobby_EventScript_293E87: @ 8293E87
-	msgbox LilycoveCity_ContestLobby_Text_2935B1, 4
+	msgbox LilycoveCity_ContestLobby_Text_2935B1, MSGBOX_DEFAULT
 	goto EventScript_StartBlending
 	end
 
 LilycoveCity_ContestLobby_EventScript_293E95: @ 8293E95
-	msgbox LilycoveCity_ContestLobby_Text_2935E5, 4
+	msgbox LilycoveCity_ContestLobby_Text_2935E5, MSGBOX_DEFAULT
 	goto LilycoveCity_ContestLobby_EventScript_293E87
 	end
 
@@ -444,7 +444,7 @@ LilycoveCity_ContestLobby_EventScript_293EA3: @ 8293EA3
 	checkitem ITEM_POKEBLOCK_CASE, 1
 	compare VAR_RESULT, 0
 	goto_eq LilycoveCity_ContestLobby_EventScript_293EF1
-	msgbox LilycoveCity_ContestLobby_Text_29354E, 4
+	msgbox LilycoveCity_ContestLobby_Text_29354E, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, GetFirstFreePokeblockSlot
 	compare VAR_RESULT, 65535
 	goto_if 5, LilycoveCity_ContestLobby_EventScript_293E6E
@@ -453,27 +453,27 @@ LilycoveCity_ContestLobby_EventScript_293EA3: @ 8293EA3
 	end
 
 LilycoveCity_ContestLobby_EventScript_293EE7: @ 8293EE7
-	msgbox LilycoveCity_ContestLobby_Text_293738, 4
+	msgbox LilycoveCity_ContestLobby_Text_293738, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_ContestLobby_EventScript_293EF1: @ 8293EF1
-	msgbox LilycoveCity_ContestLobby_Text_293792, 4
+	msgbox LilycoveCity_ContestLobby_Text_293792, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_ContestLobby_EventScript_293EFB: @ 8293EFB
 	lockall
 	setvar VAR_0x8009, 1
-	msgbox LilycoveCity_ContestLobby_Text_2C42F4, 5
+	msgbox LilycoveCity_ContestLobby_Text_2C42F4, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_ContestLobby_EventScript_293F28
-	msgbox LilycoveCity_ContestLobby_Text_2C4332, 4
+	msgbox LilycoveCity_ContestLobby_Text_2C4332, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_ContestLobby_EventScript_293F1E: @ 8293F1E
-	msgbox LilycoveCity_ContestLobby_Text_2C439D, 4
+	msgbox LilycoveCity_ContestLobby_Text_2C439D, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -492,37 +492,37 @@ LilycoveCity_ContestLobby_EventScript_293F28: @ 8293F28
 	end
 
 LilycoveCity_ContestLobby_EventScript_293F64: @ 8293F64
-	msgbox LilycoveCity_ContestLobby_Text_2C43FA, 5
+	msgbox LilycoveCity_ContestLobby_Text_2C43FA, MSGBOX_YESNO
 	compare VAR_RESULT, 0
 	call_if 1, LilycoveCity_ContestLobby_EventScript_293F85
-	msgbox LilycoveCity_ContestLobby_Text_2C451B, 4
+	msgbox LilycoveCity_ContestLobby_Text_2C451B, MSGBOX_DEFAULT
 	goto EventScript_StartBlending
 	end
 
 LilycoveCity_ContestLobby_EventScript_293F85: @ 8293F85
-	msgbox LilycoveCity_ContestLobby_Text_2C444C, 4
+	msgbox LilycoveCity_ContestLobby_Text_2C444C, MSGBOX_DEFAULT
 	return
 
 LilycoveCity_ContestLobby_EventScript_293F8E: @ 8293F8E
-	msgbox LilycoveCity_ContestLobby_Text_2C4573, 4
+	msgbox LilycoveCity_ContestLobby_Text_2C4573, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_ContestLobby_EventScript_293F98: @ 8293F98
-	msgbox LilycoveCity_ContestLobby_Text_2C45E8, 4
+	msgbox LilycoveCity_ContestLobby_Text_2C45E8, MSGBOX_DEFAULT
 	releaseall
 	end
 
 LilycoveCity_ContestLobby_EventScript_293FA2:: @ 8293FA2
-	msgbox LilycoveCity_ContestLobby_Text_2937F9, 2
+	msgbox LilycoveCity_ContestLobby_Text_2937F9, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestLobby_EventScript_293FAB:: @ 8293FAB
-	msgbox LilycoveCity_ContestLobby_Text_293842, 2
+	msgbox LilycoveCity_ContestLobby_Text_293842, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestLobby_EventScript_293FB4:: @ 8293FB4
-	msgbox LilycoveCity_ContestLobby_Text_29388F, 2
+	msgbox LilycoveCity_ContestLobby_Text_29388F, MSGBOX_NPC
 	end
 
 LilycoveCity_ContestLobby_EventScript_293FBD:: @ 8293FBD
@@ -533,7 +533,7 @@ LilycoveCity_ContestLobby_EventScript_293FBD:: @ 8293FBD
 LilycoveCity_ContestLobby_EventScript_293FC8: @ 8293FC8
 	lock
 	faceplayer
-	msgbox Text_Pblock1_Talk_0, 4
+	msgbox Text_Pblock1_Talk_0, MSGBOX_DEFAULT
 	specialvar VAR_RESULT, PlayerHasBerries
 	compare VAR_RESULT, 1
 	goto_eq LilycoveCity_ContestLobby_EventScript_293FEE
@@ -542,7 +542,7 @@ LilycoveCity_ContestLobby_EventScript_293FC8: @ 8293FC8
 	end
 
 LilycoveCity_ContestLobby_EventScript_293FEE: @ 8293FEE
-	msgbox Text_Pblock1_Talk_1, 4
+	msgbox Text_Pblock1_Talk_1, MSGBOX_DEFAULT
 	release
 	end
 
@@ -560,15 +560,15 @@ LilycoveCity_ContestLobby_EventScript_293FF8: @ 8293FF8
 	end
 
 LilycoveCity_ContestLobby_EventScript_294028: @ 8294028
-	msgbox LilycoveCity_ContestLobby_Text_293BB4, 4
+	msgbox LilycoveCity_ContestLobby_Text_293BB4, MSGBOX_DEFAULT
 	release
 	end
 
 LilycoveCity_ContestLobby_EventScript_294032: @ 8294032
-	msgbox LilycoveCity_ContestLobby_Text_293AF0, 4
+	msgbox LilycoveCity_ContestLobby_Text_293AF0, MSGBOX_DEFAULT
 	giveitem_std ITEM_PECHA_BERRY
 	setflag FLAG_0x921
-	msgbox LilycoveCity_ContestLobby_Text_293B76, 4
+	msgbox LilycoveCity_ContestLobby_Text_293B76, MSGBOX_DEFAULT
 	release
 	end
 
@@ -592,7 +592,7 @@ EventScript_PblockLink:: @ 8294055
 	end
 
 EventScript_PblocLink_Ask: @ 8294092
-	msgbox Text_PblockLink_Ask, 5
+	msgbox Text_PblockLink_Ask, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq EventScript_PblocLink_TryConnect
 	compare VAR_RESULT, 0
@@ -600,7 +600,7 @@ EventScript_PblocLink_Ask: @ 8294092
 	end
 
 EventScript_PblocLink_NoBerries: @ 82940B1
-	msgbox Text_PblockLink_NoBerries, 4
+	msgbox Text_PblockLink_NoBerries, MSGBOX_DEFAULT
 	releaseall
 	end
 
@@ -628,17 +628,17 @@ EventScript_PblocLink_TryConnect: @ 82940BB
 	end
 
 EventScript_PblocLink_1Arrived: @ 829411D
-	msgbox Text_PblockLink_1Arrived, 4
+	msgbox Text_PblockLink_1Arrived, MSGBOX_DEFAULT
 	goto EventScript_PblocLink_StartLinkBlending
 	end
 
 EventScript_PblocLink_2Arrived: @ 829412B
-	msgbox Text_PblockLink_2Arrived, 4
+	msgbox Text_PblockLink_2Arrived, MSGBOX_DEFAULT
 	goto EventScript_PblocLink_StartLinkBlending
 	end
 
 EventScript_PblocLink_3Arrived: @ 8294139
-	msgbox Text_PblockLink_3Arrived, 4
+	msgbox Text_PblockLink_3Arrived, MSGBOX_DEFAULT
 	goto EventScript_PblocLink_StartLinkBlending
 	end
 
@@ -659,36 +659,36 @@ EventScript_PblocLink_End: @ 8294160
 	end
 
 EventScript_PblocLink_FullPokeblock: @ 8294162
-	msgbox Text_PblockLink_FullPokeblock, 4
+	msgbox Text_PblockLink_FullPokeblock, MSGBOX_DEFAULT
 	releaseall
 	end
 
 EventScript_PblocLink_NoPokeblock: @ 829416C
-	msgbox Text_PblockLink_NoPokeblock, 4
+	msgbox Text_PblockLink_NoPokeblock, MSGBOX_DEFAULT
 	releaseall
 	end
 
 EventScript_PblocLink_SomeoneNotReady: @ 8294176
 	special CloseLink
-	msgbox LilycoveCity_ContestLobby_Text_2781C7, 4
+	msgbox LilycoveCity_ContestLobby_Text_2781C7, MSGBOX_DEFAULT
 	releaseall
 	end
 
 EventScript_PblocLink_DifferentSelections: @ 8294183
 	special CloseLink
-	msgbox LilycoveCity_ContestLobby_Text_278255, 4
+	msgbox LilycoveCity_ContestLobby_Text_278255, MSGBOX_DEFAULT
 	releaseall
 	end
 
 EventScript_PblocLink_CloseLink: @ 8294190
 	special CloseLink
-	msgbox gUnknown_08272D9C, 4
+	msgbox gUnknown_08272D9C, MSGBOX_DEFAULT
 	releaseall
 	end
 
 EventScript_PblocLink_LinkError: @ 829419D
 	special CloseLink
-	msgbox LilycoveCity_ContestLobby_Text_27821C, 4
+	msgbox LilycoveCity_ContestLobby_Text_27821C, MSGBOX_DEFAULT
 	releaseall
 	end
 

--- a/data/scripts/safari_zone.inc
+++ b/data/scripts/safari_zone.inc
@@ -13,7 +13,7 @@ EventScript_2A4B5D:: @ 82A4B5D
 
 EventScript_2A4B6F:: @ 82A4B6F
 	lockall
-	msgbox Text_2A4BF4, 5
+	msgbox Text_2A4BF4, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq EventScript_2A4B85
 	releaseall
@@ -45,7 +45,7 @@ EventScript_2A4BAC:: @ 82A4BAC
 	special GetPokeblockFeederInFront
 	compare VAR_RESULT, 65535
 	goto_if 5, EventScript_2A4BEB
-	msgbox Text_2A4C90, 5
+	msgbox Text_2A4C90, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq EventScript_2A4BD0
 	releaseall

--- a/data/scripts/secret_power_tm.inc
+++ b/data/scripts/secret_power_tm.inc
@@ -36,10 +36,10 @@ Route111_Text_27659D: @ 827659D
 Route111_EventScript_2765FF:: @ 82765FF
 	lock
 	faceplayer
-	msgbox Route111_Text_2762C9, 5
+	msgbox Route111_Text_2762C9, MSGBOX_YESNO
 	compare VAR_RESULT, 1
 	goto_eq Route111_EventScript_27661E
-	msgbox Route111_Text_27655C, 4
+	msgbox Route111_Text_27655C, MSGBOX_DEFAULT
 	release
 	end
 
@@ -47,7 +47,7 @@ Route111_EventScript_27661E:: @ 827661E
 	giveitem_std ITEM_TM43
 	compare VAR_RESULT, 0
 	goto_eq Route111_EventScript_276680
-	msgbox Route111_Text_27636E, 4
+	msgbox Route111_Text_27636E, MSGBOX_DEFAULT
 	closemessage
 	setflag FLAG_0x060
 	clearflag FLAG_HIDE_SLATEPORT_CITY_TM_SALESMAN
@@ -72,7 +72,7 @@ Route111_EventScript_276675:: @ 8276675
 	return
 
 Route111_EventScript_276680:: @ 8276680
-	msgbox Route111_Text_27659D, 4
+	msgbox Route111_Text_27659D, MSGBOX_DEFAULT
 	release
 	end
 

--- a/data/scripts/tv.inc
+++ b/data/scripts/tv.inc
@@ -32,18 +32,18 @@ EventScript_27EE54:: @ 827EE54
 
 EventScript_27EE8A:: @ 827EE8A
 	special GetMomOrDadStringForTVMessage
-	msgbox gUnknown_08272BCF, 4
+	msgbox gUnknown_08272BCF, MSGBOX_DEFAULT
 	special TurnOffTVScreen
 	releaseall
 	end
 
 EventScript_27EE9A:: @ 827EE9A
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7F0F, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F7F0F, MSGBOX_DEFAULT
 	releaseall
 	end
 
 EventScript_27EEA4:: @ 827EEA4
-	msgbox LittlerootTown_BrendansHouse_1F_Text_1F826F, 4
+	msgbox LittlerootTown_BrendansHouse_1F_Text_1F826F, MSGBOX_DEFAULT
 	special InitRoamer
 	clearflag FLAG_SYS_TV_LATI
 	setflag FLAG_0x0FF
@@ -68,7 +68,7 @@ EventScript_27EED0:: @ 827EED0
 
 EventScript_27EED8:: @ 827EED8
 	special GetMomOrDadStringForTVMessage
-	msgbox gUnknown_08272BCF, 4
+	msgbox gUnknown_08272BCF, MSGBOX_DEFAULT
 	goto EventScript_27EED0
 	end
 


### PR DESCRIPTION
* adds some constants for standard script names and messagebox types
* replaces some callstd calls with msgbox calls where equivalent
* replaces msgbox and callstd calls using raw digits with versions that use the constants
* adds a `register_matchcall` macro 