### PR TITLE
Fix make to look for .json files instead of folders

### DIFF
--- a/map_data_rules.mk
+++ b/map_data_rules.mk
@@ -3,7 +3,7 @@
 MAPS_DIR = $(DATA_ASM_SUBDIR)/maps
 LAYOUTS_DIR = $(DATA_ASM_SUBDIR)/layouts
 
-MAP_DIRS := $(dir $(wildcard $(MAPS_DIR)/*/))
+MAP_DIRS := $(dir $(wildcard $(MAPS_DIR)/*/map.json))
 MAP_CONNECTIONS := $(patsubst $(MAPS_DIR)/%/,$(MAPS_DIR)/%/connections.inc,$(MAP_DIRS))
 MAP_EVENTS := $(patsubst $(MAPS_DIR)/%/,$(MAPS_DIR)/%/events.inc,$(MAP_DIRS))
 MAP_HEADERS := $(patsubst $(MAPS_DIR)/%/,$(MAPS_DIR)/%/header.inc,$(MAP_DIRS))


### PR DESCRIPTION
Currently, when Make is building the maps, it considers every
folder in the data/maps/ directory as a map that needs to be built,
even folders that are empty. This can be a problem when modding on
a separate branch, because git doesn't always clean up directories
when switching branches (usually because of hidden files in those
directories), so switching back to an unmodded branch will leave
an empty folder that confuses make.

This commit changes the makefile so that it only checks directories
that have map.json files in them.