### PR TITLE
Make nonmatching PSS functions functionally equivalent

### DIFF
--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -6936,10 +6936,24 @@ static u8 InBoxInput_Normal(void)
     sPSSData->field_CD2 = 0;
     sPSSData->field_CD3 = 0;
     sPSSData->field_CD7 = 0;
-    retVal = 0;
-    if (!(gMain.newAndRepeatedKeys & DPAD_UP))
+
+    do
     {
-        if (gMain.newAndRepeatedKeys & DPAD_DOWN)
+        if (gMain.newAndRepeatedKeys & DPAD_UP)
+        {
+            retVal = TRUE;
+            if (sBoxCursorPosition >= IN_BOX_ROWS)
+            {
+                cursorPosition -= IN_BOX_ROWS;
+            }
+            else
+            {
+                cursorArea = CURSOR_AREA_BOX;
+                cursorPosition = 0;
+            }
+            break;
+        }
+        else if (gMain.newAndRepeatedKeys & DPAD_DOWN)
         {
             retVal = TRUE;
             cursorPosition += IN_BOX_ROWS;
@@ -6951,6 +6965,7 @@ static u8 InBoxInput_Normal(void)
                 sPSSData->field_CD2 = 1;
                 sPSSData->field_CD7 = 1;
             }
+            break;
         }
         else if (gMain.newAndRepeatedKeys & DPAD_LEFT)
         {
@@ -6964,6 +6979,7 @@ static u8 InBoxInput_Normal(void)
                 sPSSData->field_CD3 = -1;
                 cursorPosition += (IN_BOX_ROWS - 1);
             }
+            break;
         }
         else if (gMain.newAndRepeatedKeys & DPAD_RIGHT)
         {
@@ -6977,81 +6993,70 @@ static u8 InBoxInput_Normal(void)
                 sPSSData->field_CD3 = 1;
                 cursorPosition -= (IN_BOX_ROWS - 1);
             }
+            break;
         }
         else if (gMain.newKeys & START_BUTTON)
         {
             retVal = TRUE;
             cursorArea = CURSOR_AREA_BOX;
             cursorPosition = 0;
+            break;
         }
-        else
-        {
-            if ((gMain.newKeys & A_BUTTON) && sub_80CFA5C())
-            {
-                if (!sCanOnlyMove)
-                    return 8;
 
-                if (sPSSData->boxOption == BOX_OPTION_MOVE_MONS || sIsMonBeingMoved == TRUE)
+        if ((gMain.newKeys & A_BUTTON) && sub_80CFA5C())
+        {
+            if (!sCanOnlyMove)
+                return 8;
+
+            if (sPSSData->boxOption != BOX_OPTION_MOVE_MONS || sIsMonBeingMoved == TRUE)
+            {
+                switch (sub_80CFF98(0))
                 {
-                    switch (sub_80CFF98(0))
-                    {
-                    case 1:
-                        return 11;
-                    case 2:
-                        return 12;
-                    case 3:
-                        return 13;
-                    case 4:
-                        return 14;
-                    case 5:
-                        return 15;
-                    case 12:
-                        return 16;
-                    case 13:
-                        return 17;
-                    case 15:
-                        return 18;
-                    }
-                }
-                else
-                {
-                    sPSSData->inBoxMovingMode = 1;
-                    return 20;
+                case 1:
+                    return 11;
+                case 2:
+                    return 12;
+                case 3:
+                    return 13;
+                case 4:
+                    return 14;
+                case 5:
+                    return 15;
+                case 12:
+                    return 16;
+                case 13:
+                    return 17;
+                case 15:
+                    return 18;
                 }
             }
-
-            if (gMain.newKeys & B_BUTTON)
-                return 19;
-
-            if (gSaveBlock2Ptr->optionsButtonMode == OPTIONS_BUTTON_MODE_LR)
+            else
             {
-                if (gMain.heldKeys & L_BUTTON)
-                    return 10;
-                if (gMain.heldKeys & R_BUTTON)
-                    return 9;
+                sPSSData->inBoxMovingMode = 1;
+                return 20;
             }
+        }
 
-            if (gMain.newKeys & SELECT_BUTTON)
-            {
-                sub_80CFDC4();
-                return 0;
-            }
-            retVal = FALSE;
-        }
-    }
-    else
-    {
-        retVal = TRUE;
-        if (sBoxCursorPosition >= IN_BOX_ROWS)
+        if (gMain.newKeys & B_BUTTON)
+            return 19;
+
+        if (gSaveBlock2Ptr->optionsButtonMode == OPTIONS_BUTTON_MODE_LR)
         {
-            cursorPosition -= IN_BOX_ROWS;
+            if (gMain.heldKeys & L_BUTTON)
+                return 10;
+            if (gMain.heldKeys & R_BUTTON)
+                return 9;
         }
-        else
+
+        if (gMain.newKeys & SELECT_BUTTON)
         {
-            cursorArea = CURSOR_AREA_BOX;
-            cursorPosition = 0;
+            sub_80CFDC4();
+            return 0;
         }
-    }
+
+        retVal = 0;
+
+    } while (0);
 
     if (retVal)
         sub_80CD894(cursorArea, cursorPosition);
@@ -7533,20 +7538,30 @@ static u8 HandleInput_InParty(void)
     gotoBox = FALSE;
     retVal = 0;
 
-    if (!(gMain.newAndRepeatedKeys & DPAD_UP))
+    do
     {
-        if (gMain.newAndRepeatedKeys & DPAD_DOWN)
+        if (gMain.newAndRepeatedKeys & DPAD_UP)
+        {
+            if (--cursorPosition < 0)
+                cursorPosition = PARTY_SIZE;
+            if (cursorPosition != sBoxCursorPosition)
+                retVal = 1;
+            break;
+        }
+        else if (gMain.newAndRepeatedKeys & DPAD_DOWN)
         {
             if (++cursorPosition > PARTY_SIZE)
                 cursorPosition = 0;
             if (cursorPosition != sBoxCursorPosition)
                 retVal = 1;
+            break;
         }
-        else if ((gMain.newAndRepeatedKeys & DPAD_LEFT) && sBoxCursorPosition != 0)
+        else if (gMain.newAndRepeatedKeys & DPAD_LEFT && sBoxCursorPosition != 0)
         {
             retVal = 1;
             sPSSData->field_CD6 = sBoxCursorPosition;
             cursorPosition = 0;
+            break;
         }
         else if (gMain.newAndRepeatedKeys & DPAD_RIGHT)
         {
@@ -7561,73 +7576,67 @@ static u8 HandleInput_InParty(void)
                 cursorArea = CURSOR_AREA_IN_BOX;
                 cursorPosition = 0;
             }
+            break;
         }
-        else
+
+        if (gMain.newKeys & A_BUTTON)
         {
-            if (gMain.newKeys & A_BUTTON)
-            {
-                if (sBoxCursorPosition == PARTY_SIZE)
-                {
-                    if (sPSSData->boxOption == BOX_OPTION_DEPOSIT)
-                        return 4;
-
-                    gotoBox = TRUE;
-                }
-                else if (sub_80CFA5C())
-                {
-                    if (!sCanOnlyMove)
-                        return 8;
-
-                    switch (sub_80CFF98(0))
-                    {
-                    case 1:
-                        return 11;
-                    case 2:
-                        return 12;
-                    case 3:
-                        return 13;
-                    case 4:
-                        return 14;
-                    case 5:
-                        return 15;
-                    case 12:
-                        return 16;
-                    case 13:
-                        return 17;
-                    case 15:
-                        return 18;
-                    }
-                }
-            }
-
-            if (gMain.newKeys & B_BUTTON)
+            if (sBoxCursorPosition == PARTY_SIZE)
             {
                 if (sPSSData->boxOption == BOX_OPTION_DEPOSIT)
-                    return 19;
+                    return 4;
 
                 gotoBox = TRUE;
             }
+            else if (sub_80CFA5C())
+            {
+                if (!sCanOnlyMove)
+                    return 8;
 
-            if (gotoBox)
-            {
-                retVal = 6;
-                cursorArea = CURSOR_AREA_IN_BOX;
-                cursorPosition = 0;
-            }
-            else if (gMain.newKeys & SELECT_BUTTON)
-            {
-                sub_80CFDC4();
-                return 0;
+                switch (sub_80CFF98(0))
+                {
+                case 1:
+                    return 11;
+                case 2:
+                    return 12;
+                case 3:
+                    return 13;
+                case 4:
+                    return 14;
+                case 5:
+                    return 15;
+                case 12:
+                    return 16;
+                case 13:
+                    return 17;
+                case 15:
+                    return 18;
+                }
             }
         }
-    }
-    else
-    {
-        if (--cursorPosition < 0)
-            cursorPosition = PARTY_SIZE;
-        if (cursorPosition != sBoxCursorPosition)
-            retVal = 1;
-    }
+
+        if (gMain.newKeys & B_BUTTON)
+        {
+            if (sPSSData->boxOption == BOX_OPTION_DEPOSIT)
+                return 19;
+
+            gotoBox = TRUE;
+        }
+
+        if (gotoBox)
+        {
+            retVal = 6;
+            cursorArea = CURSOR_AREA_IN_BOX;
+            cursorPosition = 0;
+        }
+        else if (gMain.newKeys & SELECT_BUTTON)
+        {
+            sub_80CFDC4();
+            return 0;
+        }
+
+    } while (0);
+
     if (retVal != 0)
     {
         if (retVal != 6)
@@ -7911,63 +7920,63 @@ _080CF7D8:\n\
 static u8 HandleInput_OnBox(void)
 {
     u8 retVal;
-    s8 cursorArea = sBoxCursorArea;
-    s8 cursorPosition = sBoxCursorPosition;
+    s8 cursorArea;
+    s8 cursorPosition;
 
     sPSSData->field_CD3 = 0;
     sPSSData->field_CD2 = 0;
     sPSSData->field_CD7 = 0;
-    retVal = 0;
 
-    if (!(gMain.newAndRepeatedKeys & DPAD_UP))
+    do
     {
-        if (gMain.newAndRepeatedKeys & DPAD_DOWN)
+        if (gMain.newAndRepeatedKeys & DPAD_UP)
+        {
+            retVal = 1;
+            cursorArea = CURSOR_AREA_BUTTONS;
+            cursorPosition = 0;
+            sPSSData->field_CD7 = 1;
+            break;
+        }
+        else if (gMain.newAndRepeatedKeys & DPAD_DOWN)
         {
             retVal = 1;
             cursorArea = CURSOR_AREA_IN_BOX;
             cursorPosition = 2;
+            break;
         }
-        else
+
+        if (gMain.heldKeys & DPAD_LEFT)
+            return 10;
+        if (gMain.heldKeys & DPAD_RIGHT)
+            return 9;
+
+        if (gSaveBlock2Ptr->optionsButtonMode == OPTIONS_BUTTON_MODE_LR)
         {
-            if (gMain.heldKeys & DPAD_LEFT)
+            if (gMain.heldKeys & L_BUTTON)
                 return 10;
-            if (gMain.heldKeys & DPAD_RIGHT)
+            if (gMain.heldKeys & R_BUTTON)
                 return 9;
-
-            if (gSaveBlock2Ptr->optionsButtonMode == OPTIONS_BUTTON_MODE_LR)
-            {
-                if (gMain.heldKeys & L_BUTTON)
-                    return 10;
-                if (gMain.heldKeys & R_BUTTON)
-                    return 9;
-            }
-
-            if (gMain.newKeys & A_BUTTON)
-            {
-                sub_80CD1A8(FALSE);
-                AddBoxMenu();
-                return 7;
-            }
-
-            if (gMain.newKeys & B_BUTTON)
-                return 19;
-
-            if (gMain.newKeys & SELECT_BUTTON)
-            {
-                sub_80CFDC4();
-                return 0;
-            }
-
-            retVal = 0;
         }
-    }
-    else
-    {
-        retVal = 1;
-        cursorArea = CURSOR_AREA_BUTTONS;
-        cursorPosition = 0;
-        sPSSData->field_CD7 = 1;
-    }
+
+        if (gMain.newKeys & A_BUTTON)
+        {
+            sub_80CD1A8(FALSE);
+            AddBoxMenu();
+            return 7;
+        }
+
+        if (gMain.newKeys & B_BUTTON)
+            return 19;
+
+        if (gMain.newKeys & SELECT_BUTTON)
+        {
+            sub_80CFDC4();
+            return 0;
+        }
+
+        retVal = 0;
+
+    } while (0);
 
     if (retVal)
     {
@@ -8116,62 +8125,57 @@ static u8 HandleInput_OnButtons(void)
     sPSSData->field_CD2 = 0;
     sPSSData->field_CD7 = 0;
 
-    if (!(gMain.newAndRepeatedKeys & DPAD_UP))
+    do
     {
-        if (gMain.newAndRepeatedKeys & (DPAD_DOWN | START_BUTTON))
+        if (gMain.newAndRepeatedKeys & DPAD_UP)
+        {
+            retVal = 1;
+            cursorArea = CURSOR_AREA_IN_BOX;
+            sPSSData->field_CD2 = -1;
+            cursorPosition = (sBoxCursorPosition == 0) ? IN_BOX_COUNT - 1 - 5 : IN_BOX_COUNT - 1;
+            sPSSData->field_CD7 = 1;
+            break;
+        }
+        else if (gMain.newAndRepeatedKeys & (DPAD_DOWN | START_BUTTON))
         {
             retVal = 1;
             cursorArea = CURSOR_AREA_BOX;
             cursorPosition = 0;
             sPSSData->field_CD7 = 1;
+            break;
         }
-        else if (gMain.newAndRepeatedKeys & DPAD_LEFT)
+
+        if (gMain.newAndRepeatedKeys & DPAD_LEFT)
         {
             retVal = 1;
             if (--cursorPosition < 0)
-            {
                 cursorPosition = 1;
-            }
+            break;
         }
         else if (gMain.newAndRepeatedKeys & DPAD_RIGHT)
         {
             retVal = 1;
             if (++cursorPosition > 1)
-            {
                 cursorPosition = 0;
-            }
+            break;
         }
-        else if (gMain.newKeys & A_BUTTON)
-        {
+
+        if (gMain.newKeys & A_BUTTON)
             return (cursorPosition == 0) ? 5 : 4;
-        }
-        else if (gMain.newKeys & B_BUTTON)
-        {
+        if (gMain.newKeys & B_BUTTON)
             return 19;
-        }
-        else if (gMain.newKeys & SELECT_BUTTON)
+
+        if (gMain.newKeys & SELECT_BUTTON)
         {
             sub_80CFDC4();
             return 0;
         }
-        else
-        {
-            retVal = 0;
-        }
-    }
-    else
-    {
-        retVal = 1;
-        cursorArea = CURSOR_AREA_IN_BOX;
-        sPSSData->field_CD2 = -1;
-        cursorPosition = (sBoxCursorPosition == 0) ? IN_BOX_COUNT - 1 - 5 : IN_BOX_COUNT - 1;
-        sPSSData->field_CD7 = 1;
-    }
+
+        retVal = 0;
+    } while (0);
 
     if (retVal != 0)
-    {
         sub_80CD894(cursorArea, cursorPosition);
-    }
 
     return retVal;
 }
@@ -8750,9 +8754,14 @@ static s16 sub_80D00AC(void)
 {
     s32 textId = -2;
 
-    if (!(gMain.newKeys & A_BUTTON))
+    do
     {
-        if (gMain.newKeys & B_BUTTON)
+        if (gMain.newKeys & A_BUTTON)
+        {
+            textId = Menu_GetCursorPos();
+            break;
+        }
+        else if (gMain.newKeys & B_BUTTON)
         {
             PlaySE(SE_SELECT);
             textId = -1;
@@ -8768,11 +8777,7 @@ static s16 sub_80D00AC(void)
             PlaySE(SE_SELECT);
             Menu_MoveCursor(1);
         }
-    }
-    else
-    {
-        textId = Menu_GetCursorPos();
-    }
+    } while (0);
 
     if (textId != -2)
         sub_80D013C();
@@ -8780,9 +8785,6 @@ static s16 sub_80D00AC(void)
     if (textId >= 0)
         textId = sPSSData->menuItems[textId].textId;
 
-    #ifndef NONMATCHING
-    asm("":::"r4");
-    #endif // NONMATCHING
     return textId;
 }
 


### PR DESCRIPTION
Also got rid of a fakematching.
The four functions are still nonmatching, but they're a bit closer. Apparently if/else if vs if+break/if+break, while functionally the same, can affect register allocation.  