### PR TITLE
Consolidate unused escapeRope MapHeader field into filler_18 field

### DIFF
--- a/include/global.fieldmap.h
+++ b/include/global.fieldmap.h
@@ -137,8 +137,7 @@ struct MapHeader
     /* 0x15 */ u8 cave;
     /* 0x16 */ u8 weather;
     /* 0x17 */ u8 mapType;
-    /* 0x18 */ u8 filler_18;
-    /* 0x19 */ u8 escapeRope;
+    /* 0x18 */ u8 filler_18[2];
     /* 0x1A */ u8 flags;
     /* 0x1B */ u8 battleType;
 };


### PR DESCRIPTION
The escapeRope field is unused in Emerald, so I merged it into the filler_18 field by making it a u8 filler array of length 2.