### PR TITLE
Make the code clearer

### DIFF
--- a/src/play_time.c
+++ b/src/play_time.c
@@ -24,7 +24,7 @@ void PlayTimeCounter_Start(void)
 {
     sPlayTimeCounterState = RUNNING;
 
-    if (gSaveBlock2Ptr->playTimeHours > 999)
+    if (gSaveBlock2Ptr->playTimeHours >= 1000)
         PlayTimeCounter_SetToMax();
 }
 


### PR DESCRIPTION
The counter stops if the number is greater than or equal to 1000, which is more or less the same as greater than 999, but it makes the intent clearer that at 1000, the timer is set to max