### PR TITLE
[WIP] Add debug output if scaninc dependency fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,29 @@ endif
 $(DATA_ASM_BUILDDIR)/%.o: $(DATA_ASM_SUBDIR)/%.s $$(data_dep)
 	$(PREPROC) $< charmap.txt | $(CPP) -I include | $(AS) $(ASFLAGS) -o $@
 
+#If a file cannot be built we execute a debug rule to see which dependency failed
+$(DATA_ASM_BUILDDIR)/%.o: $(DATA_ASM_SUBDIR)/%.s
+	@for file in $$($(SCANINC) -I include -I "" $<) ; do \
+		make -s --dry-run $$file ; \
+	done
+	@echo "Failed to build dependencies for $<"
+	exit 1
+
+$(ASM_BUILDDIR)/%.o: $(ASM_SUBDIR)/%.s
+	@for file in $$($(SCANINC) -I include -I "" $<) ; do \
+		make -s --dry-run $$file ; \
+	done
+	@echo "Failed to build dependencies for $<"
+	exit 1
+
+$(C_BUILDDIR)/%.o: $(C_SUBDIR)/%.s
+	@for file in $$($(SCANINC) -I include -I "" $<) ; do \
+		make -s --dry-run $$file ; \
+	done
+	@echo "Failed to build dependencies for $<"
+	exit 1
+
+
 $(SONG_BUILDDIR)/%.o: $(SONG_SUBDIR)/%.s
 	$(AS) $(ASFLAGS) -I sound -o $@ $<
 


### PR DESCRIPTION
Normally if a dependency injected by scaninc fails, the error message issued by `make` is very misleading, as it only talks about the root file. This PR adds fallback rules that issue more detailed errors about the actual file that was not found, as well as the root file that was the actual build target.