### PR TITLE
Make devkitARM optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,9 @@ include $(DEVKITARM)/base_tools
 else
 PREFIX		:=	arm-none-eabi-
 
-export CC	:=	$(PREFIX)gcc
 export CXX	:=	$(PREFIX)g++
 export AS	:=	$(PREFIX)as
-export AR	:=	$(PREFIX)gcc-ar
 export OBJCOPY	:=	$(PREFIX)objcopy
-export STRIP	:=	$(PREFIX)strip
-export NM	:=	$(PREFIX)gcc-nm
-export RANLIB	:=	$(PREFIX)gcc-ranlib
 endif
 export CPP := $(PREFIX)cpp
 export LD := $(PREFIX)ld

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+ifdef DEVKITARM
+include $(DEVKITARM)/base_tools
+else
 PREFIX		:=	arm-none-eabi-
 
 export CC	:=	$(PREFIX)gcc
@@ -8,6 +11,7 @@ export OBJCOPY	:=	$(PREFIX)objcopy
 export STRIP	:=	$(PREFIX)strip
 export NM	:=	$(PREFIX)gcc-nm
 export RANLIB	:=	$(PREFIX)gcc-ranlib
+endif
 export CPP := $(PREFIX)cpp
 export LD := $(PREFIX)ld
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,13 @@
-include $(DEVKITARM)/base_tools
+PREFIX		:=	arm-none-eabi-
+
+export CC	:=	$(PREFIX)gcc
+export CXX	:=	$(PREFIX)g++
+export AS	:=	$(PREFIX)as
+export AR	:=	$(PREFIX)gcc-ar
+export OBJCOPY	:=	$(PREFIX)objcopy
+export STRIP	:=	$(PREFIX)strip
+export NM	:=	$(PREFIX)gcc-nm
+export RANLIB	:=	$(PREFIX)gcc-ranlib
 export CPP := $(PREFIX)cpp
 export LD := $(PREFIX)ld
 


### PR DESCRIPTION
This change should not affect anyone currently using devkit. This should enable users to compile without devkit if the arm-none-eabi compiler is present.

Tested working on Windows by Kurausukun with devkit installed
Tested working on 64-bit Debian by FroggestSpirit without devkit after running "sudo apt-get install gcc-arm-none-eabi binutils-arm-none-eabi"