### PR TITLE
Add Different Field Info to Wild Encounters JSON

### DIFF
--- a/src/data/wild_encounters.json
+++ b/src/data/wild_encounters.json
@@ -3,6 +3,32 @@
     {
       "label": "gWildMonHeaders",
       "for_maps": true,
+      "fields": [
+        {
+          "type": "land_mons",
+          "encounter_rates": [
+            20, 20, 10, 10, 10, 10, 5, 5, 4, 4, 1, 1
+          ]
+        },
+        {
+          "type": "water_mons",
+          "encounter_rates": [
+            60, 30, 5, 4, 1
+          ]
+        },
+        {
+          "type": "rock_smash_mons",
+          "encounter_rates": [
+            60, 30, 5, 4, 1
+          ]
+        },
+        {
+          "type": "fishing_mons",
+          "encounter_rates": [
+            70, 30, 60, 20, 20, 40, 40, 15, 4, 1
+          ]
+        }
+      ],
       "encounters": [
         {
           "map": "MAP_ROUTE101",

--- a/src/data/wild_encounters.json.txt
+++ b/src/data/wild_encounters.json.txt
@@ -1,5 +1,16 @@
 {{ doNotModifyHeader }}
+
 ## for wild_encounter_group in wild_encounter_groups
+{% if wild_encounter_group.for_maps %}
+## for wild_encounter_field in wild_encounter_group.fields
+## for encounter_rate in wild_encounter_field.encounter_rates
+{% if trackVar(encounter_rate, 100) %}
+#define ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_INDEX_{{ loop.index }} {{ encounter_rate }} {% else %}#define ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_INDEX_{{ loop.index }} ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_INDEX_{{ subtract(loop.index, 1) }} + {{ encounter_rate }}{% endif %}
+## endfor
+
+## endfor
+{% endif %}
+
 ## for encounter in wild_encounter_group.encounters
 {% if existsIn(encounter, "land_mons") %}
 const struct WildPokemon {{ encounter.base_label }}_LandMons[] =

--- a/src/data/wild_encounters.json.txt
+++ b/src/data/wild_encounters.json.txt
@@ -5,9 +5,9 @@
 ## for wild_encounter_field in wild_encounter_group.fields
 ## for encounter_rate in wild_encounter_field.encounter_rates
 {% if trackVar(encounter_rate, 100) %}
-#define ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_INDEX_{{ loop.index }} {{ encounter_rate }} {% else %}#define ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_INDEX_{{ loop.index }} ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_INDEX_{{ subtract(loop.index, 1) }} + {{ encounter_rate }}{% endif %} {{ setVarInt(wild_encounter_field.type, loop.index) }}
+#define ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_SLOT_{{ loop.index }} {{ encounter_rate }} {% else %}#define ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_SLOT_{{ loop.index }} ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_SLOT_{{ subtract(loop.index, 1) }} + {{ encounter_rate }}{% endif %} {{ setVarInt(wild_encounter_field.type, loop.index) }}
 ## endfor
-#define ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_TOTAL (ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_INDEX_{{ getVar(wild_encounter_field.type) }})
+#define ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_TOTAL (ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_SLOT_{{ getVar(wild_encounter_field.type) }})
 ## endfor
 {% endif %}
 

--- a/src/data/wild_encounters.json.txt
+++ b/src/data/wild_encounters.json.txt
@@ -5,9 +5,9 @@
 ## for wild_encounter_field in wild_encounter_group.fields
 ## for encounter_rate in wild_encounter_field.encounter_rates
 {% if trackVar(encounter_rate, 100) %}
-#define ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_INDEX_{{ loop.index }} {{ encounter_rate }} {% else %}#define ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_INDEX_{{ loop.index }} ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_INDEX_{{ subtract(loop.index, 1) }} + {{ encounter_rate }}{% endif %}
+#define ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_INDEX_{{ loop.index }} {{ encounter_rate }} {% else %}#define ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_INDEX_{{ loop.index }} ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_INDEX_{{ subtract(loop.index, 1) }} + {{ encounter_rate }}{% endif %} {{ setVarInt(wild_encounter_field.type, loop.index) }}
 ## endfor
-
+#define ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_TOTAL (ENCOUNTER_CHANCE_{{ upper(wild_encounter_field.type) }}_INDEX_{{ getVar(wild_encounter_field.type) }})
 ## endfor
 {% endif %}
 

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -145,27 +145,27 @@ static u8 ChooseWildMonIndex_Land(void)
 {
     u8 rand = Random() % ENCOUNTER_CHANCE_LAND_MONS_TOTAL;
 
-    if (rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_0)
+    if (rand < ENCOUNTER_CHANCE_LAND_MONS_SLOT_0)
         return 0;
-    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_0 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_1)
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_SLOT_0 && rand < ENCOUNTER_CHANCE_LAND_MONS_SLOT_1)
         return 1;
-    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_1 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_2)
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_SLOT_1 && rand < ENCOUNTER_CHANCE_LAND_MONS_SLOT_2)
         return 2;
-    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_2 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_3)
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_SLOT_2 && rand < ENCOUNTER_CHANCE_LAND_MONS_SLOT_3)
         return 3;
-    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_3 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_4)
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_SLOT_3 && rand < ENCOUNTER_CHANCE_LAND_MONS_SLOT_4)
         return 4;
-    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_4 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_5)
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_SLOT_4 && rand < ENCOUNTER_CHANCE_LAND_MONS_SLOT_5)
         return 5;
-    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_5 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_6)
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_SLOT_5 && rand < ENCOUNTER_CHANCE_LAND_MONS_SLOT_6)
         return 6;
-    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_6 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_7)
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_SLOT_6 && rand < ENCOUNTER_CHANCE_LAND_MONS_SLOT_7)
         return 7;
-    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_7 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_8)
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_SLOT_7 && rand < ENCOUNTER_CHANCE_LAND_MONS_SLOT_8)
         return 8;
-    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_8 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_9)
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_SLOT_8 && rand < ENCOUNTER_CHANCE_LAND_MONS_SLOT_9)
         return 9;
-    else if (rand == ENCOUNTER_CHANCE_LAND_MONS_INDEX_9)
+    else if (rand == ENCOUNTER_CHANCE_LAND_MONS_SLOT_9)
         return 10;
     else
         return 11;
@@ -175,13 +175,13 @@ static u8 ChooseWildMonIndex_WaterRock(void)
 {
     u8 rand = Random() % ENCOUNTER_CHANCE_WATER_MONS_TOTAL;
 
-    if (rand < ENCOUNTER_CHANCE_WATER_MONS_INDEX_0)
+    if (rand < ENCOUNTER_CHANCE_WATER_MONS_SLOT_0)
         return 0;
-    else if (rand >= ENCOUNTER_CHANCE_WATER_MONS_INDEX_0 && rand < ENCOUNTER_CHANCE_WATER_MONS_INDEX_1)
+    else if (rand >= ENCOUNTER_CHANCE_WATER_MONS_SLOT_0 && rand < ENCOUNTER_CHANCE_WATER_MONS_SLOT_1)
         return 1;
-    else if (rand >= ENCOUNTER_CHANCE_WATER_MONS_INDEX_1 && rand < ENCOUNTER_CHANCE_WATER_MONS_INDEX_2)
+    else if (rand >= ENCOUNTER_CHANCE_WATER_MONS_SLOT_1 && rand < ENCOUNTER_CHANCE_WATER_MONS_SLOT_2)
         return 2;
-    else if (rand >= ENCOUNTER_CHANCE_WATER_MONS_INDEX_2 && rand < ENCOUNTER_CHANCE_WATER_MONS_INDEX_3)
+    else if (rand >= ENCOUNTER_CHANCE_WATER_MONS_SLOT_2 && rand < ENCOUNTER_CHANCE_WATER_MONS_SLOT_3)
         return 3;
     else
         return 4;
@@ -202,29 +202,29 @@ static u8 ChooseWildMonIndex_Fishing(u8 rod)
     switch (rod)
     {
     case OLD_ROD:
-        if (rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_0)
+        if (rand < ENCOUNTER_CHANCE_FISHING_MONS_SLOT_0)
             wildMonIndex = 0;
         else
             wildMonIndex = 1;
         break;
     case GOOD_ROD:
-        if (rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_2)
+        if (rand < ENCOUNTER_CHANCE_FISHING_MONS_SLOT_2)
             wildMonIndex = 2;
-        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_INDEX_2 && rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_3)
+        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_SLOT_2 && rand < ENCOUNTER_CHANCE_FISHING_MONS_SLOT_3)
             wildMonIndex = 3;
-        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_INDEX_3 && rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_4)
+        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_SLOT_3 && rand < ENCOUNTER_CHANCE_FISHING_MONS_SLOT_4)
             wildMonIndex = 4;
         break;
     case SUPER_ROD:
-        if (rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_5)
+        if (rand < ENCOUNTER_CHANCE_FISHING_MONS_SLOT_5)
             wildMonIndex = 5;
-        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_INDEX_5 && rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_6)
+        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_SLOT_5 && rand < ENCOUNTER_CHANCE_FISHING_MONS_SLOT_6)
             wildMonIndex = 6;
-        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_INDEX_6 && rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_7)
+        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_SLOT_6 && rand < ENCOUNTER_CHANCE_FISHING_MONS_SLOT_7)
             wildMonIndex = 7;
-        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_INDEX_7 && rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_8)
+        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_SLOT_7 && rand < ENCOUNTER_CHANCE_FISHING_MONS_SLOT_8)
             wildMonIndex = 8;
-        if (rand == ENCOUNTER_CHANCE_FISHING_MONS_INDEX_8)
+        if (rand == ENCOUNTER_CHANCE_FISHING_MONS_SLOT_8)
             wildMonIndex = 9;
         break;
     }

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -105,7 +105,7 @@ static bool8 CheckFeebas(void)
         if (y >= gRoute119WaterTileData[3 * 2 + 0] && y <= gRoute119WaterTileData[3 * 2 + 1])
             route119Section = 2;
 
-        if (Random() % 100 > 49) // 50% chance of encountering Feebas
+        if (Random() % 100 > 49)
             return FALSE;
 
         FeebasSeedRng(gSaveBlock1Ptr->easyChatPairs[0].unk2);
@@ -145,29 +145,29 @@ static u8 ChooseWildMonIndex_Land(void)
 {
     u8 rand = Random() % 100;
 
-    if (rand < 20)                  // 20% chance
+    if (rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_0)
         return 0;
-    else if (rand >= 20 && rand < 40)    // 20% chance
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_0 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_1)
         return 1;
-    else if (rand >= 40 && rand < 50)    // 10% chance
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_1 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_2)
         return 2;
-    else if (rand >= 50 && rand < 60)    // 10% chance
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_2 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_3)
         return 3;
-    else if (rand >= 60 && rand < 70)    // 10% chance
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_3 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_4)
         return 4;
-    else if (rand >= 70 && rand < 80)    // 10% chance
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_4 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_5)
         return 5;
-    else if (rand >= 80 && rand < 85)    // 5% chance
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_5 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_6)
         return 6;
-    else if (rand >= 85 && rand < 90)    // 5% chance
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_6 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_7)
         return 7;
-    else if (rand >= 90 && rand < 94)    // 4% chance
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_7 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_8)
         return 8;
-    else if (rand >= 94 && rand < 98)    // 4% chance
+    else if (rand >= ENCOUNTER_CHANCE_LAND_MONS_INDEX_8 && rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_9)
         return 9;
-    else if (rand == 98)                 // 1% chance
+    else if (rand == ENCOUNTER_CHANCE_LAND_MONS_INDEX_9)
         return 10;
-    else                            // 1% chance
+    else
         return 11;
 }
 
@@ -175,15 +175,15 @@ static u8 ChooseWildMonIndex_WaterRock(void)
 {
     u8 rand = Random() % 100;
 
-    if (rand < 60)                  // 60% chance
+    if (rand < ENCOUNTER_CHANCE_WATER_MONS_INDEX_0)
         return 0;
-    else if (rand >= 60 && rand < 90)    // 30% chance
+    else if (rand >= ENCOUNTER_CHANCE_WATER_MONS_INDEX_0 && rand < ENCOUNTER_CHANCE_WATER_MONS_INDEX_1)
         return 1;
-    else if (rand >= 90 && rand < 95)    // 5% chance
+    else if (rand >= ENCOUNTER_CHANCE_WATER_MONS_INDEX_1 && rand < ENCOUNTER_CHANCE_WATER_MONS_INDEX_2)
         return 2;
-    else if (rand >= 95 && rand < 99)    // 4% chance
+    else if (rand >= ENCOUNTER_CHANCE_WATER_MONS_INDEX_2 && rand < ENCOUNTER_CHANCE_WATER_MONS_INDEX_3)
         return 3;
-    else                            // 1% chance
+    else
         return 4;
 }
 
@@ -202,29 +202,29 @@ static u8 ChooseWildMonIndex_Fishing(u8 rod)
     switch (rod)
     {
     case OLD_ROD:
-        if (rand < 70)  // 70% chance
+        if (rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_0)
             wildMonIndex = 0;
-        else            // 30% chance
+        else
             wildMonIndex = 1;
         break;
     case GOOD_ROD:
-        if (rand < 60)                  // 60% chance
+        if (rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_2)
             wildMonIndex = 2;
-        if (rand >= 60 && rand < 80)    // 20% chance
+        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_INDEX_2 && rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_3)
             wildMonIndex = 3;
-        if (rand >= 80 && rand < 100)   // 20% chance
+        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_INDEX_3 && rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_4)
             wildMonIndex = 4;
         break;
     case SUPER_ROD:
-        if (rand < 40)                  // 40% chance
+        if (rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_5)
             wildMonIndex = 5;
-        if (rand >= 40 && rand < 80)    // 40% chance
+        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_INDEX_5 && rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_6)
             wildMonIndex = 6;
-        if (rand >= 80 && rand < 95)    // 15% chance
+        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_INDEX_6 && rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_7)
             wildMonIndex = 7;
-        if (rand >= 95 && rand < 99)    // 4% chance
+        if (rand >= ENCOUNTER_CHANCE_FISHING_MONS_INDEX_7 && rand < ENCOUNTER_CHANCE_FISHING_MONS_INDEX_8)
             wildMonIndex = 8;
-        if (rand == 99)                 // 1% chance
+        if (rand == ENCOUNTER_CHANCE_FISHING_MONS_INDEX_8)
             wildMonIndex = 9;
         break;
     }

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -105,7 +105,7 @@ static bool8 CheckFeebas(void)
         if (y >= gRoute119WaterTileData[3 * 2 + 0] && y <= gRoute119WaterTileData[3 * 2 + 1])
             route119Section = 2;
 
-        if (Random() % 100 > 49)
+        if (Random() % 100 > 49) // 50% chance of encountering Feebas
             return FALSE;
 
         FeebasSeedRng(gSaveBlock1Ptr->easyChatPairs[0].unk2);
@@ -143,7 +143,7 @@ static void FeebasSeedRng(u16 seed)
 
 static u8 ChooseWildMonIndex_Land(void)
 {
-    u8 rand = Random() % 100;
+    u8 rand = Random() % ENCOUNTER_CHANCE_LAND_MONS_TOTAL;
 
     if (rand < ENCOUNTER_CHANCE_LAND_MONS_INDEX_0)
         return 0;
@@ -173,7 +173,7 @@ static u8 ChooseWildMonIndex_Land(void)
 
 static u8 ChooseWildMonIndex_WaterRock(void)
 {
-    u8 rand = Random() % 100;
+    u8 rand = Random() % ENCOUNTER_CHANCE_WATER_MONS_TOTAL;
 
     if (rand < ENCOUNTER_CHANCE_WATER_MONS_INDEX_0)
         return 0;
@@ -197,7 +197,7 @@ enum
 static u8 ChooseWildMonIndex_Fishing(u8 rod)
 {
     u8 wildMonIndex = 0;
-    u8 rand = Random() % 100;
+    u8 rand = Random() % ENCOUNTER_CHANCE_FISHING_MONS_TOTAL;
 
     switch (rod)
     {

--- a/tools/jsonproc/jsonproc.cpp
+++ b/tools/jsonproc/jsonproc.cpp
@@ -5,7 +5,7 @@
 #include <map>
 
 #include <string>
-using std::string;
+using std::string; using std::to_string;
 
 #include <inja.hpp>
 using namespace inja;
@@ -49,6 +49,13 @@ int main(int argc, char *argv[])
     env.add_callback("setVar", 2, [=](Arguments& args) {
         string key = args.at(0)->get<string>();
         string value = args.at(1)->get<string>();
+        set_custom_var(key, value);
+        return "";
+    });
+
+    env.add_callback("setVarInt", 2, [=](Arguments& args) {
+        string key = args.at(0)->get<string>();
+        string value = to_string(args.at(1)->get<int>());
         set_custom_var(key, value);
         return "";
     });

--- a/tools/jsonproc/jsonproc.cpp
+++ b/tools/jsonproc/jsonproc.cpp
@@ -36,7 +36,14 @@ int main(int argc, char *argv[])
 
     // Add custom command callbacks.
     env.add_callback("doNotModifyHeader", 0, [jsonfilepath, templateFilepath](Arguments& args) {
-        return "//\n// DO NOT MODIFY THIS FILE! IT IS AUTO-GENERATED FROM " + jsonfilepath +" and Inja template " + templateFilepath + "\n//\n";
+        return "//\n// DO NOT MODIFY THIS FILE! It is auto-generated from " + jsonfilepath +" and Inja template " + templateFilepath + "\n//\n";
+    });
+
+    env.add_callback("subtract", 2, [](Arguments& args) {
+        int minuend = args.at(0)->get<int>();
+        int subtrahend = args.at(1)->get<int>();
+
+        return minuend - subtrahend;
     });
 
     env.add_callback("setVar", 2, [=](Arguments& args) {
@@ -49,6 +56,21 @@ int main(int argc, char *argv[])
     env.add_callback("getVar", 1, [=](Arguments& args) {
         string key = args.at(0)->get<string>();
         return get_custom_var(key);
+    });
+
+    env.add_callback("trackVar", 2, [](Arguments& args) {
+        static int counter = 0;
+
+        int addValue = args.at(0)->get<int>();
+        int checkValue = args.at(1)->get<int>();
+
+        bool over = false;
+
+        counter = (counter + addValue) % (checkValue + 1);
+
+        if (counter <= addValue) over = true;
+
+        return over;
     });
 
     env.add_callback("concat", 2, [](Arguments& args) {
@@ -67,7 +89,6 @@ int main(int argc, char *argv[])
         return rawValue.erase(0, prefix.length());
     });
 
-    // Add custom command callbacks.
     env.add_callback("removeSuffix", 2, [](Arguments& args) {
         string rawValue = args.at(0)->get<string>();
         string suffix = args.at(1)->get<string>();


### PR DESCRIPTION
So a `fields` object describes the names ("`type`") of each field, and has an "`encounter_rates`" array which is the length of the number of pokemon to expect and their encounter rates. The purpose of this is to make modifying the wild encounters as easy as possible. My idea is that modifying "`fields`" will update every encounter object accordingly (through tools like porymap). The requirement is that for each field type, there needs to be the same number of encounterable pokemon. However, if a person wants fewer encounters than the length of this array in certain instances for whatever reason, it could be done with trivial modifications to the source.

If these changes are admissible, then of course I'll do the same for pokeruby.