### PR TITLE
add troubleshooting line in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,6 +66,14 @@ cd ../pokeemerald
 
 And build the ROM with `make`.
 
+If the step `./build.sh` in the above list of commands fails with the error `Makefile:1: /opt/devkitpro/devkitARM/base_tools: No such file or directory`, then try installing the pacman package `devkitarm-rules` by executing the command
+
+```
+sudo dkp-pacman -S devkitarm-rules
+```
+
+Executing `./build.sh` again should now succeed.
+
 # Faster builds
 
 After the first build, subsequent builds are faster. You can further speed up the build:


### PR DESCRIPTION
While following the instructions for macos (i have sierra) in INSTALL.md, agbcc/build.sh failed, complaining it couldn't find the /opt/devkitpro/devkitARM/base_tools file. After a bit of research, i found out this file is in the devkitarm-rules package (in the devkitpro repos for pacman). Since installing this package fixes the problem, i added some troubleshooting instructions for it in INSTALL.md.