### PR TITLE
Move/rename gfx start/end vars

### DIFF
--- a/include/constants/event_objects.h
+++ b/include/constants/event_objects.h
@@ -240,27 +240,29 @@
 #define EVENT_OBJ_GFX_LINK_RS_MAY                236
 #define EVENT_OBJ_GFX_LUGIA                      237
 #define EVENT_OBJ_GFX_HOOH                       238
-#define EVENT_OBJ_GFX_BARD_2                     239
+
+#define NUM_OBJ_EVENT_GFX                        239
 
 // These are dynamic object gfx ids.
 // They correspond with the values of the VAR_OBJ_GFX_ID_X vars.
 // More info about them in include/constants/vars.h
-#define EVENT_OBJ_GFX_VAR_0 240
-#define EVENT_OBJ_GFX_VAR_1 241
-#define EVENT_OBJ_GFX_VAR_2 242
-#define EVENT_OBJ_GFX_VAR_3 243
-#define EVENT_OBJ_GFX_VAR_4 244
-#define EVENT_OBJ_GFX_VAR_5 245
-#define EVENT_OBJ_GFX_VAR_6 246
-#define EVENT_OBJ_GFX_VAR_7 247
-#define EVENT_OBJ_GFX_VAR_8 248
-#define EVENT_OBJ_GFX_VAR_9 249
-#define EVENT_OBJ_GFX_VAR_A 250
-#define EVENT_OBJ_GFX_VAR_B 251
-#define EVENT_OBJ_GFX_VAR_C 252
-#define EVENT_OBJ_GFX_VAR_D 253
-#define EVENT_OBJ_GFX_VAR_E 254
-#define EVENT_OBJ_GFX_VAR_F 255
+#define OBJ_EVENT_GFX_VARS   (NUM_OBJ_EVENT_GFX + 1)
+#define EVENT_OBJ_GFX_VAR_0  (OBJ_EVENT_GFX_VARS + 0x0) // 240
+#define EVENT_OBJ_GFX_VAR_1  (OBJ_EVENT_GFX_VARS + 0x1)
+#define EVENT_OBJ_GFX_VAR_2  (OBJ_EVENT_GFX_VARS + 0x2)
+#define EVENT_OBJ_GFX_VAR_3  (OBJ_EVENT_GFX_VARS + 0x3)
+#define EVENT_OBJ_GFX_VAR_4  (OBJ_EVENT_GFX_VARS + 0x4)
+#define EVENT_OBJ_GFX_VAR_5  (OBJ_EVENT_GFX_VARS + 0x5)
+#define EVENT_OBJ_GFX_VAR_6  (OBJ_EVENT_GFX_VARS + 0x6)
+#define EVENT_OBJ_GFX_VAR_7  (OBJ_EVENT_GFX_VARS + 0x7)
+#define EVENT_OBJ_GFX_VAR_8  (OBJ_EVENT_GFX_VARS + 0x8)
+#define EVENT_OBJ_GFX_VAR_9  (OBJ_EVENT_GFX_VARS + 0x9)
+#define EVENT_OBJ_GFX_VAR_A  (OBJ_EVENT_GFX_VARS + 0xA)
+#define EVENT_OBJ_GFX_VAR_B  (OBJ_EVENT_GFX_VARS + 0xB)
+#define EVENT_OBJ_GFX_VAR_C  (OBJ_EVENT_GFX_VARS + 0xC)
+#define EVENT_OBJ_GFX_VAR_D  (OBJ_EVENT_GFX_VARS + 0xD)
+#define EVENT_OBJ_GFX_VAR_E  (OBJ_EVENT_GFX_VARS + 0xE)
+#define EVENT_OBJ_GFX_VAR_F  (OBJ_EVENT_GFX_VARS + 0xF) // 255
 
 #define SHADOW_SIZE_S   0
 #define SHADOW_SIZE_M   1

--- a/include/event_object_movement.h
+++ b/include/event_object_movement.h
@@ -1,9 +1,6 @@
 #ifndef GUARD_FIELD_EVENT_OBJ_H
 #define GUARD_FIELD_EVENT_OBJ_H
 
-#define NUM_OBJECT_GRAPHICS_INFO 239
-#define SPRITE_VAR 240
-
 enum SpinnerRunnerFollowPatterns
 {
     RUNFOLLOW_ANY,

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1861,27 +1861,30 @@ const struct EventObjectGraphicsInfo *GetEventObjectGraphicsInfo(u8 graphicsId)
 {
     u8 bard;
 
-    if (graphicsId >= SPRITE_VAR)
+    if (graphicsId >= OBJ_EVENT_GFX_VARS)
     {
-        graphicsId = VarGetEventObjectGraphicsId(graphicsId - SPRITE_VAR);
+        graphicsId = VarGetEventObjectGraphicsId(graphicsId - OBJ_EVENT_GFX_VARS);
     }
+
     if (graphicsId == EVENT_OBJ_GFX_BARD)
     {
         bard = GetCurrentMauvilleOldMan();
         return gMauvilleOldManGraphicsInfoPointers[bard];
     }
-    if (graphicsId >= NUM_OBJECT_GRAPHICS_INFO)
+
+    if (graphicsId >= NUM_OBJ_EVENT_GFX)
     {
         graphicsId = EVENT_OBJ_GFX_NINJA_BOY;
     }
+    
     return gEventObjectGraphicsInfoPointers[graphicsId];
 }
 
 static void SetEventObjectDynamicGraphicsId(struct EventObject *eventObject)
 {
-    if (eventObject->graphicsId >= SPRITE_VAR)
+    if (eventObject->graphicsId >= OBJ_EVENT_GFX_VARS)
     {
-        eventObject->graphicsId = VarGetEventObjectGraphicsId(eventObject->graphicsId - SPRITE_VAR);
+        eventObject->graphicsId = VarGetEventObjectGraphicsId(eventObject->graphicsId - OBJ_EVENT_GFX_VARS);
     }
 }
 


### PR DESCRIPTION
Moving the gfx start/end vars to somewhere that it's clearer they should be updated when adding gfx. Also removes `EVENT_OBJ_GFX_BARD_2`, I cant find any justification for it aside from overflowing `gEventObjectGraphicsInfoPointers`. The gfx id `239` is handled and set to `EVENT_OBJ_GFX_NINJA_BOY`