### PR TITLE
Documenting MAPSEC use in pokenav match call data

### DIFF
--- a/include/pokenav.h
+++ b/include/pokenav.h
@@ -107,7 +107,7 @@ void sub_81C8234(void);
 
 // pokenav_match_call_data.c
 bool32 sub_81D17E8(u32 idx);
-u8 sub_81D16DC(u32 idx);
+u8 MatchCallMapSecGetByIndex(u32 idx);
 bool32 sub_81D1BF8(u32 idx);
 bool32 MatchCallFlagGetByIndex(u32 idx);
 u32 MatchCall_GetRematchTableIdx(u32 idx);

--- a/src/pokenav_match_call_data.c
+++ b/src/pokenav_match_call_data.c
@@ -754,24 +754,24 @@ static bool32 (*const sMatchCallGetFlagFuncs[])(match_call_t) = {
     MatchCallGetFlag_Type0,
     MatchCallGetFlag_Type1,
     MatchCallGetFlag_Type2,
-    MatchCallGetFlag_Type3,
-    MatchCallGetFlag_Type4
+    MatchCallGetFlag_Type4,
+    MatchCallGetFlag_Type3
 };
 
 static u8 (*const sMatchCallGetMapsecFuncs[])(match_call_t) = {
     MatchCallGetMapSec_Type0,
     MatchCallGetMapSec_Type1,
     MatchCallGetMapSec_Type2,
-    MatchCallGetMapSec_Type3,
-    MatchCallGetMapSec_Type4
+    MatchCallGetMapSec_Type4,
+    MatchCallGetMapSec_Type3
 };
 
 static bool32 (*const sMatchCall_IsRematchableFunctions[])(match_call_t) = {
     MatchCall_IsRematchable_Type0,
     MatchCall_IsRematchable_Type1,
     MatchCall_IsRematchable_Type2,
-    MatchCall_IsRematchable_Type3,
-    MatchCall_IsRematchable_Type4
+    MatchCall_IsRematchable_Type4,
+    MatchCall_IsRematchable_Type3
 };
 
 static bool32 (*const gUnknown_08625338[])(match_call_t) = {
@@ -786,24 +786,24 @@ static u32 (*const sMatchCall_GetRematchTableIdxFunctions[])(match_call_t) = {
     MatchCall_GetRematchTableIdx_Type0,
     MatchCall_GetRematchTableIdx_Type1,
     MatchCall_GetRematchTableIdx_Type2,
-    MatchCall_GetRematchTableIdx_Type3,
-    MatchCall_GetRematchTableIdx_Type4
+    MatchCall_GetRematchTableIdx_Type4,
+    MatchCall_GetRematchTableIdx_Type3
 };
 
 static void (*const sMatchCall_GetMessageFunctions[])(match_call_t, u8 *) = {
     MatchCall_GetMessage_Type0,
     MatchCall_GetMessage_Type1,
     MatchCall_GetMessage_Type2,
-    MatchCall_GetMessage_Type3,
-    MatchCall_GetMessage_Type4
+    MatchCall_GetMessage_Type4,
+    MatchCall_GetMessage_Type3
 };
 
 static void (*const sMatchCall_GetNameAndDescFunctions[])(match_call_t, const u8 **, const u8 **) = {
     MatchCall_GetNameAndDesc_Type0,
     MatchCall_GetNameAndDesc_Type1,
     MatchCall_GetNameAndDesc_Type2,
-    MatchCall_GetNameAndDesc_Type3,
-    MatchCall_GetNameAndDesc_Type4
+    MatchCall_GetNameAndDesc_Type4,
+    MatchCall_GetNameAndDesc_Type3
 };
 
 static const struct UnkStruct_08625388 sMatchCallCheckPageOverrides[] = {
@@ -884,7 +884,7 @@ static bool32 MatchCallGetFlag_Type2(match_call_t matchCall)
     return FlagGet(matchCall.type2->flag);
 }
 
-static bool32 MatchCallGetFlag_Type3(match_call_t matchCall)
+static bool32 MatchCallGetFlag_Type4(match_call_t matchCall)
 {
     if (matchCall.type4->gender != gSaveBlock2Ptr->playerGender)
         return FALSE;
@@ -893,7 +893,7 @@ static bool32 MatchCallGetFlag_Type3(match_call_t matchCall)
     return FlagGet(matchCall.type4->flag);
 }
 
-static bool32 MatchCallGetFlag_Type4(match_call_t matchCall)
+static bool32 MatchCallGetFlag_Type3(match_call_t matchCall)
 {
     return FlagGet(matchCall.type3->flag);
 }
@@ -932,12 +932,12 @@ static u8 MatchCallGetMapSec_Type2(match_call_t matchCall)
     return matchCall.type2->v10[i].mapSec;
 }
 
-static u8 MatchCallGetMapSec_Type3(match_call_t matchCall)
+static u8 MatchCallGetMapSec_Type4(match_call_t matchCall)
 {
     return MAPSEC_NONE;
 }
 
-static u8 MatchCallGetMapSec_Type4(match_call_t matchCall)
+static u8 MatchCallGetMapSec_Type3(match_call_t matchCall)
 {
     return MAPSEC_NONE;
 }
@@ -971,12 +971,12 @@ static bool32 MatchCall_IsRematchable_Type2(match_call_t matchCall)
     return gSaveBlock1Ptr->trainerRematches[matchCall.type2->rematchTableIdx] ? TRUE : FALSE;
 }
 
-static bool32 MatchCall_IsRematchable_Type3(match_call_t matchCall)
+static bool32 MatchCall_IsRematchable_Type4(match_call_t matchCall)
 {
     return FALSE;
 }
 
-static bool32 MatchCall_IsRematchable_Type4(match_call_t matchCall)
+static bool32 MatchCall_IsRematchable_Type3(match_call_t matchCall)
 {
     return FALSE;
 }
@@ -1052,12 +1052,12 @@ static u32 MatchCall_GetRematchTableIdx_Type2(match_call_t matchCall)
     return matchCall.type2->rematchTableIdx;
 }
 
-static u32 MatchCall_GetRematchTableIdx_Type3(match_call_t matchCall)
+static u32 MatchCall_GetRematchTableIdx_Type4(match_call_t matchCall)
 {
     return REMATCH_TABLE_ENTRIES;
 }
 
-static u32 MatchCall_GetRematchTableIdx_Type4(match_call_t matchCall)
+static u32 MatchCall_GetRematchTableIdx_Type3(match_call_t matchCall)
 {
     return REMATCH_TABLE_ENTRIES;
 }
@@ -1092,12 +1092,12 @@ static void MatchCall_GetMessage_Type2(match_call_t matchCall, u8 *dest)
     sub_81D1920(matchCall.type2->textData, dest);
 }
 
-static void MatchCall_GetMessage_Type3(match_call_t matchCall, u8 *dest)
+static void MatchCall_GetMessage_Type4(match_call_t matchCall, u8 *dest)
 {
     sub_81D1920(matchCall.type4->textData, dest);
 }
 
-static void MatchCall_GetMessage_Type4(match_call_t matchCall, u8 *dest)
+static void MatchCall_GetMessage_Type3(match_call_t matchCall, u8 *dest)
 {
     sub_8197080(dest);
 }
@@ -1191,13 +1191,13 @@ static void MatchCall_GetNameAndDesc_Type2(match_call_t matchCall, const u8 **de
     *desc = matchCall.type2->desc;
 }
 
-static void MatchCall_GetNameAndDesc_Type3(match_call_t matchCall, const u8 **desc, const u8 **name)
+static void MatchCall_GetNameAndDesc_Type4(match_call_t matchCall, const u8 **desc, const u8 **name)
 {
     *desc = matchCall.type4->desc;
     *name = matchCall.type4->name;
 }
 
-static void MatchCall_GetNameAndDesc_Type4(match_call_t matchCall, const u8 **desc, const u8 **name)
+static void MatchCall_GetNameAndDesc_Type3(match_call_t matchCall, const u8 **desc, const u8 **name)
 {
     *desc = matchCall.type3->desc;
     *name = matchCall.type3->name;

--- a/src/pokenav_match_call_data.c
+++ b/src/pokenav_match_call_data.c
@@ -758,7 +758,7 @@ static bool32 (*const sMatchCallGetFlagFuncs[])(match_call_t) = {
     MatchCallGetFlag_Type3
 };
 
-static u8 (*const sMatchCallGetMapsecFuncs[])(match_call_t) = {
+static u8 (*const sMatchCallGetMapSecFuncs[])(match_call_t) = {
     MatchCallGetMapSec_Type0,
     MatchCallGetMapSec_Type1,
     MatchCallGetMapSec_Type2,
@@ -907,7 +907,7 @@ u8 MatchCallMapSecGetByIndex(u32 idx)
         return 0;
     matchCall = sMatchCallHeaders[idx];
     i = MatchCallGetFunctionIndex(matchCall);
-    return sMatchCallGetMapsecFuncs[i](matchCall);
+    return sMatchCallGetMapSecFuncs[i](matchCall);
 }
 
 static u8 MatchCallGetMapSec_Type0(match_call_t matchCall)

--- a/src/pokenav_match_call_data.c
+++ b/src/pokenav_match_call_data.c
@@ -43,7 +43,7 @@ struct MatchCallStruct1 {
 
 struct MatchCallSubstruct2 {
     u16 flag;
-    u8 v2;
+    u8 mapSec;
 };
 
 struct MatchCallStruct2 {
@@ -929,17 +929,17 @@ static u8 sub_81D171C(match_call_t matchCall)
         if (!FlagGet(matchCall.type2->v10[i].flag))
             break;
     }
-    return matchCall.type2->v10[i].v2;
+    return matchCall.type2->v10[i].mapSec;
 }
 
 static u8 sub_81D1750(match_call_t matchCall)
 {
-    return 0xd5;
+    return MAPSEC_NONE;
 }
 
 static u8 sub_81D1754(match_call_t matchCall)
 {
-    return 0xd5;
+    return MAPSEC_NONE;
 }
 
 bool32 MatchCall_IsRematchable(u32 idx)

--- a/src/pokenav_match_call_data.c
+++ b/src/pokenav_match_call_data.c
@@ -18,13 +18,13 @@ typedef struct MatchCallTextDataStruct {
 
 struct MatchCallStructCommon {
     u8 type;
-    u8 v1;
+    u8 mapSec;
     u16 flag;
 };
 
 struct MatchCallStruct0 {
     u8 type;
-    u8 v1;
+    u8 mapSec;
     u16 flag;
     const u8 *desc;
     const u8 *name;
@@ -33,7 +33,7 @@ struct MatchCallStruct0 {
 
 struct MatchCallStruct1 {
     u8 type;
-    u8 v1;
+    u8 mapSec;
     u16 flag;
     u16 rematchTableIdx;
     const u8 *desc;
@@ -48,7 +48,7 @@ struct MatchCallSubstruct2 {
 
 struct MatchCallStruct2 {
     u8 type;
-    u8 v1;
+    u8 mapSec;
     u16 flag;
     u16 rematchTableIdx;
     const u8 *desc;
@@ -58,7 +58,7 @@ struct MatchCallStruct2 {
 
 struct MatchCallStruct3 {
     u8 type;
-    u8 v1;
+    u8 mapSec;
     u16 flag;
     const u8 *desc;
     const u8 *name;
@@ -76,7 +76,7 @@ struct MatchCallStruct4 {
 // Note: Type1 and Type5 have identical struct layouts.
 struct MatchCallStruct5 {
     u8 type;
-    u8 v1;
+    u8 mapSec;
     u16 flag;
     u16 rematchTableIdx;
     const u8 *desc;
@@ -326,7 +326,7 @@ static const match_call_text_data_t sMrStoneTextScripts[] = {
 static const struct MatchCallStruct0 sMrStoneMatchCallHeader =
 {
     .type = 0,
-    .v1 = MAPSEC_RUSTBORO_CITY,
+    .mapSec = MAPSEC_RUSTBORO_CITY,
     .flag = 0xFFFF,
     .desc = gMrStoneMatchCallDesc,
     .name = gMrStoneMatchCallName,
@@ -349,7 +349,7 @@ static const match_call_text_data_t sNormanTextScripts[] = {
 static const struct MatchCallStruct5 sNormanMatchCallHeader =
 {
     .type = 5,
-    .v1 = MAPSEC_PETALBURG_CITY,
+    .mapSec = MAPSEC_PETALBURG_CITY,
     .flag = FLAG_ENABLE_NORMAN_MATCH_CALL,
     .rematchTableIdx = REMATCH_NORMAN,
     .desc = gNormanMatchCallDesc,
@@ -360,7 +360,7 @@ static const struct MatchCallStruct5 sNormanMatchCallHeader =
 static const struct MatchCallStruct3 sProfBirchMatchCallHeader =
 {
     .type = 3,
-    .v1 = 0,
+    .mapSec = 0,
     .flag = FLAG_ENABLE_PROF_BIRCH_MATCH_CALL,
     .desc = gProfBirchMatchCallDesc,
     .name = gProfBirchMatchCallName
@@ -376,7 +376,7 @@ static const match_call_text_data_t sMomTextScripts[] = {
 static const struct MatchCallStruct0 sMomMatchCallHeader =
 {
     .type = 0,
-    .v1 = MAPSEC_LITTLEROOT_TOWN,
+    .mapSec = MAPSEC_LITTLEROOT_TOWN,
     .flag = FLAG_ENABLE_MOM_MATCH_CALL,
     .desc = gMomMatchCallDesc,
     .name = gMomMatchCallName,
@@ -397,7 +397,7 @@ static const match_call_text_data_t sStevenTextScripts[] = {
 static const struct MatchCallStruct0 sStevenMatchCallHeader =
 {
     .type = 0,
-    .v1 = MAPSEC_NONE,
+    .mapSec = MAPSEC_NONE,
     .flag = FLAG_REGISTERED_STEVEN_POKENAV,
     .desc = gStevenMatchCallDesc,
     .name = gStevenMatchCallName,
@@ -483,7 +483,7 @@ const struct MatchCallSubstruct2 sWallyAdditionalData[] = {
 static const struct MatchCallStruct2 sWallyMatchCallHeader =
 {
     .type = 2,
-    .v1 = 0,
+    .mapSec = 0,
     .flag = FLAG_ENABLE_WALLY_MATCH_CALL,
     .rematchTableIdx = REMATCH_WALLY_3,
     .desc = gWallyMatchCallDesc,
@@ -506,7 +506,7 @@ static const match_call_text_data_t sScottTextScripts[] = {
 static const struct MatchCallStruct0 sScottMatchCallHeader =
 {
     .type = 0,
-    .v1 = MAPSEC_NONE,
+    .mapSec = MAPSEC_NONE,
     .flag = FLAG_ENABLE_SCOTT_MATCH_CALL,
     .desc = gScottMatchCallDesc,
     .name = gScottMatchCallName,
@@ -524,7 +524,7 @@ static const match_call_text_data_t sRoxanneTextScripts[] = {
 static const struct MatchCallStruct5 sRoxanneMatchCallHeader =
 {
     .type = 5,
-    .v1 = MAPSEC_RUSTBORO_CITY,
+    .mapSec = MAPSEC_RUSTBORO_CITY,
     .flag = FLAG_ENABLE_ROXANNE_MATCH_CALL,
     .rematchTableIdx = REMATCH_ROXANNE,
     .desc = gRoxanneMatchCallDesc,
@@ -543,7 +543,7 @@ static const match_call_text_data_t sBrawlyTextScripts[] = {
 static const struct MatchCallStruct5 sBrawlyMatchCallHeader =
 {
     .type = 5,
-    .v1 = MAPSEC_DEWFORD_TOWN,
+    .mapSec = MAPSEC_DEWFORD_TOWN,
     .flag = FLAG_ENABLE_BRAWLY_MATCH_CALL,
     .rematchTableIdx = REMATCH_BRAWLY,
     .desc = gBrawlyMatchCallDesc,
@@ -562,7 +562,7 @@ static const match_call_text_data_t sWattsonTextScripts[] = {
 static const struct MatchCallStruct5 sWattsonMatchCallHeader =
 {
     .type = 5,
-    .v1 = MAPSEC_MAUVILLE_CITY,
+    .mapSec = MAPSEC_MAUVILLE_CITY,
     .flag = FLAG_ENABLE_WATTSON_MATCH_CALL,
     .rematchTableIdx = REMATCH_WATTSON,
     .desc = gWattsonMatchCallDesc,
@@ -581,7 +581,7 @@ static const match_call_text_data_t sFlanneryTextScripts[] = {
 static const struct MatchCallStruct5 sFlanneryMatchCallHeader =
 {
     .type = 5,
-    .v1 = MAPSEC_LAVARIDGE_TOWN,
+    .mapSec = MAPSEC_LAVARIDGE_TOWN,
     .flag = FLAG_ENABLE_FLANNERY_MATCH_CALL,
     .rematchTableIdx = REMATCH_FLANNERY,
     .desc = gFlanneryMatchCallDesc,
@@ -600,7 +600,7 @@ static const match_call_text_data_t sWinonaTextScripts[] = {
 static const struct MatchCallStruct5 sWinonaMatchCallHeader =
 {
     .type = 5,
-    .v1 = MAPSEC_FORTREE_CITY,
+    .mapSec = MAPSEC_FORTREE_CITY,
     .flag = FLAG_ENABLE_WINONA_MATCH_CALL,
     .rematchTableIdx = REMATCH_WINONA,
     .desc = gWinonaMatchCallDesc,
@@ -619,7 +619,7 @@ static const match_call_text_data_t sTateLizaTextScripts[] = {
 static const struct MatchCallStruct5 sTateLizaMatchCallHeader =
 {
     .type = 5,
-    .v1 = MAPSEC_MOSSDEEP_CITY,
+    .mapSec = MAPSEC_MOSSDEEP_CITY,
     .flag = FLAG_ENABLE_TATE_AND_LIZA_MATCH_CALL,
     .rematchTableIdx = REMATCH_TATE_AND_LIZA,
     .desc = gTateLizaMatchCallDesc,
@@ -638,7 +638,7 @@ static const match_call_text_data_t sJuanTextScripts[] = {
 static const struct MatchCallStruct5 sJuanMatchCallHeader =
 {
     .type = 5,
-    .v1 = MAPSEC_SOOTOPOLIS_CITY,
+    .mapSec = MAPSEC_SOOTOPOLIS_CITY,
     .flag = FLAG_ENABLE_JUAN_MATCH_CALL,
     .rematchTableIdx = REMATCH_JUAN,
     .desc = gJuanMatchCallDesc,
@@ -654,7 +654,7 @@ static const match_call_text_data_t sSidneyTextScripts[] = {
 static const struct MatchCallStruct5 sSidneyMatchCallHeader =
 {
     .type = 5,
-    .v1 = MAPSEC_EVER_GRANDE_CITY,
+    .mapSec = MAPSEC_EVER_GRANDE_CITY,
     .flag = FLAG_REMATCH_SIDNEY,
     .rematchTableIdx = REMATCH_SIDNEY,
     .desc = gEliteFourMatchCallDesc,
@@ -670,7 +670,7 @@ static const match_call_text_data_t sPhoebeTextScripts[] = {
 static const struct MatchCallStruct5 sPhoebeMatchCallHeader =
 {
     .type = 5,
-    .v1 = MAPSEC_EVER_GRANDE_CITY,
+    .mapSec = MAPSEC_EVER_GRANDE_CITY,
     .flag = FLAG_REMATCH_PHOEBE,
     .rematchTableIdx = REMATCH_PHOEBE,
     .desc = gEliteFourMatchCallDesc,
@@ -686,7 +686,7 @@ static const match_call_text_data_t sGlaciaTextScripts[] = {
 static const struct MatchCallStruct5 sGlaciaMatchCallHeader =
 {
     .type = 5,
-    .v1 = MAPSEC_EVER_GRANDE_CITY,
+    .mapSec = MAPSEC_EVER_GRANDE_CITY,
     .flag = FLAG_REMATCH_GLACIA,
     .rematchTableIdx = REMATCH_GLACIA,
     .desc = gEliteFourMatchCallDesc,
@@ -702,7 +702,7 @@ static const match_call_text_data_t sDrakeTextScripts[] = {
 static const struct MatchCallStruct5 sDrakeMatchCallHeader =
 {
     .type = 5,
-    .v1 = MAPSEC_EVER_GRANDE_CITY,
+    .mapSec = MAPSEC_EVER_GRANDE_CITY,
     .flag = FLAG_REMATCH_DRAKE,
     .rematchTableIdx = REMATCH_DRAKE,
     .desc = gEliteFourMatchCallDesc,
@@ -718,7 +718,7 @@ static const match_call_text_data_t sWallaceTextScripts[] = {
 static const struct MatchCallStruct5 sWallaceMatchCallHeader =
 {
     .type = 5,
-    .v1 = MAPSEC_EVER_GRANDE_CITY,
+    .mapSec = MAPSEC_EVER_GRANDE_CITY,
     .flag = FLAG_REMATCH_WALLACE,
     .rematchTableIdx = REMATCH_WALLACE,
     .desc = gChampionMatchCallDesc,
@@ -912,12 +912,12 @@ u8 sub_81D16DC(u32 idx)
 
 static u8 sub_81D1714(match_call_t matchCall)
 {
-    return matchCall.type0->v1;
+    return matchCall.type0->mapSec;
 }
 
 static u8 sub_81D1718(match_call_t matchCall)
 {
-    return matchCall.type1->v1;
+    return matchCall.type1->mapSec;
 }
 
 static u8 sub_81D171C(match_call_t matchCall)

--- a/src/pokenav_match_call_data.c
+++ b/src/pokenav_match_call_data.c
@@ -898,7 +898,7 @@ static bool32 MatchCallGetFlag_Type4(match_call_t matchCall)
     return FlagGet(matchCall.type3->flag);
 }
 
-u8 sub_81D16DC(u32 idx)
+u8 MatchCallMapSecGetByIndex(u32 idx)
 {
     match_call_t matchCall;
     u32 i;

--- a/src/pokenav_match_call_data.c
+++ b/src/pokenav_match_call_data.c
@@ -474,10 +474,10 @@ static const match_call_text_data_t sWallyTextScripts[] = {
 };
 
 const struct MatchCallSubstruct2 sWallyAdditionalData[] = {
-    { FLAG_HIDE_MAUVILLE_CITY_WALLY, 0x05 },
-    { FLAG_GROUDON_AWAKENED_MAGMA_HIDEOUT, 0xD5 },
-    { FLAG_HIDE_VICTORY_ROAD_ENTRANCE_WALLY, 0x46 },
-    { 0xFFFF,     0xD5 }
+    { FLAG_HIDE_MAUVILLE_CITY_WALLY,          MAPSEC_VERDANTURF_TOWN },
+    { FLAG_GROUDON_AWAKENED_MAGMA_HIDEOUT,    MAPSEC_NONE },
+    { FLAG_HIDE_VICTORY_ROAD_ENTRANCE_WALLY,  MAPSEC_VICTORY_ROAD },
+    { 0xFFFF,                                 MAPSEC_NONE }
 };
 
 static const struct MatchCallStruct2 sWallyMatchCallHeader =

--- a/src/pokenav_match_call_data.c
+++ b/src/pokenav_match_call_data.c
@@ -6,6 +6,7 @@
 #include "battle.h"
 #include "gym_leader_rematch.h"
 #include "match_call.h"
+#include "constants/region_map_sections.h"
 
 // Static type declarations
 
@@ -325,7 +326,7 @@ static const match_call_text_data_t sMrStoneTextScripts[] = {
 static const struct MatchCallStruct0 sMrStoneMatchCallHeader =
 {
     .type = 0,
-    .v1 = 10,
+    .v1 = MAPSEC_RUSTBORO_CITY,
     .flag = 0xFFFF,
     .desc = gMrStoneMatchCallDesc,
     .name = gMrStoneMatchCallName,
@@ -348,7 +349,7 @@ static const match_call_text_data_t sNormanTextScripts[] = {
 static const struct MatchCallStruct5 sNormanMatchCallHeader =
 {
     .type = 5,
-    .v1 = 7,
+    .v1 = MAPSEC_PETALBURG_CITY,
     .flag = FLAG_ENABLE_NORMAN_MATCH_CALL,
     .rematchTableIdx = REMATCH_NORMAN,
     .desc = gNormanMatchCallDesc,
@@ -375,7 +376,7 @@ static const match_call_text_data_t sMomTextScripts[] = {
 static const struct MatchCallStruct0 sMomMatchCallHeader =
 {
     .type = 0,
-    .v1 = 0,
+    .v1 = MAPSEC_LITTLEROOT_TOWN,
     .flag = FLAG_ENABLE_MOM_MATCH_CALL,
     .desc = gMomMatchCallDesc,
     .name = gMomMatchCallName,
@@ -396,7 +397,7 @@ static const match_call_text_data_t sStevenTextScripts[] = {
 static const struct MatchCallStruct0 sStevenMatchCallHeader =
 {
     .type = 0,
-    .v1 = 0xD5,
+    .v1 = MAPSEC_NONE,
     .flag = FLAG_REGISTERED_STEVEN_POKENAV,
     .desc = gStevenMatchCallDesc,
     .name = gStevenMatchCallName,
@@ -505,7 +506,7 @@ static const match_call_text_data_t sScottTextScripts[] = {
 static const struct MatchCallStruct0 sScottMatchCallHeader =
 {
     .type = 0,
-    .v1 = 0xD5,
+    .v1 = MAPSEC_NONE,
     .flag = FLAG_ENABLE_SCOTT_MATCH_CALL,
     .desc = gScottMatchCallDesc,
     .name = gScottMatchCallName,
@@ -523,7 +524,7 @@ static const match_call_text_data_t sRoxanneTextScripts[] = {
 static const struct MatchCallStruct5 sRoxanneMatchCallHeader =
 {
     .type = 5,
-    .v1 = 10,
+    .v1 = MAPSEC_RUSTBORO_CITY,
     .flag = FLAG_ENABLE_ROXANNE_MATCH_CALL,
     .rematchTableIdx = REMATCH_ROXANNE,
     .desc = gRoxanneMatchCallDesc,
@@ -542,7 +543,7 @@ static const match_call_text_data_t sBrawlyTextScripts[] = {
 static const struct MatchCallStruct5 sBrawlyMatchCallHeader =
 {
     .type = 5,
-    .v1 = 2,
+    .v1 = MAPSEC_DEWFORD_TOWN,
     .flag = FLAG_ENABLE_BRAWLY_MATCH_CALL,
     .rematchTableIdx = REMATCH_BRAWLY,
     .desc = gBrawlyMatchCallDesc,
@@ -561,7 +562,7 @@ static const match_call_text_data_t sWattsonTextScripts[] = {
 static const struct MatchCallStruct5 sWattsonMatchCallHeader =
 {
     .type = 5,
-    .v1 = 9,
+    .v1 = MAPSEC_MAUVILLE_CITY,
     .flag = FLAG_ENABLE_WATTSON_MATCH_CALL,
     .rematchTableIdx = REMATCH_WATTSON,
     .desc = gWattsonMatchCallDesc,
@@ -580,7 +581,7 @@ static const match_call_text_data_t sFlanneryTextScripts[] = {
 static const struct MatchCallStruct5 sFlanneryMatchCallHeader =
 {
     .type = 5,
-    .v1 = 3,
+    .v1 = MAPSEC_LAVARIDGE_TOWN,
     .flag = FLAG_ENABLE_FLANNERY_MATCH_CALL,
     .rematchTableIdx = REMATCH_FLANNERY,
     .desc = gFlanneryMatchCallDesc,
@@ -599,7 +600,7 @@ static const match_call_text_data_t sWinonaTextScripts[] = {
 static const struct MatchCallStruct5 sWinonaMatchCallHeader =
 {
     .type = 5,
-    .v1 = 11,
+    .v1 = MAPSEC_FORTREE_CITY,
     .flag = FLAG_ENABLE_WINONA_MATCH_CALL,
     .rematchTableIdx = REMATCH_WINONA,
     .desc = gWinonaMatchCallDesc,
@@ -618,7 +619,7 @@ static const match_call_text_data_t sTateLizaTextScripts[] = {
 static const struct MatchCallStruct5 sTateLizaMatchCallHeader =
 {
     .type = 5,
-    .v1 = 13,
+    .v1 = MAPSEC_MOSSDEEP_CITY,
     .flag = FLAG_ENABLE_TATE_AND_LIZA_MATCH_CALL,
     .rematchTableIdx = REMATCH_TATE_AND_LIZA,
     .desc = gTateLizaMatchCallDesc,
@@ -637,7 +638,7 @@ static const match_call_text_data_t sJuanTextScripts[] = {
 static const struct MatchCallStruct5 sJuanMatchCallHeader =
 {
     .type = 5,
-    .v1 = 14,
+    .v1 = MAPSEC_SOOTOPOLIS_CITY,
     .flag = FLAG_ENABLE_JUAN_MATCH_CALL,
     .rematchTableIdx = REMATCH_JUAN,
     .desc = gJuanMatchCallDesc,
@@ -653,7 +654,7 @@ static const match_call_text_data_t sSidneyTextScripts[] = {
 static const struct MatchCallStruct5 sSidneyMatchCallHeader =
 {
     .type = 5,
-    .v1 = 15,
+    .v1 = MAPSEC_EVER_GRANDE_CITY,
     .flag = FLAG_REMATCH_SIDNEY,
     .rematchTableIdx = REMATCH_SIDNEY,
     .desc = gEliteFourMatchCallDesc,
@@ -669,7 +670,7 @@ static const match_call_text_data_t sPhoebeTextScripts[] = {
 static const struct MatchCallStruct5 sPhoebeMatchCallHeader =
 {
     .type = 5,
-    .v1 = 15,
+    .v1 = MAPSEC_EVER_GRANDE_CITY,
     .flag = FLAG_REMATCH_PHOEBE,
     .rematchTableIdx = REMATCH_PHOEBE,
     .desc = gEliteFourMatchCallDesc,
@@ -685,7 +686,7 @@ static const match_call_text_data_t sGlaciaTextScripts[] = {
 static const struct MatchCallStruct5 sGlaciaMatchCallHeader =
 {
     .type = 5,
-    .v1 = 15,
+    .v1 = MAPSEC_EVER_GRANDE_CITY,
     .flag = FLAG_REMATCH_GLACIA,
     .rematchTableIdx = REMATCH_GLACIA,
     .desc = gEliteFourMatchCallDesc,
@@ -701,7 +702,7 @@ static const match_call_text_data_t sDrakeTextScripts[] = {
 static const struct MatchCallStruct5 sDrakeMatchCallHeader =
 {
     .type = 5,
-    .v1 = 15,
+    .v1 = MAPSEC_EVER_GRANDE_CITY,
     .flag = FLAG_REMATCH_DRAKE,
     .rematchTableIdx = REMATCH_DRAKE,
     .desc = gEliteFourMatchCallDesc,
@@ -717,7 +718,7 @@ static const match_call_text_data_t sWallaceTextScripts[] = {
 static const struct MatchCallStruct5 sWallaceMatchCallHeader =
 {
     .type = 5,
-    .v1 = 15,
+    .v1 = MAPSEC_EVER_GRANDE_CITY,
     .flag = FLAG_REMATCH_WALLACE,
     .rematchTableIdx = REMATCH_WALLACE,
     .desc = gChampionMatchCallDesc,

--- a/src/pokenav_match_call_data.c
+++ b/src/pokenav_match_call_data.c
@@ -111,11 +111,11 @@ static bool32 MatchCallGetFlag_Type2(match_call_t);
 static bool32 MatchCallGetFlag_Type3(match_call_t);
 static bool32 MatchCallGetFlag_Type4(match_call_t);
 
-static u8 sub_81D1714(match_call_t);
-static u8 sub_81D1718(match_call_t);
-static u8 sub_81D171C(match_call_t);
-static u8 sub_81D1750(match_call_t);
-static u8 sub_81D1754(match_call_t);
+static u8 MatchCallGetMapSec_Type0(match_call_t);
+static u8 MatchCallGetMapSec_Type1(match_call_t);
+static u8 MatchCallGetMapSec_Type2(match_call_t);
+static u8 MatchCallGetMapSec_Type3(match_call_t);
+static u8 MatchCallGetMapSec_Type4(match_call_t);
 
 static bool32 MatchCall_IsRematchable_Type0(match_call_t);
 static bool32 MatchCall_IsRematchable_Type1(match_call_t);
@@ -758,12 +758,12 @@ static bool32 (*const sMatchCallGetFlagFuncs[])(match_call_t) = {
     MatchCallGetFlag_Type4
 };
 
-static u8 (*const gUnknown_08625310[])(match_call_t) = {
-    sub_81D1714,
-    sub_81D1718,
-    sub_81D171C,
-    sub_81D1750,
-    sub_81D1754
+static u8 (*const sMatchCallGetMapsecFuncs[])(match_call_t) = {
+    MatchCallGetMapSec_Type0,
+    MatchCallGetMapSec_Type1,
+    MatchCallGetMapSec_Type2,
+    MatchCallGetMapSec_Type3,
+    MatchCallGetMapSec_Type4
 };
 
 static bool32 (*const sMatchCall_IsRematchableFunctions[])(match_call_t) = {
@@ -907,20 +907,20 @@ u8 sub_81D16DC(u32 idx)
         return 0;
     matchCall = sMatchCallHeaders[idx];
     i = MatchCallGetFunctionIndex(matchCall);
-    return gUnknown_08625310[i](matchCall);
+    return sMatchCallGetMapsecFuncs[i](matchCall);
 }
 
-static u8 sub_81D1714(match_call_t matchCall)
+static u8 MatchCallGetMapSec_Type0(match_call_t matchCall)
 {
     return matchCall.type0->mapSec;
 }
 
-static u8 sub_81D1718(match_call_t matchCall)
+static u8 MatchCallGetMapSec_Type1(match_call_t matchCall)
 {
     return matchCall.type1->mapSec;
 }
 
-static u8 sub_81D171C(match_call_t matchCall)
+static u8 MatchCallGetMapSec_Type2(match_call_t matchCall)
 {
     s32 i;
 
@@ -932,12 +932,12 @@ static u8 sub_81D171C(match_call_t matchCall)
     return matchCall.type2->v10[i].mapSec;
 }
 
-static u8 sub_81D1750(match_call_t matchCall)
+static u8 MatchCallGetMapSec_Type3(match_call_t matchCall)
 {
     return MAPSEC_NONE;
 }
 
-static u8 sub_81D1754(match_call_t matchCall)
+static u8 MatchCallGetMapSec_Type4(match_call_t matchCall)
 {
     return MAPSEC_NONE;
 }

--- a/src/pokenav_unk_3.c
+++ b/src/pokenav_unk_3.c
@@ -208,7 +208,7 @@ static u32 sub_81CAD20(s32 taskState)
             {
                 state->unk1C[state->unkA].unk2 = j;
                 state->unk1C[state->unkA].unk0 = 1;
-                state->unk1C[state->unkA].unk1 = sub_81D16DC(j);
+                state->unk1C[state->unkA].unk1 = MatchCallMapSecGetByIndex(j);
                 state->unkA++;
             }
 


### PR DESCRIPTION
Wally and Prof. Birch are skipped. Wally has a variable location, and Prof Birch (despite being listed as .v1 = 0, which is Littleroot) is actually listed as location unknown in the pokenav. Rival is also skipped, as they dont have a location field and are also listed as unknown