### PR TITLE
Speed up the game

### DIFF
--- a/asm/crt0.s
+++ b/asm/crt0.s
@@ -98,7 +98,7 @@ Init: @ 8000204
 
 	.align 2, 0
 sp_sys: .word IWRAM_END - 0x1c0
-sp_irq: .word IWRAM_END - 0x60
+sp_irq: .word 0203FFF0
 
 	.pool
 


### PR DESCRIPTION
Setting stack in EWRAM as opposed to IWRAM has many benefits, the most important of course being the game running even 2x faster! Forget about lag and enjoy the smooth gaming experience.

https://hastebin.com/godifayeki.nginx