### PR TITLE
Fix LD script to not contain huge gap sections

### DIFF
--- a/ld_script.txt
+++ b/ld_script.txt
@@ -3,6 +3,12 @@ ENTRY(Start)
 gNumMusicPlayers = 4;
 gMaxLines = 0;
 
+/* Modify the following load addresses as needed to make more room. Alternately, delete both the
+   declarations below and their references further down to get rid of the gaps.                  */
+
+__anim_mon_load_address = 0x8b00000;
+__gfx_load_address = 0x8c00000;
+
 SECTIONS {
     . = 0x2000000;
 
@@ -1217,27 +1223,13 @@ SECTIONS {
         data/multiboot_pokemon_colosseum.o(.rodata);
     } =0
 
-    gap1 :
-    {
-        gap1_start = ABSOLUTE(.);
-        BYTE(0x00)
-        . = 0x8B00000 - gap1_start;
-    } =0
-
-    anim_mon_front_pic_data :
+    anim_mon_front_pic_data __anim_mon_load_address :
     ALIGN(4)
     {
         src/anim_mon_front_pics.o(.rodata);
     } =0
 
-    gap2 :
-    {
-        gap2_start = ABSOLUTE(.);
-        BYTE(0x00)
-        . = 0x8C00000 - gap2_start;
-    } =0
-
-    gfx_data :
+    gfx_data __gfx_load_address :
     ALIGN(4)
     {
         src/graphics.o(.rodata);


### PR DESCRIPTION
The LD script currently in the repository defines two sections, `gap1` and `gap2`, which contain nothing but zeroes. These sections exist purely to pad the ROM to a certain address, since it seems that the original ROM places some data at fixed base addresses, creating a gap.

However, the current approach creates fake sections full of null bytes. This prevents using the section information in the ELF to properly analyze the ROM, and it also makes the ELF bigger by about a megabyte and a half (the size of the gap sections).

This pull request eliminates those gap sections and instead declares the load addresses explicitly at the top of the LD script, thus generating accurate metadata in the ELF file and removing the megabyte-and-a-half of zero bytes. (Of course, the output ROM still matches.)