### PR TITLE
Add requirements to the fields of the object_event macro

### DIFF
--- a/asm/macros/map.inc
+++ b/asm/macros/map.inc
@@ -15,6 +15,7 @@
 	.endm
 
 	.macro object_event index:req, gfx:req, replacement:req, x:req, y:req, elevation:req, movement_type:req, x_radius:req, y_radius:req, trainer_type:req, sight_radius_tree_etc:req, script:req, event_flag:req
+	.byte \index, \gfx, \replacement, 0
 	.2byte \x
 	.2byte \y
 	.byte \elevation, \movement_type, ((\y_radius << 4) | \x_radius), 0

--- a/asm/macros/map.inc
+++ b/asm/macros/map.inc
@@ -14,8 +14,7 @@
 	.4byte \address
 	.endm
 
-	.macro object_event index, gfx, replacement, x, y, elevation, movement_type, x_radius, y_radius, trainer_type, sight_radius_tree_etc, script, event_flag
-	.byte \index, \gfx, \replacement, 0
+	.macro object_event index:req, gfx:req, replacement:req, x:req, y:req, elevation:req, movement_type:req, x_radius:req, y_radius:req, trainer_type:req, sight_radius_tree_etc:req, script:req, event_flag:req
 	.2byte \x
 	.2byte \y
 	.byte \elevation, \movement_type, ((\y_radius << 4) | \x_radius), 0


### PR DESCRIPTION
With these changes, the compiler will yell at you if you screw up the number of fields for your event objects while manually editing a map's events.inc. Making these fields required will prevent event corruption of all map events that are included after the map with the messed up fields.