### PR TITLE
Shop: Document some object event constants

### DIFF
--- a/include/shop.h
+++ b/include/shop.h
@@ -41,7 +41,7 @@ struct ShopData
     /*0x200B*/ u8 scrollIndicatorsTaskId;
     /*0x200C*/ u8 iconSlot;
     /*0x200D*/ u8 itemSpriteIds[2];
-    /*0x2010*/ s16 viewportObjects[16][5];
+    /*0x2010*/ s16 viewportObjects[OBJECT_EVENTS_COUNT][5];
 };
 
 void CreatePokemartMenu(const u16 *);

--- a/src/shop.c
+++ b/src/shop.c
@@ -796,15 +796,15 @@ static void BuyMenuCollectObjectEventData(void)
     u8 r8 = 0;
 
     GetXYCoordsOneStepInFrontOfPlayer(&facingX, &facingY);
-    for (y = 0; y < 16; y++)
-        gShopDataPtr->viewportObjects[y][OBJ_EVENT_ID] = 16;
+    for (y = 0; y < OBJECT_EVENTS_COUNT; y++)
+        gShopDataPtr->viewportObjects[y][OBJ_EVENT_ID] = OBJECT_EVENTS_COUNT;
     for (y = 0; y < 5; y++)
     {
         for (x = 0; x < 7; x++)
         {
             u8 objEventId = GetObjectEventIdByXY(facingX - 4 + x, facingY - 2 + y);
 
-            if (objEventId != 16)
+            if (objEventId != OBJECT_EVENTS_COUNT)
             {
                 gShopDataPtr->viewportObjects[r8][OBJ_EVENT_ID] = objEventId;
                 gShopDataPtr->viewportObjects[r8][X_COORD] = x;
@@ -839,9 +839,9 @@ static void BuyMenuDrawObjectEvents(void)
     u8 spriteId;
     const struct ObjectEventGraphicsInfo *graphicsInfo;
 
-    for (i = 0; i < 16; i++) // max objects?
+    for (i = 0; i < OBJECT_EVENTS_COUNT; i++) // max objects?
     {
-        if (gShopDataPtr->viewportObjects[i][OBJ_EVENT_ID] == 16)
+        if (gShopDataPtr->viewportObjects[i][OBJ_EVENT_ID] == OBJECT_EVENTS_COUNT)
             continue;
 
         graphicsInfo = GetObjectEventGraphicsInfo(gObjectEvents[gShopDataPtr->viewportObjects[i][OBJ_EVENT_ID]].graphicsId);

--- a/src/shop.c
+++ b/src/shop.c
@@ -839,7 +839,7 @@ static void BuyMenuDrawObjectEvents(void)
     u8 spriteId;
     const struct ObjectEventGraphicsInfo *graphicsInfo;
 
-    for (i = 0; i < OBJECT_EVENTS_COUNT; i++) // max objects?
+    for (i = 0; i < OBJECT_EVENTS_COUNT; i++)
     {
         if (gShopDataPtr->viewportObjects[i][OBJ_EVENT_ID] == OBJECT_EVENTS_COUNT)
             continue;


### PR DESCRIPTION
Some stray `16`'s should be `OBJECT_EVENTS_COUNT` - this breaks some possible modifications to this constant.