### PR TITLE
add BUGFIX macro

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -26,4 +26,12 @@
 #define UNITS_METRIC
 #endif
 
+// Fix bugs which may or may not be related to modern gcc versions.
+// There is no reason for keeping bugs other than matching, so
+// always fix bugs when the build isn't supposed to match with
+// a newer compiler.
+#if MODERN
+#define BUGFIX
+#endif
+
 #endif // GUARD_CONFIG_H


### PR DESCRIPTION
The BUGFIX macro can be used to fix small bugs in the game if matching is not required. This, for example, is the case when using a modern compiler which might not like the bugs and will produce non-matching results anyway.