### PR TITLE
Fix undefined behaviour in protect animation

### DIFF
--- a/src/battle_anim_effects_1.c
+++ b/src/battle_anim_effects_1.c
@@ -3967,21 +3967,21 @@ static void AnimProtect(struct Sprite* sprite)
 
 static void AnimProtect_Step(struct Sprite *sprite)
 {
-    int a;
-    int i;
+    int i, id, savedPal;
     sprite->data[5] += 96;
     sprite->pos2.x = -(sprite->data[5] >> 8);
     if (++sprite->data[1] > 1)
     {
         sprite->data[1] = 0;
-        a = gPlttBufferFaded[sprite->data[2] + 1];
+        savedPal = gPlttBufferFaded[sprite->data[2] + 1];
         i = 0;
-        do
+        while (i < 6)
         {
-            gPlttBufferFaded[sprite->data[2] + ++i] = gPlttBufferFaded[sprite->data[2] + i + 1];
-        } while (i < 6);
+            id = sprite->data[2] + ++i;
+            gPlttBufferFaded[id] = gPlttBufferFaded[id + 1];
+        }
 
-        gPlttBufferFaded[sprite->data[2] + 7] = a;
+        gPlttBufferFaded[sprite->data[2] + 7] = savedPal;
     }
 
     if (sprite->data[7] > 6 && sprite->data[0] >0 && ++sprite->data[6] > 1)


### PR DESCRIPTION
gPlttBufferFaded[sprite->data[2] + ++i] = gPlttBufferFaded[sprite->data[2] + i + 1] 

The above does NOT make it certain that i gets incremented before reading from the right side. Changed it, so the function always increments i first, then reads from pal buffer.