### PR TITLE
Fix some UB exposed with GCC 10.1.0

### DIFF
--- a/include/item_menu.h
+++ b/include/item_menu.h
@@ -52,10 +52,7 @@ struct BagMenuStruct
     void (*exitCallback)(void);
     u8 tilemapBuffer[0x800];
     u8 spriteId[12];
-    u8 windowPointers[7];
-    u8 unk817;
-    u8 unk818;
-    u8 unk819;
+    u8 windowPointers[10];
     u8 itemOriginalLocation;
     u8 pocketSwitchDisabled:4;
     u8 itemIconSlot:2;

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -1776,7 +1776,7 @@ void Task_ChooseHowManyToToss(u8 taskId)
 
     if (AdjustQuantityAccordingToDPadInput(&tItemCount, data[2]) == TRUE)
     {
-        PrintItemDepositAmount(gBagMenu->unk817, tItemCount);
+        PrintItemDepositAmount(gBagMenu->windowPointers[7], tItemCount);
     }
     else if (gMain.newKeys & A_BUTTON)
     {
@@ -2050,7 +2050,7 @@ void Task_BuyHowManyDialogueHandleInput(u8 taskId)
 
     if (AdjustQuantityAccordingToDPadInput(&tItemCount, data[2]) == TRUE)
     {
-        PrintItemSoldAmount(gBagMenu->unk818, tItemCount, (ItemId_GetPrice(gSpecialVar_ItemId) / 2) * tItemCount);
+        PrintItemSoldAmount(gBagMenu->windowPointers[8], tItemCount, (ItemId_GetPrice(gSpecialVar_ItemId) / 2) * tItemCount);
     }
     else if (gMain.newKeys & A_BUTTON)
     {
@@ -2094,7 +2094,7 @@ void sub_81AD8C8(u8 taskId)
     LoadBagItemListBuffers(gBagPositionStruct.pocket);
     data[0] = ListMenuInit(&gMultiuseListMenuTemplate, *scrollPos, *cursorPos);
     BagMenu_PrintCursor_(data[0], 2);
-    PrintMoneyAmountInMoneyBox(gBagMenu->unk819, GetMoney(&gSaveBlock1Ptr->money), 0);
+    PrintMoneyAmountInMoneyBox(gBagMenu->windowPointers[9], GetMoney(&gSaveBlock1Ptr->money), 0);
     gTasks[taskId].func = sub_81AD9C0;
 }
 
@@ -2134,7 +2134,7 @@ void sub_81ADA7C(u8 taskId)
 
     if (AdjustQuantityAccordingToDPadInput(&tItemCount, data[2]) == TRUE)
     {
-        PrintItemDepositAmount(gBagMenu->unk817, tItemCount);
+        PrintItemDepositAmount(gBagMenu->windowPointers[7], tItemCount);
     }
     else if (gMain.newKeys & A_BUTTON)
     {

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -4521,7 +4521,11 @@ static void UnusedPrintMonName(u8 windowId, const u8* name, u8 left, u8 top)
         ;
     for (i = 0; i < nameLength; i++)
         str[ARRAY_COUNT(str) - nameLength + i] = name[i];
+#ifdef UBFIX
+    str[ARRAY_COUNT(str) - 1] = EOS;
+#else
     str[ARRAY_COUNT(str)] = EOS;
+#endif
     PrintInfoSubMenuText(windowId, str, left, top);
 }
 


### PR DESCRIPTION
devkitARM release 54 supplies arm-none-eabi-gcc version 10.1.0, which when used to compile pokeemerald_modern.gba will issue warnings about out-of-array accesses in item_menu.c and pokedex.c. These changes resolve these warnings without affecting the vanilla build. The function in pokedex.c is an unused print-right-aligned function so should not affect gameplay.