### PR TITLE
Feature/debug info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,10 @@ else
 $(C_BUILDDIR)/%.o: c_dep = $(shell $(SCANINC) -I include $(C_SUBDIR)/$*.c)
 endif
 
+ifeq ($(DINFO),1)
+CFLAGS += -g
+endif
+
 $(C_BUILDDIR)/%.o : $(C_SUBDIR)/%.c $$(c_dep)
 	@$(CPP) $(CPPFLAGS) $< -o $(C_BUILDDIR)/$*.i
 	@$(PREPROC) $(C_BUILDDIR)/$*.i charmap.txt | $(CC1) $(CFLAGS) -o $(C_BUILDDIR)/$*.s

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ $(C_BUILDDIR)/%.o: c_dep = $(shell $(SCANINC) -I include $(C_SUBDIR)/$*.c)
 endif
 
 ifeq ($(DINFO),1)
-CFLAGS += -g
+override CFLAGS += -g
 endif
 
 $(C_BUILDDIR)/%.o : $(C_SUBDIR)/%.c $$(c_dep)

--- a/ld_script.txt
+++ b/ld_script.txt
@@ -1194,6 +1194,31 @@ SECTIONS {
         src/graphics.o(.rodata);
     } =0
 
+    /* DWARF debug sections.
+       Symbols in the DWARF debugging sections are relative to the beginning
+       of the section so we begin them at 0.  */
+
+    /* DWARF 1 */
+    .debug          0 : { *(.debug) }
+    .line           0 : { *(.line) }
+
+    /* GNU DWARF 1 extensions */
+    .debug_srcinfo  0 : { *(.debug_srcinfo) }
+    .debug_sfnames  0 : { *(.debug_sfnames) }
+
+    /* DWARF 1.1 and DWARF 2 */
+    .debug_aranges  0 : { *(.debug_aranges) }
+    .debug_pubnames 0 : { *(.debug_pubnames) }
+
+    /* DWARF 2 */
+    .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+    .debug_abbrev   0 : { *(.debug_abbrev) }
+    .debug_line     0 : { *(.debug_line) }
+    .debug_frame    0 : { *(.debug_frame) }
+    .debug_str      0 : { *(.debug_str) }
+    .debug_loc      0 : { *(.debug_loc) }
+    .debug_macinfo  0 : { *(.debug_macinfo) }
+
     /* Discard everything not specifically mentioned above. */
     /DISCARD/ :
     {


### PR DESCRIPTION
Compile with debug symbols, and expose them to the linker, to compile with debug information, use

`make DINFO=1 -jN`

Comments appreciated, in the linker script I included some common dwarf sections, probably a bit more than agbcc will create, but they are linked if and only if compiled with `-g` so it does not affect the normal build process at all.