### PR TITLE
Use constants in compare macro

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -233,14 +233,12 @@
 	.endm
 
 	@ Generic compare macro which attempts to deduce argument types based on their values
-	@ Any values between 0x4000 to 0x4FFF and 0x8000 to 0x8FFF are considered event variable identifiers
-	.macro compare arg1:req, arg2:req
-		.if ((\arg1 >> 12) == 4 || (\arg1 >> 12) == 8) && ((\arg2 >> 12) == 4 || (\arg2 >> 12) == 8)
-			compare_var_to_var \arg1, \arg2
-		.elseif ((\arg1 >> 12) == 4 || (\arg1 >> 12) == 8) && (\arg2 >= 0 && \arg2 <= 0xFFFF)
-			compare_var_to_value \arg1, \arg2
+	@ Any values between 0x4000 to 0x40FF and 0x8000 to 0x8015 are considered event variable identifiers
+	.macro compare var:req, arg:req
+		.if (\arg >= VARS_START && \arg <= VARS_END) || (\arg >= SPECIAL_VARS_START && \arg <= SPECIAL_VARS_END)
+			compare_var_to_var \var, \arg
 		.else
-			.error "Invalid arguments for 'compare'"
+			compare_var_to_value \var, \arg
 		.endif
 	.endm
 

--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -235,7 +235,7 @@
 	@ Generic compare macro which attempts to deduce argument types based on their values
 	@ Any values between 0x4000 to 0x40FF and 0x8000 to 0x8015 are considered event variable identifiers
 	.macro compare var:req, arg:req
-		.if (\arg >= VARS_START && \arg <= VARS_END) || (\arg >= SPECIAL_VARS_START && \arg <= SPECIAL_VARS_END)
+		.if ((\arg >= VARS_START && \arg <= VARS_END) || (\arg >= SPECIAL_VARS_START && \arg <= SPECIAL_VARS_END))
 			compare_var_to_var \var, \arg
 		.else
 			compare_var_to_value \var, \arg

--- a/data/scripts/mevent_altering_cave.inc
+++ b/data/scripts/mevent_altering_cave.inc
@@ -1,7 +1,7 @@
 MysteryEventScript_AlteringCave:: @ 86756E3
 	setvaddress MysteryEventScript_AlteringCave
 	addvar VAR_ALTERING_CAVE_WILD_SET, 1
-	compare_var_to_value VAR_ALTERING_CAVE_WILD_SET, 10
+	compare VAR_ALTERING_CAVE_WILD_SET, 10
 	vgoto_if_ne MysteryEventScript_AlteringCave_
 	setvar VAR_ALTERING_CAVE_WILD_SET, 0
 MysteryEventScript_AlteringCave_: @ 86756FD

--- a/data/scripts/mevent_aurora_ticket.inc
+++ b/data/scripts/mevent_aurora_ticket.inc
@@ -7,13 +7,13 @@ MysteryEventScript_AuroraTicket:: @ 867533C
 	checkflag FLAG_BATTLED_DEOXYS
 	vgoto_if_eq AuroraTicket_Obtained
 	checkitem ITEM_AURORA_TICKET, 1
-	compare_var_to_value VAR_RESULT, TRUE
+	compare VAR_RESULT, TRUE
 	vgoto_if_eq AuroraTicket_Obtained
 	vmessage sText_AuroraTicketForYou
 	waitmessage
 	waitbuttonpress
 	checkitemspace ITEM_AURORA_TICKET, 1
-	compare_var_to_value VAR_RESULT, FALSE
+	compare VAR_RESULT, FALSE
 	vgoto_if_eq AuroraTicket_NoBagSpace
 	giveitem_std ITEM_AURORA_TICKET
 	setflag FLAG_ENABLE_SHIP_BIRTH_ISLAND

--- a/data/scripts/mevent_battle_card.inc
+++ b/data/scripts/mevent_battle_card.inc
@@ -4,7 +4,7 @@ MysteryEventScript_BattleCard:: @ 867513C
 	vgoto_if_eq MysteryEventScript_BattleCardInfo
 	setorcopyvar VAR_RESULT, GET_CARD_BATTLES_WON
 	specialvar VAR_0x8008, GetMysteryEventCardVal
-	compare_var_to_value VAR_0x8008, REQUIRED_CARD_BATTLES
+	compare VAR_0x8008, REQUIRED_CARD_BATTLES
 	vgoto_if_ne MysteryEventScript_BattleCardInfo
 	lock
 	faceplayer

--- a/data/scripts/mevent_mystic_ticket.inc
+++ b/data/scripts/mevent_mystic_ticket.inc
@@ -9,13 +9,13 @@ MysteryEventScript_MysticTicket:: @ 867550B
 	checkflag FLAG_CAUGHT_HO_OH
 	vgoto_if_eq MysticTicket_Obtained
 	checkitem ITEM_MYSTIC_TICKET, 1
-	compare_var_to_value VAR_RESULT, TRUE
+	compare VAR_RESULT, TRUE
 	vgoto_if_eq MysticTicket_Obtained
 	vmessage sText_MysticTicketForYou
 	waitmessage
 	waitbuttonpress
 	checkitemspace ITEM_MYSTIC_TICKET, 1
-	compare_var_to_value VAR_RESULT, FALSE
+	compare VAR_RESULT, FALSE
 	vgoto_if_eq MysticTicket_NoBagSpace
 	giveitem_std ITEM_MYSTIC_TICKET
 	setflag FLAG_ENABLE_SHIP_NAVEL_ROCK

--- a/data/scripts/mevent_old_sea_map.inc
+++ b/data/scripts/mevent_old_sea_map.inc
@@ -7,13 +7,13 @@ MysteryEventScript_OldSeaMap:: @ 86757F4
 	checkflag FLAG_CAUGHT_MEW
 	vgoto_if_eq OldSeaMap_Obtained
 	checkitem ITEM_OLD_SEA_MAP, 1
-	compare_var_to_value VAR_RESULT, TRUE
+	compare VAR_RESULT, TRUE
 	vgoto_if_eq OldSeaMap_Obtained
 	vmessage sText_MysteryGiftOldSeaMapForYou
 	waitmessage
 	waitbuttonpress
 	checkitemspace ITEM_OLD_SEA_MAP, 1
-	compare_var_to_value VAR_RESULT, FALSE
+	compare VAR_RESULT, FALSE
 	vgoto_if_eq OldSeaMap_NoBagSpace
 	giveitem_std ITEM_OLD_SEA_MAP
 	setflag FLAG_ENABLE_SHIP_FARAWAY_ISLAND

--- a/data/scripts/mevent_pichu.inc
+++ b/data/scripts/mevent_pichu.inc
@@ -6,7 +6,7 @@ MysteryEventScript_SurfPichu:: @ 8674D3D
 
 SurfPichu_GiveIfPossible: @ 8674D4C
 	specialvar VAR_EVENT_PICHU_SLOT, CalculatePlayerPartyCount
-	compare_var_to_value VAR_EVENT_PICHU_SLOT, PARTY_SIZE
+	compare VAR_EVENT_PICHU_SLOT, PARTY_SIZE
 	vgoto_if_eq SurfPichu_FullParty
 	setflag FLAG_MYSTERY_EVENT_DONE
 	vcall SurfPichu_GiveEgg
@@ -33,15 +33,15 @@ SurfPichu_GiveEgg: @ 8674D7E
 	giveegg SPECIES_PICHU
 	setmonobedient VAR_EVENT_PICHU_SLOT
 	setmonmetlocation VAR_EVENT_PICHU_SLOT, METLOC_FATEFUL_ENCOUNTER
-	compare_var_to_value VAR_EVENT_PICHU_SLOT, 1
+	compare VAR_EVENT_PICHU_SLOT, 1
 	vgoto_if_eq SurfPichu_Slot1
-	compare_var_to_value VAR_EVENT_PICHU_SLOT, 2
+	compare VAR_EVENT_PICHU_SLOT, 2
 	vgoto_if_eq SurfPichu_Slot2
-	compare_var_to_value VAR_EVENT_PICHU_SLOT, 3
+	compare VAR_EVENT_PICHU_SLOT, 3
 	vgoto_if_eq SurfPichu_Slot3
-	compare_var_to_value VAR_EVENT_PICHU_SLOT, 4
+	compare VAR_EVENT_PICHU_SLOT, 4
 	vgoto_if_eq SurfPichu_Slot4
-	compare_var_to_value VAR_EVENT_PICHU_SLOT, 5
+	compare VAR_EVENT_PICHU_SLOT, 5
 	vgoto_if_eq SurfPichu_Slot5
 	return
 

--- a/data/scripts/mevent_trainer.inc
+++ b/data/scripts/mevent_trainer.inc
@@ -1,7 +1,7 @@
 MysteryEventScript_VisitingTrainer:: @ 8674EC1
 	setvaddress MysteryEventScript_VisitingTrainer
 	special ValidateEReaderTrainer
-	compare_var_to_value VAR_RESULT, 0
+	compare VAR_RESULT, 0
 	vgoto_if_eq MysteryEventScript_VisitingTrainerArrived
 	lock
 	faceplayer

--- a/include/constants/vars.h
+++ b/include/constants/vars.h
@@ -273,7 +273,9 @@
 #define VAR_UNUSED_0x40FE                    0x40FE // Unused Var
 #define VAR_UNUSED_0x40FF                    0x40FF // Unused Var
 
-#define SPECIAL_VARS_START 0x8000
+#define VARS_END                             0x40FF
+
+#define SPECIAL_VARS_START            0x8000
 // special vars
 // They are commonly used as parameters to commands, or return values from commands.
 #define VAR_0x8000                    0x8000
@@ -298,5 +300,7 @@
 #define VAR_MON_BOX_POS               0x8013
 #define VAR_UNUSED_0x8014             0x8014
 #define VAR_TRAINER_BATTLE_OPPONENT_A 0x8015 // Alias of gTrainerBattleOpponent_A
+
+#define SPECIAL_VARS_END              0x8015
 
 #endif // GUARD_CONSTANTS_VARS_H


### PR DESCRIPTION
The current macro doesnt use the correct range of vars. This one is correct and (hopefully) more readable. It also assumes that `\var` is a proper variable id as we do with all the other macros that take vars