### PR TITLE
Use a constant instead of integer literals when checking for shinyness

### DIFF
--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -82,4 +82,7 @@
 #define NUM_STATS 6
 #define NUM_BATTLE_STATS 8
 
+// Shiny odds
+#define SHINY_ODDS 8 // Actual probability is SHINY_ODDS/65536
+
 #endif // GUARD_CONSTANTS_POKEMON_H

--- a/src/battle_anim_special.c
+++ b/src/battle_anim_special.c
@@ -2029,7 +2029,7 @@ void sub_8172EF0(u8 battler, struct Pokemon *mon)
     if (IsBattlerSpriteVisible(battler))
     {
         shinyValue = HIHALF(otId) ^ LOHALF(otId) ^ HIHALF(personality) ^ LOHALF(personality);
-        if (shinyValue < 8)
+        if (shinyValue < SHINY_ODDS)
             isShiny = TRUE;
 
         if (isShiny)

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2183,7 +2183,7 @@ void CreateBoxMon(struct BoxPokemon *boxMon, u16 species, u8 level, u8 fixedIV, 
         {
             value = Random32();
             shinyValue = HIHALF(value) ^ LOHALF(value) ^ HIHALF(personality) ^ LOHALF(personality);
-        } while (shinyValue < 8);
+        } while (shinyValue < SHINY_ODDS);
     }
     else if (otIdType == OT_ID_PRESET) //Pokemon has a preset OT ID
     {
@@ -6332,7 +6332,7 @@ const u32 *GetFrontSpritePalFromSpeciesAndPersonality(u16 species, u32 otId, u32
         return gMonPaletteTable[0].data;
 
     shinyValue = HIHALF(otId) ^ LOHALF(otId) ^ HIHALF(personality) ^ LOHALF(personality);
-    if (shinyValue < 8)
+    if (shinyValue < SHINY_ODDS)
         return gMonShinyPaletteTable[species].data;
     else
         return gMonPaletteTable[species].data;
@@ -6351,7 +6351,7 @@ const struct CompressedSpritePalette *GetMonSpritePalStructFromOtIdPersonality(u
     u32 shinyValue;
 
     shinyValue = HIHALF(otId) ^ LOHALF(otId) ^ HIHALF(personality) ^ LOHALF(personality);
-    if (shinyValue < 8)
+    if (shinyValue < SHINY_ODDS)
         return &gMonShinyPaletteTable[species];
     else
         return &gMonPaletteTable[species];
@@ -6525,7 +6525,7 @@ bool8 IsShinyOtIdPersonality(u32 otId, u32 personality)
 {
     bool8 retVal = FALSE;
     u32 shinyValue = HIHALF(otId) ^ LOHALF(otId) ^ HIHALF(personality) ^ LOHALF(personality);
-    if (shinyValue < 8)
+    if (shinyValue < SHINY_ODDS)
         retVal = TRUE;
     return retVal;
 }


### PR DESCRIPTION
Even though there are functions to determine whether a pokemon is shiny or not, those are not used every time the game needs to check for shininess, which makes it tedious to edit shiny rate since you need to edit every extra check that isn't done using IsMonShiny() or IsShinyOtIdPersonnality(), instead of the one in IsShinyOtIdPersonnality() only. 
This PR makes it so the value against which the games checks to determine shininess is defined in only one place, which makes editing shiny rate much more practical.