### PR TITLE
Overhaul scaninc to work recursively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ $(ASM_BUILDDIR)/%.o: $(ASM_SUBDIR)/%.s $$(asm_dep)
 ifeq ($(NODEP),1)
 $(DATA_ASM_BUILDDIR)/%.o: data_dep :=
 else
-$(DATA_ASM_BUILDDIR)/%.o: data_dep = $(shell $(SCANINC) $(DATA_ASM_SUBDIR)/$*.s)
+$(DATA_ASM_BUILDDIR)/%.o: data_dep = $(shell $(SCANINC) -I include $(DATA_ASM_SUBDIR)/$*.s)
 endif
 
 $(DATA_ASM_BUILDDIR)/%.o: $(DATA_ASM_SUBDIR)/%.s $$(data_dep)

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ $(C_BUILDDIR)/%.o : $(C_SUBDIR)/%.c $$(c_dep)
 ifeq ($(NODEP),1)
 $(ASM_BUILDDIR)/%.o: asm_dep :=
 else
-$(ASM_BUILDDIR)/%.o: asm_dep = $(shell $(SCANINC) $(ASM_SUBDIR)/$*.s)
+$(ASM_BUILDDIR)/%.o: asm_dep = $(shell $(SCANINC) -I "" $(ASM_SUBDIR)/$*.s)
 endif
 
 $(ASM_BUILDDIR)/%.o: $(ASM_SUBDIR)/%.s $$(asm_dep)
@@ -168,7 +168,7 @@ $(ASM_BUILDDIR)/%.o: $(ASM_SUBDIR)/%.s $$(asm_dep)
 ifeq ($(NODEP),1)
 $(DATA_ASM_BUILDDIR)/%.o: data_dep :=
 else
-$(DATA_ASM_BUILDDIR)/%.o: data_dep = $(shell $(SCANINC) -I include $(DATA_ASM_SUBDIR)/$*.s)
+$(DATA_ASM_BUILDDIR)/%.o: data_dep = $(shell $(SCANINC) -I include -I "" $(DATA_ASM_SUBDIR)/$*.s)
 endif
 
 $(DATA_ASM_BUILDDIR)/%.o: $(DATA_ASM_SUBDIR)/%.s $$(data_dep)

--- a/src/field_message_box.c
+++ b/src/field_message_box.c
@@ -1,6 +1,6 @@
+#include <string.h>
 #include "global.h"
 #include "menu.h"
-#include "string.h"
 #include "string_util.h"
 #include "task.h"
 #include "text.h"

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "global.h"
 #include "item_menu.h"
 #include "battle.h"
@@ -40,7 +41,6 @@
 #include "shop.h"
 #include "sound.h"
 #include "sprite.h"
-#include "string.h"
 #include "strings.h"
 #include "string_util.h"
 #include "task.h"

--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "global.h"
 #include "trainer_pokemon_sprites.h"
 #include "bg.h"
@@ -30,7 +31,6 @@
 #include "scanline_effect.h"
 #include "sound.h"
 #include "sprite.h"
-#include "string.h"
 #include "strings.h"
 #include "string_util.h"
 #include "task.h"

--- a/tools/scaninc/Makefile
+++ b/tools/scaninc/Makefile
@@ -2,9 +2,9 @@ CXX = g++
 
 CXXFLAGS = -Wall -Werror -std=c++11 -O2
 
-SRCS = scaninc.cpp c_file.cpp asm_file.cpp
+SRCS = scaninc.cpp c_file.cpp asm_file.cpp source_file.cpp
 
-HEADERS := scaninc.h asm_file.h c_file.h
+HEADERS := scaninc.h asm_file.h c_file.h source_file.h
 
 .PHONY: clean
 

--- a/tools/scaninc/asm_file.cpp
+++ b/tools/scaninc/asm_file.cpp
@@ -64,7 +64,8 @@ IncDirectiveType AsmFile::ReadUntilIncDirective(std::string &path)
 
         IncDirectiveType incDirectiveType = IncDirectiveType::None;
 
-        if (PeekChar() == '.')
+        char c = PeekChar();
+        if (c == '.' || c == '#')
         {
             m_pos++;
 

--- a/tools/scaninc/scaninc.cpp
+++ b/tools/scaninc/scaninc.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv)
                 argv++;
                 includeDir = std::string(argv[0]);
             }
-            if (includeDir.back() != '/')
+            if (!includeDir.empty() && includeDir.back() != '/')
             {
                 includeDir += '/';
             }

--- a/tools/scaninc/scaninc.h
+++ b/tools/scaninc/scaninc.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2019 Phlosioneer
+// Copyright(c) 2015-2017 YamaArashi
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/tools/scaninc/scaninc.h
+++ b/tools/scaninc/scaninc.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2015-2017 YamaArashi
+// Copyright(c) 2019 Phlosioneer
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/tools/scaninc/source_file.cpp
+++ b/tools/scaninc/source_file.cpp
@@ -1,0 +1,125 @@
+// Copyright(c) 2019 Phlosioneer
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <new>
+#include "source_file.h"
+
+
+SourceFileType GetFileType(std::string& path)
+{
+    std::size_t pos = path.find_last_of('.');
+
+    if (pos == std::string::npos)
+        FATAL_ERROR("no file extension in path \"%s\"\n", path.c_str());
+
+    std::string extension = path.substr(pos + 1);
+
+    if (extension == "c")
+        return SourceFileType::Cpp;
+    else if (extension == "s")
+        return SourceFileType::Asm;
+    else if (extension == "h")
+        return SourceFileType::Header;
+    else if (extension == "inc")
+        return SourceFileType::Inc;
+    else
+        FATAL_ERROR("Unrecognized extension \"%s\"\n", extension.c_str());
+    
+    // Unreachable
+    return SourceFileType::Cpp;
+}
+
+std::string GetDir(std::string& path)
+{
+    std::size_t slash = path.rfind('/');
+
+    if (slash != std::string::npos)
+        return path.substr(0, slash + 1);
+    else
+        return std::string("");
+}
+
+SourceFile::SourceFile(std::string path)
+{
+    m_file_type = GetFileType(path);
+
+    m_src_dir = GetDir(path);
+
+    if (m_file_type == SourceFileType::Cpp
+            || m_file_type == SourceFileType::Header)
+    {
+        new (&m_source_file.c_file) CFile(path);
+        m_source_file.c_file.FindIncbins();
+    }
+    else
+    {
+        AsmFile file(path);
+        std::set<std::string> incbins;
+        std::set<std::string> includes;
+
+        IncDirectiveType incDirectiveType;
+        std::string outputPath;
+
+        while ((incDirectiveType = file.ReadUntilIncDirective(outputPath)) != IncDirectiveType::None)
+        {
+            if (incDirectiveType == IncDirectiveType::Include)
+                includes.insert(outputPath);
+            else
+                incbins.insert(outputPath);
+        }
+        
+        new (&m_source_file.asm_wrapper) SourceFile::InnerUnion::AsmWrapper{incbins, includes};
+    }
+}
+
+SourceFile::~SourceFile()
+{
+    if (m_file_type == SourceFileType::Cpp || m_file_type == SourceFileType::Header)
+    {
+        m_source_file.c_file.~CFile();
+    }
+    else
+    {
+        m_source_file.asm_wrapper.asm_incbins.~set();
+        m_source_file.asm_wrapper.asm_includes.~set();
+    }
+}
+
+const std::set<std::string>& SourceFile::GetIncbins()
+{
+    if (m_file_type == SourceFileType::Cpp || m_file_type == SourceFileType::Header)
+        return m_source_file.c_file.GetIncbins();
+    else
+        return m_source_file.asm_wrapper.asm_incbins;
+}
+
+const std::set<std::string>& SourceFile::GetIncludes()
+{
+    if (m_file_type == SourceFileType::Cpp || m_file_type == SourceFileType::Header)
+        return m_source_file.c_file.GetIncludes();
+    else
+        return m_source_file.asm_wrapper.asm_includes;
+}
+
+std::string& SourceFile::GetSrcDir()
+{
+    return m_src_dir;
+}
+

--- a/tools/scaninc/source_file.h
+++ b/tools/scaninc/source_file.h
@@ -1,0 +1,71 @@
+// Copyright(c) 2015-2017 YamaArashi
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef SOURCE_FILE_H
+#define SOURCE_FILE_H
+
+#include <string>
+#include "scaninc.h"
+#include "asm_file.h"
+#include "c_file.h"
+
+enum class SourceFileType
+{
+    Cpp,
+    Header,
+    Asm,
+    Inc
+};
+
+SourceFileType GetFileType(std::string& path);
+
+class SourceFile
+{
+public:
+
+    SourceFile(std::string path);
+    ~SourceFile();
+    SourceFile(SourceFile const&) = delete;
+    SourceFile(SourceFile&&) = delete;
+    SourceFile& operator =(SourceFile const&) = delete;
+    SourceFile& operator =(SourceFile&&) = delete;
+    bool HasIncbins();
+    const std::set<std::string>& GetIncbins();
+    const std::set<std::string>& GetIncludes();
+    std::string& GetSrcDir();
+
+private:
+    union InnerUnion {
+        CFile c_file;
+        struct AsmWrapper {
+            std::set<std::string> asm_incbins;
+            std::set<std::string> asm_includes;
+        } asm_wrapper;
+
+        // Construction and destruction handled by SourceFile.
+        InnerUnion() {};
+        ~InnerUnion() {};
+    } m_source_file;
+    SourceFileType m_file_type;
+    std::string m_src_dir;
+};
+
+#endif // SOURCE_FILE_H
+

--- a/tools/scaninc/source_file.h
+++ b/tools/scaninc/source_file.h
@@ -1,4 +1,4 @@
-// Copyright(c) 2015-2017 YamaArashi
+// Copyright(c) 2019 Phlosioneer
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This also fixes the bug where scaninc would ignore #include lines
in assembly files.

This is a followup on #565 