### PR TITLE
Allow crt0.s to compile on more platforms

### DIFF
--- a/src/crt0.s
+++ b/src/crt0.s
@@ -82,12 +82,12 @@ GPIOPortReadEnable: @ 80000C8
 	.align 2, 0
 	.global Init
 Init: @ 8000204
-	mov r0, PSR_IRQ_MODE
-	msr cpsr_cf, r0
+	mov r0, #PSR_IRQ_MODE
+	msr cpsr, r0
 	ldr sp, sp_irq
-	mov r0, PSR_SYS_MODE
-	msr cpsr_cf, r0
-	ldr sp, sp_sys
+	mov r0, #PSR_SYS_MODE
+	msr cpsr, r0
+	ldr sp, sp_usr
 	ldr r1, =INTR_VECTOR
 	adr r0, IntrMain
 	str r0, [r1]
@@ -97,7 +97,7 @@ Init: @ 8000204
 	b Init
 
 	.align 2, 0
-sp_sys: .word IWRAM_END - 0x1c0
+sp_usr: .word IWRAM_END - 0x1c0
 sp_irq: .word IWRAM_END - 0x60
 
 	.pool
@@ -106,92 +106,92 @@ sp_irq: .word IWRAM_END - 0x60
 	.align 2, 0
 	.global IntrMain
 IntrMain: @ 8000248
-	mov r3, REG_BASE
-	add r3, r3, 0x200
-	ldr r2, [r3, OFFSET_REG_IE - 0x200]
-	ldrh r1, [r3, OFFSET_REG_IME - 0x200]
+	mov r3, #REG_BASE
+	add r3, r3, #OFFSET_REG_IE
+	ldr r2, [r3]
+	ldrh r1, [r3, #REG_IME - REG_IE]
 	mrs r0, spsr
-	stmdb sp!, {r0-r3,lr}
+	stmfd sp!, {r0-r3,lr}
 	mov r0, 0
-	strh r0, [r3, OFFSET_REG_IME - 0x200]
+	strh r0, [r3, #REG_IME - REG_IE]
 	and r1, r2, r2, lsr 16
 	mov r12, 0
-	ands r0, r1, INTR_FLAG_VCOUNT
+	ands r0, r1, #INTR_FLAG_VCOUNT
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
 	mov r0, 0x1
-	strh r0, [r3, OFFSET_REG_IME - 0x200]
+	strh r0, [r3, #REG_IME - REG_IE]
 	ands r0, r1, INTR_FLAG_SERIAL
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_TIMER3
+	ands r0, r1, #INTR_FLAG_TIMER3
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_HBLANK
+	ands r0, r1, #INTR_FLAG_HBLANK
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_VBLANK
+	ands r0, r1, #INTR_FLAG_VBLANK
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_TIMER0
+	ands r0, r1, #INTR_FLAG_TIMER0
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_TIMER1
+	ands r0, r1, #INTR_FLAG_TIMER1
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_TIMER2
+	ands r0, r1, #INTR_FLAG_TIMER2
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_DMA0
+	ands r0, r1, #INTR_FLAG_DMA0
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_DMA1
+	ands r0, r1, #INTR_FLAG_DMA1
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_DMA2
+	ands r0, r1, #INTR_FLAG_DMA2
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_DMA3
+	ands r0, r1, #INTR_FLAG_DMA3
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_KEYPAD
+	ands r0, r1, #INTR_FLAG_KEYPAD
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_GAMEPAK
-	strbne r0, [r3, OFFSET_REG_SOUNDCNT_X - 0x200]
+	ands r0, r1, #INTR_FLAG_GAMEPAK
+	strbne r0, [r3, #REG_SOUNDCNT_X - REG_IE]
 	bne . @ spin
 IntrMain_FoundIntr:
-	strh r0, [r3, OFFSET_REG_IF - 0x200]
+	strh r0, [r3, 2]
 	bic r2, r2, r0
 	ldr r0, =gSTWIStatus
 	ldr r0, [r0]
 	ldrb r0, [r0, 0xA]
 	mov r1, 0x8
 	mov r0, r1, lsl r0
-	orr r0, r0, INTR_FLAG_GAMEPAK
-	orr r1, r0, INTR_FLAG_SERIAL | INTR_FLAG_TIMER3 | INTR_FLAG_VCOUNT | INTR_FLAG_HBLANK
+	orr r0, r0, #INTR_FLAG_GAMEPAK
+	orr r1, r0, #INTR_FLAG_SERIAL | INTR_FLAG_TIMER3 | INTR_FLAG_VCOUNT | INTR_FLAG_HBLANK
 	and r1, r1, r2
-	strh r1, [r3, OFFSET_REG_IE - 0x200]
+	strh r1, [r3]
 	mrs r3, cpsr
-	bic r3, r3, PSR_I_BIT | PSR_F_BIT | PSR_MODE_MASK
-	orr r3, r3, PSR_SYS_MODE
-	msr cpsr_cf, r3
+	bic r3, r3, #PSR_I_BIT | PSR_F_BIT | PSR_MODE_MASK
+	orr r3, r3, #PSR_SYS_MODE
+	msr cpsr, r3
 	ldr r1, =gIntrTable
 	add r1, r1, r12
 	ldr r0, [r1]
-	stmdb sp!, {lr}
+	stmfd sp!, {lr}
 	adr lr, IntrMain_RetAddr
 	bx r0
 IntrMain_RetAddr:
-	ldmia sp!, {lr}
+	ldmfd sp!, {lr}
 	mrs r3, cpsr
-	bic r3, r3, PSR_I_BIT | PSR_F_BIT | PSR_MODE_MASK
-	orr r3, r3, PSR_I_BIT | PSR_IRQ_MODE
-	msr cpsr_cf, r3
-	ldmia sp!, {r0-r3,lr}
-	strh r2, [r3, OFFSET_REG_IE - 0x200]
-	strh r1, [r3, OFFSET_REG_IME - 0x200]
-	msr spsr_cf, r0
+	bic r3, r3, #PSR_I_BIT | PSR_F_BIT | PSR_MODE_MASK
+	orr r3, r3, #PSR_I_BIT | PSR_IRQ_MODE
+	msr cpsr, r3
+	ldmfd sp!, {r0-r3,lr}
+	strh r2, [r3]
+	strh r1, [r3, #REG_IME - REG_IE]
+	msr spsr, r0
 	bx lr
 
 	.pool

--- a/src/m4a_1.s
+++ b/src/m4a_1.s
@@ -13,7 +13,7 @@ umul3232H32:
 	.arm
 __umul3232H32:
 	umull r2, r3, r0, r1
-	add r0, r3, 0
+	add r0, r3, #0
 	bx lr
 	thumb_func_end umul3232H32
 
@@ -27,17 +27,17 @@ SoundMain:
 	beq SoundMain_1
 	bx lr @ Exit the function if ident doesn't match ID_NUMBER.
 SoundMain_1:
-	adds r3, 1
+	adds r3, #1
 	str r3, [r0, o_SoundInfo_ident]
 	push {r4-r7,lr}
 	mov r1, r8
 	mov r2, r9
-	mov r3, r10
-	mov r4, r11
+	mov r3, sl
+	mov r4, fp
 	push {r0-r4}
 	sub sp, 0x18
 	ldrb r1, [r0, o_SoundInfo_maxLines]
-	cmp r1, 0 @ if maxLines is 0, there is no maximum
+	cmp r1, #0 @ if maxLines is 0, there is no maximum
 	beq SoundMain_3
 	ldr r2, lt_REG_VCOUNT
 	ldrb r2, [r2]
@@ -49,7 +49,7 @@ SoundMain_2:
 SoundMain_3:
 	str r1, [sp, 0x14]
 	ldr r3, [r0, o_SoundInfo_func]
-	cmp r3, 0
+	cmp r3, #0
 	beq SoundMain_4
 	ldr r0, [r0, o_SoundInfo_intp]
 	bl _081DD25E
@@ -63,7 +63,7 @@ SoundMain_4:
 	ldr r5, lt_o_SoundInfo_pcmBuffer
 	adds r5, r0
 	ldrb r4, [r0, o_SoundInfo_pcmDmaCounter]
-	subs r7, r4, 1
+	subs r7, r4, #1
 	bls SoundMain_5
 	ldrb r1, [r0, o_SoundInfo_pcmDmaPeriod]
 	subs r1, r7
@@ -88,7 +88,7 @@ lt_PCM_DMA_BUF_SIZE:      .word PCM_DMA_BUF_SIZE
 	thumb_func_start SoundMainRAM
 SoundMainRAM:
 	ldrb r3, [r0, o_SoundInfo_reverb]
-	cmp r3, 0
+	cmp r3, #0
 	beq SoundMainRAM_NoReverb
 	adr r1, SoundMainRAM_Reverb
 	bx r1
@@ -107,7 +107,7 @@ _081DCEC4:
 	ldrsb r1, [r7], 0x1
 	add r0, r0, r1
 	mul r1, r0, r3
-	mov r0, r1, asr 9
+	asr	r0, r1, #9
 	tst r0, 0x80
 	addne r0, r0, 0x1
 	strb r0, [r5, r6]
@@ -118,15 +118,15 @@ _081DCEC4:
 	bx r0
 	.thumb
 SoundMainRAM_NoReverb:
-	movs r0, 0
+	movs r0, #0
 	mov r1, r8
 	adds r6, r5
-	lsrs r1, 3
+	lsrs r1, #3
 	bcc SoundMainRAM_NoReverb_Ok
 	stm r5!, {r0}
 	stm r6!, {r0}
 SoundMainRAM_NoReverb_Ok:
-	lsrs r1, 1
+	lsrs r1, #1
 	bcc SoundMainRAM_NoReverb_Loop
 	stm r5!, {r0}
 	stm r6!, {r0}
@@ -141,12 +141,12 @@ SoundMainRAM_NoReverb_Loop:
 	stm r6!, {r0}
 	stm r5!, {r0}
 	stm r6!, {r0}
-	subs r1, 1
+	subs r1, #1
 	bgt SoundMainRAM_NoReverb_Loop
 _081DCF36:
 	ldr r4, [sp, 0x18]
 	ldr r0, [r4, o_SoundInfo_divFreq]
-	mov r12, r0
+	mov ip, r0
 	ldrb r0, [r4, o_SoundInfo_maxChans]
 	adds r4, o_SoundInfo_chans
 
@@ -154,7 +154,7 @@ SoundMainRAM_ChanLoop:
 	str r0, [sp, 0x4]
 	ldr r3, [r4, o_SoundChannel_wav]
 	ldr r0, [sp, 0x14]
-	cmp r0, 0
+	cmp r0, #0
 	beq _081DCF60
 	ldr r1, =REG_VCOUNT
 	ldrb r1, [r1]
@@ -183,7 +183,7 @@ _081DCF6A:
 	bne _081DCFB0
 	movs r6, 0x3
 	strb r6, [r4, o_SoundChannel_status]
-	adds r0, r3, 0
+	adds r0, r3, #0
 	adds r0, 0x10
 	ldr r1, [r4, o_SoundChannel_ct]
 	adds r0, r1
@@ -191,7 +191,7 @@ _081DCF6A:
 	ldr r0, [r3, 0xC]
 	subs r0, r1
 	str r0, [r4, o_SoundChannel_ct]
-	movs r5, 0
+	movs r5, #0
 	strb r5, [r4, o_SoundChannel_ev]
 	str r5, [r4, o_SoundChannel_fw]
 	ldrb r2, [r3, 0x3]
@@ -208,11 +208,11 @@ _081DCFA0:
 	tst r0, r6
 	beq _081DCFB6
 	ldrb r0, [r4, o_SoundChannel_iel]
-	subs r0, 1
+	subs r0, #1
 	strb r0, [r4, o_SoundChannel_iel]
 	bhi _081DD006
 _081DCFB0:
-	movs r0, 0
+	movs r0, #0
 	strb r0, [r4, o_SoundChannel_status]
 	b _081DD240
 _081DCFB6:
@@ -221,13 +221,13 @@ _081DCFB6:
 	beq _081DCFD6
 	ldrb r0, [r4, o_SoundChannel_release]
 	muls r5, r0
-	lsrs r5, 8
+	lsrs r5, #8
 	ldrb r0, [r4, o_SoundChannel_iev]
 	cmp r5, r0
 	bhi _081DD006
 _081DCFC8:
 	ldrb r5, [r4, o_SoundChannel_iev]
-	cmp r5, 0
+	cmp r5, #0
 	beq _081DCFB0
 	movs r0, 0x4
 	orrs r6, r0
@@ -240,11 +240,11 @@ _081DCFD6:
 	bne _081DCFF4
 	ldrb r0, [r4, o_SoundChannel_decay]
 	muls r5, r0
-	lsrs r5, 8
+	lsrs r5, #8
 	ldrb r0, [r4, o_SoundChannel_sustain]
 	cmp r5, r0
 	bhi _081DD006
-	adds r5, r0, 0
+	adds r5, r0, #0
 	beq _081DCFC8
 	subs r6, 0x1
 	strb r6, [r4, o_SoundChannel_status]
@@ -269,17 +269,17 @@ _081DD006:
 	lsrs r5, r0, 4
 	ldrb r0, [r4, o_SoundChannel_rightVolume]
 	muls r0, r5
-	lsrs r0, 8
+	lsrs r0, #8
 	strb r0, [r4, o_SoundChannel_er]
 	ldrb r0, [r4, o_SoundChannel_leftVolume]
 	muls r0, r5
-	lsrs r0, 8
+	lsrs r0, #8
 	strb r0, [r4, o_SoundChannel_el]
 	movs r0, 0x10
 	ands r0, r6
 	str r0, [sp, 0x10]
 	beq _081DD03A
-	adds r0, r3, 0
+	adds r0, r3, #0
 	adds r0, 0x10
 	ldr r1, [r3, 0x8]
 	adds r0, r1
@@ -297,16 +297,16 @@ _081DD03A:
 _081DD044:
 	str r8, [sp]
 	ldr r9, [r4, o_SoundChannel_fw]
-	ldrb r10, [r4, o_SoundChannel_er]
-	ldrb r11, [r4, o_SoundChannel_el]
+	ldrb sl, [r4, o_SoundChannel_er]
+	ldrb fp, [r4, o_SoundChannel_el]
 	ldrb r0, [r4, o_SoundChannel_type]
 	tst r0, 0x30
 	beq _081DD068
 	bl sub_82DF49C
 	b _081DD228
 _081DD068:
-	mov r10, r10, lsl 16
-	mov r11, r11, lsl 16
+	lsl	sl, sl, #16
+	lsl	fp, fp, #16
 	ldrb r0, [r4, o_SoundChannel_type]
 	tst r0, 0x8
 	beq _081DD19C
@@ -314,7 +314,7 @@ _081DD07C:
 	cmp r2, 0x4
 	ble _081DD0EC
 	subs r2, r2, r8
-	movgt r9, 0
+	movgt r9, #0
 	bgt _081DD0A8
 	mov r9, r8
 	add r2, r2, r8
@@ -327,12 +327,12 @@ _081DD0A8:
 	ldr r7, [r5, 0x630]
 _081DD0B0:
 	ldrsb r0, [r3], 0x1
-	mul r1, r10, r0
+	mul r1, sl, r0
 	bic r1, r1, 0xFF0000
-	add r6, r1, r6, ror 8
-	mul r1, r11, r0
+	add r6, r1, r6, ror #8
+	mul r1, fp, r0
 	bic r1, r1, 0xFF0000
-	add r7, r1, r7, ror 8
+	add r7, r1, r7, ror #8
 	adds r5, r5, 0x40000000
 	bcc _081DD0B0
 	str r7, [r5, 0x630]
@@ -346,12 +346,12 @@ _081DD0EC:
 	ldr r7, [r5, 0x630]
 _081DD0F4:
 	ldrsb r0, [r3], 0x1
-	mul r1, r10, r0
+	mul r1, sl, r0
 	bic r1, r1, 0xFF0000
-	add r6, r1, r6, ror 8
-	mul r1, r11, r0
+	add r6, r1, r6, ror #8
+	mul r1, fp, r0
 	bic r1, r1, 0xFF0000
-	add r7, r1, r7, ror 8
+	add r7, r1, r7, ror #8
 	subs r2, r2, 0x1
 	beq _081DD164
 _081DD118:
@@ -364,39 +364,39 @@ _081DD118:
 	b _081DD22C
 _081DD134:
 	ldr r0, [sp, 0x18]
-	cmp r0, 0
+	cmp r0, #0
 	beq _081DD158
 	ldr r3, [sp, 0x14]
-	rsb lr, r2, 0
+	rsb lr, r2, #0
 _081DD148:
 	adds r2, r0, r2
 	bgt _081DD1FC
 	sub lr, lr, r0
 	b _081DD148
 _081DD158:
-	pop {r4,r12}
-	mov r2, 0
+	pop {r4,ip}
+	mov r2, #0
 	b _081DD174
 _081DD164:
 	ldr r2, [sp, 0x10]
-	cmp r2, 0
+	cmp r2, #0
 	ldrne r3, [sp, 0xC]
 	bne _081DD118
 _081DD174:
 	strb r2, [r4, o_SoundChannel_status]
-	mov r0, r5, lsr 30
+	lsr	r0, r5, #30
 	bic r5, r5, 0xC0000000
 	rsb r0, r0, 0x3
-	mov r0, r0, lsl 3
-	mov r6, r6, ror r0
-	mov r7, r7, ror r0
+	lsl	r0, r0, 0x3
+	ror	r6, r6, r0
+	ror	r7, r7, r0
 	str r7, [r5, 0x630]
 	str r6, [r5], 0x4
 	b _081DD234
 _081DD19C:
-	push {r4,r12}
+	push {r4,ip}
 	ldr r1, [r4, o_SoundChannel_freq]
-	mul r4, r12, r1
+	mul r4, ip, r1
 	ldrsb r0, [r3]
 	ldrsb r1, [r3, 0x1]!
 	sub r1, r1, r0
@@ -406,12 +406,12 @@ _081DD1B4:
 _081DD1BC:
 	mul lr, r9, r1
 	add lr, r0, lr, asr 23
-	mul r12, r10, lr
-	bic r12, r12, 0xFF0000
-	add r6, r12, r6, ror 8
-	mul r12, r11, lr
-	bic r12, r12, 0xFF0000
-	add r7, r12, r7, ror 8
+	mul ip, sl, lr
+	bic ip, ip, 0xFF0000
+	add r6, ip, r6, ror #8
+	mul ip, fp, lr
+	bic ip, ip, 0xFF0000
+	add r7, ip, r7, ror #8
 	add r9, r9, r4
 	movs lr, r9, lsr 23
 	beq _081DD208
@@ -432,7 +432,7 @@ _081DD208:
 	subs r8, r8, 0x4
 	bgt _081DD1B4
 	sub r3, r3, 0x1
-	pop {r4,r12}
+	pop {r4,ip}
 _081DD228:
 	str r9, [r4, o_SoundChannel_fw]
 _081DD22C:
@@ -445,7 +445,7 @@ _081DD234:
 	.thumb
 _081DD240:
 	ldr r0, [sp, 0x4]
-	subs r0, 1
+	subs r0, #1
 	ble _081DD24A
 	adds r4, SoundChannel_size
 	b SoundMainRAM_ChanLoop
@@ -457,8 +457,8 @@ _081DD24A:
 	pop {r0-r7}
 	mov r8, r0
 	mov r9, r1
-	mov r10, r2
-	mov r11, r3
+	mov sl, r2
+	mov fp, r3
 	pop {r3}
 _081DD25E:
 	bx r3
@@ -477,28 +477,28 @@ sub_82DF49C:
 	tst r0, 0x10
 	beq _081DD29C
 	ldr r1, [r6, 0xC]
-	add r1, r1, r6, lsl 1
+	add r1, r1, r6, lsl #1
 	add r1, r1, 0x20
 	sub r3, r1, r3
 	str r3, [r4, o_SoundChannel_cp]
 _081DD29C:
 	ldrh r0, [r6]
-	cmp r0, 0
+	cmp r0, #0
 	beq _081DD2B4
 	sub r3, r3, r6
 	sub r3, r3, 0x10
 	str r3, [r4, o_SoundChannel_cp]
 _081DD2B4:
-	push {r8,r12,lr}
-	mov r10, r10, lsl 16
-	mov r11, r11, lsl 16
+	push {r8,ip,lr}
+	lsl	sl, sl, #16
+	lsl	fp, fp, #16
 	ldr r1, [r4, o_SoundChannel_freq]
 	ldrb r0, [r4, o_SoundChannel_type]
 	tst r0, 0x8
 	movne r8, 0x800000
-	muleq r8, r12, r1
+	muleq r8, ip, r1
 	ldrh r0, [r6]
-	cmp r0, 0
+	cmp r0, #0
 	beq _081DD468
 	mov r0, 0xFF000000
 	str r0, [r4, o_SoundChannel_xpi]
@@ -516,12 +516,12 @@ _081DD308:
 _081DD310:
 	mul lr, r9, r1
 	add lr, r0, lr, asr 23
-	mul r12, r10, lr
-	bic r12, r12, 0xFF0000
-	add r6, r12, r6, ror 8
-	mul r12, r11, lr
-	bic r12, r12, 0xFF0000
-	add r7, r12, r7, ror 8
+	mul ip, sl, lr
+	bic ip, ip, 0xFF0000
+	add r6, ip, r6, ror #8
+	mul ip, fp, lr
+	bic ip, ip, 0xFF0000
+	add r7, ip, r7, ror #8
 	add r9, r9, r8
 	movs lr, r9, lsr 23
 	beq _081DD370
@@ -553,11 +553,11 @@ _081DD370:
 	b _081DD4F0
 _081DD398:
 	ldr r0, [sp, 0x1C]
-	cmp r0, 0
+	cmp r0, #0
 	beq _081DD4F4
 	ldr r3, [r4, o_SoundChannel_wav]
 	ldr r3, [r3, 0x8]
-	rsb lr, r2, 0
+	rsb lr, r2, #0
 _081DD3B0:
 	adds r2, r2, r0
 	bgt _081DD358
@@ -576,12 +576,12 @@ _081DD3D8:
 _081DD3E0:
 	mul lr, r9, r1
 	add lr, r0, lr, asr 23
-	mul r12, r10, lr
-	bic r12, r12, 0xFF0000
-	add r6, r12, r6, ror 8
-	mul r12, r11, lr
-	bic r12, r12, 0xFF0000
-	add r7, r12, r7, ror 8
+	mul ip, sl, lr
+	bic ip, ip, 0xFF0000
+	add r6, ip, r6, ror #8
+	mul ip, fp, lr
+	bic ip, ip, 0xFF0000
+	add r7, ip, r7, ror #8
 	add r9, r9, r8
 	movs lr, r9, lsr 23
 	beq _081DD440
@@ -623,15 +623,15 @@ _081DD480:
 	ldr r7, [r5, 0x630]
 _081DD488:
 	mul lr, r9, r1
-	add lr, r0, lr, asr 23
-	mul r12, r10, lr
-	bic r12, r12, 0xFF0000
-	add r6, r12, r6, ror 8
-	mul r12, r11, lr
-	bic r12, r12, 0xFF0000
-	add r7, r12, r7, ror 8
+	add lr, r0, lr, asr #23
+	mul ip, sl, lr
+	bic ip, ip, 0xFF0000
+	add r6, ip, r6, ror #8
+	mul ip, fp, lr
+	bic ip, ip, 0xFF0000
+	add r7, ip, r7, ror #8
 	add r9, r9, r8
-	movs lr, r9, lsr 23
+	lsrs lr, r9, #23
 	beq _081DD4CC
 	bic r9, r9, 0x3F800000
 	subs r2, r2, lr
@@ -650,25 +650,25 @@ _081DD4CC:
 	bgt _081DD480
 	add r3, r3, 0x1
 _081DD4F0:
-	pop {r8,r12,pc}
+	pop {r8,ip,pc}
 _081DD4F4:
-	mov r2, 0
+	mov r2, #0
 	strb r2, [r4, o_SoundChannel_status]
-	mov r0, r5, lsr 30
+	lsr	r0, r5, #30
 	bic r5, r5, 0xC0000000
 	rsb r0, r0, 0x3
-	mov r0, r0, lsl 3
-	mov r6, r6, ror r0
-	mov r7, r7, ror r0
+	lsl r0, r0, 0x3
+	ror r6, r6, r0
+	ror r7, r7, r0
 	str r7, [r5, 0x630]
 	str r6, [r5], 0x4
-	pop {r8,r12,pc}
+	pop {r8,ip,pc}
 	arm_func_end sub_82DF49C
 
 	arm_func_start sub_82DF758
 sub_82DF758:
 	push {r0,r2,r5-r7,lr}
-	mov r0, r3, lsr 6
+	lsr r0, r3, 0x6
 	ldr r1, [r4, o_SoundChannel_xpi]
 	cmp r0, r1
 	beq _081DD594
@@ -681,21 +681,21 @@ sub_82DF758:
 	ldr r5, =gUnknown_03001300
 	ldr r6, =gDeltaEncodingTable
 	mov r7, 0x40
-	ldrb lr, [r2], 1
-	strb lr, [r5], 1
-	ldrb r1, [r2], 1
+	ldrb lr, [r2], #1
+	strb lr, [r5], #1
+	ldrb r1, [r2], #1
 	b _081DD57C
 _081DD568:
-	ldrb r1, [r2], 1
-	mov r0, r1, lsr 4
+	ldrb r1, [r2], #1
+	lsr r0, r1, #4
 	ldrsb r0, [r6, r0]
 	add lr, lr, r0
-	strb lr, [r5], 1
+	strb lr, [r5], #1
 _081DD57C:
 	and r0, r1, 0xF
 	ldrsb r0, [r6, r0]
 	add lr, lr, r0
-	strb lr, [r5], 1
+	strb lr, [r5], #1
 	subs r7, r7, 2
 	bgt _081DD568
 _081DD594:
@@ -708,38 +708,38 @@ _081DD594:
 
 	thumb_func_start SoundMainBTM
 SoundMainBTM:
-	mov r12, r4
-	movs r1, 0
-	movs r2, 0
-	movs r3, 0
-	movs r4, 0
+	mov ip, r4
+	movs r1, #0
+	movs r2, #0
+	movs r3, #0
+	movs r4, #0
 	stm r0!, {r1-r4}
 	stm r0!, {r1-r4}
 	stm r0!, {r1-r4}
 	stm r0!, {r1-r4}
-	mov r4, r12
+	mov r4, ip
 	bx lr
 	thumb_func_end SoundMainBTM
 
 	thumb_func_start RealClearChain
 RealClearChain:
 	ldr r3, [r0, 0x2C]
-	cmp r3, 0
+	cmp r3, #0
 	beq _081DD5E2
 	ldr r1, [r0, 0x34]
 	ldr r2, [r0, 0x30]
-	cmp r2, 0
+	cmp r2, #0
 	beq _081DD5D6
 	str r1, [r2, 0x34]
 	b _081DD5D8
 _081DD5D6:
 	str r1, [r3, 0x20]
 _081DD5D8:
-	cmp r1, 0
+	cmp r1, #0
 	beq _081DD5DE
 	str r2, [r1, 0x30]
 _081DD5DE:
-	movs r1, 0
+	movs r1, #0
 	str r1, [r0, 0x2C]
 _081DD5E2:
 	bx lr
@@ -748,9 +748,9 @@ _081DD5E2:
 	thumb_func_start ply_fine
 ply_fine:
 	push {r4,r5,lr}
-	adds r5, r1, 0
+	adds r5, r1, #0
 	ldr r4, [r5, o_MusicPlayerTrack_chan]
-	cmp r4, 0
+	cmp r4, #0
 	beq ply_fine_done
 ply_fine_loop:
 	ldrb r1, [r4]
@@ -761,13 +761,13 @@ ply_fine_loop:
 	orrs r1, r0
 	strb r1, [r4]
 ply_fine_ok:
-	adds r0, r4, 0
+	adds r0, r4, #0
 	bl RealClearChain
 	ldr r4, [r4, 0x34]
-	cmp r4, 0
+	cmp r4, #0
 	bne ply_fine_loop
 ply_fine_done:
-	movs r0, 0
+	movs r0, #0
 	strb r0, [r5]
 	pop {r4,r5}
 	pop {r0}
@@ -776,7 +776,7 @@ ply_fine_done:
 
 	thumb_func_start MPlayJumpTableCopy
 MPlayJumpTableCopy:
-	mov r12, lr
+	mov ip, lr
 	movs r1, 0x24
 	ldr r2, lt_MPlayJumpTableTemplate
 MPlayJumpTableCopy_Loop:
@@ -786,7 +786,7 @@ MPlayJumpTableCopy_Loop:
 	adds r2, 0x4
 	subs r1, 0x1
 	bgt MPlayJumpTableCopy_Loop
-	bx r12
+	bx ip
 	thumb_func_end MPlayJumpTableCopy
 
 	.align 2, 0
@@ -808,7 +808,7 @@ chk_adr_r2:
 	lsrs r0, r2, 14
 	beq chk_adr_r2_done @ if adr < 0x40000 (i.e. in BIOS ROM), accept it
 chk_adr_r2_reject:
-	movs r3, 0
+	movs r3, #0
 chk_adr_r2_done:
 	pop {r0}
 	bx lr
@@ -832,13 +832,13 @@ ply_goto:
 ply_goto_1:
 	ldr r2, [r1, o_MusicPlayerTrack_cmdPtr]
 	ldrb r0, [r2, 0x3]
-	lsls r0, 8
+	lsls r0, #8
 	ldrb r3, [r2, 0x2]
 	orrs r0, r3
-	lsls r0, 8
+	lsls r0, #8
 	ldrb r3, [r2, 0x1]
 	orrs r0, r3
-	lsls r0, 8
+	lsls r0, #8
 	bl ldrb_r3_r2
 	orrs r0, r3
 	str r0, [r1, o_MusicPlayerTrack_cmdPtr]
@@ -857,7 +857,7 @@ ply_patt:
 	adds r2, 0x4
 	str r2, [r3, o_MusicPlayerTrack_patternStack]
 	ldrb r2, [r1, o_MusicPlayerTrack_patternLevel]
-	adds r2, 1
+	adds r2, #1
 	strb r2, [r1, o_MusicPlayerTrack_patternLevel]
 	b ply_goto
 ply_patt_done:
@@ -867,9 +867,9 @@ ply_patt_done:
 	thumb_func_start ply_pend
 ply_pend:
 	ldrb r2, [r1, o_MusicPlayerTrack_patternLevel]
-	cmp r2, 0
+	cmp r2, #0
 	beq ply_pend_done
-	subs r2, 1
+	subs r2, #1
 	strb r2, [r1, o_MusicPlayerTrack_patternLevel]
 	lsls r2, 2
 	adds r3, r1, r2
@@ -884,22 +884,22 @@ ply_rept:
 	push {lr}
 	ldr r2, [r1, o_MusicPlayerTrack_cmdPtr]
 	ldrb r3, [r2]
-	cmp r3, 0
+	cmp r3, #0
 	bne ply_rept_1
-	adds r2, 1
+	adds r2, #1
 	str r2, [r1, o_MusicPlayerTrack_cmdPtr]
 	b ply_goto_1
 ply_rept_1:
 	ldrb r3, [r1, o_MusicPlayerTrack_repN]
-	adds r3, 1
+	adds r3, #1
 	strb r3, [r1, o_MusicPlayerTrack_repN]
-	mov r12, r3
+	mov ip, r3
 	bl ld_r3_tp_adr_i
-	cmp r12, r3
+	cmp ip, r3
 	bhs ply_rept_2
 	b ply_goto_1
 ply_rept_2:
-	movs r3, 0
+	movs r3, #0
 	strb r3, [r1, o_MusicPlayerTrack_repN]
 	adds r2, 5
 	str r2, [r1, o_MusicPlayerTrack_cmdPtr]
@@ -909,45 +909,45 @@ ply_rept_2:
 
 	thumb_func_start ply_prio
 ply_prio:
-	mov r12, lr
+	mov ip, lr
 	bl ld_r3_tp_adr_i
 	strb r3, [r1, o_MusicPlayerTrack_priority]
-	bx r12
+	bx ip
 	thumb_func_end ply_prio
 
 	thumb_func_start ply_tempo
 ply_tempo:
-	mov r12, lr
+	mov ip, lr
 	bl ld_r3_tp_adr_i
-	lsls r3, 1
+	lsls r3, #1
 	strh r3, [r0, o_MusicPlayerInfo_tempoD]
 	ldrh r2, [r0, o_MusicPlayerInfo_tempoU]
 	muls r3, r2
-	lsrs r3, 8
+	lsrs r3, #8
 	strh r3, [r0, o_MusicPlayerInfo_tempoI]
-	bx r12
+	bx ip
 	thumb_func_end ply_tempo
 
 	thumb_func_start ply_keysh
 ply_keysh:
-	mov r12, lr
+	mov ip, lr
 	bl ld_r3_tp_adr_i
 	strb r3, [r1, o_MusicPlayerTrack_keyShift]
 	ldrb r3, [r1, o_MusicPlayerTrack_flags]
 	movs r2, 0xC
 	orrs r3, r2
 	strb r3, [r1, o_MusicPlayerTrack_flags]
-	bx r12
+	bx ip
 	thumb_func_end ply_keysh
 
 	thumb_func_start ply_voice
 ply_voice:
-	mov r12, lr
+	mov ip, lr
 	ldr r2, [r1, o_MusicPlayerTrack_cmdPtr]
 	ldrb r3, [r2]
-	adds r2, 1
+	adds r2, #1
 	str r2, [r1, o_MusicPlayerTrack_cmdPtr]
-	lsls r2, r3, 1
+	lsls r2, r3, #1
 	adds r2, r3
 	lsls r2, 2
 	ldr r3, [r0, o_MusicPlayerInfo_tone]
@@ -961,24 +961,24 @@ ply_voice:
 	ldr r3, [r2, 0x8]
 	bl chk_adr_r2
 	str r3, [r1, o_MusicPlayerTrack_ToneData_attack]
-	bx r12
+	bx ip
 	thumb_func_end ply_voice
 
 	thumb_func_start ply_vol
 ply_vol:
-	mov r12, lr
+	mov ip, lr
 	bl ld_r3_tp_adr_i
 	strb r3, [r1, o_MusicPlayerTrack_vol]
 	ldrb r3, [r1, o_MusicPlayerTrack_flags]
 	movs r2, 0x3
 	orrs r3, r2
 	strb r3, [r1, o_MusicPlayerTrack_flags]
-	bx r12
+	bx ip
 	thumb_func_end ply_vol
 
 	thumb_func_start ply_pan
 ply_pan:
-	mov r12, lr
+	mov ip, lr
 	bl ld_r3_tp_adr_i
 	subs r3, 0x40
 	strb r3, [r1, o_MusicPlayerTrack_pan]
@@ -986,12 +986,12 @@ ply_pan:
 	movs r2, 0x3
 	orrs r3, r2
 	strb r3, [r1, o_MusicPlayerTrack_flags]
-	bx r12
+	bx ip
 	thumb_func_end ply_pan
 
 	thumb_func_start ply_bend
 ply_bend:
-	mov r12, lr
+	mov ip, lr
 	bl ld_r3_tp_adr_i
 	subs r3, 0x40
 	strb r3, [r1, o_MusicPlayerTrack_bend]
@@ -999,32 +999,32 @@ ply_bend:
 	movs r2, 0xC
 	orrs r3, r2
 	strb r3, [r1, o_MusicPlayerTrack_flags]
-	bx r12
+	bx ip
 	thumb_func_end ply_bend
 
 	thumb_func_start ply_bendr
 ply_bendr:
-	mov r12, lr
+	mov ip, lr
 	bl ld_r3_tp_adr_i
 	strb r3, [r1, o_MusicPlayerTrack_bendRange]
 	ldrb r3, [r1, o_MusicPlayerTrack_flags]
 	movs r2, 0xC
 	orrs r3, r2
 	strb r3, [r1, o_MusicPlayerTrack_flags]
-	bx r12
+	bx ip
 	thumb_func_end ply_bendr
 
 	thumb_func_start ply_lfodl
 ply_lfodl:
-	mov r12, lr
+	mov ip, lr
 	bl ld_r3_tp_adr_i
 	strb r3, [r1, o_MusicPlayerTrack_lfoDelay]
-	bx r12
+	bx ip
 	thumb_func_end ply_lfodl
 
 	thumb_func_start ply_modt
 ply_modt:
-	mov r12, lr
+	mov ip, lr
 	bl ld_r3_tp_adr_i
 	ldrb r0, [r1, o_MusicPlayerTrack_modT]
 	cmp r0, r3
@@ -1035,12 +1035,12 @@ ply_modt:
 	orrs r3, r2
 	strb r3, [r1, o_MusicPlayerTrack_flags]
 _081DD7AA:
-	bx r12
+	bx ip
 	thumb_func_end ply_modt
 
 	thumb_func_start ply_tune
 ply_tune:
-	mov r12, lr
+	mov ip, lr
 	bl ld_r3_tp_adr_i
 	subs r3, 0x40
 	strb r3, [r1, o_MusicPlayerTrack_tune]
@@ -1048,20 +1048,20 @@ ply_tune:
 	movs r2, 0xC
 	orrs r3, r2
 	strb r3, [r1, o_MusicPlayerTrack_flags]
-	bx r12
+	bx ip
 	thumb_func_end ply_tune
 
 	thumb_func_start ply_port
 ply_port:
-	mov r12, lr
+	mov ip, lr
 	ldr r2, [r1, o_MusicPlayerTrack_cmdPtr]
 	ldrb r3, [r2]
-	adds r2, 1
+	adds r2, #1
 	ldr r0, =REG_SOUND1CNT_L @ sound register base address
 	adds r0, r3
 	bl _081DD64A
 	strb r3, [r0]
-	bx r12
+	bx ip
 	.pool
 	thumb_func_end ply_port
 
@@ -1070,16 +1070,16 @@ m4aSoundVSync:
 	ldr r0, lt2_SOUND_INFO_PTR
 	ldr r0, [r0]
 
-	@ Exit the function if ident is not ID_NUMBER or ID_NUMBER+1.
+	@ Exit the function if ident is not ID_NUMBER or ID_NUMBER+#1.
 	ldr r2, lt2_ID_NUMBER
 	ldr r3, [r0, o_SoundInfo_ident]
 	subs r3, r2
-	cmp r3, 1
+	cmp r3, #1
 	bhi m4aSoundVSync_Done
 
-	@ Decrement the PCM DMA counter. If it reaches 0, we need to do a DMA.
+	@ Decrement the PCM DMA counter. If it reaches #0, we need to do a DMA.
 	ldrb r1, [r0, o_SoundInfo_pcmDmaCounter]
-	subs r1, 1
+	subs r1, #1
 	strb r1, [r0, o_SoundInfo_pcmDmaCounter]
 	bgt m4aSoundVSync_Done
 
@@ -1108,13 +1108,13 @@ m4aSoundVSync_SkipDMA2:
 
 	@ turn off DMA1/DMA2
 	movs r1, DMA_32BIT >> 8
-	lsls r1, 8
+	lsls r1, #8
 	strh r1, [r2, 0xA]       @ DMA1CNT_H
 	strh r1, [r2, 0xC + 0xA] @ DMA2CNT_H
 
 	@ turn on DMA1/DMA2 direct-sound FIFO mode
 	movs r1, (DMA_ENABLE | DMA_START_SPECIAL | DMA_32BIT | DMA_REPEAT) >> 8
-	lsls r1, 8 @ LSB is 0, so DMA_SRC_INC is used (destination is always fixed in FIFO mode)
+	lsls r1, #8 @ LSB is #0, so DMA_SRC_INC is used (destination is always fixed in FIFO mode)
 	strh r1, [r2, 0xA]       @ DMA1CNT_H
 	strh r1, [r2, 0xC + 0xA] @ DMA2CNT_H
 
@@ -1136,7 +1136,7 @@ _081DD82E:
 	str r3, [r0, o_MusicPlayerInfo_ident]
 	push {r0,lr}
 	ldr r3, [r0, o_MusicPlayerInfo_func]
-	cmp r3, 0
+	cmp r3, #0
 	beq _081DD840
 	ldr r0, [r0, o_MusicPlayerInfo_intp]
 	bl call_r3
@@ -1145,22 +1145,22 @@ _081DD840:
 	push {r4-r7}
 	mov r4, r8
 	mov r5, r9
-	mov r6, r10
-	mov r7, r11
+	mov r6, sl
+	mov r7, fp
 	push {r4-r7}
-	adds r7, r0, 0
+	adds r7, r0, #0
 	ldr r0, [r7, o_MusicPlayerInfo_status]
-	cmp r0, 0
+	cmp r0, #0
 	bge _081DD858
 	b _081DDA6C
 _081DD858:
 	ldr r0, lt2_SOUND_INFO_PTR
 	ldr r0, [r0]
 	mov r8, r0
-	adds r0, r7, 0
+	adds r0, r7, #0
 	bl FadeOutBody
 	ldr r0, [r7, o_MusicPlayerInfo_status]
-	cmp r0, 0
+	cmp r0, #0
 	bge _081DD86C
 	b _081DDA6C
 _081DD86C:
@@ -1172,7 +1172,7 @@ _081DD874:
 	ldrb r6, [r7, o_MusicPlayerInfo_trackCount]
 	ldr r5, [r7, o_MusicPlayerInfo_tracks]
 	movs r3, 0x1
-	movs r4, 0
+	movs r4, #0
 _081DD87C:
 	ldrb r0, [r5]
 	movs r1, 0x80
@@ -1180,11 +1180,11 @@ _081DD87C:
 	bne _081DD886
 	b _081DD998
 _081DD886:
-	mov r10, r3
+	mov sl, r3
 	orrs r4, r3
-	mov r11, r4
+	mov fp, r4
 	ldr r4, [r5, o_MusicPlayerTrack_chan]
-	cmp r4, 0
+	cmp r4, #0
 	beq _081DD8BA
 _081DD892:
 	ldrb r1, [r4]
@@ -1192,7 +1192,7 @@ _081DD892:
 	tst r0, r1
 	beq _081DD8AE
 	ldrb r0, [r4, 0x10]
-	cmp r0, 0
+	cmp r0, #0
 	beq _081DD8B4
 	subs r0, 0x1
 	strb r0, [r4, 0x10]
@@ -1202,18 +1202,18 @@ _081DD892:
 	strb r1, [r4]
 	b _081DD8B4
 _081DD8AE:
-	adds r0, r4, 0
+	adds r0, r4, #0
 	bl ClearChain
 _081DD8B4:
 	ldr r4, [r4, 0x34]
-	cmp r4, 0
+	cmp r4, #0
 	bne _081DD892
 _081DD8BA:
 	ldrb r3, [r5, o_MusicPlayerTrack_flags]
 	movs r0, 0x40
 	tst r0, r3
 	beq _081DD938
-	adds r0, r5, 0
+	adds r0, r5, #0
 	bl Clear64byte
 	movs r0, 0x80
 	strb r0, [r5]
@@ -1245,27 +1245,27 @@ _081DD8F6:
 	bcc _081DD90C
 	mov r0, r8
 	ldr r3, [r0, o_SoundInfo_plynote]
-	adds r0, r1, 0
+	adds r0, r1, #0
 	subs r0, 0xCF
-	adds r1, r7, 0
-	adds r2, r5, 0
+	adds r1, r7, #0
+	adds r2, r5, #0
 	bl call_r3
 	b _081DD938
 _081DD90C:
 	cmp r1, 0xB0
 	bls _081DD92E
-	adds r0, r1, 0
+	adds r0, r1, #0
 	subs r0, 0xB1
 	strb r0, [r7, o_MusicPlayerInfo_cmd]
 	mov r3, r8
 	ldr r3, [r3, o_SoundInfo_MPlayJumpTable]
 	lsls r0, 2
 	ldr r3, [r3, r0]
-	adds r0, r7, 0
-	adds r1, r5, 0
+	adds r0, r7, #0
+	adds r1, r5, #0
 	bl call_r3
 	ldrb r0, [r5, o_MusicPlayerTrack_flags]
-	cmp r0, 0
+	cmp r0, #0
 	beq _081DD994
 	b _081DD938
 _081DD92E:
@@ -1276,18 +1276,18 @@ _081DD92E:
 	strb r0, [r5, o_MusicPlayerTrack_wait]
 _081DD938:
 	ldrb r0, [r5, o_MusicPlayerTrack_wait]
-	cmp r0, 0
+	cmp r0, #0
 	beq _081DD8E0
 	subs r0, 0x1
 	strb r0, [r5, o_MusicPlayerTrack_wait]
 	ldrb r1, [r5, o_MusicPlayerTrack_lfoSpeed]
-	cmp r1, 0
+	cmp r1, #0
 	beq _081DD994
 	ldrb r0, [r5, o_MusicPlayerTrack_mod]
-	cmp r0, 0
+	cmp r0, #0
 	beq _081DD994
 	ldrb r0, [r5, o_MusicPlayerTrack_lfoDelayC]
-	cmp r0, 0
+	cmp r0, #0
 	beq _081DD95A
 	subs r0, 0x1
 	strb r0, [r5, o_MusicPlayerTrack_lfoDelayC]
@@ -1296,7 +1296,7 @@ _081DD95A:
 	ldrb r0, [r5, o_MusicPlayerTrack_lfoSpeedC]
 	adds r0, r1
 	strb r0, [r5, o_MusicPlayerTrack_lfoSpeedC]
-	adds r1, r0, 0
+	adds r1, r0, #0
 	subs r0, 0x40
 	lsls r0, 24
 	bpl _081DD96E
@@ -1317,7 +1317,7 @@ _081DD972:
 	strb r2, [r5, o_MusicPlayerTrack_modM]
 	ldrb r0, [r5]
 	ldrb r1, [r5, o_MusicPlayerTrack_modT]
-	cmp r1, 0
+	cmp r1, #0
 	bne _081DD98E
 	movs r1, 0xC
 	b _081DD990
@@ -1327,20 +1327,20 @@ _081DD990:
 	orrs r0, r1
 	strb r0, [r5, o_MusicPlayerTrack_flags]
 _081DD994:
-	mov r3, r10
-	mov r4, r11
+	mov r3, sl
+	mov r4, fp
 _081DD998:
 	subs r6, 0x1
 	ble _081DD9A4
 	movs r0, 0x50
 	adds r5, r0
-	lsls r3, 1
+	lsls r3, #1
 	b _081DD87C
 _081DD9A4:
 	ldr r0, [r7, o_MusicPlayerInfo_clock]
 	adds r0, 0x1
 	str r0, [r7, o_MusicPlayerInfo_clock]
-	cmp r4, 0
+	cmp r4, #0
 	bne _081DD9B6
 	movs r0, 0x80
 	lsls r0, 24
@@ -1367,18 +1367,18 @@ _081DD9C8:
 	tst r1, r0
 	beq _081DDA62
 	mov r9, r2
-	adds r0, r7, 0
-	adds r1, r5, 0
+	adds r0, r7, #0
+	adds r1, r5, #0
 	bl TrkVolPitSet
 	ldr r4, [r5, o_MusicPlayerTrack_chan]
-	cmp r4, 0
+	cmp r4, #0
 	beq _081DDA58
 _081DD9E6:
 	ldrb r1, [r4, o_SoundChannel_status]
 	movs r0, 0xC7
 	tst r0, r1
 	bne _081DD9F6
-	adds r0, r4, 0
+	adds r0, r4, #0
 	bl ClearChain
 	b _081DDA52
 _081DD9F6:
@@ -1390,7 +1390,7 @@ _081DD9F6:
 	tst r0, r3
 	beq _081DDA14
 	bl ChnVolSetAsm
-	cmp r6, 0
+	cmp r6, #0
 	beq _081DDA14
 	ldrb r0, [r4, o_CgbChannel_mo]
 	movs r1, 0x1
@@ -1406,15 +1406,15 @@ _081DDA14:
 	ldrsb r0, [r5, r0]
 	adds r2, r1, r0
 	bpl _081DDA28
-	movs r2, 0
+	movs r2, #0
 _081DDA28:
-	cmp r6, 0
+	cmp r6, #0
 	beq _081DDA46
 	mov r0, r8
 	ldr r3, [r0, o_SoundInfo_MidiKeyToCgbFreq]
-	adds r1, r2, 0
+	adds r1, r2, #0
 	ldrb r2, [r5, o_MusicPlayerTrack_pitM]
-	adds r0, r6, 0
+	adds r0, r6, #0
 	bl call_r3
 	str r0, [r4, o_CgbChannel_fr]
 	ldrb r0, [r4, o_CgbChannel_mo]
@@ -1423,14 +1423,14 @@ _081DDA28:
 	strb r0, [r4, o_CgbChannel_mo]
 	b _081DDA52
 _081DDA46:
-	adds r1, r2, 0
+	adds r1, r2, #0
 	ldrb r2, [r5, o_MusicPlayerTrack_pitM]
 	ldr r0, [r4, o_SoundChannel_wav]
 	bl MidiKeyToFreq
 	str r0, [r4, o_SoundChannel_freq]
 _081DDA52:
 	ldr r4, [r4, o_SoundChannel_np]
-	cmp r4, 0
+	cmp r4, #0
 	bne _081DD9E6
 _081DDA58:
 	ldrb r0, [r5, o_MusicPlayerTrack_flags]
@@ -1450,8 +1450,8 @@ _081DDA6C:
 	pop {r0-r7}
 	mov r8, r0
 	mov r9, r1
-	mov r10, r2
-	mov r11, r3
+	mov sl, r2
+	mov fp, r3
 	pop {r3}
 
 call_r3:
@@ -1466,18 +1466,18 @@ lt2_ID_NUMBER:      .word ID_NUMBER
 	thumb_func_start TrackStop
 TrackStop:
 	push {r4-r6,lr}
-	adds r5, r1, 0
+	adds r5, r1, #0
 	ldrb r1, [r5, o_MusicPlayerTrack_flags]
 	movs r0, 0x80
 	tst r0, r1
 	beq TrackStop_Done
 	ldr r4, [r5, o_MusicPlayerTrack_chan]
-	cmp r4, 0
+	cmp r4, #0
 	beq TrackStop_3
-	movs r6, 0
+	movs r6, #0
 TrackStop_Loop:
 	ldrb r0, [r4, o_SoundChannel_status]
-	cmp r0, 0
+	cmp r0, #0
 	beq TrackStop_2
 	ldrb r0, [r4, o_SoundChannel_type]
 	movs r3, 0x7
@@ -1492,7 +1492,7 @@ TrackStop_1:
 TrackStop_2:
 	str r6, [r4, o_SoundChannel_track]
 	ldr r4, [r4, o_SoundChannel_np]
-	cmp r4, 0
+	cmp r4, #0
 	bne TrackStop_Loop
 TrackStop_3:
 	str r4, [r5, o_MusicPlayerTrack_chan]
@@ -1538,12 +1538,12 @@ ply_note:
 	push {r4-r7,lr}
 	mov r4, r8
 	mov r5, r9
-	mov r6, r10
-	mov r7, r11
+	mov r6, sl
+	mov r7, fp
 	push {r4-r7}
 	sub sp, 0x18
 	str r1, [sp]
-	adds r5, r2, 0
+	adds r5, r2, #0
 	ldr r1, =SOUND_INFO_PTR
 	ldr r1, [r1]
 	str r1, [sp, 0x4]
@@ -1572,9 +1572,9 @@ ply_note:
 _081DDB44:
 	str r3, [r5, o_MusicPlayerTrack_cmdPtr]
 _081DDB46:
-	movs r0, 0
+	movs r0, #0
 	str r0, [sp, 0x14]
-	adds r4, r5, 0
+	adds r4, r5, #0
 	adds r4, o_MusicPlayerTrack_ToneData_type
 	ldrb r2, [r4]
 	movs r0, TONEDATA_TYPE_RHY | TONEDATA_TYPE_SPL
@@ -1589,9 +1589,9 @@ _081DDB46:
 	ldrb r0, [r1]
 	b _081DDB68
 _081DDB66:
-	adds r0, r3, 0
+	adds r0, r3, #0
 _081DDB68:
-	lsls r1, r0, 1
+	lsls r1, r0, #1
 	adds r1, r0
 	lsls r1, 2
 	ldr r0, [r5, o_MusicPlayerTrack_ToneData_wav]
@@ -1612,7 +1612,7 @@ _081DDB80:
 	tst r0, r1
 	beq _081DDB94
 	subs r1, 0xC0
-	lsls r1, 1
+	lsls r1, #1
 	str r1, [sp, 0x14]
 _081DDB94:
 	ldrb r3, [r6, 0x1]
@@ -1639,7 +1639,7 @@ _081DDBAC:
 	beq _081DDBEC
 	ldr r0, [sp, 0x4]
 	ldr r4, [r0, 0x1C]
-	cmp r4, 0
+	cmp r4, #0
 	bne _081DDBC4
 	b _081DDCEA
 _081DDBC4:
@@ -1666,8 +1666,8 @@ _081DDBE4:
 	b _081DDCEA
 _081DDBEC:
 	ldr r6, [sp, 0x10]
-	adds r7, r5, 0
-	movs r2, 0
+	adds r7, r5, #0
+	movs r2, #0
 	mov r8, r2
 	ldr r4, [sp, 0x4]
 	ldrb r3, [r4, 0x6]
@@ -1680,20 +1680,20 @@ _081DDBFA:
 	movs r0, 0x40
 	tst r0, r1
 	beq _081DDC14
-	cmp r2, 0
+	cmp r2, #0
 	bne _081DDC18
 	adds r2, 0x1
 	ldrb r6, [r4, 0x13]
 	ldr r7, [r4, 0x2C]
 	b _081DDC32
 _081DDC14:
-	cmp r2, 0
+	cmp r2, #0
 	bne _081DDC34
 _081DDC18:
 	ldrb r0, [r4, 0x13]
 	cmp r0, r6
 	bcs _081DDC24
-	adds r6, r0, 0
+	adds r6, r0, #0
 	ldr r7, [r4, 0x2C]
 	b _081DDC32
 _081DDC24:
@@ -1701,7 +1701,7 @@ _081DDC24:
 	ldr r0, [r4, 0x2C]
 	cmp r0, r7
 	bls _081DDC30
-	adds r7, r0, 0
+	adds r7, r0, #0
 	b _081DDC32
 _081DDC30:
 	bcc _081DDC34
@@ -1712,16 +1712,16 @@ _081DDC34:
 	subs r3, 0x1
 	bgt _081DDBFA
 	mov r4, r8
-	cmp r4, 0
+	cmp r4, #0
 	beq _081DDCEA
 _081DDC40:
-	adds r0, r4, 0
+	adds r0, r4, #0
 	bl ClearChain
-	movs r1, 0
+	movs r1, #0
 	str r1, [r4, 0x30]
 	ldr r3, [r5, 0x20]
 	str r3, [r4, 0x34]
-	cmp r3, 0
+	cmp r3, #0
 	beq _081DDC54
 	str r4, [r3, 0x30]
 _081DDC54:
@@ -1731,11 +1731,11 @@ _081DDC54:
 	strb r0, [r5, 0x1C]
 	cmp r0, r1
 	beq _081DDC66
-	adds r1, r5, 0
+	adds r1, r5, #0
 	bl clear_modM
 _081DDC66:
 	ldr r0, [sp]
-	adds r1, r5, 0
+	adds r1, r5, #0
 	bl TrkVolPitSet
 	ldr r0, [r5, 0x4]
 	str r0, [r4, 0x10]
@@ -1760,10 +1760,10 @@ _081DDC66:
 	ldrsb r0, [r5, r0]
 	adds r3, r1, r0
 	bpl _081DDCA0
-	movs r3, 0
+	movs r3, #0
 _081DDCA0:
 	ldr r6, [sp, 0xC]
-	cmp r6, 0
+	cmp r6, #0
 	beq _081DDCCE
 	mov r6, r9
 	ldrb r0, [r6, 0x2]
@@ -1780,7 +1780,7 @@ _081DDCBA:
 _081DDCBC:
 	strb r1, [r4, 0x1F]
 	ldrb r2, [r5, 0x9]
-	adds r1, r3, 0
+	adds r1, r3, #0
 	ldr r0, [sp, 0xC]
 	ldr r3, [sp, 0x4]
 	ldr r3, [r3, 0x30]
@@ -1790,8 +1790,8 @@ _081DDCCE:
 	ldr r0, [r5, o_MusicPlayerTrack_unk_3C]
 	str r0, [r4, 0x18]
 	ldrb r2, [r5, 0x9]
-	adds r1, r3, 0
-	adds r0, r7, 0
+	adds r1, r3, #0
+	adds r0, r7, #0
 	bl MidiKeyToFreq
 _081DDCDC:
 	str r0, [r4, 0x20]
@@ -1806,8 +1806,8 @@ _081DDCEA:
 	pop {r0-r7}
 	mov r8, r0
 	mov r9, r1
-	mov r10, r2
-	mov r11, r3
+	mov sl, r2
+	mov fp, r3
 	pop {r0}
 	bx r0
 	.pool
@@ -1828,7 +1828,7 @@ _081DDD16:
 	ldrb r3, [r1, o_MusicPlayerTrack_key]
 _081DDD18:
 	ldr r1, [r1, o_MusicPlayerTrack_chan]
-	cmp r1, 0
+	cmp r1, #0
 	beq _081DDD40
 	movs r4, 0x83
 	movs r5, 0x40
@@ -1847,7 +1847,7 @@ _081DDD22:
 	b _081DDD40
 _081DDD3A:
 	ldr r1, [r1, o_SoundChannel_np]
-	cmp r1, 0
+	cmp r1, #0
 	bne _081DDD22
 _081DDD40:
 	pop {r4,r5}
@@ -1856,11 +1856,11 @@ _081DDD40:
 
 	thumb_func_start clear_modM
 clear_modM:
-	movs r2, 0
+	movs r2, #0
 	strb r2, [r1, o_MusicPlayerTrack_modM]
 	strb r2, [r1, o_MusicPlayerTrack_lfoSpeedC]
 	ldrb r2, [r1, o_MusicPlayerTrack_modT]
-	cmp r2, 0
+	cmp r2, #0
 	bne _081DDD54
 	movs r2, 0xC
 	b _081DDD56
@@ -1876,7 +1876,7 @@ _081DDD56:
 	thumb_func_start ld_r3_tp_adr_i
 ld_r3_tp_adr_i_unchecked:
 	ldr r2, [r1, o_MusicPlayerTrack_cmdPtr]
-	adds r3, r2, 1
+	adds r3, r2, #1
 	str r3, [r1, o_MusicPlayerTrack_cmdPtr]
 	ldrb r3, [r2]
 	bx lr
@@ -1884,26 +1884,26 @@ ld_r3_tp_adr_i_unchecked:
 
 	thumb_func_start ply_lfos
 ply_lfos:
-	mov r12, lr
+	mov ip, lr
 	bl ld_r3_tp_adr_i_unchecked
 	strb r3, [r1, o_MusicPlayerTrack_lfoSpeed]
-	cmp r3, 0
+	cmp r3, #0
 	bne _081DDD7C
 	bl clear_modM
 _081DDD7C:
-	bx r12
+	bx ip
 	thumb_func_end ply_lfos
 
 	thumb_func_start ply_mod
 ply_mod:
-	mov r12, lr
+	mov ip, lr
 	bl ld_r3_tp_adr_i_unchecked
 	strb r3, [r1, o_MusicPlayerTrack_mod]
-	cmp r3, 0
+	cmp r3, #0
 	bne _081DDD90
 	bl clear_modM
 _081DDD90:
-	bx r12
+	bx ip
 	thumb_func_end ply_mod
 
 	.align 2, 0 @ Don't pad with nop.


### PR DESCRIPTION
One of the main gripes I had was that with the og asm, clang would throw errors in the assembler, and I had to fix it up myself.

I made changes so the clang compiler can better compile it, while ensuring the supported toolchains would output the exact same binary.