### PR TITLE
Allow assembly on Clang

### DIFF
--- a/berry_fix/asm/loader.s
+++ b/berry_fix/asm/loader.s
@@ -75,21 +75,21 @@ _send: @ 14c
 _150:
 	bl _recv
 	bne _150
-	mov r2, 0
+	mov r2, #0
 	strh r2, [r0, 0xa] @ SIOMLT_SEND
-	cmp r1, 0
+	cmp r1, #0
 	bne _150
 	mov r2, 0x8000
 _16c:
-	mov r1, 0
+	mov r1, #0
 _170:
 	strh r1, [r0, 0xa] @ SIOMLT_SEND
 	bl _recv
 	bne _150
 	cmp r1, r2
 	bne _16c
-	lsr r2, 5
-	cmp r1, 0
+	lsr r2, #5
+	cmp r1, #0
 	bne _170
 	ldr r3, =BerryFixMBHeaderGameCode
 	ldrh r2, [r3]
@@ -105,7 +105,7 @@ _1a0:
 	bne _1a0
 	cmp r1, r2
 	bne _1a0
-	mov r1, 0
+	mov r1, #0
 	strh r1, [r0, 0xa] @ SIOMLT_SEND
 	ldr r0, =_data_2f0
 	ldr r1, =gCode

--- a/berry_fix/payload/asm/crt0.s
+++ b/berry_fix/payload/asm/crt0.s
@@ -9,10 +9,10 @@
 	.align 2, 0
 	.global Init
 Init:
-	mov r0, PSR_IRQ_MODE
+	mov r0, #PSR_IRQ_MODE
 	msr cpsr_cf, r0
 	ldr sp, sp_irq
-	mov r0, PSR_SYS_MODE
+	mov r0, #PSR_SYS_MODE
 	msr cpsr_cf, r0
 	ldr sp, sp_sys
 	ldr r1, =INTR_VECTOR
@@ -34,8 +34,8 @@ sp_irq: .word IWRAM_END - 0x60
 	.align 2, 0
 	.global IntrMain
 IntrMain: @ 0x2010048
-	mov ip, REG_BASE
-	add r3, ip, OFFSET_REG_IE
+	mov ip, #REG_BASE
+	add r3, ip, #OFFSET_REG_IE
 	ldr r2, [r3]
 	and r1, r2, r2, lsr #16
 	mov r2, #0

--- a/berry_fix/payload/asm/libagbsyscall.s
+++ b/berry_fix/payload/asm/libagbsyscall.s
@@ -7,39 +7,39 @@
 
 	thumb_func_start CpuSet
 CpuSet: @ 81E3B64
-	swi 0xB
+	svc 0xB
 	bx lr
 	thumb_func_end CpuSet
 
 	thumb_func_start Div
 Div: @ 81E3B68
-	swi 0x6
+	svc 0x6
 	bx lr
 	thumb_func_end Div
 
 	thumb_func_start Mod
 Mod:
-	swi 0x6
+	svc 0x6
 	adds r0, r1, 0
 	bx lr
 	thumb_func_end Mod
 
 	thumb_func_start LZ77UnCompVram
 LZ77UnCompVram: @ 81E3B6C
-	swi 0x12
+	svc 0x12
 	bx lr
 	thumb_func_end LZ77UnCompVram
 
 	thumb_func_start RegisterRamReset
 RegisterRamReset: @ 81E3B80
-	swi 0x1
+	svc 0x1
 	bx lr
 	thumb_func_end RegisterRamReset
 
 	thumb_func_start VBlankIntrWait
 VBlankIntrWait: @ 81E3BA0
 	movs r2, 0
-	swi 0x5
+	svc 0x5
 	bx lr
 	thumb_func_end VBlankIntrWait
 

--- a/libagbsyscall/libagbsyscall.s
+++ b/libagbsyscall/libagbsyscall.s
@@ -55,8 +55,8 @@
 	.ifdef L_IntrWait
 	thumb_func_start IntrWait
 IntrWait:
-	mov r2, #0
-	swi 4
+	movs r2, #0
+	svc #4
 	bx lr
 	thumb_func_end IntrWait
 	.endif
@@ -64,7 +64,7 @@ IntrWait:
 	.ifdef L_RegisterRamReset
 	thumb_func_start RegisterRamReset
 RegisterRamReset:
-	swi 1
+	svc #1
 	bx lr
 	thumb_func_end RegisterRamReset
 	.endif
@@ -72,7 +72,7 @@ RegisterRamReset:
 	.ifdef L_Sqrt
 	thumb_func_start Sqrt
 Sqrt:
-	swi 8
+	svc #8
 	bx lr
 	thumb_func_end Sqrt
 	.endif
@@ -80,7 +80,7 @@ Sqrt:
 	.ifdef L_MusicPlayerOpen
 	thumb_func_start MusicPlayerOpen
 MusicPlayerOpen:
-	swi 32
+	svc #32
 	bx lr
 	thumb_func_end MusicPlayerOpen
 	.endif
@@ -88,8 +88,8 @@ MusicPlayerOpen:
 	.ifdef L_SoundBiasReset
 	thumb_func_start SoundBiasReset
 SoundBiasReset:
-	mov r0, #0
-	swi 25
+	movs r0, #0
+	svc #25
 	bx lr
 	thumb_func_end SoundBiasReset
 	.endif
@@ -97,7 +97,7 @@ SoundBiasReset:
 	.ifdef L_SoundDriverVSyncOn
 	thumb_func_start SoundDriverVSyncOn
 SoundDriverVSyncOn:
-	swi 41
+	svc #41
 	bx lr
 	thumb_func_end SoundDriverVSyncOn
 	.endif
@@ -105,7 +105,7 @@ SoundDriverVSyncOn:
 	.ifdef L_Mod
 	thumb_func_start Mod
 Mod:
-	swi 6
+	svc #6
 	mov r0, r1
 	bx lr
 	thumb_func_end Mod
@@ -114,8 +114,8 @@ Mod:
 	.ifdef L_VBlankIntrWait
 	thumb_func_start VBlankIntrWait
 VBlankIntrWait:
-	mov r2, #0
-	swi 5
+	movs r2, #0
+	svc #5
 	bx lr
 	thumb_func_end VBlankIntrWait
 	.endif
@@ -123,7 +123,7 @@ VBlankIntrWait:
 	.ifdef L_MusicPlayerStart
 	thumb_func_start MusicPlayerStart
 MusicPlayerStart:
-	swi 33
+	svc #33
 	bx lr
 	thumb_func_end MusicPlayerStart
 	.endif
@@ -131,7 +131,7 @@ MusicPlayerStart:
 	.ifdef L_SoundDriverVSyncOff
 	thumb_func_start SoundDriverVSyncOff
 SoundDriverVSyncOff:
-	swi 40
+	svc #40
 	bx lr
 	thumb_func_end SoundDriverVSyncOff
 	.endif
@@ -139,34 +139,34 @@ SoundDriverVSyncOff:
 	.ifdef L_HuffUnComp
 	thumb_func_start HuffUnComp
 HuffUnComp:
-	swi 19
+	svc #19
 	bx lr
 	thumb_func_end HuffUnComp
 	.endif
 
 	.ifdef L_SoftResetExram
-	thumb_func_start SoftResetExram
+	arm_func_start SoftResetExram
 SoftResetExram:
 	ldr r3, =REG_IME
-	mov r2, #0
+	movs r2, #0
 	strb r2, [r3, #0]
 	ldr r3, =SOFT_RESET_DIRECT_BUF
-	mov r2, #1
+	movs r2, #1
 	strb r2, [r3, #0]
-	sub r3, #SOFT_RESET_DIRECT_BUF - 0x3007f00
+	subs r3, #SOFT_RESET_DIRECT_BUF - 0x3007f00
 	mov sp, r3
-	mov r2, #RESET_EX_WRAM_FLAG
-	bic r0, r2
-	swi 1
-	swi 0
+	movs r2, #RESET_EX_WRAM_FLAG
+	bics r0, r2
+	svc #1
+	svc #0
 	.pool
-	thumb_func_end SoftResetExram
+	arm_func_end SoftResetExram
 	.endif
 
 	.ifdef L_MusicPlayerFadeOut
 	thumb_func_start MusicPlayerFadeOut
 MusicPlayerFadeOut:
-	swi 36
+	svc #36
 	bx lr
 	thumb_func_end MusicPlayerFadeOut
 	.endif
@@ -174,7 +174,7 @@ MusicPlayerFadeOut:
 	.ifdef L_LZ77UnCompWram
 	thumb_func_start LZ77UnCompWram
 LZ77UnCompWram:
-	swi 17
+	svc #17
 	bx lr
 	thumb_func_end LZ77UnCompWram
 	.endif
@@ -182,7 +182,7 @@ LZ77UnCompWram:
 	.ifdef L_SoundDriverMain
 	thumb_func_start SoundDriverMain
 SoundDriverMain:
-	swi 28
+	svc #28
 	bx lr
 	thumb_func_end SoundDriverMain
 	.endif
@@ -190,7 +190,7 @@ SoundDriverMain:
 	.ifdef L_SoundBiasChange
 	thumb_func_start SoundBiasChange
 SoundBiasChange:
-	swi 25
+	svc #25
 	bx lr
 	thumb_func_end SoundBiasChange
 	.endif
@@ -198,7 +198,7 @@ SoundBiasChange:
 	.ifdef L_LZ77UnCompVram
 	thumb_func_start LZ77UnCompVram
 LZ77UnCompVram:
-	swi 18
+	svc #18
 	bx lr
 	thumb_func_end LZ77UnCompVram
 	.endif
@@ -206,7 +206,7 @@ LZ77UnCompVram:
 	.ifdef L_ArcTan2
 	thumb_func_start ArcTan2
 ArcTan2:
-	swi 10
+	svc #10
 	bx lr
 	thumb_func_end ArcTan2
 	.endif
@@ -214,7 +214,7 @@ ArcTan2:
 	.ifdef L_MusicPlayerStop
 	thumb_func_start MusicPlayerStop
 MusicPlayerStop:
-	swi 34
+	svc #34
 	bx lr
 	thumb_func_end MusicPlayerStop
 	.endif
@@ -222,7 +222,7 @@ MusicPlayerStop:
 	.ifdef L_DivArm
 	thumb_func_start DivArm
 DivArm:
-	swi 7
+	svc #7
 	bx lr
 	thumb_func_end DivArm
 	.endif
@@ -230,7 +230,7 @@ DivArm:
 	.ifdef L_ModArm
 	thumb_func_start ModArm
 ModArm:
-	swi 7
+	svc #7
 	mov r0, r1
 	bx lr
 	thumb_func_end ModArm
@@ -239,7 +239,7 @@ ModArm:
 	.ifdef L_SoundDriverVSync
 	thumb_func_start SoundDriverVSync
 SoundDriverVSync:
-	swi 29
+	svc #29
 	bx lr
 	thumb_func_end SoundDriverVSync
 	.endif
@@ -247,7 +247,7 @@ SoundDriverVSync:
 	.ifdef L_SoundDriverInit
 	thumb_func_start SoundDriverInit
 SoundDriverInit:
-	swi 26
+	svc #26
 	bx lr
 	thumb_func_end SoundDriverInit
 	.endif
@@ -255,7 +255,7 @@ SoundDriverInit:
 	.ifdef L_BgAffineSet
 	thumb_func_start BgAffineSet
 BgAffineSet:
-	swi 14
+	svc #14
 	bx lr
 	thumb_func_end BgAffineSet
 	.endif
@@ -263,7 +263,7 @@ BgAffineSet:
 	.ifdef L_Diff8bitUnFilterWram
 	thumb_func_start Diff8bitUnFilterWram
 Diff8bitUnFilterWram:
-	swi 22
+	svc #22
 	bx lr
 	thumb_func_end Diff8bitUnFilterWram
 	.endif
@@ -272,7 +272,7 @@ Diff8bitUnFilterWram:
 	thumb_func_start MultiBoot
 MultiBoot:
 	mov r1, #1
-	swi 37
+	svc #37
 	bx lr
 	thumb_func_end MultiBoot
 	.endif
@@ -280,7 +280,7 @@ MultiBoot:
 	.ifdef L_MidiKey2Freq
 	thumb_func_start MidiKey2Freq
 MidiKey2Freq:
-	swi 31
+	svc #31
 	bx lr
 	thumb_func_end MidiKey2Freq
 	.endif
@@ -288,7 +288,7 @@ MidiKey2Freq:
 	.ifdef L_Div
 	thumb_func_start Div
 Div:
-	swi 6
+	svc #6
 	bx lr
 	thumb_func_end Div
 	.endif
@@ -296,7 +296,7 @@ Div:
 	.ifdef L_Diff8bitUnFilterVram
 	thumb_func_start Diff8bitUnFilterVram
 Diff8bitUnFilterVram:
-	swi 23
+	svc #23
 	bx lr
 	thumb_func_end Diff8bitUnFilterVram
 	.endif
@@ -304,7 +304,7 @@ Diff8bitUnFilterVram:
 	.ifdef L_ArcTan
 	thumb_func_start ArcTan
 ArcTan:
-	swi 9
+	svc #9
 	bx lr
 	thumb_func_end ArcTan
 	.endif
@@ -312,7 +312,7 @@ ArcTan:
 	.ifdef L_ObjAffineSet
 	thumb_func_start ObjAffineSet
 ObjAffineSet:
-	swi 15
+	svc #15
 	bx lr
 	thumb_func_end ObjAffineSet
 	.endif
@@ -321,15 +321,15 @@ ObjAffineSet:
 	thumb_func_start SoftResetRom
 SoftResetRom:
 	ldr r3, =REG_IME
-	mov r2, #0
+	movs r2, #0
 	strb r2, [r3, #0]
 	ldr r3, =SOFT_RESET_DIRECT_BUF
-	mov r2, #0
+	movs r2, #0
 	strb r2, [r3, #0]
 	sub r3, #SOFT_RESET_DIRECT_BUF - 0x3007f00
 	mov sp, r3
-	swi 1
-	swi 0
+	svc #1
+	svc #0
 	.pool
 	thumb_func_end SoftResetRom
 	.endif
@@ -337,7 +337,7 @@ SoftResetRom:
 	.ifdef L_SoundDriverMode
 	thumb_func_start SoundDriverMode
 SoundDriverMode:
-	swi 27
+	svc #27
 	bx lr
 	thumb_func_end SoundDriverMode
 	.endif
@@ -345,7 +345,7 @@ SoundDriverMode:
 	.ifdef L_RLUnCompWram
 	thumb_func_start RLUnCompWram
 RLUnCompWram:
-	swi 20
+	svc #20
 	bx lr
 	thumb_func_end RLUnCompWram
 	.endif
@@ -353,7 +353,7 @@ RLUnCompWram:
 	.ifdef L_BitUnPack
 	thumb_func_start BitUnPack
 BitUnPack:
-	swi 16
+	svc #16
 	bx lr
 	thumb_func_end BitUnPack
 	.endif
@@ -361,7 +361,7 @@ BitUnPack:
 	.ifdef L_SoundChannelClear
 	thumb_func_start SoundChannelClear
 SoundChannelClear:
-	swi 30
+	svc #30
 	bx lr
 	thumb_func_end SoundChannelClear
 	.endif
@@ -369,7 +369,7 @@ SoundChannelClear:
 	.ifdef L_CpuFastSet
 	thumb_func_start CpuFastSet
 CpuFastSet:
-	swi 12
+	svc #12
 	bx lr
 	thumb_func_end CpuFastSet
 	.endif
@@ -377,7 +377,7 @@ CpuFastSet:
 	.ifdef L_CpuSet
 	thumb_func_start CpuSet
 CpuSet:
-	swi 11
+	svc #11
 	bx lr
 	thumb_func_end CpuSet
 	.endif
@@ -385,7 +385,7 @@ CpuSet:
 	.ifdef L_Diff16bitUnFilter
 	thumb_func_start Diff16bitUnFilter
 Diff16bitUnFilter:
-	swi 24
+	svc #24
 	bx lr
 	thumb_func_end Diff16bitUnFilter
 	.endif
@@ -393,8 +393,8 @@ Diff16bitUnFilter:
 	.ifdef L_SoundBiasSet
 	thumb_func_start SoundBiasSet
 SoundBiasSet:
-	mov r0, #1
-	swi 25
+	movs r0, #1
+	svc #25
 	bx lr
 	thumb_func_end SoundBiasSet
 	.endif
@@ -402,7 +402,7 @@ SoundBiasSet:
 	.ifdef L_MusicPlayerContinue
 	thumb_func_start MusicPlayerContinue
 MusicPlayerContinue:
-	swi 35
+	svc #35
 	bx lr
 	thumb_func_end MusicPlayerContinue
 	.endif
@@ -411,12 +411,12 @@ MusicPlayerContinue:
 	thumb_func_start SoftReset
 SoftReset:
 	ldr r3, =REG_IME
-	mov r2, #0
+	movs r2, #0
 	strb r2, [r3, #0]
 	ldr r1, =0x3007f00
 	mov sp, r1
-	swi 1
-	swi 0
+	svc #1
+	svc #0
 	.pool
 	thumb_func_end SoftReset
 	.endif
@@ -424,7 +424,7 @@ SoftReset:
 	.ifdef L_RLUnCompVram
 	thumb_func_start RLUnCompVram
 RLUnCompVram:
-	swi 21
+	svc #21
 	bx lr
 	thumb_func_end RLUnCompVram
 	.endif

--- a/src/crt0.s
+++ b/src/crt0.s
@@ -82,10 +82,10 @@ GPIOPortReadEnable: @ 80000C8
 	.align 2, 0
 	.global Init
 Init: @ 8000204
-	mov r0, PSR_IRQ_MODE
+	mov r0, #PSR_IRQ_MODE
 	msr cpsr_cf, r0
 	ldr sp, sp_irq
-	mov r0, PSR_SYS_MODE
+	mov r0, #PSR_SYS_MODE
 	msr cpsr_cf, r0
 	ldr sp, sp_sys
 	ldr r1, =INTR_VECTOR
@@ -106,91 +106,91 @@ sp_irq: .word IWRAM_END - 0x60
 	.align 2, 0
 	.global IntrMain
 IntrMain: @ 8000248
-	mov r3, REG_BASE
-	add r3, r3, 0x200
-	ldr r2, [r3, OFFSET_REG_IE - 0x200]
-	ldrh r1, [r3, OFFSET_REG_IME - 0x200]
+	mov r3, #REG_BASE
+	add r3, r3, #OFFSET_REG_IE
+	ldr r2, [r3]
+	ldrh r1, [r3, #OFFSET_REG_IME - 0x200]
 	mrs r0, spsr
-	stmdb sp!, {r0-r3,lr}
-	mov r0, 0
-	strh r0, [r3, OFFSET_REG_IME - 0x200]
-	and r1, r2, r2, lsr 16
-	mov r12, 0
-	ands r0, r1, INTR_FLAG_VCOUNT
+	stmfd sp!, {r0-r3,lr}
+	mov r0, #0
+	strh r0, [r3, #OFFSET_REG_IME - 0x200]
+	and r1, r2, r2, lsr #16
+	mov r12, #0
+	ands r0, r1, #INTR_FLAG_VCOUNT
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
 	mov r0, 0x1
-	strh r0, [r3, OFFSET_REG_IME - 0x200]
-	ands r0, r1, INTR_FLAG_SERIAL
+	strh r0, [r3, #OFFSET_REG_IME - 0x200]
+	ands r0, r1, #INTR_FLAG_SERIAL
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_TIMER3
+	ands r0, r1, #INTR_FLAG_TIMER3
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_HBLANK
+	ands r0, r1, #INTR_FLAG_HBLANK
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_VBLANK
+	ands r0, r1, #INTR_FLAG_VBLANK
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_TIMER0
+	ands r0, r1, #INTR_FLAG_TIMER0
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_TIMER1
+	ands r0, r1, #INTR_FLAG_TIMER1
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_TIMER2
+	ands r0, r1, #INTR_FLAG_TIMER2
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_DMA0
+	ands r0, r1, #INTR_FLAG_DMA0
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_DMA1
+	ands r0, r1, #INTR_FLAG_DMA1
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_DMA2
+	ands r0, r1, #INTR_FLAG_DMA2
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_DMA3
+	ands r0, r1, #INTR_FLAG_DMA3
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_KEYPAD
+	ands r0, r1, #INTR_FLAG_KEYPAD
 	bne IntrMain_FoundIntr
 	add r12, r12, 0x4
-	ands r0, r1, INTR_FLAG_GAMEPAK
-	strbne r0, [r3, OFFSET_REG_SOUNDCNT_X - 0x200]
+	ands r0, r1, #INTR_FLAG_GAMEPAK
+	strbne r0, [r3, #REG_SOUNDCNT_X - REG_IE]
 	bne . @ spin
 IntrMain_FoundIntr:
-	strh r0, [r3, OFFSET_REG_IF - 0x200]
+	strh r0, [r3, #OFFSET_REG_IF - 0x200]
 	bic r2, r2, r0
 	ldr r0, =gSTWIStatus
 	ldr r0, [r0]
 	ldrb r0, [r0, 0xA]
 	mov r1, 0x8
-	mov r0, r1, lsl r0
-	orr r0, r0, INTR_FLAG_GAMEPAK
-	orr r1, r0, INTR_FLAG_SERIAL | INTR_FLAG_TIMER3 | INTR_FLAG_VCOUNT | INTR_FLAG_HBLANK
+	lsl r0, r1, r0
+	orr r0, r0, #INTR_FLAG_GAMEPAK
+	orr r1, r0, #INTR_FLAG_SERIAL | INTR_FLAG_TIMER3 | INTR_FLAG_VCOUNT | INTR_FLAG_HBLANK
 	and r1, r1, r2
-	strh r1, [r3, OFFSET_REG_IE - 0x200]
+	strh r1, [r3, #OFFSET_REG_IE - 0x200]
 	mrs r3, cpsr
-	bic r3, r3, PSR_I_BIT | PSR_F_BIT | PSR_MODE_MASK
-	orr r3, r3, PSR_SYS_MODE
+	bic r3, r3, #PSR_I_BIT | PSR_F_BIT | PSR_MODE_MASK
+	orr r3, r3, #PSR_SYS_MODE
 	msr cpsr_cf, r3
 	ldr r1, =gIntrTable
 	add r1, r1, r12
 	ldr r0, [r1]
-	stmdb sp!, {lr}
+	stmfd sp!, {lr}
 	adr lr, IntrMain_RetAddr
 	bx r0
 IntrMain_RetAddr:
-	ldmia sp!, {lr}
+	ldmfd sp!, {lr}
 	mrs r3, cpsr
-	bic r3, r3, PSR_I_BIT | PSR_F_BIT | PSR_MODE_MASK
-	orr r3, r3, PSR_I_BIT | PSR_IRQ_MODE
+	bic r3, r3, #PSR_I_BIT | PSR_F_BIT | PSR_MODE_MASK
+	orr r3, r3, #PSR_I_BIT | PSR_IRQ_MODE
 	msr cpsr_cf, r3
 	ldmia sp!, {r0-r3,lr}
-	strh r2, [r3, OFFSET_REG_IE - 0x200]
-	strh r1, [r3, OFFSET_REG_IME - 0x200]
+	strh r2, [r3, #OFFSET_REG_IE - 0x200]
+	strh r1, [r3, #OFFSET_REG_IME - 0x200]
 	msr spsr_cf, r0
 	bx lr
 

--- a/src/libgcnmultiboot.s
+++ b/src/libgcnmultiboot.s
@@ -22,7 +22,7 @@ GameCubeMultiBoot_Hash: @ 82DED70
 	movs r2, 0x20
 
 GameCubeMultiBoot_Hash_Loop:
-	lsrs r3, 1
+	lsrs r3, #1
 	bcc GameCubeMultiBoot_Hash_SkipEor
 
 	eors r3, r4
@@ -37,8 +37,8 @@ GameCubeMultiBoot_Hash_SkipEor:
 	thumb_func_start GameCubeMultiBoot_Main
 @ void GameCubeMultiBoot_Main(struct GameCubeMultiBoot *mb);
 GameCubeMultiBoot_Main: @ 82DED84
-	ldr r1, [r0, GCMB_STRUCT_SERIAL_INTR_HANDLER]
-	cmp r1, 0
+	ldr r1, [r0, #GCMB_STRUCT_SERIAL_INTR_HANDLER]
+	cmp r1, #0
 	beq _082DEDAA
 	ldrb r1, [r0, 0x1]
 	adds r1, 0x1
@@ -47,30 +47,30 @@ GameCubeMultiBoot_Main: @ 82DED84
 	cmp r1, 0x2
 	beq _082DEDF4
 	ldr r3, pool_InterruptRegs
-	ldrh r2, [r3, OFFSET_REG_IME - 0x200]
+	ldrh r2, [r3, #OFFSET_REG_IME - 0x200]
 	movs r1, 0
-	strh r1, [r3, OFFSET_REG_IME - 0x200]
+	strh r1, [r3, #OFFSET_REG_IME - 0x200]
 	ldrb r1, [r0]
 	cmp r1, 0xA
 	bgt _082DEDA8
 	adds r1, 0x1
 	strb r1, [r0]
 _082DEDA8:
-	strh r2, [r3, OFFSET_REG_IME - 0x200]
+	strh r2, [r3, #OFFSET_REG_IME - 0x200]
 _082DEDAA:
 	bcs GameCubeMultiBoot_Init
 	ldrb r1, [r0, 0x2]
 	cmp r1, 0
 	bne _082DEDF6
-	ldr r1, [r0, GCMB_STRUCT_CUR_DEST_PTR]
-	ldr r2, [r0, GCMB_STRUCT_BASE_DEST_PTR]
+	ldr r1, [r0, #GCMB_STRUCT_CUR_DEST_PTR]
+	ldr r2, [r0, #GCMB_STRUCT_BASE_DEST_PTR]
 	subs r1, r2
 	beq _082DEE76
 	cmp r1, 0xA0
 	bcc _082DEE76
 	push {r4-r6}
 	movs r1, 0x98
-	adds r2, ROM_HEADER_NINTENDO_LOGO_OFFSET
+	adds r2, #ROM_HEADER_NINTENDO_LOGO_OFFSET
 	ldr r4, pool_NintendoLogo
 _082DEDC6:
 	ldm r2!, {r5}
@@ -82,8 +82,8 @@ _082DEDC6:
 	ldm r2!, {r5}
 	ldm r4!, {r6}
 	eors r5, r6
-	lsrs r5, 8
-	str r2, [r0, GCMB_STRUCT_BASE_DEST_PTR]
+	lsrs r5, #8
+	str r2, [r0, #GCMB_STRUCT_BASE_DEST_PTR]
 _082DEDDC:
 	pop {r4-r6}
 	bne GameCubeMultiBoot_Init
@@ -100,11 +100,11 @@ _082DEDDC:
 _082DEDF4:
 	bx lr
 _082DEDF6:
-	ldr r1, [r0, GCMB_STRUCT_CUR_DEST_PTR]
+	ldr r1, [r0, #GCMB_STRUCT_CUR_DEST_PTR]
 	mov r12, r1
 	ldr r3, [r0, 0x18]
 	push {r4-r7}
-	ldr r4, [r0, GCMB_STRUCT_BASE_DEST_PTR]
+	ldr r4, [r0, #GCMB_STRUCT_BASE_DEST_PTR]
 	ldr r5, pool_Kawa
 	ldr r6, [r0, 0x14]
 	ldr r7, pool_HashVal
@@ -118,7 +118,7 @@ _082DEE06:
 	eors r3, r1
 	movs r2, 0x20
 _082DEE16:
-	lsrs r3, 1
+	lsrs r3, #1
 	bcc _082DEE1C
 	eors r3, r7
 _082DEE1C:
@@ -128,22 +128,22 @@ _082DEE1C:
 	adds r6, 0x1
 	b _082DEE06
 _082DEE26:
-	str r4, [r0, GCMB_STRUCT_BASE_DEST_PTR]
+	str r4, [r0, #GCMB_STRUCT_BASE_DEST_PTR]
 	str r6, [r0, 0x14]
 	pop {r4-r7}
 	str r3, [r0, 0x18]
 	ldrh r1, [r0, 0x12]
-	cmp r1, 0
+	cmp r1, #0
 	bne _082DEE76
-	ldr r1, [r0, GCMB_STRUCT_CUR_DEST_PTR]
-	ldr r2, [r0, GCMB_STRUCT_BASE_DEST_PTR]
+	ldr r1, [r0, #GCMB_STRUCT_CUR_DEST_PTR]
+	ldr r2, [r0, #GCMB_STRUCT_BASE_DEST_PTR]
 	cmp r1, r2
 	bne _082DEE76
 	ldr r1, [r0, 0xC]
-	cmp r1, 0
+	cmp r1, #0
 	beq _082DEE60
 	ldrh r1, [r0, 0x10]
-	cmp r1, 0
+	cmp r1, #0
 	beq _082DEDF4
 	mov r12, lr
 	movs r1, 0xBB
@@ -159,11 +159,11 @@ _082DEE26:
 _082DEE60:
 	mov r12, lr
 	ldrb r1, [r0, 0x3]
-	lsls r1, 24
+	lsls r1, #24
 	subs r1, 0x1
 	str r1, [r0, 0xC]
 	bl GameCubeMultiBoot_Hash
-	lsls r3, 8
+	lsls r3, #8
 	adds r3, 0xFF
 	str r3, [r0, 0x1C]
 	bx r12
@@ -186,8 +186,8 @@ GameCubeMultiBoot_ExecuteProgram: @ 82DEE84
 	cmp r1, 0x2
 	bne GameCubeMultiBoot_ExecuteProgram_Fail
 	ldr r3, pool_InterruptRegs
-	movs r1, 0
-	strh r1, [r3, OFFSET_REG_IME - 0x200]
+	movs r1, #0
+	strh r1, [r3, #OFFSET_REG_IME - 0x200]
 	ldr r1, pool_MultiBootLoadAddr
 	adds r1, 0xC0
 	bx r1
@@ -201,25 +201,25 @@ GameCubeMultiBoot_Init: @ 82DEE98
 	ldr r3, pool_InterruptRegs
 
 @ Save IME register.
-	ldrh r2, [r3, OFFSET_REG_IME - 0x200]
+	ldrh r2, [r3, #OFFSET_REG_IME - 0x200]
 
 @ Disable interrupts.
 	movs r1, 0
-	strh r1, [r3, OFFSET_REG_IME - 0x200]
+	strh r1, [r3, #OFFSET_REG_IME - 0x200]
 
 @ Set the handler to the "Stop" routine.
 @ Unless the first command that is received is a device reset command, the
 @ "Stop" routine will be executed and no further commands will be processed.
 	adr r3, GcMbIntrHandler_Stop
-	str r3, [r0, GCMB_STRUCT_SERIAL_INTR_HANDLER]
+	str r3, [r0, #GCMB_STRUCT_SERIAL_INTR_HANDLER]
 
 	ldrb r3, [r0, 0x3]
 	push {r3}
 	ldrb r3, [r0, 0x1]
 	push {r0,r3}
 
-	adds r3, r0, 0
-	adds r3, GCMB_STRUCT_BASE_DEST_PTR
+	adds r3, r0, #0
+	adds r3, #GCMB_STRUCT_BASE_DEST_PTR
 
 @ clear all but the last 3 fields of the struct
 GameCubeMultiBoot_Init_ClearStructLoop:
@@ -261,7 +261,7 @@ GameCubeMultiBoot_Init_ClearStructLoop:
 	strh r1, [r3, OFFSET_REG_IE - 0x200]
 
 @ Restore IME register.
-	strh r2, [r3, OFFSET_REG_IME - 0x200]
+	strh r2, [r3, #OFFSET_REG_IME - 0x200]
 
 	bx lr
 	thumb_func_end GameCubeMultiBoot_Init
@@ -275,11 +275,11 @@ GameCubeMultiBoot_HandleSerialInterrupt: @ 82DEEE2
 	ldrh r1, [r3, OFFSET_REG_JOYCNT - 0x120]
 	strh r1, [r3, OFFSET_REG_JOYCNT - 0x120]
 
-	movs r2, 0
+	movs r2, #0
 	strb r2, [r0]
 
-	ldr r2, [r0, GCMB_STRUCT_SERIAL_INTR_HANDLER]
-	cmp r2, 0
+	ldr r2, [r0, #GCMB_STRUCT_SERIAL_INTR_HANDLER]
+	cmp r2, #0
 	beq GameCubeMultiBoot_HandleSerialInterruptDone
 
 	lsrs r1, 1 @ was a device reset command received?
@@ -297,7 +297,7 @@ GcMbIntrHandler_Stop:
 	strh r2, [r3, OFFSET_REG_JOYSTAT - 0x120]
 
 GameCubeMultiBoot_SetInterruptHandler:
-	str r2, [r0, GCMB_STRUCT_SERIAL_INTR_HANDLER]
+	str r2, [r0, #GCMB_STRUCT_SERIAL_INTR_HANDLER]
 
 GameCubeMultiBoot_ReadVCount:
 	ldr r3, pool_RegDispstat
@@ -319,8 +319,8 @@ GameCubeMultiBoot_BeginHandshake:
 	cmp r1, 0
 	bne GcMbIntrHandler_Stop
 	ldr r1, pool_MultiBootLoadAddr
-	str r1, [r0, GCMB_STRUCT_BASE_DEST_PTR]
-	str r1, [r0, GCMB_STRUCT_CUR_DEST_PTR]
+	str r1, [r0, #GCMB_STRUCT_BASE_DEST_PTR]
+	str r1, [r0, #GCMB_STRUCT_CUR_DEST_PTR]
 	adr r2, GcMbIntrHandler_CheckGameCodeSent
 	b GameCubeMultiBoot_SetInterruptHandler
 
@@ -417,8 +417,8 @@ _082DEF94:
 _082DEFA6:
 	bne GcMbIntrHandler_Stop
 	ldr r1, pool_MultiBootLoadAddr
-	str r1, [r0, GCMB_STRUCT_BASE_DEST_PTR]
-	str r1, [r0, GCMB_STRUCT_CUR_DEST_PTR]
+	str r1, [r0, #GCMB_STRUCT_BASE_DEST_PTR]
+	str r1, [r0, #GCMB_STRUCT_CUR_DEST_PTR]
 	adr r2, GcMbIntrHandler_82DEFB4
 	b GameCubeMultiBoot_SetInterruptHandler
 
@@ -427,7 +427,7 @@ _082DEFA6:
 GcMbIntrHandler_82DEFB4: @ 82DEFB4
 	lsrs r1, 1 @ is receive complete?
 	bcc GcMbIntrHandler_Stop @ branch if not
-	ldr r2, [r0, GCMB_STRUCT_CUR_DEST_PTR]
+	ldr r2, [r0, #GCMB_STRUCT_CUR_DEST_PTR]
 	movs r1, 0x4
 	ands r1, r2
 	adds r1, 0x8
@@ -435,7 +435,7 @@ GcMbIntrHandler_82DEFB4: @ 82DEFB4
 	strh r1, [r3, OFFSET_REG_JOYSTAT - 0x120]
 	ldr r1, [r3, OFFSET_REG_JOY_RECV - 0x120]
 	stm r2!, {r1}
-	str r2, [r0, GCMB_STRUCT_CUR_DEST_PTR]
+	str r2, [r0, #GCMB_STRUCT_CUR_DEST_PTR]
 	ldrh r1, [r0, 0x12]
 	subs r1, 0x1
 	strh r1, [r0, 0x12]
@@ -500,11 +500,11 @@ GameCubeMultiBoot_Quit: @ 82DF012
 	ldr r3, pool_InterruptRegs
 
 @ Save IME register.
-	ldrh r2, [r3, OFFSET_REG_IME - 0x200]
+	ldrh r2, [r3, #OFFSET_REG_IME - 0x200]
 
 @ Disable interrupts.
 	movs r1, 0
-	strh r1, [r3, OFFSET_REG_IME - 0x200]
+	strh r1, [r3, #OFFSET_REG_IME - 0x200]
 
 	ldr r3, pool_SerialRegs
 
@@ -528,7 +528,7 @@ GameCubeMultiBoot_Quit: @ 82DF012
 	strh r1, [r3, OFFSET_REG_IE - 0x200]
 
 @ Restore IME register.
-	strh r2, [r3, OFFSET_REG_IME - 0x200]
+	strh r2, [r3, #OFFSET_REG_IME - 0x200]
 
 	bx lr
 	thumb_func_end GameCubeMultiBoot_Quit


### PR DESCRIPTION
Whenever I use another toolchain, especially clang, I get errors such as "expected a register" while pointing to a macro that should compile fine. Additionally, there are some idioms that worked on GAS, but not on any other assembler. An example would be the "mov r0, r0, lsr" instructions. Converting those functions to the modern and equivalent machine instruction allows these assembly instructions to compile exactly on clang and GNU,