### PR TITLE
set Pointers to NULL, rather than 0

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -26,9 +26,9 @@ void InitScriptContext(struct ScriptContext *ctx, void *cmdTable, void *cmdTable
     s32 i;
 
     ctx->mode = 0;
-    ctx->scriptPtr = 0;
+    ctx->scriptPtr = NULL;
     ctx->stackDepth = 0;
-    ctx->nativePtr = 0;
+    ctx->nativePtr = NULL;
     ctx->cmdTable = cmdTable;
     ctx->cmdTableEnd = cmdTableEnd;
 
@@ -55,7 +55,7 @@ void SetupNativeScript(struct ScriptContext *ctx, bool8 (*ptr)(void))
 void StopScript(struct ScriptContext *ctx)
 {
     ctx->mode = 0;
-    ctx->scriptPtr = 0;
+    ctx->scriptPtr = NULL;
 }
 
 bool8 RunScriptCommand(struct ScriptContext *ctx)
@@ -104,7 +104,7 @@ bool8 RunScriptCommand(struct ScriptContext *ctx)
             }
 
             if ((*func)(ctx) == 1)
-                return TRUE;
+                break;
         }
     }
 

--- a/src/script.c
+++ b/src/script.c
@@ -255,7 +255,7 @@ u8 *MapHeaderGetScriptTable(u8 tag)
         if (*mapScripts == tag)
         {
             mapScripts++;
-            return (u8 *)(mapScripts[0] + (mapScripts[1] << 8) + (mapScripts[2] << 16) + (mapScripts[3] << 24));
+            return (u8 *)(*mapScripts + (*(mapScripts + 1) << 8) + (*(mapScripts + 2) << 16) + (*(mapScripts + 3) << 24));
         }
         mapScripts += 5;
     }


### PR DESCRIPTION
NULL is for pointers, not 0.

Also, according to the disassembly, a more accurate decompilation would be to break when (*func)(ctx) is 1, not return true directly.