### PR TITLE
fix unaligned memory access in BlendPalette

### DIFF
--- a/src/palette.c
+++ b/src/palette.c
@@ -54,8 +54,10 @@ static void UpdateBlendRegisters(void);
 static bool8 IsSoftwarePaletteFadeFinishing(void);
 static void sub_80A2D54(u8 taskId);
 
-EWRAM_DATA u16 gPlttBufferUnfaded[PLTT_BUFFER_SIZE] = {0};
-EWRAM_DATA u16 gPlttBufferFaded[PLTT_BUFFER_SIZE] = {0};
+// palette buffers require alignment with agbcc because
+// unaligned word reads are issued in BlendPalette otherwise
+ALIGNED(4) EWRAM_DATA u16 gPlttBufferUnfaded[PLTT_BUFFER_SIZE] = {0};
+ALIGNED(4) EWRAM_DATA u16 gPlttBufferFaded[PLTT_BUFFER_SIZE] = {0};
 EWRAM_DATA struct PaletteStruct sPaletteStructs[0x10] = {0};
 EWRAM_DATA struct PaletteFadeControl gPaletteFade = {0};
 static EWRAM_DATA u32 gFiller_2037FE0 = 0;


### PR DESCRIPTION
This problem is only going to occur in versions where the palette
buffer isn't aligned to 4 bytes (which it is in a matching pokeemerald).

Since agbcc returns sizeof(PlttData) = 4, it will read words
instead of half words. This causes unnecessary emulator warnings
in the function "BlendPalette".
Aligning the buffers to 4 bytes fixes this.