### PR TITLE
Fix scaninc ignoring .h includes in asm files

### DIFF
--- a/tools/scaninc/asm_file.cpp
+++ b/tools/scaninc/asm_file.cpp
@@ -64,7 +64,7 @@ IncDirectiveType AsmFile::ReadUntilIncDirective(std::string &path)
 
         IncDirectiveType incDirectiveType = IncDirectiveType::None;
 
-		auto peek = PeekChar();
+        auto peek = PeekChar();
         if (peek == '.' || peek == '#')
         {
             m_pos++;

--- a/tools/scaninc/asm_file.cpp
+++ b/tools/scaninc/asm_file.cpp
@@ -64,7 +64,8 @@ IncDirectiveType AsmFile::ReadUntilIncDirective(std::string &path)
 
         IncDirectiveType incDirectiveType = IncDirectiveType::None;
 
-        if (PeekChar() == '.')
+		auto peek = PeekChar();
+        if (peek == '.' || peek == '#')
         {
             m_pos++;
 

--- a/tools/scaninc/scaninc.cpp
+++ b/tools/scaninc/scaninc.cpp
@@ -145,9 +145,11 @@ int main(int argc, char **argv)
 
             while ((incDirectiveType = file.ReadUntilIncDirective(path)) != IncDirectiveType::None)
             {
-                if (path.back() == 'h') {
+                if (path.back() == 'h')
+                {
                     std::string newPath("include/" + path);
-                    if (!CanOpenFile(newPath)) {
+                    if (!CanOpenFile(newPath))
+                    {
                         newPath = "include/constants/" + path;
                     }
                     path = newPath;

--- a/tools/scaninc/scaninc.cpp
+++ b/tools/scaninc/scaninc.cpp
@@ -145,6 +145,13 @@ int main(int argc, char **argv)
 
             while ((incDirectiveType = file.ReadUntilIncDirective(path)) != IncDirectiveType::None)
             {
+                if (path.back() == 'h') {
+                    std::string newPath("include/" + path);
+                    if (!CanOpenFile(newPath)) {
+                        newPath = "include/constants/" + path;
+                    }
+                    path = newPath;
+                }
                 bool inserted = dependencies.insert(path).second;
                 if (inserted
                     && incDirectiveType == IncDirectiveType::Include


### PR DESCRIPTION
It was parsing lines starting with # as a comment, when we are using
those comments to include C header files.