### PR TITLE
Remove false positives from partial doc calcrom

### DIFF
--- a/.travis/calcrom/calcrom.pl
+++ b/.travis/calcrom/calcrom.pl
@@ -64,7 +64,7 @@ my $undoc_cmd = "grep '[Uu]nknown_[0-9a-fA-F]*\\|sub_[0-9a-fA-F]*'";
 # This looks for every symbol with an address at the end of it. Some things are
 # given a name based on their type / location, but still have an unknown purpose.
 # For example, FooMap_EventScript_FFFFFFF.
-my $partial_doc_cmd = "grep '[0-9a-fA-F]\\{6,7\\}'";
+my $partial_doc_cmd = "grep '_[0-28][0-9a-fA-F]\\{5,6\\}'";
 
 my $count_cmd = "wc -l";
 


### PR DESCRIPTION
Around half of the current matches for "partially documented" in the calcrom are strings with 6 of  A-F in them (e.g. `facade` or `dEffec` in `FieldEffect`). This enforces address suffixes that start with `_0`, `_1`, `_2`, or `_8` for partially documented symbols, which should be all of them.