### PR TITLE
Unnest if statements

### DIFF
--- a/src/play_time.c
+++ b/src/play_time.c
@@ -35,31 +35,31 @@ void PlayTimeCounter_Stop(void)
 
 void PlayTimeCounter_Update(void)
 {
-    if (sPlayTimeCounterState == RUNNING)
-    {
-        gSaveBlock2Ptr->playTimeVBlanks++;
+    if (sPlayTimeCounterState != RUNNING)
+        return;
 
-        if (gSaveBlock2Ptr->playTimeVBlanks > 59)
-        {
-            gSaveBlock2Ptr->playTimeVBlanks = 0;
-            gSaveBlock2Ptr->playTimeSeconds++;
+    gSaveBlock2Ptr->playTimeVBlanks++;
 
-            if (gSaveBlock2Ptr->playTimeSeconds > 59)
-            {
-                gSaveBlock2Ptr->playTimeSeconds = 0;
-                gSaveBlock2Ptr->playTimeMinutes++;
+    if (gSaveBlock2Ptr->playTimeVBlanks < 60)
+        return;
 
-                if (gSaveBlock2Ptr->playTimeMinutes > 59)
-                {
-                    gSaveBlock2Ptr->playTimeMinutes = 0;
-                    gSaveBlock2Ptr->playTimeHours++;
+    gSaveBlock2Ptr->playTimeVBlanks = 0;
+    gSaveBlock2Ptr->playTimeSeconds++;
 
-                    if (gSaveBlock2Ptr->playTimeHours > 999)
-                        PlayTimeCounter_SetToMax();
-                }
-            }
-        }
-    }
+    if (gSaveBlock2Ptr->playTimeSeconds < 60)
+        return;
+
+    gSaveBlock2Ptr->playTimeSeconds = 0;
+    gSaveBlock2Ptr->playTimeMinutes++;
+
+    if (gSaveBlock2Ptr->playTimeMinutes < 60)
+        return;
+
+    gSaveBlock2Ptr->playTimeMinutes = 0;
+    gSaveBlock2Ptr->playTimeHours++;
+
+    if (gSaveBlock2Ptr->playTimeHours > 999)
+        PlayTimeCounter_SetToMax();
 }
 
 void PlayTimeCounter_SetToMax(void)


### PR DESCRIPTION
Overall, it is generally considered bad style to continually nest loops. However, if this is what the decompiler outputted, then why bother touching it?

However, this can be rewritten as returning early if the playtime is less than 60.

The reason for this is not because of the original code, but because it looks better, has the same output, and is easier to understand.