### PR TITLE
Update scaninc to include missing .include files in assembler files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ endif
 ifeq ($(NODEP),1)
 $(C_BUILDDIR)/%.o: c_dep :=
 else
-$(C_BUILDDIR)/%.o: c_dep = $(shell $(SCANINC) -I include $(C_SUBDIR)/$*.c)
+$(C_BUILDDIR)/%.o: c_dep = $(shell $(SCANINC) -I include -I tools/agbcc/include $(C_SUBDIR)/$*.c)
 endif
 
 ifeq ($(DINFO),1)

--- a/tools/scaninc/scaninc.cpp
+++ b/tools/scaninc/scaninc.cpp
@@ -97,18 +97,25 @@ int main(int argc, char **argv)
         }
         for (auto include : file.GetIncludes())
         {
+            bool exists = false;
+            std::string path("");
             for (auto includeDir : includeDirs)
             {
-                std::string path(includeDir + include);
+                path = includeDir + include;
                 if (CanOpenFile(path))
                 {
-                    bool inserted = dependencies.insert(path).second;
-                    if (inserted)
-                    {
-                        filesToProcess.push(path);
-                    }
+                    exists = true;
                     break;
                 }
+            }
+            if (!exists && file.FileType() == SourceFileType::Asm)
+            {
+                path = include;
+            }
+            bool inserted = dependencies.insert(path).second;
+            if (inserted && exists)
+            {
+                filesToProcess.push(path);
             }
         }
         includeDirs.pop_back();

--- a/tools/scaninc/source_file.cpp
+++ b/tools/scaninc/source_file.cpp
@@ -89,6 +89,11 @@ SourceFile::SourceFile(std::string path)
     }
 }
 
+SourceFileType SourceFile::FileType()
+{
+    return m_file_type;
+}
+
 SourceFile::~SourceFile()
 {
     if (m_file_type == SourceFileType::Cpp || m_file_type == SourceFileType::Header)

--- a/tools/scaninc/source_file.h
+++ b/tools/scaninc/source_file.h
@@ -50,6 +50,7 @@ public:
     const std::set<std::string>& GetIncbins();
     const std::set<std::string>& GetIncludes();
     std::string& GetSrcDir();
+    SourceFileType FileType();
 
 private:
     union InnerUnion {


### PR DESCRIPTION
If files are auto-generated, then they don't exist yet when `scaninc` runs.  Therefore, they never get added as a dependency for the file.  This change makes it so missing files *do* get added as a dependency.  However, this was slightly more complicated because assembler files do not use relative filepaths for the `.include` paths, while C files do.

I've run into this issue and ignored it the past, and I ran into it again when trying to integrate auto-generated poryscript files as part of the Makefile.