### PR TITLE
Add warnings to generated map/layout files

### DIFF
--- a/include/constants/layouts.h
+++ b/include/constants/layouts.h
@@ -1,6 +1,10 @@
 #ifndef GUARD_CONSTANTS_LAYOUTS_H
 #define GUARD_CONSTANTS_LAYOUTS_H
 
+//
+// DO NOT MODIFY THIS FILE! It is auto-generated from data/layouts/layouts.json
+//
+
 #define LAYOUT_PETALBURG_CITY 1
 #define LAYOUT_SLATEPORT_CITY 2
 #define LAYOUT_MAUVILLE_CITY 3

--- a/include/constants/map_groups.h
+++ b/include/constants/map_groups.h
@@ -1,6 +1,10 @@
 #ifndef GUARD_CONSTANTS_MAP_GROUPS_H
 #define GUARD_CONSTANTS_MAP_GROUPS_H
 
+//
+// DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/map_groups.json
+//
+
 // Map Group 0
 #define MAP_PETALBURG_CITY   (0 | (0 << 8))
 #define MAP_SLATEPORT_CITY   (1 | (0 << 8))

--- a/tools/mapjson/mapjson.cpp
+++ b/tools/mapjson/mapjson.cpp
@@ -77,6 +77,10 @@ string generate_map_header_text(Json map_data, Json layouts_data, string version
 
     ostringstream text;
 
+    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/" 
+         << map_data["name"].string_value() 
+         << "/map.json\n@\n\n";
+
     text << map_data["name"].string_value() << ":\n"
          << "\t.4byte " << layout["name"].string_value() << "\n";
 
@@ -124,6 +128,10 @@ string generate_map_connections_text(Json map_data) {
 
     ostringstream text;
 
+    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/" 
+         << map_data["name"].string_value() 
+         << "/map.json\n@\n\n";
+
     text << map_data["name"].string_value() << "_MapConnectionsList:\n";
 
     for (auto &connection : map_data["connections"].array_items()) {
@@ -145,6 +153,10 @@ string generate_map_events_text(Json map_data) {
         return string("\n");
 
     ostringstream text;
+
+    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/" 
+         << map_data["name"].string_value() 
+         << "/map.json\n@\n\n";
 
     string objects_label, warps_label, coords_label, bgs_label;
 
@@ -286,6 +298,8 @@ void process_map(string map_filepath, string layouts_filepath, string version) {
 string generate_groups_text(Json groups_data) {
     ostringstream text;
 
+    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/map_groups.json\n@\n\n";
+
     for (auto &key : groups_data["group_order"].array_items()) {
         string group = key.string_value();
         text << group << "::\n";
@@ -325,6 +339,8 @@ string generate_connections_text(Json groups_data) {
 
     ostringstream text;
 
+    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/map_groups.json\n@\n\n";
+
     for (Json map_name : map_names)
         text << "\t.include \"data/maps/" << map_name.string_value() << "/connections.inc\"\n";
 
@@ -339,6 +355,8 @@ string generate_headers_text(Json groups_data) {
         map_names.push_back(map_name.string_value());
 
     ostringstream text;
+
+    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/map_groups.json\n@\n\n";
 
     for (string map_name : map_names)
         text << "\t.include \"data/maps/" << map_name << "/header.inc\"\n";
@@ -355,6 +373,8 @@ string generate_events_text(Json groups_data) {
 
     ostringstream text;
 
+    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/map_groups.json\n@\n\n";
+
     for (string map_name : map_names)
         text << "\t.include \"data/maps/" << map_name << "/events.inc\"\n";
 
@@ -369,6 +389,8 @@ string generate_map_constants_text(string groups_filepath, Json groups_data) {
 
     text << "#ifndef GUARD_CONSTANTS_MAP_GROUPS_H\n"
          << "#define GUARD_CONSTANTS_MAP_GROUPS_H\n\n";
+
+    text << "//\n// DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/map_groups.json\n//\n\n";
 
     int group_num = 0;
 
@@ -428,6 +450,8 @@ void process_groups(string groups_filepath) {
 string generate_layout_headers_text(Json layouts_data) {
     ostringstream text;
 
+    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/layouts/layouts.json\n@\n\n";
+
     for (auto &layout : layouts_data["layouts"].array_items()) {
         string border_label = layout["name"].string_value() + "_Border";
         string blockdata_label = layout["name"].string_value() + "_Blockdata";
@@ -451,6 +475,8 @@ string generate_layout_headers_text(Json layouts_data) {
 string generate_layouts_table_text(Json layouts_data) {
     ostringstream text;
 
+    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/layouts/layouts.json\n@\n\n";
+
     text << "\t.align 2\n"
          << layouts_data["layouts_table_label"].string_value() << "::\n";
 
@@ -465,6 +491,8 @@ string generate_layouts_constants_text(Json layouts_data) {
 
     text << "#ifndef GUARD_CONSTANTS_LAYOUTS_H\n"
          << "#define GUARD_CONSTANTS_LAYOUTS_H\n\n";
+
+    text << "//\n// DO NOT MODIFY THIS FILE! It is auto-generated from data/layouts/layouts.json\n//\n\n";
 
     int i = 0;
     for (auto &layout : layouts_data["layouts"].array_items())


### PR DESCRIPTION
People often mistakenly edit these files