### PR TITLE
Make more effective use of pokemon move macros

### DIFF
--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -134,6 +134,13 @@
 #define MAX_TOTAL_EVS 510
 #define UNOWN_FORM_COUNT 28
 
+#define LEVEL_UP_MOVE(level, move) ((level << 9) | move)
+#define LEVEL_UP_END 0xFFFF
+#define LEVEL_UP_MOVE_MASK 0x1FF
+#define LEVEL_UP_LEVEL_MASK 0xFE00
+#define LEVEL_UP_NUM_AS_LEVEL(level) (level << 9)
+#define LEVEL_UP_GET_MOVE(entry) (entry & LEVEL_UP_MOVE_MASK)
+
 struct PokemonSubstruct0
 {
     u16 species;

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -135,7 +135,7 @@
 #define UNOWN_FORM_COUNT 28
 
 #define LEVEL_UP_MOVE(level, move) ((level << 9) | move)
-#define LEVEL_UP_END 0xFFFF
+//#define 0xFFFF 0xFFFF
 #define LEVEL_UP_MOVE_MASK 0x1FF
 #define LEVEL_UP_LEVEL_MASK 0xFE00
 #define LEVEL_UP_NUM_AS_LEVEL(level) (level << 9)

--- a/src/apprentice.c
+++ b/src/apprentice.c
@@ -14,6 +14,7 @@
 #include "menu.h"
 #include "new_game.h"
 #include "party_menu.h"
+#include "pokemon.h"
 #include "random.h"
 #include "script.h"
 #include "script_menu.h"
@@ -1291,9 +1292,9 @@ static u16 sub_819FF98(u8 arg0)
     else
         level = 60;
 
-    for (j = 0; learnset[j] != 0xFFFF; j++)
+    for (j = 0; learnset[j] != LEVEL_UP_END; j++)
     {
-        if ((learnset[j] & 0xFE00) > (level << 9))
+        if ((learnset[j] & LEVEL_UP_LEVEL_MASK) > LEVEL_UP_NUM_AS_LEVEL(level))
             break;
     }
 
@@ -1322,7 +1323,7 @@ static u16 sub_819FF98(u8 arg0)
 
                 for (; j < knownMovesCount; j++)
                 {
-                    if ((learnset[j] & 0x1FF) == moveId)
+                    if (LEVEL_UP_GET_MOVE(learnset[j]) == moveId)
                     {
                         valid = FALSE;
                         break;
@@ -1342,11 +1343,11 @@ static u16 sub_819FF98(u8 arg0)
                 do
                 {
                     u8 learnsetId = Random() % (knownMovesCount - MAX_MON_MOVES);
-                    moveId = learnset[learnsetId] & 0x1FF;
+                    moveId = LEVEL_UP_GET_MOVE(learnset[learnsetId]);
                     valid = TRUE;
                     for (j = knownMovesCount - MAX_MON_MOVES; j < knownMovesCount; j++)
                     {
-                        if ((learnset[j] & 0x1FF) == moveId)
+                        if (LEVEL_UP_GET_MOVE(learnset[j]) == moveId)
                         {
                             valid = FALSE;
                             break;
@@ -1394,9 +1395,9 @@ static void GetLatestLearnedMoves(u16 species, u16 *moves)
         level = 60;
 
     learnset = gLevelUpLearnsets[species];
-    for (i = 0; learnset[i] != 0xFFFF; i++)
+    for (i = 0; learnset[i] != LEVEL_UP_END; i++)
     {
-        if ((learnset[i] & 0xFE00) > (level << 9))
+        if ((learnset[i] & LEVEL_UP_LEVEL_MASK) > LEVEL_UP_NUM_AS_LEVEL(level))
             break;
     }
 
@@ -1405,7 +1406,7 @@ static void GetLatestLearnedMoves(u16 species, u16 *moves)
         knownMovesCount = MAX_MON_MOVES;
 
     for (j = 0; j < knownMovesCount; j++)
-        moves[j] = learnset[(i - 1) - j] & 0x1FF;
+        moves[j] = LEVEL_UP_GET_MOVE(learnset[(i - 1) - j]);
 }
 
 static u16 sub_81A0284(u8 arg0, u8 speciesTableId, u8 arg2)

--- a/src/apprentice.c
+++ b/src/apprentice.c
@@ -1292,7 +1292,7 @@ static u16 sub_819FF98(u8 arg0)
     else
         level = 60;
 
-    for (j = 0; learnset[j] != LEVEL_UP_END; j++)
+    for (j = 0; learnset[j] != 0xFFFF; j++)
     {
         if ((learnset[j] & LEVEL_UP_LEVEL_MASK) > LEVEL_UP_NUM_AS_LEVEL(level))
             break;
@@ -1395,7 +1395,7 @@ static void GetLatestLearnedMoves(u16 species, u16 *moves)
         level = 60;
 
     learnset = gLevelUpLearnsets[species];
-    for (i = 0; learnset[i] != LEVEL_UP_END; i++)
+    for (i = 0; learnset[i] != 0xFFFF; i++)
     {
         if ((learnset[i] & LEVEL_UP_LEVEL_MASK) > LEVEL_UP_NUM_AS_LEVEL(level))
             break;

--- a/src/data/pokemon/level_up_learnsets.h
+++ b/src/data/pokemon/level_up_learnsets.h
@@ -1,6 +1,3 @@
-#define LEVEL_UP_MOVE(lvl, move) ((lvl << 9) | move)
-#define LEVEL_UP_END 0xffff
-
 static const u16 sBulbasaurLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
     LEVEL_UP_MOVE( 4, MOVE_GROWL),

--- a/src/data/pokemon/level_up_learnsets.h
+++ b/src/data/pokemon/level_up_learnsets.h
@@ -10,7 +10,7 @@ static const u16 sBulbasaurLevelUpLearnset[] = {
     LEVEL_UP_MOVE(32, MOVE_GROWTH),
     LEVEL_UP_MOVE(39, MOVE_SYNTHESIS),
     LEVEL_UP_MOVE(46, MOVE_SOLAR_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sIvysaurLevelUpLearnset[] = {
@@ -27,7 +27,7 @@ static const u16 sIvysaurLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_GROWTH),
     LEVEL_UP_MOVE(47, MOVE_SYNTHESIS),
     LEVEL_UP_MOVE(56, MOVE_SOLAR_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sVenusaurLevelUpLearnset[] = {
@@ -45,7 +45,7 @@ static const u16 sVenusaurLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_GROWTH),
     LEVEL_UP_MOVE(53, MOVE_SYNTHESIS),
     LEVEL_UP_MOVE(65, MOVE_SOLAR_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCharmanderLevelUpLearnset[] = {
@@ -59,7 +59,7 @@ static const u16 sCharmanderLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_SLASH),
     LEVEL_UP_MOVE(43, MOVE_DRAGON_RAGE),
     LEVEL_UP_MOVE(49, MOVE_FIRE_SPIN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCharmeleonLevelUpLearnset[] = {
@@ -74,7 +74,7 @@ static const u16 sCharmeleonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_SLASH),
     LEVEL_UP_MOVE(48, MOVE_DRAGON_RAGE),
     LEVEL_UP_MOVE(55, MOVE_FIRE_SPIN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCharizardLevelUpLearnset[] = {
@@ -91,7 +91,7 @@ static const u16 sCharizardLevelUpLearnset[] = {
     LEVEL_UP_MOVE(44, MOVE_SLASH),
     LEVEL_UP_MOVE(54, MOVE_DRAGON_RAGE),
     LEVEL_UP_MOVE(64, MOVE_FIRE_SPIN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSquirtleLevelUpLearnset[] = {
@@ -106,7 +106,7 @@ static const u16 sSquirtleLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_RAIN_DANCE),
     LEVEL_UP_MOVE(40, MOVE_SKULL_BASH),
     LEVEL_UP_MOVE(47, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWartortleLevelUpLearnset[] = {
@@ -123,7 +123,7 @@ static const u16 sWartortleLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_RAIN_DANCE),
     LEVEL_UP_MOVE(45, MOVE_SKULL_BASH),
     LEVEL_UP_MOVE(53, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sBlastoiseLevelUpLearnset[] = {
@@ -141,19 +141,19 @@ static const u16 sBlastoiseLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_RAIN_DANCE),
     LEVEL_UP_MOVE(55, MOVE_SKULL_BASH),
     LEVEL_UP_MOVE(68, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCaterpieLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
     LEVEL_UP_MOVE( 1, MOVE_STRING_SHOT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMetapodLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_HARDEN),
     LEVEL_UP_MOVE( 7, MOVE_HARDEN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sButterfreeLevelUpLearnset[] = {
@@ -168,19 +168,19 @@ static const u16 sButterfreeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_PSYBEAM),
     LEVEL_UP_MOVE(40, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(47, MOVE_SILVER_WIND),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWeedleLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_POISON_STING),
     LEVEL_UP_MOVE( 1, MOVE_STRING_SHOT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sKakunaLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_HARDEN),
     LEVEL_UP_MOVE( 7, MOVE_HARDEN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sBeedrillLevelUpLearnset[] = {
@@ -193,7 +193,7 @@ static const u16 sBeedrillLevelUpLearnset[] = {
     LEVEL_UP_MOVE(35, MOVE_PIN_MISSILE),
     LEVEL_UP_MOVE(40, MOVE_AGILITY),
     LEVEL_UP_MOVE(45, MOVE_ENDEAVOR),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPidgeyLevelUpLearnset[] = {
@@ -206,7 +206,7 @@ static const u16 sPidgeyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_FEATHER_DANCE),
     LEVEL_UP_MOVE(39, MOVE_AGILITY),
     LEVEL_UP_MOVE(47, MOVE_MIRROR_MOVE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPidgeottoLevelUpLearnset[] = {
@@ -221,7 +221,7 @@ static const u16 sPidgeottoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_FEATHER_DANCE),
     LEVEL_UP_MOVE(43, MOVE_AGILITY),
     LEVEL_UP_MOVE(52, MOVE_MIRROR_MOVE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPidgeotLevelUpLearnset[] = {
@@ -237,7 +237,7 @@ static const u16 sPidgeotLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_FEATHER_DANCE),
     LEVEL_UP_MOVE(48, MOVE_AGILITY),
     LEVEL_UP_MOVE(62, MOVE_MIRROR_MOVE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRattataLevelUpLearnset[] = {
@@ -249,7 +249,7 @@ static const u16 sRattataLevelUpLearnset[] = {
     LEVEL_UP_MOVE(27, MOVE_PURSUIT),
     LEVEL_UP_MOVE(34, MOVE_SUPER_FANG),
     LEVEL_UP_MOVE(41, MOVE_ENDEAVOR),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRaticateLevelUpLearnset[] = {
@@ -262,7 +262,7 @@ static const u16 sRaticateLevelUpLearnset[] = {
     LEVEL_UP_MOVE(30, MOVE_PURSUIT),
     LEVEL_UP_MOVE(40, MOVE_SUPER_FANG),
     LEVEL_UP_MOVE(50, MOVE_ENDEAVOR),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpearowLevelUpLearnset[] = {
@@ -275,7 +275,7 @@ static const u16 sSpearowLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_MIRROR_MOVE),
     LEVEL_UP_MOVE(37, MOVE_DRILL_PECK),
     LEVEL_UP_MOVE(43, MOVE_AGILITY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sFearowLevelUpLearnset[] = {
@@ -289,7 +289,7 @@ static const u16 sFearowLevelUpLearnset[] = {
     LEVEL_UP_MOVE(32, MOVE_MIRROR_MOVE),
     LEVEL_UP_MOVE(40, MOVE_DRILL_PECK),
     LEVEL_UP_MOVE(47, MOVE_AGILITY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sEkansLevelUpLearnset[] = {
@@ -304,7 +304,7 @@ static const u16 sEkansLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_SWALLOW),
     LEVEL_UP_MOVE(37, MOVE_SPIT_UP),
     LEVEL_UP_MOVE(44, MOVE_HAZE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sArbokLevelUpLearnset[] = {
@@ -321,7 +321,7 @@ static const u16 sArbokLevelUpLearnset[] = {
     LEVEL_UP_MOVE(46, MOVE_SWALLOW),
     LEVEL_UP_MOVE(46, MOVE_SPIT_UP),
     LEVEL_UP_MOVE(56, MOVE_HAZE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPikachuLevelUpLearnset[] = {
@@ -336,7 +336,7 @@ static const u16 sPikachuLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_AGILITY),
     LEVEL_UP_MOVE(41, MOVE_THUNDER),
     LEVEL_UP_MOVE(50, MOVE_LIGHT_SCREEN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRaichuLevelUpLearnset[] = {
@@ -344,7 +344,7 @@ static const u16 sRaichuLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE( 1, MOVE_QUICK_ATTACK),
     LEVEL_UP_MOVE( 1, MOVE_THUNDERBOLT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSandshrewLevelUpLearnset[] = {
@@ -357,7 +357,7 @@ static const u16 sSandshrewLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_FURY_SWIPES),
     LEVEL_UP_MOVE(45, MOVE_SAND_TOMB),
     LEVEL_UP_MOVE(53, MOVE_SANDSTORM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSandslashLevelUpLearnset[] = {
@@ -372,7 +372,7 @@ static const u16 sSandslashLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_FURY_SWIPES),
     LEVEL_UP_MOVE(52, MOVE_SAND_TOMB),
     LEVEL_UP_MOVE(62, MOVE_SANDSTORM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sNidoranFLevelUpLearnset[] = {
@@ -386,7 +386,7 @@ static const u16 sNidoranFLevelUpLearnset[] = {
     LEVEL_UP_MOVE(30, MOVE_FURY_SWIPES),
     LEVEL_UP_MOVE(38, MOVE_FLATTER),
     LEVEL_UP_MOVE(47, MOVE_CRUNCH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sNidorinaLevelUpLearnset[] = {
@@ -400,7 +400,7 @@ static const u16 sNidorinaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_FURY_SWIPES),
     LEVEL_UP_MOVE(43, MOVE_FLATTER),
     LEVEL_UP_MOVE(53, MOVE_CRUNCH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sNidoqueenLevelUpLearnset[] = {
@@ -409,7 +409,7 @@ static const u16 sNidoqueenLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_DOUBLE_KICK),
     LEVEL_UP_MOVE( 1, MOVE_POISON_STING),
     LEVEL_UP_MOVE(23, MOVE_BODY_SLAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sNidoranMLevelUpLearnset[] = {
@@ -423,7 +423,7 @@ static const u16 sNidoranMLevelUpLearnset[] = {
     LEVEL_UP_MOVE(30, MOVE_FURY_ATTACK),
     LEVEL_UP_MOVE(38, MOVE_FLATTER),
     LEVEL_UP_MOVE(47, MOVE_HORN_DRILL),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sNidorinoLevelUpLearnset[] = {
@@ -437,7 +437,7 @@ static const u16 sNidorinoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_FURY_ATTACK),
     LEVEL_UP_MOVE(43, MOVE_FLATTER),
     LEVEL_UP_MOVE(53, MOVE_HORN_DRILL),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sNidokingLevelUpLearnset[] = {
@@ -446,7 +446,7 @@ static const u16 sNidokingLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_DOUBLE_KICK),
     LEVEL_UP_MOVE( 1, MOVE_POISON_STING),
     LEVEL_UP_MOVE(23, MOVE_THRASH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sClefairyLevelUpLearnset[] = {
@@ -463,7 +463,7 @@ static const u16 sClefairyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_MOONLIGHT),
     LEVEL_UP_MOVE(41, MOVE_LIGHT_SCREEN),
     LEVEL_UP_MOVE(45, MOVE_METEOR_MASH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sClefableLevelUpLearnset[] = {
@@ -471,7 +471,7 @@ static const u16 sClefableLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_DOUBLE_SLAP),
     LEVEL_UP_MOVE( 1, MOVE_MINIMIZE),
     LEVEL_UP_MOVE( 1, MOVE_METRONOME),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sVulpixLevelUpLearnset[] = {
@@ -486,7 +486,7 @@ static const u16 sVulpixLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(37, MOVE_GRUDGE),
     LEVEL_UP_MOVE(41, MOVE_FIRE_SPIN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sNinetalesLevelUpLearnset[] = {
@@ -495,7 +495,7 @@ static const u16 sNinetalesLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_CONFUSE_RAY),
     LEVEL_UP_MOVE( 1, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(45, MOVE_FIRE_SPIN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sJigglypuffLevelUpLearnset[] = {
@@ -510,7 +510,7 @@ static const u16 sJigglypuffLevelUpLearnset[] = {
     LEVEL_UP_MOVE(39, MOVE_MIMIC),
     LEVEL_UP_MOVE(44, MOVE_HYPER_VOICE),
     LEVEL_UP_MOVE(49, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWigglytuffLevelUpLearnset[] = {
@@ -518,7 +518,7 @@ static const u16 sWigglytuffLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_DISABLE),
     LEVEL_UP_MOVE( 1, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE( 1, MOVE_DOUBLE_SLAP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sZubatLevelUpLearnset[] = {
@@ -532,7 +532,7 @@ static const u16 sZubatLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_MEAN_LOOK),
     LEVEL_UP_MOVE(41, MOVE_POISON_FANG),
     LEVEL_UP_MOVE(46, MOVE_HAZE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGolbatLevelUpLearnset[] = {
@@ -549,7 +549,7 @@ static const u16 sGolbatLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_MEAN_LOOK),
     LEVEL_UP_MOVE(49, MOVE_POISON_FANG),
     LEVEL_UP_MOVE(56, MOVE_HAZE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sOddishLevelUpLearnset[] = {
@@ -561,7 +561,7 @@ static const u16 sOddishLevelUpLearnset[] = {
     LEVEL_UP_MOVE(23, MOVE_ACID),
     LEVEL_UP_MOVE(32, MOVE_MOONLIGHT),
     LEVEL_UP_MOVE(39, MOVE_PETAL_DANCE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGloomLevelUpLearnset[] = {
@@ -575,7 +575,7 @@ static const u16 sGloomLevelUpLearnset[] = {
     LEVEL_UP_MOVE(24, MOVE_ACID),
     LEVEL_UP_MOVE(35, MOVE_MOONLIGHT),
     LEVEL_UP_MOVE(44, MOVE_PETAL_DANCE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sVileplumeLevelUpLearnset[] = {
@@ -584,7 +584,7 @@ static const u16 sVileplumeLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_STUN_SPORE),
     LEVEL_UP_MOVE( 1, MOVE_MEGA_DRAIN),
     LEVEL_UP_MOVE(44, MOVE_PETAL_DANCE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sParasLevelUpLearnset[] = {
@@ -597,7 +597,7 @@ static const u16 sParasLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_GROWTH),
     LEVEL_UP_MOVE(43, MOVE_GIGA_DRAIN),
     LEVEL_UP_MOVE(49, MOVE_AROMATHERAPY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sParasectLevelUpLearnset[] = {
@@ -612,7 +612,7 @@ static const u16 sParasectLevelUpLearnset[] = {
     LEVEL_UP_MOVE(43, MOVE_GROWTH),
     LEVEL_UP_MOVE(51, MOVE_GIGA_DRAIN),
     LEVEL_UP_MOVE(59, MOVE_AROMATHERAPY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sVenonatLevelUpLearnset[] = {
@@ -627,7 +627,7 @@ static const u16 sVenonatLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_PSYBEAM),
     LEVEL_UP_MOVE(36, MOVE_SLEEP_POWDER),
     LEVEL_UP_MOVE(41, MOVE_PSYCHIC),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sVenomothLevelUpLearnset[] = {
@@ -645,7 +645,7 @@ static const u16 sVenomothLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_PSYBEAM),
     LEVEL_UP_MOVE(42, MOVE_SLEEP_POWDER),
     LEVEL_UP_MOVE(52, MOVE_PSYCHIC),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDiglettLevelUpLearnset[] = {
@@ -658,7 +658,7 @@ static const u16 sDiglettLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_SLASH),
     LEVEL_UP_MOVE(41, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(49, MOVE_FISSURE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDugtrioLevelUpLearnset[] = {
@@ -674,7 +674,7 @@ static const u16 sDugtrioLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_SLASH),
     LEVEL_UP_MOVE(51, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(64, MOVE_FISSURE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMeowthLevelUpLearnset[] = {
@@ -687,7 +687,7 @@ static const u16 sMeowthLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_FURY_SWIPES),
     LEVEL_UP_MOVE(46, MOVE_SLASH),
     LEVEL_UP_MOVE(50, MOVE_FAKE_OUT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPersianLevelUpLearnset[] = {
@@ -701,7 +701,7 @@ static const u16 sPersianLevelUpLearnset[] = {
     LEVEL_UP_MOVE(46, MOVE_FURY_SWIPES),
     LEVEL_UP_MOVE(53, MOVE_SLASH),
     LEVEL_UP_MOVE(59, MOVE_FAKE_OUT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPsyduckLevelUpLearnset[] = {
@@ -714,7 +714,7 @@ static const u16 sPsyduckLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_PSYCH_UP),
     LEVEL_UP_MOVE(40, MOVE_FURY_SWIPES),
     LEVEL_UP_MOVE(50, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGolduckLevelUpLearnset[] = {
@@ -729,7 +729,7 @@ static const u16 sGolduckLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_PSYCH_UP),
     LEVEL_UP_MOVE(44, MOVE_FURY_SWIPES),
     LEVEL_UP_MOVE(58, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMankeyLevelUpLearnset[] = {
@@ -743,7 +743,7 @@ static const u16 sMankeyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(39, MOVE_CROSS_CHOP),
     LEVEL_UP_MOVE(45, MOVE_SCREECH),
     LEVEL_UP_MOVE(51, MOVE_THRASH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPrimeapeLevelUpLearnset[] = {
@@ -760,7 +760,7 @@ static const u16 sPrimeapeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(45, MOVE_CROSS_CHOP),
     LEVEL_UP_MOVE(54, MOVE_SCREECH),
     LEVEL_UP_MOVE(63, MOVE_THRASH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGrowlitheLevelUpLearnset[] = {
@@ -774,7 +774,7 @@ static const u16 sGrowlitheLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_HELPING_HAND),
     LEVEL_UP_MOVE(43, MOVE_AGILITY),
     LEVEL_UP_MOVE(49, MOVE_FLAMETHROWER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sArcanineLevelUpLearnset[] = {
@@ -783,7 +783,7 @@ static const u16 sArcanineLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_EMBER),
     LEVEL_UP_MOVE( 1, MOVE_ODOR_SLEUTH),
     LEVEL_UP_MOVE(49, MOVE_EXTREME_SPEED),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPoliwagLevelUpLearnset[] = {
@@ -795,7 +795,7 @@ static const u16 sPoliwagLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_BODY_SLAM),
     LEVEL_UP_MOVE(37, MOVE_BELLY_DRUM),
     LEVEL_UP_MOVE(43, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPoliwhirlLevelUpLearnset[] = {
@@ -809,7 +809,7 @@ static const u16 sPoliwhirlLevelUpLearnset[] = {
     LEVEL_UP_MOVE(35, MOVE_BODY_SLAM),
     LEVEL_UP_MOVE(43, MOVE_BELLY_DRUM),
     LEVEL_UP_MOVE(51, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPoliwrathLevelUpLearnset[] = {
@@ -819,12 +819,12 @@ static const u16 sPoliwrathLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_SUBMISSION),
     LEVEL_UP_MOVE(35, MOVE_SUBMISSION),
     LEVEL_UP_MOVE(51, MOVE_MIND_READER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sAbraLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TELEPORT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sKadabraLevelUpLearnset[] = {
@@ -840,7 +840,7 @@ static const u16 sKadabraLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_ROLE_PLAY),
     LEVEL_UP_MOVE(36, MOVE_PSYCHIC),
     LEVEL_UP_MOVE(43, MOVE_TRICK),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sAlakazamLevelUpLearnset[] = {
@@ -856,7 +856,7 @@ static const u16 sAlakazamLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_CALM_MIND),
     LEVEL_UP_MOVE(36, MOVE_PSYCHIC),
     LEVEL_UP_MOVE(43, MOVE_TRICK),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMachopLevelUpLearnset[] = {
@@ -872,7 +872,7 @@ static const u16 sMachopLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_CROSS_CHOP),
     LEVEL_UP_MOVE(43, MOVE_SCARY_FACE),
     LEVEL_UP_MOVE(49, MOVE_DYNAMIC_PUNCH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMachokeLevelUpLearnset[] = {
@@ -889,7 +889,7 @@ static const u16 sMachokeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(46, MOVE_CROSS_CHOP),
     LEVEL_UP_MOVE(51, MOVE_SCARY_FACE),
     LEVEL_UP_MOVE(59, MOVE_DYNAMIC_PUNCH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMachampLevelUpLearnset[] = {
@@ -906,7 +906,7 @@ static const u16 sMachampLevelUpLearnset[] = {
     LEVEL_UP_MOVE(46, MOVE_CROSS_CHOP),
     LEVEL_UP_MOVE(51, MOVE_SCARY_FACE),
     LEVEL_UP_MOVE(59, MOVE_DYNAMIC_PUNCH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sBellsproutLevelUpLearnset[] = {
@@ -920,7 +920,7 @@ static const u16 sBellsproutLevelUpLearnset[] = {
     LEVEL_UP_MOVE(30, MOVE_SWEET_SCENT),
     LEVEL_UP_MOVE(37, MOVE_RAZOR_LEAF),
     LEVEL_UP_MOVE(45, MOVE_SLAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWeepinbellLevelUpLearnset[] = {
@@ -936,7 +936,7 @@ static const u16 sWeepinbellLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_SWEET_SCENT),
     LEVEL_UP_MOVE(42, MOVE_RAZOR_LEAF),
     LEVEL_UP_MOVE(54, MOVE_SLAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sVictreebelLevelUpLearnset[] = {
@@ -944,7 +944,7 @@ static const u16 sVictreebelLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_SLEEP_POWDER),
     LEVEL_UP_MOVE( 1, MOVE_SWEET_SCENT),
     LEVEL_UP_MOVE( 1, MOVE_RAZOR_LEAF),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTentacoolLevelUpLearnset[] = {
@@ -957,7 +957,7 @@ static const u16 sTentacoolLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_BARRIER),
     LEVEL_UP_MOVE(43, MOVE_SCREECH),
     LEVEL_UP_MOVE(49, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTentacruelLevelUpLearnset[] = {
@@ -972,7 +972,7 @@ static const u16 sTentacruelLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_BARRIER),
     LEVEL_UP_MOVE(47, MOVE_SCREECH),
     LEVEL_UP_MOVE(55, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGeodudeLevelUpLearnset[] = {
@@ -987,7 +987,7 @@ static const u16 sGeodudeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(41, MOVE_EXPLOSION),
     LEVEL_UP_MOVE(46, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGravelerLevelUpLearnset[] = {
@@ -1004,7 +1004,7 @@ static const u16 sGravelerLevelUpLearnset[] = {
     LEVEL_UP_MOVE(45, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(53, MOVE_EXPLOSION),
     LEVEL_UP_MOVE(62, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGolemLevelUpLearnset[] = {
@@ -1021,7 +1021,7 @@ static const u16 sGolemLevelUpLearnset[] = {
     LEVEL_UP_MOVE(45, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(53, MOVE_EXPLOSION),
     LEVEL_UP_MOVE(62, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPonytaLevelUpLearnset[] = {
@@ -1035,7 +1035,7 @@ static const u16 sPonytaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_AGILITY),
     LEVEL_UP_MOVE(45, MOVE_BOUNCE),
     LEVEL_UP_MOVE(53, MOVE_FIRE_BLAST),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRapidashLevelUpLearnset[] = {
@@ -1053,7 +1053,7 @@ static const u16 sRapidashLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_FURY_ATTACK),
     LEVEL_UP_MOVE(50, MOVE_BOUNCE),
     LEVEL_UP_MOVE(63, MOVE_FIRE_BLAST),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSlowpokeLevelUpLearnset[] = {
@@ -1067,7 +1067,7 @@ static const u16 sSlowpokeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_HEADBUTT),
     LEVEL_UP_MOVE(43, MOVE_AMNESIA),
     LEVEL_UP_MOVE(48, MOVE_PSYCHIC),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSlowbroLevelUpLearnset[] = {
@@ -1083,7 +1083,7 @@ static const u16 sSlowbroLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_WITHDRAW),
     LEVEL_UP_MOVE(46, MOVE_AMNESIA),
     LEVEL_UP_MOVE(54, MOVE_PSYCHIC),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMagnemiteLevelUpLearnset[] = {
@@ -1098,7 +1098,7 @@ static const u16 sMagnemiteLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_SWIFT),
     LEVEL_UP_MOVE(44, MOVE_SCREECH),
     LEVEL_UP_MOVE(50, MOVE_ZAP_CANNON),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMagnetonLevelUpLearnset[] = {
@@ -1115,7 +1115,7 @@ static const u16 sMagnetonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(44, MOVE_TRI_ATTACK),
     LEVEL_UP_MOVE(53, MOVE_SCREECH),
     LEVEL_UP_MOVE(62, MOVE_ZAP_CANNON),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sFarfetchdLevelUpLearnset[] = {
@@ -1129,7 +1129,7 @@ static const u16 sFarfetchdLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_AGILITY),
     LEVEL_UP_MOVE(41, MOVE_SLASH),
     LEVEL_UP_MOVE(46, MOVE_FALSE_SWIPE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDoduoLevelUpLearnset[] = {
@@ -1142,7 +1142,7 @@ static const u16 sDoduoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_UPROAR),
     LEVEL_UP_MOVE(37, MOVE_DRILL_PECK),
     LEVEL_UP_MOVE(45, MOVE_AGILITY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDodrioLevelUpLearnset[] = {
@@ -1157,7 +1157,7 @@ static const u16 sDodrioLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_UPROAR),
     LEVEL_UP_MOVE(47, MOVE_DRILL_PECK),
     LEVEL_UP_MOVE(60, MOVE_AGILITY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSeelLevelUpLearnset[] = {
@@ -1169,7 +1169,7 @@ static const u16 sSeelLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(41, MOVE_ICE_BEAM),
     LEVEL_UP_MOVE(49, MOVE_SAFEGUARD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDewgongLevelUpLearnset[] = {
@@ -1185,7 +1185,7 @@ static const u16 sDewgongLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(51, MOVE_ICE_BEAM),
     LEVEL_UP_MOVE(64, MOVE_SAFEGUARD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGrimerLevelUpLearnset[] = {
@@ -1199,7 +1199,7 @@ static const u16 sGrimerLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_ACID_ARMOR),
     LEVEL_UP_MOVE(43, MOVE_SLUDGE_BOMB),
     LEVEL_UP_MOVE(53, MOVE_MEMENTO),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMukLevelUpLearnset[] = {
@@ -1214,7 +1214,7 @@ static const u16 sMukLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_ACID_ARMOR),
     LEVEL_UP_MOVE(47, MOVE_SLUDGE_BOMB),
     LEVEL_UP_MOVE(61, MOVE_MEMENTO),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sShellderLevelUpLearnset[] = {
@@ -1226,7 +1226,7 @@ static const u16 sShellderLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_LEER),
     LEVEL_UP_MOVE(41, MOVE_CLAMP),
     LEVEL_UP_MOVE(49, MOVE_ICE_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCloysterLevelUpLearnset[] = {
@@ -1236,7 +1236,7 @@ static const u16 sCloysterLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_PROTECT),
     LEVEL_UP_MOVE(33, MOVE_SPIKES),
     LEVEL_UP_MOVE(41, MOVE_SPIKE_CANNON),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGastlyLevelUpLearnset[] = {
@@ -1249,7 +1249,7 @@ static const u16 sGastlyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(28, MOVE_CONFUSE_RAY),
     LEVEL_UP_MOVE(33, MOVE_DREAM_EATER),
     LEVEL_UP_MOVE(36, MOVE_DESTINY_BOND),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sHaunterLevelUpLearnset[] = {
@@ -1264,7 +1264,7 @@ static const u16 sHaunterLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_CONFUSE_RAY),
     LEVEL_UP_MOVE(39, MOVE_DREAM_EATER),
     LEVEL_UP_MOVE(48, MOVE_DESTINY_BOND),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGengarLevelUpLearnset[] = {
@@ -1279,7 +1279,7 @@ static const u16 sGengarLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_CONFUSE_RAY),
     LEVEL_UP_MOVE(39, MOVE_DREAM_EATER),
     LEVEL_UP_MOVE(48, MOVE_DESTINY_BOND),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sOnixLevelUpLearnset[] = {
@@ -1294,7 +1294,7 @@ static const u16 sOnixLevelUpLearnset[] = {
     LEVEL_UP_MOVE(45, MOVE_IRON_TAIL),
     LEVEL_UP_MOVE(49, MOVE_SAND_TOMB),
     LEVEL_UP_MOVE(57, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDrowzeeLevelUpLearnset[] = {
@@ -1308,7 +1308,7 @@ static const u16 sDrowzeeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_PSYCHIC),
     LEVEL_UP_MOVE(43, MOVE_PSYCH_UP),
     LEVEL_UP_MOVE(45, MOVE_FUTURE_SIGHT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sHypnoLevelUpLearnset[] = {
@@ -1324,7 +1324,7 @@ static const u16 sHypnoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(49, MOVE_PSYCHIC),
     LEVEL_UP_MOVE(55, MOVE_PSYCH_UP),
     LEVEL_UP_MOVE(60, MOVE_FUTURE_SIGHT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sKrabbyLevelUpLearnset[] = {
@@ -1337,7 +1337,7 @@ static const u16 sKrabbyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_GUILLOTINE),
     LEVEL_UP_MOVE(41, MOVE_PROTECT),
     LEVEL_UP_MOVE(45, MOVE_CRABHAMMER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sKinglerLevelUpLearnset[] = {
@@ -1352,7 +1352,7 @@ static const u16 sKinglerLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_GUILLOTINE),
     LEVEL_UP_MOVE(49, MOVE_PROTECT),
     LEVEL_UP_MOVE(57, MOVE_CRABHAMMER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sVoltorbLevelUpLearnset[] = {
@@ -1367,7 +1367,7 @@ static const u16 sVoltorbLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_SWIFT),
     LEVEL_UP_MOVE(46, MOVE_EXPLOSION),
     LEVEL_UP_MOVE(49, MOVE_MIRROR_COAT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sElectrodeLevelUpLearnset[] = {
@@ -1384,7 +1384,7 @@ static const u16 sElectrodeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(48, MOVE_SWIFT),
     LEVEL_UP_MOVE(54, MOVE_EXPLOSION),
     LEVEL_UP_MOVE(59, MOVE_MIRROR_COAT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sExeggcuteLevelUpLearnset[] = {
@@ -1398,7 +1398,7 @@ static const u16 sExeggcuteLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_POISON_POWDER),
     LEVEL_UP_MOVE(37, MOVE_SLEEP_POWDER),
     LEVEL_UP_MOVE(43, MOVE_SOLAR_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sExeggutorLevelUpLearnset[] = {
@@ -1407,7 +1407,7 @@ static const u16 sExeggutorLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_CONFUSION),
     LEVEL_UP_MOVE(19, MOVE_STOMP),
     LEVEL_UP_MOVE(31, MOVE_EGG_BOMB),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCuboneLevelUpLearnset[] = {
@@ -1423,7 +1423,7 @@ static const u16 sCuboneLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_THRASH),
     LEVEL_UP_MOVE(41, MOVE_BONE_RUSH),
     LEVEL_UP_MOVE(45, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMarowakLevelUpLearnset[] = {
@@ -1442,7 +1442,7 @@ static const u16 sMarowakLevelUpLearnset[] = {
     LEVEL_UP_MOVE(46, MOVE_THRASH),
     LEVEL_UP_MOVE(53, MOVE_BONE_RUSH),
     LEVEL_UP_MOVE(61, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sHitmonleeLevelUpLearnset[] = {
@@ -1459,7 +1459,7 @@ static const u16 sHitmonleeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_ENDURE),
     LEVEL_UP_MOVE(46, MOVE_MEGA_KICK),
     LEVEL_UP_MOVE(51, MOVE_REVERSAL),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sHitmonchanLevelUpLearnset[] = {
@@ -1475,7 +1475,7 @@ static const u16 sHitmonchanLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_MEGA_PUNCH),
     LEVEL_UP_MOVE(44, MOVE_DETECT),
     LEVEL_UP_MOVE(50, MOVE_COUNTER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLickitungLevelUpLearnset[] = {
@@ -1489,7 +1489,7 @@ static const u16 sLickitungLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_SLAM),
     LEVEL_UP_MOVE(45, MOVE_SCREECH),
     LEVEL_UP_MOVE(51, MOVE_REFRESH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sKoffingLevelUpLearnset[] = {
@@ -1503,7 +1503,7 @@ static const u16 sKoffingLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_EXPLOSION),
     LEVEL_UP_MOVE(45, MOVE_DESTINY_BOND),
     LEVEL_UP_MOVE(49, MOVE_MEMENTO),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWeezingLevelUpLearnset[] = {
@@ -1519,7 +1519,7 @@ static const u16 sWeezingLevelUpLearnset[] = {
     LEVEL_UP_MOVE(44, MOVE_EXPLOSION),
     LEVEL_UP_MOVE(51, MOVE_DESTINY_BOND),
     LEVEL_UP_MOVE(58, MOVE_MEMENTO),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRhyhornLevelUpLearnset[] = {
@@ -1533,7 +1533,7 @@ static const u16 sRhyhornLevelUpLearnset[] = {
     LEVEL_UP_MOVE(43, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(52, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(57, MOVE_MEGAHORN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRhydonLevelUpLearnset[] = {
@@ -1549,7 +1549,7 @@ static const u16 sRhydonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(46, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(58, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(66, MOVE_MEGAHORN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sChanseyLevelUpLearnset[] = {
@@ -1565,7 +1565,7 @@ static const u16 sChanseyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE(49, MOVE_LIGHT_SCREEN),
     LEVEL_UP_MOVE(57, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTangelaLevelUpLearnset[] = {
@@ -1581,7 +1581,7 @@ static const u16 sTangelaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_STUN_SPORE),
     LEVEL_UP_MOVE(40, MOVE_SLAM),
     LEVEL_UP_MOVE(46, MOVE_TICKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sKangaskhanLevelUpLearnset[] = {
@@ -1595,7 +1595,7 @@ static const u16 sKangaskhanLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_ENDURE),
     LEVEL_UP_MOVE(43, MOVE_DIZZY_PUNCH),
     LEVEL_UP_MOVE(49, MOVE_REVERSAL),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sHorseaLevelUpLearnset[] = {
@@ -1607,7 +1607,7 @@ static const u16 sHorseaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_AGILITY),
     LEVEL_UP_MOVE(43, MOVE_HYDRO_PUMP),
     LEVEL_UP_MOVE(50, MOVE_DRAGON_DANCE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSeadraLevelUpLearnset[] = {
@@ -1622,7 +1622,7 @@ static const u16 sSeadraLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_AGILITY),
     LEVEL_UP_MOVE(51, MOVE_HYDRO_PUMP),
     LEVEL_UP_MOVE(62, MOVE_DRAGON_DANCE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGoldeenLevelUpLearnset[] = {
@@ -1636,7 +1636,7 @@ static const u16 sGoldeenLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_WATERFALL),
     LEVEL_UP_MOVE(43, MOVE_HORN_DRILL),
     LEVEL_UP_MOVE(52, MOVE_AGILITY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSeakingLevelUpLearnset[] = {
@@ -1651,7 +1651,7 @@ static const u16 sSeakingLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_WATERFALL),
     LEVEL_UP_MOVE(49, MOVE_HORN_DRILL),
     LEVEL_UP_MOVE(61, MOVE_AGILITY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sStaryuLevelUpLearnset[] = {
@@ -1667,7 +1667,7 @@ static const u16 sStaryuLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_LIGHT_SCREEN),
     LEVEL_UP_MOVE(42, MOVE_COSMIC_POWER),
     LEVEL_UP_MOVE(46, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sStarmieLevelUpLearnset[] = {
@@ -1676,7 +1676,7 @@ static const u16 sStarmieLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_RECOVER),
     LEVEL_UP_MOVE( 1, MOVE_SWIFT),
     LEVEL_UP_MOVE(33, MOVE_CONFUSE_RAY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMrmimeLevelUpLearnset[] = {
@@ -1695,7 +1695,7 @@ static const u16 sMrmimeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(45, MOVE_PSYCHIC),
     LEVEL_UP_MOVE(49, MOVE_BATON_PASS),
     LEVEL_UP_MOVE(53, MOVE_SAFEGUARD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sScytherLevelUpLearnset[] = {
@@ -1710,7 +1710,7 @@ static const u16 sScytherLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_SWORDS_DANCE),
     LEVEL_UP_MOVE(41, MOVE_DOUBLE_TEAM),
     LEVEL_UP_MOVE(46, MOVE_FURY_CUTTER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sJynxLevelUpLearnset[] = {
@@ -1727,7 +1727,7 @@ static const u16 sJynxLevelUpLearnset[] = {
     LEVEL_UP_MOVE(51, MOVE_BODY_SLAM),
     LEVEL_UP_MOVE(57, MOVE_PERISH_SONG),
     LEVEL_UP_MOVE(67, MOVE_BLIZZARD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sElectabuzzLevelUpLearnset[] = {
@@ -1740,7 +1740,7 @@ static const u16 sElectabuzzLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_SCREECH),
     LEVEL_UP_MOVE(47, MOVE_THUNDERBOLT),
     LEVEL_UP_MOVE(58, MOVE_THUNDER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMagmarLevelUpLearnset[] = {
@@ -1756,7 +1756,7 @@ static const u16 sMagmarLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_FLAMETHROWER),
     LEVEL_UP_MOVE(49, MOVE_CONFUSE_RAY),
     LEVEL_UP_MOVE(57, MOVE_FIRE_BLAST),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPinsirLevelUpLearnset[] = {
@@ -1770,7 +1770,7 @@ static const u16 sPinsirLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_GUILLOTINE),
     LEVEL_UP_MOVE(43, MOVE_SUBMISSION),
     LEVEL_UP_MOVE(49, MOVE_SWORDS_DANCE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTaurosLevelUpLearnset[] = {
@@ -1783,14 +1783,14 @@ static const u16 sTaurosLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_REST),
     LEVEL_UP_MOVE(43, MOVE_THRASH),
     LEVEL_UP_MOVE(53, MOVE_TAKE_DOWN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMagikarpLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_SPLASH),
     LEVEL_UP_MOVE(15, MOVE_TACKLE),
     LEVEL_UP_MOVE(30, MOVE_FLAIL),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGyaradosLevelUpLearnset[] = {
@@ -1803,7 +1803,7 @@ static const u16 sGyaradosLevelUpLearnset[] = {
     LEVEL_UP_MOVE(45, MOVE_RAIN_DANCE),
     LEVEL_UP_MOVE(50, MOVE_DRAGON_DANCE),
     LEVEL_UP_MOVE(55, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLaprasLevelUpLearnset[] = {
@@ -1819,12 +1819,12 @@ static const u16 sLaprasLevelUpLearnset[] = {
     LEVEL_UP_MOVE(43, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(49, MOVE_HYDRO_PUMP),
     LEVEL_UP_MOVE(55, MOVE_SHEER_COLD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDittoLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TRANSFORM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sEeveeLevelUpLearnset[] = {
@@ -1837,7 +1837,7 @@ static const u16 sEeveeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(30, MOVE_BITE),
     LEVEL_UP_MOVE(36, MOVE_BATON_PASS),
     LEVEL_UP_MOVE(42, MOVE_TAKE_DOWN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sVaporeonLevelUpLearnset[] = {
@@ -1852,7 +1852,7 @@ static const u16 sVaporeonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_HAZE),
     LEVEL_UP_MOVE(47, MOVE_ACID_ARMOR),
     LEVEL_UP_MOVE(52, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sJolteonLevelUpLearnset[] = {
@@ -1867,7 +1867,7 @@ static const u16 sJolteonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_THUNDER_WAVE),
     LEVEL_UP_MOVE(47, MOVE_AGILITY),
     LEVEL_UP_MOVE(52, MOVE_THUNDER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sFlareonLevelUpLearnset[] = {
@@ -1882,7 +1882,7 @@ static const u16 sFlareonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_SMOG),
     LEVEL_UP_MOVE(47, MOVE_LEER),
     LEVEL_UP_MOVE(52, MOVE_FLAMETHROWER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPorygonLevelUpLearnset[] = {
@@ -1897,7 +1897,7 @@ static const u16 sPorygonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_TRI_ATTACK),
     LEVEL_UP_MOVE(44, MOVE_RECYCLE),
     LEVEL_UP_MOVE(48, MOVE_ZAP_CANNON),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sOmanyteLevelUpLearnset[] = {
@@ -1911,7 +1911,7 @@ static const u16 sOmanyteLevelUpLearnset[] = {
     LEVEL_UP_MOVE(43, MOVE_TICKLE),
     LEVEL_UP_MOVE(49, MOVE_ANCIENT_POWER),
     LEVEL_UP_MOVE(55, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sOmastarLevelUpLearnset[] = {
@@ -1927,7 +1927,7 @@ static const u16 sOmastarLevelUpLearnset[] = {
     LEVEL_UP_MOVE(46, MOVE_TICKLE),
     LEVEL_UP_MOVE(55, MOVE_ANCIENT_POWER),
     LEVEL_UP_MOVE(65, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sKabutoLevelUpLearnset[] = {
@@ -1941,7 +1941,7 @@ static const u16 sKabutoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(43, MOVE_METAL_SOUND),
     LEVEL_UP_MOVE(49, MOVE_MEGA_DRAIN),
     LEVEL_UP_MOVE(55, MOVE_ANCIENT_POWER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sKabutopsLevelUpLearnset[] = {
@@ -1957,7 +1957,7 @@ static const u16 sKabutopsLevelUpLearnset[] = {
     LEVEL_UP_MOVE(46, MOVE_METAL_SOUND),
     LEVEL_UP_MOVE(55, MOVE_MEGA_DRAIN),
     LEVEL_UP_MOVE(65, MOVE_ANCIENT_POWER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sAerodactylLevelUpLearnset[] = {
@@ -1969,7 +1969,7 @@ static const u16 sAerodactylLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_SCARY_FACE),
     LEVEL_UP_MOVE(43, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(50, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSnorlaxLevelUpLearnset[] = {
@@ -1986,7 +1986,7 @@ static const u16 sSnorlaxLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_COVET),
     LEVEL_UP_MOVE(46, MOVE_ROLLOUT),
     LEVEL_UP_MOVE(51, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sArticunoLevelUpLearnset[] = {
@@ -1999,7 +1999,7 @@ static const u16 sArticunoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(61, MOVE_REFLECT),
     LEVEL_UP_MOVE(73, MOVE_BLIZZARD),
     LEVEL_UP_MOVE(85, MOVE_SHEER_COLD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sZapdosLevelUpLearnset[] = {
@@ -2012,7 +2012,7 @@ static const u16 sZapdosLevelUpLearnset[] = {
     LEVEL_UP_MOVE(61, MOVE_CHARGE),
     LEVEL_UP_MOVE(73, MOVE_LIGHT_SCREEN),
     LEVEL_UP_MOVE(85, MOVE_THUNDER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMoltresLevelUpLearnset[] = {
@@ -2025,7 +2025,7 @@ static const u16 sMoltresLevelUpLearnset[] = {
     LEVEL_UP_MOVE(61, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(73, MOVE_HEAT_WAVE),
     LEVEL_UP_MOVE(85, MOVE_SKY_ATTACK),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDratiniLevelUpLearnset[] = {
@@ -2039,7 +2039,7 @@ static const u16 sDratiniLevelUpLearnset[] = {
     LEVEL_UP_MOVE(43, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(50, MOVE_OUTRAGE),
     LEVEL_UP_MOVE(57, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDragonairLevelUpLearnset[] = {
@@ -2055,7 +2055,7 @@ static const u16 sDragonairLevelUpLearnset[] = {
     LEVEL_UP_MOVE(47, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(56, MOVE_OUTRAGE),
     LEVEL_UP_MOVE(65, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDragoniteLevelUpLearnset[] = {
@@ -2072,7 +2072,7 @@ static const u16 sDragoniteLevelUpLearnset[] = {
     LEVEL_UP_MOVE(55, MOVE_WING_ATTACK),
     LEVEL_UP_MOVE(61, MOVE_OUTRAGE),
     LEVEL_UP_MOVE(75, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMewtwoLevelUpLearnset[] = {
@@ -2087,7 +2087,7 @@ static const u16 sMewtwoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(77, MOVE_AMNESIA),
     LEVEL_UP_MOVE(88, MOVE_RECOVER),
     LEVEL_UP_MOVE(99, MOVE_SAFEGUARD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMewLevelUpLearnset[] = {
@@ -2097,7 +2097,7 @@ static const u16 sMewLevelUpLearnset[] = {
     LEVEL_UP_MOVE(30, MOVE_METRONOME),
     LEVEL_UP_MOVE(40, MOVE_PSYCHIC),
     LEVEL_UP_MOVE(50, MOVE_ANCIENT_POWER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sChikoritaLevelUpLearnset[] = {
@@ -2111,7 +2111,7 @@ static const u16 sChikoritaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_LIGHT_SCREEN),
     LEVEL_UP_MOVE(43, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(50, MOVE_SOLAR_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sBayleefLevelUpLearnset[] = {
@@ -2127,7 +2127,7 @@ static const u16 sBayleefLevelUpLearnset[] = {
     LEVEL_UP_MOVE(39, MOVE_LIGHT_SCREEN),
     LEVEL_UP_MOVE(47, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(55, MOVE_SOLAR_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMeganiumLevelUpLearnset[] = {
@@ -2143,7 +2143,7 @@ static const u16 sMeganiumLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_LIGHT_SCREEN),
     LEVEL_UP_MOVE(51, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(61, MOVE_SOLAR_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCyndaquilLevelUpLearnset[] = {
@@ -2155,7 +2155,7 @@ static const u16 sCyndaquilLevelUpLearnset[] = {
     LEVEL_UP_MOVE(27, MOVE_FLAME_WHEEL),
     LEVEL_UP_MOVE(36, MOVE_SWIFT),
     LEVEL_UP_MOVE(46, MOVE_FLAMETHROWER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sQuilavaLevelUpLearnset[] = {
@@ -2168,7 +2168,7 @@ static const u16 sQuilavaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_FLAME_WHEEL),
     LEVEL_UP_MOVE(42, MOVE_SWIFT),
     LEVEL_UP_MOVE(54, MOVE_FLAMETHROWER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTyphlosionLevelUpLearnset[] = {
@@ -2182,7 +2182,7 @@ static const u16 sTyphlosionLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_FLAME_WHEEL),
     LEVEL_UP_MOVE(45, MOVE_SWIFT),
     LEVEL_UP_MOVE(60, MOVE_FLAMETHROWER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTotodileLevelUpLearnset[] = {
@@ -2195,7 +2195,7 @@ static const u16 sTotodileLevelUpLearnset[] = {
     LEVEL_UP_MOVE(35, MOVE_SLASH),
     LEVEL_UP_MOVE(43, MOVE_SCREECH),
     LEVEL_UP_MOVE(52, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCroconawLevelUpLearnset[] = {
@@ -2209,7 +2209,7 @@ static const u16 sCroconawLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_SLASH),
     LEVEL_UP_MOVE(45, MOVE_SCREECH),
     LEVEL_UP_MOVE(55, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sFeraligatrLevelUpLearnset[] = {
@@ -2224,7 +2224,7 @@ static const u16 sFeraligatrLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_SLASH),
     LEVEL_UP_MOVE(47, MOVE_SCREECH),
     LEVEL_UP_MOVE(58, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSentretLevelUpLearnset[] = {
@@ -2237,7 +2237,7 @@ static const u16 sSentretLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_FOLLOW_ME),
     LEVEL_UP_MOVE(40, MOVE_REST),
     LEVEL_UP_MOVE(49, MOVE_AMNESIA),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sFurretLevelUpLearnset[] = {
@@ -2252,7 +2252,7 @@ static const u16 sFurretLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_FOLLOW_ME),
     LEVEL_UP_MOVE(48, MOVE_REST),
     LEVEL_UP_MOVE(59, MOVE_AMNESIA),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sHoothootLevelUpLearnset[] = {
@@ -2265,7 +2265,7 @@ static const u16 sHoothootLevelUpLearnset[] = {
     LEVEL_UP_MOVE(28, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(34, MOVE_CONFUSION),
     LEVEL_UP_MOVE(48, MOVE_DREAM_EATER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sNoctowlLevelUpLearnset[] = {
@@ -2280,7 +2280,7 @@ static const u16 sNoctowlLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(41, MOVE_CONFUSION),
     LEVEL_UP_MOVE(57, MOVE_DREAM_EATER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLedybaLevelUpLearnset[] = {
@@ -2294,7 +2294,7 @@ static const u16 sLedybaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_SWIFT),
     LEVEL_UP_MOVE(43, MOVE_AGILITY),
     LEVEL_UP_MOVE(50, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLedianLevelUpLearnset[] = {
@@ -2309,7 +2309,7 @@ static const u16 sLedianLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_SWIFT),
     LEVEL_UP_MOVE(51, MOVE_AGILITY),
     LEVEL_UP_MOVE(60, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpinarakLevelUpLearnset[] = {
@@ -2323,7 +2323,7 @@ static const u16 sSpinarakLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_SPIDER_WEB),
     LEVEL_UP_MOVE(45, MOVE_AGILITY),
     LEVEL_UP_MOVE(53, MOVE_PSYCHIC),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sAriadosLevelUpLearnset[] = {
@@ -2339,7 +2339,7 @@ static const u16 sAriadosLevelUpLearnset[] = {
     LEVEL_UP_MOVE(43, MOVE_SPIDER_WEB),
     LEVEL_UP_MOVE(53, MOVE_AGILITY),
     LEVEL_UP_MOVE(63, MOVE_PSYCHIC),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCrobatLevelUpLearnset[] = {
@@ -2356,7 +2356,7 @@ static const u16 sCrobatLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_MEAN_LOOK),
     LEVEL_UP_MOVE(49, MOVE_POISON_FANG),
     LEVEL_UP_MOVE(56, MOVE_HAZE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sChinchouLevelUpLearnset[] = {
@@ -2370,7 +2370,7 @@ static const u16 sChinchouLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(41, MOVE_HYDRO_PUMP),
     LEVEL_UP_MOVE(49, MOVE_CHARGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLanturnLevelUpLearnset[] = {
@@ -2385,7 +2385,7 @@ static const u16 sLanturnLevelUpLearnset[] = {
     LEVEL_UP_MOVE(43, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(50, MOVE_HYDRO_PUMP),
     LEVEL_UP_MOVE(61, MOVE_CHARGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPichuLevelUpLearnset[] = {
@@ -2394,7 +2394,7 @@ static const u16 sPichuLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 6, MOVE_TAIL_WHIP),
     LEVEL_UP_MOVE( 8, MOVE_THUNDER_WAVE),
     LEVEL_UP_MOVE(11, MOVE_SWEET_KISS),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCleffaLevelUpLearnset[] = {
@@ -2403,7 +2403,7 @@ static const u16 sCleffaLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 4, MOVE_ENCORE),
     LEVEL_UP_MOVE( 8, MOVE_SING),
     LEVEL_UP_MOVE(13, MOVE_SWEET_KISS),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sIgglybuffLevelUpLearnset[] = {
@@ -2412,7 +2412,7 @@ static const u16 sIgglybuffLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 4, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE( 9, MOVE_POUND),
     LEVEL_UP_MOVE(14, MOVE_SWEET_KISS),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTogepiLevelUpLearnset[] = {
@@ -2426,7 +2426,7 @@ static const u16 sTogepiLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_WISH),
     LEVEL_UP_MOVE(36, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(41, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTogeticLevelUpLearnset[] = {
@@ -2440,7 +2440,7 @@ static const u16 sTogeticLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_WISH),
     LEVEL_UP_MOVE(36, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(41, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sNatuLevelUpLearnset[] = {
@@ -2452,7 +2452,7 @@ static const u16 sNatuLevelUpLearnset[] = {
     LEVEL_UP_MOVE(30, MOVE_FUTURE_SIGHT),
     LEVEL_UP_MOVE(40, MOVE_CONFUSE_RAY),
     LEVEL_UP_MOVE(50, MOVE_PSYCHIC),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sXatuLevelUpLearnset[] = {
@@ -2464,7 +2464,7 @@ static const u16 sXatuLevelUpLearnset[] = {
     LEVEL_UP_MOVE(35, MOVE_FUTURE_SIGHT),
     LEVEL_UP_MOVE(50, MOVE_CONFUSE_RAY),
     LEVEL_UP_MOVE(65, MOVE_PSYCHIC),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMareepLevelUpLearnset[] = {
@@ -2475,7 +2475,7 @@ static const u16 sMareepLevelUpLearnset[] = {
     LEVEL_UP_MOVE(23, MOVE_COTTON_SPORE),
     LEVEL_UP_MOVE(30, MOVE_LIGHT_SCREEN),
     LEVEL_UP_MOVE(37, MOVE_THUNDER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sFlaaffyLevelUpLearnset[] = {
@@ -2487,7 +2487,7 @@ static const u16 sFlaaffyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(27, MOVE_COTTON_SPORE),
     LEVEL_UP_MOVE(36, MOVE_LIGHT_SCREEN),
     LEVEL_UP_MOVE(45, MOVE_THUNDER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sAmpharosLevelUpLearnset[] = {
@@ -2501,7 +2501,7 @@ static const u16 sAmpharosLevelUpLearnset[] = {
     LEVEL_UP_MOVE(30, MOVE_THUNDER_PUNCH),
     LEVEL_UP_MOVE(42, MOVE_LIGHT_SCREEN),
     LEVEL_UP_MOVE(57, MOVE_THUNDER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sBellossomLevelUpLearnset[] = {
@@ -2511,7 +2511,7 @@ static const u16 sBellossomLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_MAGICAL_LEAF),
     LEVEL_UP_MOVE(44, MOVE_PETAL_DANCE),
     LEVEL_UP_MOVE(55, MOVE_SOLAR_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMarillLevelUpLearnset[] = {
@@ -2524,7 +2524,7 @@ static const u16 sMarillLevelUpLearnset[] = {
     LEVEL_UP_MOVE(28, MOVE_DOUBLE_EDGE),
     LEVEL_UP_MOVE(36, MOVE_RAIN_DANCE),
     LEVEL_UP_MOVE(45, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sAzumarillLevelUpLearnset[] = {
@@ -2540,7 +2540,7 @@ static const u16 sAzumarillLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_DOUBLE_EDGE),
     LEVEL_UP_MOVE(45, MOVE_RAIN_DANCE),
     LEVEL_UP_MOVE(57, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSudowoodoLevelUpLearnset[] = {
@@ -2553,7 +2553,7 @@ static const u16 sSudowoodoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_FAINT_ATTACK),
     LEVEL_UP_MOVE(49, MOVE_SLAM),
     LEVEL_UP_MOVE(57, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPolitoedLevelUpLearnset[] = {
@@ -2563,7 +2563,7 @@ static const u16 sPolitoedLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_PERISH_SONG),
     LEVEL_UP_MOVE(35, MOVE_PERISH_SONG),
     LEVEL_UP_MOVE(51, MOVE_SWAGGER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sHoppipLevelUpLearnset[] = {
@@ -2577,7 +2577,7 @@ static const u16 sHoppipLevelUpLearnset[] = {
     LEVEL_UP_MOVE(20, MOVE_LEECH_SEED),
     LEVEL_UP_MOVE(25, MOVE_COTTON_SPORE),
     LEVEL_UP_MOVE(30, MOVE_MEGA_DRAIN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSkiploomLevelUpLearnset[] = {
@@ -2594,7 +2594,7 @@ static const u16 sSkiploomLevelUpLearnset[] = {
     LEVEL_UP_MOVE(22, MOVE_LEECH_SEED),
     LEVEL_UP_MOVE(29, MOVE_COTTON_SPORE),
     LEVEL_UP_MOVE(36, MOVE_MEGA_DRAIN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sJumpluffLevelUpLearnset[] = {
@@ -2611,7 +2611,7 @@ static const u16 sJumpluffLevelUpLearnset[] = {
     LEVEL_UP_MOVE(22, MOVE_LEECH_SEED),
     LEVEL_UP_MOVE(33, MOVE_COTTON_SPORE),
     LEVEL_UP_MOVE(44, MOVE_MEGA_DRAIN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sAipomLevelUpLearnset[] = {
@@ -2625,7 +2625,7 @@ static const u16 sAipomLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_SWIFT),
     LEVEL_UP_MOVE(43, MOVE_SCREECH),
     LEVEL_UP_MOVE(50, MOVE_AGILITY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSunkernLevelUpLearnset[] = {
@@ -2637,7 +2637,7 @@ static const u16 sSunkernLevelUpLearnset[] = {
     LEVEL_UP_MOVE(30, MOVE_SUNNY_DAY),
     LEVEL_UP_MOVE(37, MOVE_SYNTHESIS),
     LEVEL_UP_MOVE(42, MOVE_GIGA_DRAIN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSunfloraLevelUpLearnset[] = {
@@ -2650,7 +2650,7 @@ static const u16 sSunfloraLevelUpLearnset[] = {
     LEVEL_UP_MOVE(30, MOVE_SUNNY_DAY),
     LEVEL_UP_MOVE(37, MOVE_PETAL_DANCE),
     LEVEL_UP_MOVE(42, MOVE_SOLAR_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sYanmaLevelUpLearnset[] = {
@@ -2664,7 +2664,7 @@ static const u16 sYanmaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_UPROAR),
     LEVEL_UP_MOVE(43, MOVE_WING_ATTACK),
     LEVEL_UP_MOVE(49, MOVE_SCREECH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWooperLevelUpLearnset[] = {
@@ -2678,7 +2678,7 @@ static const u16 sWooperLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_RAIN_DANCE),
     LEVEL_UP_MOVE(51, MOVE_MIST),
     LEVEL_UP_MOVE(51, MOVE_HAZE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sQuagsireLevelUpLearnset[] = {
@@ -2692,7 +2692,7 @@ static const u16 sQuagsireLevelUpLearnset[] = {
     LEVEL_UP_MOVE(49, MOVE_RAIN_DANCE),
     LEVEL_UP_MOVE(61, MOVE_MIST),
     LEVEL_UP_MOVE(61, MOVE_HAZE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sEspeonLevelUpLearnset[] = {
@@ -2707,7 +2707,7 @@ static const u16 sEspeonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_PSYCH_UP),
     LEVEL_UP_MOVE(47, MOVE_PSYCHIC),
     LEVEL_UP_MOVE(52, MOVE_MORNING_SUN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sUmbreonLevelUpLearnset[] = {
@@ -2722,7 +2722,7 @@ static const u16 sUmbreonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_MEAN_LOOK),
     LEVEL_UP_MOVE(47, MOVE_SCREECH),
     LEVEL_UP_MOVE(52, MOVE_MOONLIGHT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMurkrowLevelUpLearnset[] = {
@@ -2734,7 +2734,7 @@ static const u16 sMurkrowLevelUpLearnset[] = {
     LEVEL_UP_MOVE(35, MOVE_FAINT_ATTACK),
     LEVEL_UP_MOVE(40, MOVE_TAUNT),
     LEVEL_UP_MOVE(48, MOVE_MEAN_LOOK),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSlowkingLevelUpLearnset[] = {
@@ -2748,7 +2748,7 @@ static const u16 sSlowkingLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_HEADBUTT),
     LEVEL_UP_MOVE(43, MOVE_SWAGGER),
     LEVEL_UP_MOVE(48, MOVE_PSYCHIC),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMisdreavusLevelUpLearnset[] = {
@@ -2762,12 +2762,12 @@ static const u16 sMisdreavusLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_PAIN_SPLIT),
     LEVEL_UP_MOVE(45, MOVE_PERISH_SONG),
     LEVEL_UP_MOVE(53, MOVE_GRUDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sUnownLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_HIDDEN_POWER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWobbuffetLevelUpLearnset[] = {
@@ -2775,7 +2775,7 @@ static const u16 sWobbuffetLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_MIRROR_COAT),
     LEVEL_UP_MOVE( 1, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE( 1, MOVE_DESTINY_BOND),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGirafarigLevelUpLearnset[] = {
@@ -2789,7 +2789,7 @@ static const u16 sGirafarigLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_BATON_PASS),
     LEVEL_UP_MOVE(43, MOVE_PSYBEAM),
     LEVEL_UP_MOVE(49, MOVE_CRUNCH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPinecoLevelUpLearnset[] = {
@@ -2802,7 +2802,7 @@ static const u16 sPinecoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_EXPLOSION),
     LEVEL_UP_MOVE(43, MOVE_SPIKES),
     LEVEL_UP_MOVE(50, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sForretressLevelUpLearnset[] = {
@@ -2816,7 +2816,7 @@ static const u16 sForretressLevelUpLearnset[] = {
     LEVEL_UP_MOVE(39, MOVE_EXPLOSION),
     LEVEL_UP_MOVE(49, MOVE_SPIKES),
     LEVEL_UP_MOVE(59, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDunsparceLevelUpLearnset[] = {
@@ -2829,7 +2829,7 @@ static const u16 sDunsparceLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_SCREECH),
     LEVEL_UP_MOVE(34, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(41, MOVE_ENDEAVOR),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGligarLevelUpLearnset[] = {
@@ -2841,7 +2841,7 @@ static const u16 sGligarLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_SLASH),
     LEVEL_UP_MOVE(44, MOVE_SCREECH),
     LEVEL_UP_MOVE(52, MOVE_GUILLOTINE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSteelixLevelUpLearnset[] = {
@@ -2856,7 +2856,7 @@ static const u16 sSteelixLevelUpLearnset[] = {
     LEVEL_UP_MOVE(45, MOVE_IRON_TAIL),
     LEVEL_UP_MOVE(49, MOVE_CRUNCH),
     LEVEL_UP_MOVE(57, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSnubbullLevelUpLearnset[] = {
@@ -2870,7 +2870,7 @@ static const u16 sSnubbullLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_RAGE),
     LEVEL_UP_MOVE(43, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(53, MOVE_CRUNCH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGranbullLevelUpLearnset[] = {
@@ -2884,7 +2884,7 @@ static const u16 sGranbullLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_RAGE),
     LEVEL_UP_MOVE(49, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(61, MOVE_CRUNCH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sQwilfishLevelUpLearnset[] = {
@@ -2897,7 +2897,7 @@ static const u16 sQwilfishLevelUpLearnset[] = {
     LEVEL_UP_MOVE(28, MOVE_PIN_MISSILE),
     LEVEL_UP_MOVE(37, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(46, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sScizorLevelUpLearnset[] = {
@@ -2912,7 +2912,7 @@ static const u16 sScizorLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_SWORDS_DANCE),
     LEVEL_UP_MOVE(41, MOVE_DOUBLE_TEAM),
     LEVEL_UP_MOVE(46, MOVE_FURY_CUTTER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sShuckleLevelUpLearnset[] = {
@@ -2923,7 +2923,7 @@ static const u16 sShuckleLevelUpLearnset[] = {
     LEVEL_UP_MOVE(23, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(28, MOVE_BIDE),
     LEVEL_UP_MOVE(37, MOVE_REST),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sHeracrossLevelUpLearnset[] = {
@@ -2937,7 +2937,7 @@ static const u16 sHeracrossLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(45, MOVE_REVERSAL),
     LEVEL_UP_MOVE(53, MOVE_MEGAHORN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSneaselLevelUpLearnset[] = {
@@ -2953,7 +2953,7 @@ static const u16 sSneaselLevelUpLearnset[] = {
     LEVEL_UP_MOVE(50, MOVE_SLASH),
     LEVEL_UP_MOVE(57, MOVE_BEAT_UP),
     LEVEL_UP_MOVE(64, MOVE_METAL_CLAW),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTeddiursaLevelUpLearnset[] = {
@@ -2967,7 +2967,7 @@ static const u16 sTeddiursaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_SLASH),
     LEVEL_UP_MOVE(43, MOVE_SNORE),
     LEVEL_UP_MOVE(49, MOVE_THRASH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sUrsaringLevelUpLearnset[] = {
@@ -2983,7 +2983,7 @@ static const u16 sUrsaringLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_SLASH),
     LEVEL_UP_MOVE(43, MOVE_SNORE),
     LEVEL_UP_MOVE(49, MOVE_THRASH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSlugmaLevelUpLearnset[] = {
@@ -2996,7 +2996,7 @@ static const u16 sSlugmaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_FLAMETHROWER),
     LEVEL_UP_MOVE(43, MOVE_ROCK_SLIDE),
     LEVEL_UP_MOVE(50, MOVE_BODY_SLAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMagcargoLevelUpLearnset[] = {
@@ -3011,7 +3011,7 @@ static const u16 sMagcargoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_FLAMETHROWER),
     LEVEL_UP_MOVE(48, MOVE_ROCK_SLIDE),
     LEVEL_UP_MOVE(60, MOVE_BODY_SLAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSwinubLevelUpLearnset[] = {
@@ -3023,7 +3023,7 @@ static const u16 sSwinubLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_MIST),
     LEVEL_UP_MOVE(46, MOVE_BLIZZARD),
     LEVEL_UP_MOVE(55, MOVE_AMNESIA),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPiloswineLevelUpLearnset[] = {
@@ -3038,7 +3038,7 @@ static const u16 sPiloswineLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_MIST),
     LEVEL_UP_MOVE(56, MOVE_BLIZZARD),
     LEVEL_UP_MOVE(70, MOVE_AMNESIA),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCorsolaLevelUpLearnset[] = {
@@ -3052,7 +3052,7 @@ static const u16 sCorsolaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_ROCK_BLAST),
     LEVEL_UP_MOVE(39, MOVE_MIRROR_COAT),
     LEVEL_UP_MOVE(45, MOVE_ANCIENT_POWER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRemoraidLevelUpLearnset[] = {
@@ -3064,7 +3064,7 @@ static const u16 sRemoraidLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_FOCUS_ENERGY),
     LEVEL_UP_MOVE(44, MOVE_ICE_BEAM),
     LEVEL_UP_MOVE(55, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sOctilleryLevelUpLearnset[] = {
@@ -3077,12 +3077,12 @@ static const u16 sOctilleryLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_FOCUS_ENERGY),
     LEVEL_UP_MOVE(54, MOVE_ICE_BEAM),
     LEVEL_UP_MOVE(70, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDelibirdLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_PRESENT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMantineLevelUpLearnset[] = {
@@ -3095,7 +3095,7 @@ static const u16 sMantineLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_WING_ATTACK),
     LEVEL_UP_MOVE(43, MOVE_WATER_PULSE),
     LEVEL_UP_MOVE(50, MOVE_CONFUSE_RAY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSkarmoryLevelUpLearnset[] = {
@@ -3109,7 +3109,7 @@ static const u16 sSkarmoryLevelUpLearnset[] = {
     LEVEL_UP_MOVE(32, MOVE_STEEL_WING),
     LEVEL_UP_MOVE(42, MOVE_SPIKES),
     LEVEL_UP_MOVE(45, MOVE_METAL_SOUND),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sHoundourLevelUpLearnset[] = {
@@ -3123,7 +3123,7 @@ static const u16 sHoundourLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_FAINT_ATTACK),
     LEVEL_UP_MOVE(43, MOVE_FLAMETHROWER),
     LEVEL_UP_MOVE(49, MOVE_CRUNCH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sHoundoomLevelUpLearnset[] = {
@@ -3138,7 +3138,7 @@ static const u16 sHoundoomLevelUpLearnset[] = {
     LEVEL_UP_MOVE(43, MOVE_FAINT_ATTACK),
     LEVEL_UP_MOVE(51, MOVE_FLAMETHROWER),
     LEVEL_UP_MOVE(59, MOVE_CRUNCH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sKingdraLevelUpLearnset[] = {
@@ -3153,7 +3153,7 @@ static const u16 sKingdraLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_AGILITY),
     LEVEL_UP_MOVE(51, MOVE_HYDRO_PUMP),
     LEVEL_UP_MOVE(62, MOVE_DRAGON_DANCE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPhanpyLevelUpLearnset[] = {
@@ -3166,7 +3166,7 @@ static const u16 sPhanpyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_ROLLOUT),
     LEVEL_UP_MOVE(41, MOVE_ENDURE),
     LEVEL_UP_MOVE(49, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDonphanLevelUpLearnset[] = {
@@ -3179,7 +3179,7 @@ static const u16 sDonphanLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_ROLLOUT),
     LEVEL_UP_MOVE(41, MOVE_RAPID_SPIN),
     LEVEL_UP_MOVE(49, MOVE_EARTHQUAKE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPorygon2LevelUpLearnset[] = {
@@ -3194,7 +3194,7 @@ static const u16 sPorygon2LevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_TRI_ATTACK),
     LEVEL_UP_MOVE(44, MOVE_RECYCLE),
     LEVEL_UP_MOVE(48, MOVE_ZAP_CANNON),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sStantlerLevelUpLearnset[] = {
@@ -3207,7 +3207,7 @@ static const u16 sStantlerLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(43, MOVE_CONFUSE_RAY),
     LEVEL_UP_MOVE(49, MOVE_CALM_MIND),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSmeargleLevelUpLearnset[] = {
@@ -3221,12 +3221,12 @@ static const u16 sSmeargleLevelUpLearnset[] = {
     LEVEL_UP_MOVE(71, MOVE_SKETCH),
     LEVEL_UP_MOVE(81, MOVE_SKETCH),
     LEVEL_UP_MOVE(91, MOVE_SKETCH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTyrogueLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sHitmontopLevelUpLearnset[] = {
@@ -3241,7 +3241,7 @@ static const u16 sHitmontopLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_AGILITY),
     LEVEL_UP_MOVE(43, MOVE_DETECT),
     LEVEL_UP_MOVE(49, MOVE_ENDEAVOR),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSmoochumLevelUpLearnset[] = {
@@ -3256,7 +3256,7 @@ static const u16 sSmoochumLevelUpLearnset[] = {
     LEVEL_UP_MOVE(45, MOVE_PSYCHIC),
     LEVEL_UP_MOVE(49, MOVE_PERISH_SONG),
     LEVEL_UP_MOVE(57, MOVE_BLIZZARD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sElekidLevelUpLearnset[] = {
@@ -3268,7 +3268,7 @@ static const u16 sElekidLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_SCREECH),
     LEVEL_UP_MOVE(41, MOVE_THUNDERBOLT),
     LEVEL_UP_MOVE(49, MOVE_THUNDER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMagbyLevelUpLearnset[] = {
@@ -3281,7 +3281,7 @@ static const u16 sMagbyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_FLAMETHROWER),
     LEVEL_UP_MOVE(43, MOVE_CONFUSE_RAY),
     LEVEL_UP_MOVE(49, MOVE_FIRE_BLAST),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMiltankLevelUpLearnset[] = {
@@ -3294,7 +3294,7 @@ static const u16 sMiltankLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_ROLLOUT),
     LEVEL_UP_MOVE(43, MOVE_BODY_SLAM),
     LEVEL_UP_MOVE(53, MOVE_HEAL_BELL),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sBlisseyLevelUpLearnset[] = {
@@ -3310,7 +3310,7 @@ static const u16 sBlisseyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_DEFENSE_CURL),
     LEVEL_UP_MOVE(40, MOVE_LIGHT_SCREEN),
     LEVEL_UP_MOVE(47, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRaikouLevelUpLearnset[] = {
@@ -3324,7 +3324,7 @@ static const u16 sRaikouLevelUpLearnset[] = {
     LEVEL_UP_MOVE(61, MOVE_CRUNCH),
     LEVEL_UP_MOVE(71, MOVE_THUNDER),
     LEVEL_UP_MOVE(81, MOVE_CALM_MIND),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sEnteiLevelUpLearnset[] = {
@@ -3338,7 +3338,7 @@ static const u16 sEnteiLevelUpLearnset[] = {
     LEVEL_UP_MOVE(61, MOVE_SWAGGER),
     LEVEL_UP_MOVE(71, MOVE_FIRE_BLAST),
     LEVEL_UP_MOVE(81, MOVE_CALM_MIND),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSuicuneLevelUpLearnset[] = {
@@ -3352,7 +3352,7 @@ static const u16 sSuicuneLevelUpLearnset[] = {
     LEVEL_UP_MOVE(61, MOVE_MIRROR_COAT),
     LEVEL_UP_MOVE(71, MOVE_HYDRO_PUMP),
     LEVEL_UP_MOVE(81, MOVE_CALM_MIND),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLarvitarLevelUpLearnset[] = {
@@ -3366,7 +3366,7 @@ static const u16 sLarvitarLevelUpLearnset[] = {
     LEVEL_UP_MOVE(43, MOVE_CRUNCH),
     LEVEL_UP_MOVE(50, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(57, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPupitarLevelUpLearnset[] = {
@@ -3382,7 +3382,7 @@ static const u16 sPupitarLevelUpLearnset[] = {
     LEVEL_UP_MOVE(47, MOVE_CRUNCH),
     LEVEL_UP_MOVE(56, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(65, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTyranitarLevelUpLearnset[] = {
@@ -3398,7 +3398,7 @@ static const u16 sTyranitarLevelUpLearnset[] = {
     LEVEL_UP_MOVE(47, MOVE_CRUNCH),
     LEVEL_UP_MOVE(61, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(75, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLugiaLevelUpLearnset[] = {
@@ -3412,7 +3412,7 @@ static const u16 sLugiaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(77, MOVE_AEROBLAST),
     LEVEL_UP_MOVE(88, MOVE_ANCIENT_POWER),
     LEVEL_UP_MOVE(99, MOVE_FUTURE_SIGHT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sHoOhLevelUpLearnset[] = {
@@ -3426,7 +3426,7 @@ static const u16 sHoOhLevelUpLearnset[] = {
     LEVEL_UP_MOVE(77, MOVE_SACRED_FIRE),
     LEVEL_UP_MOVE(88, MOVE_ANCIENT_POWER),
     LEVEL_UP_MOVE(99, MOVE_FUTURE_SIGHT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCelebiLevelUpLearnset[] = {
@@ -3439,132 +3439,132 @@ static const u16 sCelebiLevelUpLearnset[] = {
     LEVEL_UP_MOVE(30, MOVE_FUTURE_SIGHT),
     LEVEL_UP_MOVE(40, MOVE_BATON_PASS),
     LEVEL_UP_MOVE(50, MOVE_PERISH_SONG),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies252LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies253LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies254LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies255LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies256LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies257LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies258LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies259LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies260LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies261LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies262LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies263LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies264LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies265LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies266LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies267LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies268LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies269LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies270LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies271LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies272LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies273LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies274LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies275LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpecies276LevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTreeckoLevelUpLearnset[] = {
@@ -3579,7 +3579,7 @@ static const u16 sTreeckoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_SLAM),
     LEVEL_UP_MOVE(41, MOVE_DETECT),
     LEVEL_UP_MOVE(46, MOVE_GIGA_DRAIN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGrovyleLevelUpLearnset[] = {
@@ -3597,7 +3597,7 @@ static const u16 sGrovyleLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_SLAM),
     LEVEL_UP_MOVE(47, MOVE_DETECT),
     LEVEL_UP_MOVE(53, MOVE_FALSE_SWIPE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSceptileLevelUpLearnset[] = {
@@ -3615,7 +3615,7 @@ static const u16 sSceptileLevelUpLearnset[] = {
     LEVEL_UP_MOVE(43, MOVE_SLAM),
     LEVEL_UP_MOVE(51, MOVE_DETECT),
     LEVEL_UP_MOVE(59, MOVE_FALSE_SWIPE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTorchicLevelUpLearnset[] = {
@@ -3630,7 +3630,7 @@ static const u16 sTorchicLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_SLASH),
     LEVEL_UP_MOVE(37, MOVE_MIRROR_MOVE),
     LEVEL_UP_MOVE(43, MOVE_FLAMETHROWER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCombuskenLevelUpLearnset[] = {
@@ -3648,7 +3648,7 @@ static const u16 sCombuskenLevelUpLearnset[] = {
     LEVEL_UP_MOVE(39, MOVE_SLASH),
     LEVEL_UP_MOVE(43, MOVE_MIRROR_MOVE),
     LEVEL_UP_MOVE(50, MOVE_SKY_UPPERCUT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sBlazikenLevelUpLearnset[] = {
@@ -3668,7 +3668,7 @@ static const u16 sBlazikenLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_SLASH),
     LEVEL_UP_MOVE(49, MOVE_MIRROR_MOVE),
     LEVEL_UP_MOVE(59, MOVE_SKY_UPPERCUT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMudkipLevelUpLearnset[] = {
@@ -3684,7 +3684,7 @@ static const u16 sMudkipLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_PROTECT),
     LEVEL_UP_MOVE(42, MOVE_HYDRO_PUMP),
     LEVEL_UP_MOVE(46, MOVE_ENDEAVOR),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMarshtompLevelUpLearnset[] = {
@@ -3703,7 +3703,7 @@ static const u16 sMarshtompLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_PROTECT),
     LEVEL_UP_MOVE(46, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(53, MOVE_ENDEAVOR),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSwampertLevelUpLearnset[] = {
@@ -3722,7 +3722,7 @@ static const u16 sSwampertLevelUpLearnset[] = {
     LEVEL_UP_MOVE(46, MOVE_PROTECT),
     LEVEL_UP_MOVE(52, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(61, MOVE_ENDEAVOR),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPoochyenaLevelUpLearnset[] = {
@@ -3738,7 +3738,7 @@ static const u16 sPoochyenaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_TAUNT),
     LEVEL_UP_MOVE(41, MOVE_CRUNCH),
     LEVEL_UP_MOVE(45, MOVE_THIEF),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMightyenaLevelUpLearnset[] = {
@@ -3757,7 +3757,7 @@ static const u16 sMightyenaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_TAUNT),
     LEVEL_UP_MOVE(47, MOVE_CRUNCH),
     LEVEL_UP_MOVE(52, MOVE_THIEF),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sZigzagoonLevelUpLearnset[] = {
@@ -3773,7 +3773,7 @@ static const u16 sZigzagoonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_FLAIL),
     LEVEL_UP_MOVE(37, MOVE_REST),
     LEVEL_UP_MOVE(41, MOVE_BELLY_DRUM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLinooneLevelUpLearnset[] = {
@@ -3791,20 +3791,20 @@ static const u16 sLinooneLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_SLASH),
     LEVEL_UP_MOVE(47, MOVE_REST),
     LEVEL_UP_MOVE(53, MOVE_BELLY_DRUM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWurmpleLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TACKLE),
     LEVEL_UP_MOVE( 1, MOVE_STRING_SHOT),
     LEVEL_UP_MOVE( 5, MOVE_POISON_STING),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSilcoonLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_HARDEN),
     LEVEL_UP_MOVE( 7, MOVE_HARDEN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sBeautiflyLevelUpLearnset[] = {
@@ -3818,13 +3818,13 @@ static const u16 sBeautiflyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_ATTRACT),
     LEVEL_UP_MOVE(34, MOVE_SILVER_WIND),
     LEVEL_UP_MOVE(38, MOVE_GIGA_DRAIN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCascoonLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_HARDEN),
     LEVEL_UP_MOVE( 7, MOVE_HARDEN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDustoxLevelUpLearnset[] = {
@@ -3838,7 +3838,7 @@ static const u16 sDustoxLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_LIGHT_SCREEN),
     LEVEL_UP_MOVE(34, MOVE_SILVER_WIND),
     LEVEL_UP_MOVE(38, MOVE_TOXIC),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLotadLevelUpLearnset[] = {
@@ -3849,7 +3849,7 @@ static const u16 sLotadLevelUpLearnset[] = {
     LEVEL_UP_MOVE(21, MOVE_MIST),
     LEVEL_UP_MOVE(31, MOVE_RAIN_DANCE),
     LEVEL_UP_MOVE(43, MOVE_MEGA_DRAIN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLombreLevelUpLearnset[] = {
@@ -3863,7 +3863,7 @@ static const u16 sLombreLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_THIEF),
     LEVEL_UP_MOVE(43, MOVE_UPROAR),
     LEVEL_UP_MOVE(49, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLudicoloLevelUpLearnset[] = {
@@ -3871,7 +3871,7 @@ static const u16 sLudicoloLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_GROWL),
     LEVEL_UP_MOVE( 1, MOVE_ABSORB),
     LEVEL_UP_MOVE( 1, MOVE_NATURE_POWER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSeedotLevelUpLearnset[] = {
@@ -3882,7 +3882,7 @@ static const u16 sSeedotLevelUpLearnset[] = {
     LEVEL_UP_MOVE(21, MOVE_SYNTHESIS),
     LEVEL_UP_MOVE(31, MOVE_SUNNY_DAY),
     LEVEL_UP_MOVE(43, MOVE_EXPLOSION),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sNuzleafLevelUpLearnset[] = {
@@ -3896,7 +3896,7 @@ static const u16 sNuzleafLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_RAZOR_WIND),
     LEVEL_UP_MOVE(43, MOVE_SWAGGER),
     LEVEL_UP_MOVE(49, MOVE_EXTRASENSORY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sShiftryLevelUpLearnset[] = {
@@ -3904,7 +3904,7 @@ static const u16 sShiftryLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_HARDEN),
     LEVEL_UP_MOVE( 1, MOVE_GROWTH),
     LEVEL_UP_MOVE( 1, MOVE_NATURE_POWER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sNincadaLevelUpLearnset[] = {
@@ -3918,7 +3918,7 @@ static const u16 sNincadaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_MUD_SLAP),
     LEVEL_UP_MOVE(38, MOVE_METAL_CLAW),
     LEVEL_UP_MOVE(45, MOVE_DIG),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sNinjaskLevelUpLearnset[] = {
@@ -3937,7 +3937,7 @@ static const u16 sNinjaskLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_SLASH),
     LEVEL_UP_MOVE(38, MOVE_AGILITY),
     LEVEL_UP_MOVE(45, MOVE_BATON_PASS),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sShedinjaLevelUpLearnset[] = {
@@ -3951,7 +3951,7 @@ static const u16 sShedinjaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_CONFUSE_RAY),
     LEVEL_UP_MOVE(38, MOVE_SHADOW_BALL),
     LEVEL_UP_MOVE(45, MOVE_GRUDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTaillowLevelUpLearnset[] = {
@@ -3964,7 +3964,7 @@ static const u16 sTaillowLevelUpLearnset[] = {
     LEVEL_UP_MOVE(26, MOVE_ENDEAVOR),
     LEVEL_UP_MOVE(34, MOVE_AERIAL_ACE),
     LEVEL_UP_MOVE(43, MOVE_AGILITY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSwellowLevelUpLearnset[] = {
@@ -3979,7 +3979,7 @@ static const u16 sSwellowLevelUpLearnset[] = {
     LEVEL_UP_MOVE(28, MOVE_ENDEAVOR),
     LEVEL_UP_MOVE(38, MOVE_AERIAL_ACE),
     LEVEL_UP_MOVE(49, MOVE_AGILITY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sShroomishLevelUpLearnset[] = {
@@ -3993,7 +3993,7 @@ static const u16 sShroomishLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_GROWTH),
     LEVEL_UP_MOVE(45, MOVE_GIGA_DRAIN),
     LEVEL_UP_MOVE(54, MOVE_SPORE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sBreloomLevelUpLearnset[] = {
@@ -4011,7 +4011,7 @@ static const u16 sBreloomLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_SKY_UPPERCUT),
     LEVEL_UP_MOVE(45, MOVE_MIND_READER),
     LEVEL_UP_MOVE(54, MOVE_DYNAMIC_PUNCH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpindaLevelUpLearnset[] = {
@@ -4026,7 +4026,7 @@ static const u16 sSpindaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(45, MOVE_DOUBLE_EDGE),
     LEVEL_UP_MOVE(49, MOVE_FLAIL),
     LEVEL_UP_MOVE(56, MOVE_THRASH),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWingullLevelUpLearnset[] = {
@@ -4038,7 +4038,7 @@ static const u16 sWingullLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_QUICK_ATTACK),
     LEVEL_UP_MOVE(43, MOVE_PURSUIT),
     LEVEL_UP_MOVE(55, MOVE_AGILITY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPelipperLevelUpLearnset[] = {
@@ -4055,7 +4055,7 @@ static const u16 sPelipperLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_SWALLOW),
     LEVEL_UP_MOVE(47, MOVE_SPIT_UP),
     LEVEL_UP_MOVE(61, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSurskitLevelUpLearnset[] = {
@@ -4067,7 +4067,7 @@ static const u16 sSurskitLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_AGILITY),
     LEVEL_UP_MOVE(37, MOVE_MIST),
     LEVEL_UP_MOVE(37, MOVE_HAZE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMasquerainLevelUpLearnset[] = {
@@ -4083,7 +4083,7 @@ static const u16 sMasquerainLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_STUN_SPORE),
     LEVEL_UP_MOVE(47, MOVE_SILVER_WIND),
     LEVEL_UP_MOVE(53, MOVE_WHIRLWIND),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWailmerLevelUpLearnset[] = {
@@ -4099,7 +4099,7 @@ static const u16 sWailmerLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_WATER_SPOUT),
     LEVEL_UP_MOVE(46, MOVE_AMNESIA),
     LEVEL_UP_MOVE(50, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWailordLevelUpLearnset[] = {
@@ -4118,7 +4118,7 @@ static const u16 sWailordLevelUpLearnset[] = {
     LEVEL_UP_MOVE(44, MOVE_WATER_SPOUT),
     LEVEL_UP_MOVE(52, MOVE_AMNESIA),
     LEVEL_UP_MOVE(59, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSkittyLevelUpLearnset[] = {
@@ -4134,7 +4134,7 @@ static const u16 sSkittyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_COVET),
     LEVEL_UP_MOVE(37, MOVE_HEAL_BELL),
     LEVEL_UP_MOVE(39, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDelcattyLevelUpLearnset[] = {
@@ -4142,7 +4142,7 @@ static const u16 sDelcattyLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_ATTRACT),
     LEVEL_UP_MOVE( 1, MOVE_SING),
     LEVEL_UP_MOVE( 1, MOVE_DOUBLE_SLAP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sKecleonLevelUpLearnset[] = {
@@ -4159,7 +4159,7 @@ static const u16 sKecleonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_SLASH),
     LEVEL_UP_MOVE(40, MOVE_SUBSTITUTE),
     LEVEL_UP_MOVE(49, MOVE_ANCIENT_POWER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sBaltoyLevelUpLearnset[] = {
@@ -4174,7 +4174,7 @@ static const u16 sBaltoyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_SANDSTORM),
     LEVEL_UP_MOVE(37, MOVE_COSMIC_POWER),
     LEVEL_UP_MOVE(45, MOVE_EXPLOSION),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sClaydolLevelUpLearnset[] = {
@@ -4193,7 +4193,7 @@ static const u16 sClaydolLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_HYPER_BEAM),
     LEVEL_UP_MOVE(42, MOVE_COSMIC_POWER),
     LEVEL_UP_MOVE(55, MOVE_EXPLOSION),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sNosepassLevelUpLearnset[] = {
@@ -4207,7 +4207,7 @@ static const u16 sNosepassLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_REST),
     LEVEL_UP_MOVE(43, MOVE_ZAP_CANNON),
     LEVEL_UP_MOVE(46, MOVE_LOCK_ON),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTorkoalLevelUpLearnset[] = {
@@ -4223,7 +4223,7 @@ static const u16 sTorkoalLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_AMNESIA),
     LEVEL_UP_MOVE(43, MOVE_FLAIL),
     LEVEL_UP_MOVE(46, MOVE_HEAT_WAVE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSableyeLevelUpLearnset[] = {
@@ -4240,7 +4240,7 @@ static const u16 sSableyeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_CONFUSE_RAY),
     LEVEL_UP_MOVE(41, MOVE_SHADOW_BALL),
     LEVEL_UP_MOVE(45, MOVE_MEAN_LOOK),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sBarboachLevelUpLearnset[] = {
@@ -4255,7 +4255,7 @@ static const u16 sBarboachLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(36, MOVE_FUTURE_SIGHT),
     LEVEL_UP_MOVE(41, MOVE_FISSURE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWhiscashLevelUpLearnset[] = {
@@ -4273,7 +4273,7 @@ static const u16 sWhiscashLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(46, MOVE_FUTURE_SIGHT),
     LEVEL_UP_MOVE(56, MOVE_FISSURE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLuvdiscLevelUpLearnset[] = {
@@ -4286,7 +4286,7 @@ static const u16 sLuvdiscLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_SWEET_KISS),
     LEVEL_UP_MOVE(40, MOVE_FLAIL),
     LEVEL_UP_MOVE(48, MOVE_SAFEGUARD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCorphishLevelUpLearnset[] = {
@@ -4301,7 +4301,7 @@ static const u16 sCorphishLevelUpLearnset[] = {
     LEVEL_UP_MOVE(35, MOVE_CRABHAMMER),
     LEVEL_UP_MOVE(38, MOVE_SWORDS_DANCE),
     LEVEL_UP_MOVE(44, MOVE_GUILLOTINE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCrawdauntLevelUpLearnset[] = {
@@ -4319,14 +4319,14 @@ static const u16 sCrawdauntLevelUpLearnset[] = {
     LEVEL_UP_MOVE(39, MOVE_CRABHAMMER),
     LEVEL_UP_MOVE(44, MOVE_SWORDS_DANCE),
     LEVEL_UP_MOVE(52, MOVE_GUILLOTINE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sFeebasLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_SPLASH),
     LEVEL_UP_MOVE(15, MOVE_TACKLE),
     LEVEL_UP_MOVE(30, MOVE_FLAIL),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMiloticLevelUpLearnset[] = {
@@ -4341,7 +4341,7 @@ static const u16 sMiloticLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_HYDRO_PUMP),
     LEVEL_UP_MOVE(45, MOVE_ATTRACT),
     LEVEL_UP_MOVE(50, MOVE_SAFEGUARD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCarvanhaLevelUpLearnset[] = {
@@ -4355,7 +4355,7 @@ static const u16 sCarvanhaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_TAKE_DOWN),
     LEVEL_UP_MOVE(37, MOVE_SWAGGER),
     LEVEL_UP_MOVE(43, MOVE_AGILITY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSharpedoLevelUpLearnset[] = {
@@ -4373,7 +4373,7 @@ static const u16 sSharpedoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(43, MOVE_SWAGGER),
     LEVEL_UP_MOVE(48, MOVE_SKULL_BASH),
     LEVEL_UP_MOVE(53, MOVE_AGILITY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTrapinchLevelUpLearnset[] = {
@@ -4385,7 +4385,7 @@ static const u16 sTrapinchLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_DIG),
     LEVEL_UP_MOVE(49, MOVE_SANDSTORM),
     LEVEL_UP_MOVE(57, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sVibravaLevelUpLearnset[] = {
@@ -4401,7 +4401,7 @@ static const u16 sVibravaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_SCREECH),
     LEVEL_UP_MOVE(49, MOVE_SANDSTORM),
     LEVEL_UP_MOVE(57, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sFlygonLevelUpLearnset[] = {
@@ -4417,7 +4417,7 @@ static const u16 sFlygonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_SCREECH),
     LEVEL_UP_MOVE(53, MOVE_SANDSTORM),
     LEVEL_UP_MOVE(65, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMakuhitaLevelUpLearnset[] = {
@@ -4434,7 +4434,7 @@ static const u16 sMakuhitaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_ENDURE),
     LEVEL_UP_MOVE(46, MOVE_SEISMIC_TOSS),
     LEVEL_UP_MOVE(49, MOVE_REVERSAL),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sHariyamaLevelUpLearnset[] = {
@@ -4453,7 +4453,7 @@ static const u16 sHariyamaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(44, MOVE_ENDURE),
     LEVEL_UP_MOVE(51, MOVE_SEISMIC_TOSS),
     LEVEL_UP_MOVE(55, MOVE_REVERSAL),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sElectrikeLevelUpLearnset[] = {
@@ -4468,7 +4468,7 @@ static const u16 sElectrikeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(33, MOVE_BITE),
     LEVEL_UP_MOVE(36, MOVE_THUNDER),
     LEVEL_UP_MOVE(41, MOVE_CHARGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sManectricLevelUpLearnset[] = {
@@ -4486,7 +4486,7 @@ static const u16 sManectricLevelUpLearnset[] = {
     LEVEL_UP_MOVE(39, MOVE_BITE),
     LEVEL_UP_MOVE(45, MOVE_THUNDER),
     LEVEL_UP_MOVE(53, MOVE_CHARGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sNumelLevelUpLearnset[] = {
@@ -4500,7 +4500,7 @@ static const u16 sNumelLevelUpLearnset[] = {
     LEVEL_UP_MOVE(35, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(41, MOVE_FLAMETHROWER),
     LEVEL_UP_MOVE(49, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCameruptLevelUpLearnset[] = {
@@ -4517,7 +4517,7 @@ static const u16 sCameruptLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_EARTHQUAKE),
     LEVEL_UP_MOVE(45, MOVE_ERUPTION),
     LEVEL_UP_MOVE(55, MOVE_FISSURE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSphealLevelUpLearnset[] = {
@@ -4533,7 +4533,7 @@ static const u16 sSphealLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_SNORE),
     LEVEL_UP_MOVE(43, MOVE_BLIZZARD),
     LEVEL_UP_MOVE(49, MOVE_SHEER_COLD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSealeoLevelUpLearnset[] = {
@@ -4550,7 +4550,7 @@ static const u16 sSealeoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(39, MOVE_SNORE),
     LEVEL_UP_MOVE(47, MOVE_BLIZZARD),
     LEVEL_UP_MOVE(55, MOVE_SHEER_COLD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWalreinLevelUpLearnset[] = {
@@ -4567,7 +4567,7 @@ static const u16 sWalreinLevelUpLearnset[] = {
     LEVEL_UP_MOVE(39, MOVE_SNORE),
     LEVEL_UP_MOVE(50, MOVE_BLIZZARD),
     LEVEL_UP_MOVE(61, MOVE_SHEER_COLD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCacneaLevelUpLearnset[] = {
@@ -4584,7 +4584,7 @@ static const u16 sCacneaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_NEEDLE_ARM),
     LEVEL_UP_MOVE(41, MOVE_COTTON_SPORE),
     LEVEL_UP_MOVE(45, MOVE_SANDSTORM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCacturneLevelUpLearnset[] = {
@@ -4603,7 +4603,7 @@ static const u16 sCacturneLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_NEEDLE_ARM),
     LEVEL_UP_MOVE(47, MOVE_COTTON_SPORE),
     LEVEL_UP_MOVE(53, MOVE_SANDSTORM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSnoruntLevelUpLearnset[] = {
@@ -4618,7 +4618,7 @@ static const u16 sSnoruntLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_ICE_BEAM),
     LEVEL_UP_MOVE(37, MOVE_HAIL),
     LEVEL_UP_MOVE(43, MOVE_BLIZZARD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGlalieLevelUpLearnset[] = {
@@ -4636,7 +4636,7 @@ static const u16 sGlalieLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_HAIL),
     LEVEL_UP_MOVE(53, MOVE_BLIZZARD),
     LEVEL_UP_MOVE(61, MOVE_SHEER_COLD),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLunatoneLevelUpLearnset[] = {
@@ -4650,7 +4650,7 @@ static const u16 sLunatoneLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_PSYCHIC),
     LEVEL_UP_MOVE(43, MOVE_FUTURE_SIGHT),
     LEVEL_UP_MOVE(49, MOVE_EXPLOSION),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSolrockLevelUpLearnset[] = {
@@ -4664,7 +4664,7 @@ static const u16 sSolrockLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_ROCK_SLIDE),
     LEVEL_UP_MOVE(43, MOVE_SOLAR_BEAM),
     LEVEL_UP_MOVE(49, MOVE_EXPLOSION),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sAzurillLevelUpLearnset[] = {
@@ -4674,7 +4674,7 @@ static const u16 sAzurillLevelUpLearnset[] = {
     LEVEL_UP_MOVE(10, MOVE_BUBBLE),
     LEVEL_UP_MOVE(15, MOVE_SLAM),
     LEVEL_UP_MOVE(21, MOVE_WATER_GUN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSpoinkLevelUpLearnset[] = {
@@ -4689,7 +4689,7 @@ static const u16 sSpoinkLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_REST),
     LEVEL_UP_MOVE(37, MOVE_SNORE),
     LEVEL_UP_MOVE(43, MOVE_BOUNCE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGrumpigLevelUpLearnset[] = {
@@ -4707,7 +4707,7 @@ static const u16 sGrumpigLevelUpLearnset[] = {
     LEVEL_UP_MOVE(43, MOVE_REST),
     LEVEL_UP_MOVE(43, MOVE_SNORE),
     LEVEL_UP_MOVE(55, MOVE_BOUNCE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sPlusleLevelUpLearnset[] = {
@@ -4722,7 +4722,7 @@ static const u16 sPlusleLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_THUNDER),
     LEVEL_UP_MOVE(40, MOVE_BATON_PASS),
     LEVEL_UP_MOVE(47, MOVE_AGILITY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMinunLevelUpLearnset[] = {
@@ -4737,7 +4737,7 @@ static const u16 sMinunLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_THUNDER),
     LEVEL_UP_MOVE(40, MOVE_BATON_PASS),
     LEVEL_UP_MOVE(47, MOVE_AGILITY),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMawileLevelUpLearnset[] = {
@@ -4753,7 +4753,7 @@ static const u16 sMawileLevelUpLearnset[] = {
     LEVEL_UP_MOVE(46, MOVE_STOCKPILE),
     LEVEL_UP_MOVE(46, MOVE_SWALLOW),
     LEVEL_UP_MOVE(46, MOVE_SPIT_UP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMedititeLevelUpLearnset[] = {
@@ -4768,7 +4768,7 @@ static const u16 sMedititeLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_PSYCH_UP),
     LEVEL_UP_MOVE(42, MOVE_REVERSAL),
     LEVEL_UP_MOVE(48, MOVE_RECOVER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMedichamLevelUpLearnset[] = {
@@ -4789,7 +4789,7 @@ static const u16 sMedichamLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_PSYCH_UP),
     LEVEL_UP_MOVE(46, MOVE_REVERSAL),
     LEVEL_UP_MOVE(54, MOVE_RECOVER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSwabluLevelUpLearnset[] = {
@@ -4804,7 +4804,7 @@ static const u16 sSwabluLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_MIRROR_MOVE),
     LEVEL_UP_MOVE(41, MOVE_REFRESH),
     LEVEL_UP_MOVE(48, MOVE_PERISH_SONG),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sAltariaLevelUpLearnset[] = {
@@ -4823,7 +4823,7 @@ static const u16 sAltariaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(45, MOVE_REFRESH),
     LEVEL_UP_MOVE(54, MOVE_PERISH_SONG),
     LEVEL_UP_MOVE(59, MOVE_SKY_ATTACK),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWynautLevelUpLearnset[] = {
@@ -4834,7 +4834,7 @@ static const u16 sWynautLevelUpLearnset[] = {
     LEVEL_UP_MOVE(15, MOVE_MIRROR_COAT),
     LEVEL_UP_MOVE(15, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(15, MOVE_DESTINY_BOND),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDuskullLevelUpLearnset[] = {
@@ -4849,7 +4849,7 @@ static const u16 sDuskullLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_WILL_O_WISP),
     LEVEL_UP_MOVE(45, MOVE_MEAN_LOOK),
     LEVEL_UP_MOVE(49, MOVE_FUTURE_SIGHT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDusclopsLevelUpLearnset[] = {
@@ -4867,7 +4867,7 @@ static const u16 sDusclopsLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_WILL_O_WISP),
     LEVEL_UP_MOVE(51, MOVE_MEAN_LOOK),
     LEVEL_UP_MOVE(58, MOVE_FUTURE_SIGHT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRoseliaLevelUpLearnset[] = {
@@ -4886,7 +4886,7 @@ static const u16 sRoseliaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(49, MOVE_PETAL_DANCE),
     LEVEL_UP_MOVE(53, MOVE_AROMATHERAPY),
     LEVEL_UP_MOVE(57, MOVE_SYNTHESIS),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSlakothLevelUpLearnset[] = {
@@ -4899,7 +4899,7 @@ static const u16 sSlakothLevelUpLearnset[] = {
     LEVEL_UP_MOVE(31, MOVE_COVET),
     LEVEL_UP_MOVE(37, MOVE_COUNTER),
     LEVEL_UP_MOVE(43, MOVE_FLAIL),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sVigorothLevelUpLearnset[] = {
@@ -4915,7 +4915,7 @@ static const u16 sVigorothLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_COUNTER),
     LEVEL_UP_MOVE(43, MOVE_FOCUS_PUNCH),
     LEVEL_UP_MOVE(49, MOVE_REVERSAL),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSlakingLevelUpLearnset[] = {
@@ -4931,7 +4931,7 @@ static const u16 sSlakingLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_SWAGGER),
     LEVEL_UP_MOVE(37, MOVE_COUNTER),
     LEVEL_UP_MOVE(43, MOVE_FLAIL),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGulpinLevelUpLearnset[] = {
@@ -4946,7 +4946,7 @@ static const u16 sGulpinLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_SPIT_UP),
     LEVEL_UP_MOVE(34, MOVE_SWALLOW),
     LEVEL_UP_MOVE(39, MOVE_SLUDGE_BOMB),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSwalotLevelUpLearnset[] = {
@@ -4965,7 +4965,7 @@ static const u16 sSwalotLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_SPIT_UP),
     LEVEL_UP_MOVE(40, MOVE_SWALLOW),
     LEVEL_UP_MOVE(48, MOVE_SLUDGE_BOMB),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sTropiusLevelUpLearnset[] = {
@@ -4980,7 +4980,7 @@ static const u16 sTropiusLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_BODY_SLAM),
     LEVEL_UP_MOVE(41, MOVE_SOLAR_BEAM),
     LEVEL_UP_MOVE(47, MOVE_SYNTHESIS),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sWhismurLevelUpLearnset[] = {
@@ -4995,7 +4995,7 @@ static const u16 sWhismurLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_REST),
     LEVEL_UP_MOVE(41, MOVE_SLEEP_TALK),
     LEVEL_UP_MOVE(45, MOVE_HYPER_VOICE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLoudredLevelUpLearnset[] = {
@@ -5013,7 +5013,7 @@ static const u16 sLoudredLevelUpLearnset[] = {
     LEVEL_UP_MOVE(51, MOVE_REST),
     LEVEL_UP_MOVE(51, MOVE_SLEEP_TALK),
     LEVEL_UP_MOVE(57, MOVE_HYPER_VOICE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sExploudLevelUpLearnset[] = {
@@ -5032,7 +5032,7 @@ static const u16 sExploudLevelUpLearnset[] = {
     LEVEL_UP_MOVE(55, MOVE_REST),
     LEVEL_UP_MOVE(55, MOVE_SLEEP_TALK),
     LEVEL_UP_MOVE(63, MOVE_HYPER_VOICE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sClamperlLevelUpLearnset[] = {
@@ -5040,7 +5040,7 @@ static const u16 sClamperlLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_WATER_GUN),
     LEVEL_UP_MOVE( 1, MOVE_WHIRLPOOL),
     LEVEL_UP_MOVE( 1, MOVE_IRON_DEFENSE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sHuntailLevelUpLearnset[] = {
@@ -5052,7 +5052,7 @@ static const u16 sHuntailLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_CRUNCH),
     LEVEL_UP_MOVE(43, MOVE_BATON_PASS),
     LEVEL_UP_MOVE(50, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGorebyssLevelUpLearnset[] = {
@@ -5064,7 +5064,7 @@ static const u16 sGorebyssLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_PSYCHIC),
     LEVEL_UP_MOVE(43, MOVE_BATON_PASS),
     LEVEL_UP_MOVE(50, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sAbsolLevelUpLearnset[] = {
@@ -5079,7 +5079,7 @@ static const u16 sAbsolLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_SLASH),
     LEVEL_UP_MOVE(41, MOVE_FUTURE_SIGHT),
     LEVEL_UP_MOVE(46, MOVE_PERISH_SONG),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sShuppetLevelUpLearnset[] = {
@@ -5093,7 +5093,7 @@ static const u16 sShuppetLevelUpLearnset[] = {
     LEVEL_UP_MOVE(44, MOVE_SHADOW_BALL),
     LEVEL_UP_MOVE(49, MOVE_SNATCH),
     LEVEL_UP_MOVE(56, MOVE_GRUDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sBanetteLevelUpLearnset[] = {
@@ -5110,7 +5110,7 @@ static const u16 sBanetteLevelUpLearnset[] = {
     LEVEL_UP_MOVE(48, MOVE_SHADOW_BALL),
     LEVEL_UP_MOVE(55, MOVE_SNATCH),
     LEVEL_UP_MOVE(64, MOVE_GRUDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSeviperLevelUpLearnset[] = {
@@ -5124,7 +5124,7 @@ static const u16 sSeviperLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_POISON_FANG),
     LEVEL_UP_MOVE(37, MOVE_SWAGGER),
     LEVEL_UP_MOVE(43, MOVE_HAZE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sZangooseLevelUpLearnset[] = {
@@ -5139,7 +5139,7 @@ static const u16 sZangooseLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_TAUNT),
     LEVEL_UP_MOVE(46, MOVE_DETECT),
     LEVEL_UP_MOVE(55, MOVE_FALSE_SWIPE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRelicanthLevelUpLearnset[] = {
@@ -5154,7 +5154,7 @@ static const u16 sRelicanthLevelUpLearnset[] = {
     LEVEL_UP_MOVE(50, MOVE_REST),
     LEVEL_UP_MOVE(57, MOVE_DOUBLE_EDGE),
     LEVEL_UP_MOVE(64, MOVE_HYDRO_PUMP),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sAronLevelUpLearnset[] = {
@@ -5170,7 +5170,7 @@ static const u16 sAronLevelUpLearnset[] = {
     LEVEL_UP_MOVE(34, MOVE_PROTECT),
     LEVEL_UP_MOVE(39, MOVE_METAL_SOUND),
     LEVEL_UP_MOVE(44, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLaironLevelUpLearnset[] = {
@@ -5189,7 +5189,7 @@ static const u16 sLaironLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_PROTECT),
     LEVEL_UP_MOVE(45, MOVE_METAL_SOUND),
     LEVEL_UP_MOVE(53, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sAggronLevelUpLearnset[] = {
@@ -5208,7 +5208,7 @@ static const u16 sAggronLevelUpLearnset[] = {
     LEVEL_UP_MOVE(37, MOVE_PROTECT),
     LEVEL_UP_MOVE(50, MOVE_METAL_SOUND),
     LEVEL_UP_MOVE(63, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCastformLevelUpLearnset[] = {
@@ -5220,7 +5220,7 @@ static const u16 sCastformLevelUpLearnset[] = {
     LEVEL_UP_MOVE(20, MOVE_SUNNY_DAY),
     LEVEL_UP_MOVE(20, MOVE_HAIL),
     LEVEL_UP_MOVE(30, MOVE_WEATHER_BALL),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sVolbeatLevelUpLearnset[] = {
@@ -5234,7 +5234,7 @@ static const u16 sVolbeatLevelUpLearnset[] = {
     LEVEL_UP_MOVE(29, MOVE_PROTECT),
     LEVEL_UP_MOVE(33, MOVE_HELPING_HAND),
     LEVEL_UP_MOVE(37, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sIllumiseLevelUpLearnset[] = {
@@ -5248,7 +5248,7 @@ static const u16 sIllumiseLevelUpLearnset[] = {
     LEVEL_UP_MOVE(29, MOVE_FLATTER),
     LEVEL_UP_MOVE(33, MOVE_HELPING_HAND),
     LEVEL_UP_MOVE(37, MOVE_COVET),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLileepLevelUpLearnset[] = {
@@ -5262,7 +5262,7 @@ static const u16 sLileepLevelUpLearnset[] = {
     LEVEL_UP_MOVE(50, MOVE_STOCKPILE),
     LEVEL_UP_MOVE(50, MOVE_SPIT_UP),
     LEVEL_UP_MOVE(50, MOVE_SWALLOW),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sCradilyLevelUpLearnset[] = {
@@ -5279,7 +5279,7 @@ static const u16 sCradilyLevelUpLearnset[] = {
     LEVEL_UP_MOVE(60, MOVE_STOCKPILE),
     LEVEL_UP_MOVE(60, MOVE_SPIT_UP),
     LEVEL_UP_MOVE(60, MOVE_SWALLOW),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sAnorithLevelUpLearnset[] = {
@@ -5293,7 +5293,7 @@ static const u16 sAnorithLevelUpLearnset[] = {
     LEVEL_UP_MOVE(43, MOVE_FURY_CUTTER),
     LEVEL_UP_MOVE(49, MOVE_SLASH),
     LEVEL_UP_MOVE(55, MOVE_ROCK_BLAST),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sArmaldoLevelUpLearnset[] = {
@@ -5310,7 +5310,7 @@ static const u16 sArmaldoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(46, MOVE_FURY_CUTTER),
     LEVEL_UP_MOVE(55, MOVE_SLASH),
     LEVEL_UP_MOVE(64, MOVE_ROCK_BLAST),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRaltsLevelUpLearnset[] = {
@@ -5324,7 +5324,7 @@ static const u16 sRaltsLevelUpLearnset[] = {
     LEVEL_UP_MOVE(36, MOVE_FUTURE_SIGHT),
     LEVEL_UP_MOVE(41, MOVE_HYPNOSIS),
     LEVEL_UP_MOVE(46, MOVE_DREAM_EATER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sKirliaLevelUpLearnset[] = {
@@ -5341,7 +5341,7 @@ static const u16 sKirliaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_FUTURE_SIGHT),
     LEVEL_UP_MOVE(47, MOVE_HYPNOSIS),
     LEVEL_UP_MOVE(54, MOVE_DREAM_EATER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGardevoirLevelUpLearnset[] = {
@@ -5358,7 +5358,7 @@ static const u16 sGardevoirLevelUpLearnset[] = {
     LEVEL_UP_MOVE(42, MOVE_FUTURE_SIGHT),
     LEVEL_UP_MOVE(51, MOVE_HYPNOSIS),
     LEVEL_UP_MOVE(60, MOVE_DREAM_EATER),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sBagonLevelUpLearnset[] = {
@@ -5373,7 +5373,7 @@ static const u16 sBagonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(41, MOVE_CRUNCH),
     LEVEL_UP_MOVE(49, MOVE_DRAGON_CLAW),
     LEVEL_UP_MOVE(53, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sShelgonLevelUpLearnset[] = {
@@ -5392,7 +5392,7 @@ static const u16 sShelgonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(56, MOVE_CRUNCH),
     LEVEL_UP_MOVE(69, MOVE_DRAGON_CLAW),
     LEVEL_UP_MOVE(78, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sSalamenceLevelUpLearnset[] = {
@@ -5412,12 +5412,12 @@ static const u16 sSalamenceLevelUpLearnset[] = {
     LEVEL_UP_MOVE(61, MOVE_CRUNCH),
     LEVEL_UP_MOVE(79, MOVE_DRAGON_CLAW),
     LEVEL_UP_MOVE(93, MOVE_DOUBLE_EDGE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sBeldumLevelUpLearnset[] = {
     LEVEL_UP_MOVE( 1, MOVE_TAKE_DOWN),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMetangLevelUpLearnset[] = {
@@ -5431,7 +5431,7 @@ static const u16 sMetangLevelUpLearnset[] = {
     LEVEL_UP_MOVE(50, MOVE_METEOR_MASH),
     LEVEL_UP_MOVE(56, MOVE_AGILITY),
     LEVEL_UP_MOVE(62, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sMetagrossLevelUpLearnset[] = {
@@ -5448,7 +5448,7 @@ static const u16 sMetagrossLevelUpLearnset[] = {
     LEVEL_UP_MOVE(55, MOVE_METEOR_MASH),
     LEVEL_UP_MOVE(66, MOVE_AGILITY),
     LEVEL_UP_MOVE(77, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRegirockLevelUpLearnset[] = {
@@ -5461,7 +5461,7 @@ static const u16 sRegirockLevelUpLearnset[] = {
     LEVEL_UP_MOVE(49, MOVE_ZAP_CANNON),
     LEVEL_UP_MOVE(57, MOVE_LOCK_ON),
     LEVEL_UP_MOVE(65, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRegiceLevelUpLearnset[] = {
@@ -5474,7 +5474,7 @@ static const u16 sRegiceLevelUpLearnset[] = {
     LEVEL_UP_MOVE(49, MOVE_ZAP_CANNON),
     LEVEL_UP_MOVE(57, MOVE_LOCK_ON),
     LEVEL_UP_MOVE(65, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRegisteelLevelUpLearnset[] = {
@@ -5488,7 +5488,7 @@ static const u16 sRegisteelLevelUpLearnset[] = {
     LEVEL_UP_MOVE(49, MOVE_ZAP_CANNON),
     LEVEL_UP_MOVE(57, MOVE_LOCK_ON),
     LEVEL_UP_MOVE(65, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sKyogreLevelUpLearnset[] = {
@@ -5503,7 +5503,7 @@ static const u16 sKyogreLevelUpLearnset[] = {
     LEVEL_UP_MOVE(60, MOVE_SHEER_COLD),
     LEVEL_UP_MOVE(65, MOVE_DOUBLE_EDGE),
     LEVEL_UP_MOVE(75, MOVE_WATER_SPOUT),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sGroudonLevelUpLearnset[] = {
@@ -5518,7 +5518,7 @@ static const u16 sGroudonLevelUpLearnset[] = {
     LEVEL_UP_MOVE(60, MOVE_FISSURE),
     LEVEL_UP_MOVE(65, MOVE_SOLAR_BEAM),
     LEVEL_UP_MOVE(75, MOVE_ERUPTION),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sRayquazaLevelUpLearnset[] = {
@@ -5533,7 +5533,7 @@ static const u16 sRayquazaLevelUpLearnset[] = {
     LEVEL_UP_MOVE(60, MOVE_EXTREME_SPEED),
     LEVEL_UP_MOVE(65, MOVE_OUTRAGE),
     LEVEL_UP_MOVE(75, MOVE_HYPER_BEAM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLatiasLevelUpLearnset[] = {
@@ -5548,7 +5548,7 @@ static const u16 sLatiasLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_PSYCHIC),
     LEVEL_UP_MOVE(45, MOVE_RECOVER),
     LEVEL_UP_MOVE(50, MOVE_CHARM),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sLatiosLevelUpLearnset[] = {
@@ -5563,7 +5563,7 @@ static const u16 sLatiosLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_PSYCHIC),
     LEVEL_UP_MOVE(45, MOVE_RECOVER),
     LEVEL_UP_MOVE(50, MOVE_DRAGON_DANCE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sJirachiLevelUpLearnset[] = {
@@ -5579,7 +5579,7 @@ static const u16 sJirachiLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_FUTURE_SIGHT),
     LEVEL_UP_MOVE(45, MOVE_COSMIC_POWER),
     LEVEL_UP_MOVE(50, MOVE_DOOM_DESIRE),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sDeoxysLevelUpLearnset[] = {
@@ -5595,7 +5595,7 @@ static const u16 sDeoxysLevelUpLearnset[] = {
     LEVEL_UP_MOVE(40, MOVE_RECOVER),
     LEVEL_UP_MOVE(45, MOVE_PSYCHO_BOOST),
     LEVEL_UP_MOVE(50, MOVE_EXTREME_SPEED),
-    LEVEL_UP_END
+    0xFFFF
 };
 
 static const u16 sChimechoLevelUpLearnset[] = {
@@ -5611,5 +5611,5 @@ static const u16 sChimechoLevelUpLearnset[] = {
     LEVEL_UP_MOVE(38, MOVE_HEAL_BELL),
     LEVEL_UP_MOVE(41, MOVE_SAFEGUARD),
     LEVEL_UP_MOVE(46, MOVE_PSYCHIC),
-    LEVEL_UP_END
+    0xFFFF
 };

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3326,14 +3326,14 @@ void GiveBoxMonInitialMoveset(struct BoxPokemon *boxMon)
         u16 moveLevel;
         u16 move;
 
-        moveLevel = (gLevelUpLearnsets[species][i] & 0xFE00);
+        moveLevel = (gLevelUpLearnsets[species][i] & LEVEL_UP_LEVEL_MASK);
 
-        if (moveLevel > (level << 9))
+        if (moveLevel > LEVEL_UP_NUM_AS_LEVEL(level))
             break;
 
-        move = (gLevelUpLearnsets[species][i] & 0x1FF);
+        move = LEVEL_UP_GET_MOVE(gLevelUpLearnsets[species][i]);
 
-        if (GiveMoveToBoxMon(boxMon, move) == 0xFFFF)
+        if (GiveMoveToBoxMon(boxMon, move) == LEVEL_UP_END)
             DeleteFirstMoveAndGiveMoveToBoxMon(boxMon, move);
     }
 }
@@ -3352,7 +3352,7 @@ u16 MonTryLearningNewMove(struct Pokemon *mon, bool8 firstMove)
     {
         sLearningMoveTableID = 0;
 
-        while ((gLevelUpLearnsets[species][sLearningMoveTableID] & 0xFE00) != (level << 9))
+        while ((gLevelUpLearnsets[species][sLearningMoveTableID] & LEVEL_UP_LEVEL_MASK) != LEVEL_UP_NUM_AS_LEVEL(level))
         {
             sLearningMoveTableID++;
             if (gLevelUpLearnsets[species][sLearningMoveTableID] == LEVEL_UP_END)
@@ -3360,9 +3360,9 @@ u16 MonTryLearningNewMove(struct Pokemon *mon, bool8 firstMove)
         }
     }
 
-    if ((gLevelUpLearnsets[species][sLearningMoveTableID] & 0xFE00) == (level << 9))
+    if ((gLevelUpLearnsets[species][sLearningMoveTableID] & LEVEL_UP_LEVEL_MASK) == LEVEL_UP_NUM_AS_LEVEL(level))
     {
-        gMoveToLearn = (gLevelUpLearnsets[species][sLearningMoveTableID] & 0x1FF);
+        gMoveToLearn = LEVEL_UP_GET_MOVE(gLevelUpLearnsets[species][sLearningMoveTableID]);
         sLearningMoveTableID++;
         retVal = GiveMoveToMon(mon, gMoveToLearn);
     }
@@ -6487,23 +6487,23 @@ u8 GetMoveRelearnerMoves(struct Pokemon *mon, u16 *moves)
     {
         u16 moveLevel;
 
-        if (gLevelUpLearnsets[species][i] == 0xFFFF)
+        if (gLevelUpLearnsets[species][i] == LEVEL_UP_END)
             break;
 
-        moveLevel = gLevelUpLearnsets[species][i] & 0xFE00;
+        moveLevel = gLevelUpLearnsets[species][i] & LEVEL_UP_LEVEL_MASK;
 
-        if (moveLevel <= (level << 9))
+        if (moveLevel <= LEVEL_UP_NUM_AS_LEVEL(level))
         {
-            for (j = 0; j < MAX_MON_MOVES && learnedMoves[j] != (gLevelUpLearnsets[species][i] & 0x1FF); j++)
+            for (j = 0; j < MAX_MON_MOVES && learnedMoves[j] != LEVEL_UP_GET_MOVE(gLevelUpLearnsets[species][i]); j++)
                 ;
 
             if (j == MAX_MON_MOVES)
             {
-                for (k = 0; k < numMoves && moves[k] != (gLevelUpLearnsets[species][i] & 0x1FF); k++)
+                for (k = 0; k < numMoves && moves[k] != LEVEL_UP_GET_MOVE(gLevelUpLearnsets[species][i]); k++)
                     ;
 
                 if (k == numMoves)
-                    moves[numMoves++] = gLevelUpLearnsets[species][i] & 0x1FF;
+                    moves[numMoves++] = LEVEL_UP_GET_MOVE(gLevelUpLearnsets[species][i]);
             }
         }
     }
@@ -6516,8 +6516,8 @@ u8 GetLevelUpMovesBySpecies(u16 species, u16 *moves)
     u8 numMoves = 0;
     int i;
 
-    for (i = 0; i < 20 && gLevelUpLearnsets[species][i] != 0xFFFF; i++)
-         moves[numMoves++] = gLevelUpLearnsets[species][i] & 0x1FF;
+    for (i = 0; i < 20 && gLevelUpLearnsets[species][i] != LEVEL_UP_END; i++)
+         moves[numMoves++] = LEVEL_UP_GET_MOVE(gLevelUpLearnsets[species][i]);
 
      return numMoves;
 }
@@ -6541,23 +6541,23 @@ u8 GetNumberOfRelearnableMoves(struct Pokemon *mon)
     {
         u16 moveLevel;
 
-        if (gLevelUpLearnsets[species][i] == 0xFFFF)
+        if (gLevelUpLearnsets[species][i] == LEVEL_UP_END)
             break;
 
-        moveLevel = gLevelUpLearnsets[species][i] & 0xFE00;
+        moveLevel = gLevelUpLearnsets[species][i] & LEVEL_UP_LEVEL_MASK;
 
-        if (moveLevel <= (level << 9))
+        if (moveLevel <= LEVEL_UP_NUM_AS_LEVEL(level))
         {
-            for (j = 0; j < MAX_MON_MOVES && learnedMoves[j] != (gLevelUpLearnsets[species][i] & 0x1FF); j++)
+            for (j = 0; j < MAX_MON_MOVES && learnedMoves[j] != LEVEL_UP_GET_MOVE(gLevelUpLearnsets[species][i]); j++)
                 ;
 
             if (j == MAX_MON_MOVES)
             {
-                for (k = 0; k < numMoves && moves[k] != (gLevelUpLearnsets[species][i] & 0x1FF); k++)
+                for (k = 0; k < numMoves && moves[k] != LEVEL_UP_GET_MOVE(gLevelUpLearnsets[species][i]); k++)
                     ;
 
                 if (k == numMoves)
-                    moves[numMoves++] = gLevelUpLearnsets[species][i] & 0x1FF;
+                    moves[numMoves++] = LEVEL_UP_GET_MOVE(gLevelUpLearnsets[species][i]);
             }
         }
     }

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3321,7 +3321,7 @@ void GiveBoxMonInitialMoveset(struct BoxPokemon *boxMon)
     s32 level = GetLevelFromBoxMonExp(boxMon);
     s32 i;
 
-    for (i = 0; gLevelUpLearnsets[species][i] != LEVEL_UP_END; i++)
+    for (i = 0; gLevelUpLearnsets[species][i] != 0xFFFF; i++)
     {
         u16 moveLevel;
         u16 move;
@@ -3333,7 +3333,7 @@ void GiveBoxMonInitialMoveset(struct BoxPokemon *boxMon)
 
         move = LEVEL_UP_GET_MOVE(gLevelUpLearnsets[species][i]);
 
-        if (GiveMoveToBoxMon(boxMon, move) == LEVEL_UP_END)
+        if (GiveMoveToBoxMon(boxMon, move) == 0xFFFF)
             DeleteFirstMoveAndGiveMoveToBoxMon(boxMon, move);
     }
 }
@@ -3355,7 +3355,7 @@ u16 MonTryLearningNewMove(struct Pokemon *mon, bool8 firstMove)
         while ((gLevelUpLearnsets[species][sLearningMoveTableID] & LEVEL_UP_LEVEL_MASK) != LEVEL_UP_NUM_AS_LEVEL(level))
         {
             sLearningMoveTableID++;
-            if (gLevelUpLearnsets[species][sLearningMoveTableID] == LEVEL_UP_END)
+            if (gLevelUpLearnsets[species][sLearningMoveTableID] == 0xFFFF)
                 return 0;
         }
     }
@@ -6487,7 +6487,7 @@ u8 GetMoveRelearnerMoves(struct Pokemon *mon, u16 *moves)
     {
         u16 moveLevel;
 
-        if (gLevelUpLearnsets[species][i] == LEVEL_UP_END)
+        if (gLevelUpLearnsets[species][i] == 0xFFFF)
             break;
 
         moveLevel = gLevelUpLearnsets[species][i] & LEVEL_UP_LEVEL_MASK;
@@ -6516,7 +6516,7 @@ u8 GetLevelUpMovesBySpecies(u16 species, u16 *moves)
     u8 numMoves = 0;
     int i;
 
-    for (i = 0; i < 20 && gLevelUpLearnsets[species][i] != LEVEL_UP_END; i++)
+    for (i = 0; i < 20 && gLevelUpLearnsets[species][i] != 0xFFFF; i++)
          moves[numMoves++] = LEVEL_UP_GET_MOVE(gLevelUpLearnsets[species][i]);
 
      return numMoves;
@@ -6541,7 +6541,7 @@ u8 GetNumberOfRelearnableMoves(struct Pokemon *mon)
     {
         u16 moveLevel;
 
-        if (gLevelUpLearnsets[species][i] == LEVEL_UP_END)
+        if (gLevelUpLearnsets[species][i] == 0xFFFF)
             break;
 
         moveLevel = gLevelUpLearnsets[species][i] & LEVEL_UP_LEVEL_MASK;


### PR DESCRIPTION
I'm open to possible name changes, particularly the prefix. `LEVEL_UP_*` isn't great, but I couldn't think of a better one, so I stuck with the original.