### PR TITLE
Match battle script commands

### DIFF
--- a/include/battle.h
+++ b/include/battle.h
@@ -124,22 +124,22 @@ struct ProtectStruct
     u32 flinchImmobility:1;
     u32 notFirstStrike:1;
     u32 palaceUnableToUseMove:1;
-    u32 physicalDmg;
-    u32 specialDmg;
+    s32 physicalDmg;
+    s32 specialDmg;
     u8 physicalBattlerId;
     u8 specialBattlerId;
 };
 
 struct SpecialStatus
 {
-    u8 statLowered:1;
-    u8 lightningRodRedirected:1;
-    u8 restoredBattlerSprite: 1;
-    u8 intimidatedMon:1;
-    u8 traced:1;
-    u8 ppNotAffectedByPressure:1;
-    u8 flag40:1;
-    u8 focusBanded:1;
+    u32 statLowered:1;
+    u32 lightningRodRedirected:1;
+    u32 restoredBattlerSprite: 1;
+    u32 intimidatedMon:1;
+    u32 traced:1;
+    u32 ppNotAffectedByPressure:1;
+    u32 flag40:1;
+    u32 focusBanded:1;
     s32 dmg;
     s32 physicalDmg;
     s32 specialDmg;
@@ -254,7 +254,7 @@ struct BattleResults
     u16 playerMon2Species;    // 0x26
     u16 caughtMonSpecies;     // 0x28
     u8 caughtMonNick[POKEMON_NAME_LENGTH + 1];     // 0x2A
-    u8 filler35[1];           // 0x35
+    u8 filler35;              // 0x35
     u8 catchAttempts[11];     // 0x36
 };
 

--- a/include/constants/battle.h
+++ b/include/constants/battle.h
@@ -186,7 +186,7 @@
 #define HITMARKER_x4000000              (1 << 26)
 #define HITMARKER_CHARGING              (1 << 27)
 #define HITMARKER_FAINTED(battler)      (gBitTable[battler] << 28)
-#define HITMARKER_FAINTED2(battler)     (1 << (28 + battler))
+#define HITMARKER_FAINTED2(battler)     ((1 << 28) << battler)
 
 // Per-side statuses that affect an entire party
 #define SIDE_STATUS_REFLECT          (1 << 0)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3489,7 +3489,6 @@ static void Cmd_getexp(void)
     }
 }
 
-#ifdef NONMATCHING
 static void Cmd_unknown_24(void)
 {
     u16 HP_count = 0;
@@ -3521,7 +3520,9 @@ static void Cmd_unknown_24(void)
     if (HP_count == 0)
         gBattleOutcome |= B_OUTCOME_LOST;
 
-    for (HP_count = 0, i = 0; i < PARTY_SIZE; i++)
+    HP_count = 0;
+
+    for (i = 0; i < PARTY_SIZE; i++)
     {
         if (GetMonData(&gEnemyParty[i], MON_DATA_SPECIES) && !GetMonData(&gEnemyParty[i], MON_DATA_IS_EGG)
             && (!(gBattleTypeFlags & BATTLE_TYPE_ARENA) || !(gBattleStruct->arenaLostOpponentMons & gBitTable[i])))
@@ -3535,33 +3536,31 @@ static void Cmd_unknown_24(void)
 
     if (gBattleOutcome == 0 && (gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_x2000000)))
     {
-        s32 foundPlayer;
-        s32 foundOpponent;
-
-        // Impossible to decompile loops.
-        for (foundPlayer = 0, i = 0; i < gBattlersCount; i += 2)
+        s32 foundPlayer = 0, foundOpponent;
+        for (i = 0; i < gBattlersCount; i += 2)
         {
-            if (HITMARKER_FAINTED2(i) & gHitMarker && !gSpecialStatuses[i].flag40)
+            if ((gHitMarker & HITMARKER_FAINTED2(i)) && (!gSpecialStatuses[i].flag40))
                 foundPlayer++;
         }
 
-        for (foundOpponent = 0, i = 1; i < gBattlersCount; i += 2)
+        foundOpponent = 0;
+        for (i = 1; i < gBattlersCount; i += 2)
         {
-            if (HITMARKER_FAINTED2(i) & gHitMarker && !gSpecialStatuses[i].flag40)
+            if ((gHitMarker & HITMARKER_FAINTED2(i)) && (!gSpecialStatuses[i].flag40))
                 foundOpponent++;
         }
 
         if (gBattleTypeFlags & BATTLE_TYPE_MULTI)
         {
             if (foundOpponent + foundPlayer > 1)
-                gBattlescriptCurrInstr = T2_READ_PTR(gBattlescriptCurrInstr + 1);
+                gBattlescriptCurrInstr = (u8*) T2_READ_32(gBattlescriptCurrInstr + 1);
             else
                 gBattlescriptCurrInstr += 5;
         }
         else
         {
             if (foundOpponent != 0 && foundPlayer != 0)
-                gBattlescriptCurrInstr = T2_READ_PTR(gBattlescriptCurrInstr + 1);
+                gBattlescriptCurrInstr = (u8*) T2_READ_32(gBattlescriptCurrInstr + 1);
             else
                 gBattlescriptCurrInstr += 5;
         }
@@ -3571,301 +3570,6 @@ static void Cmd_unknown_24(void)
         gBattlescriptCurrInstr += 5;
     }
 }
-#else
-NAKED
-static void Cmd_unknown_24(void)
-{
-    asm("\n\
-        .syntax unified\n\
-        push {r4-r7,lr}\n\
-        mov r7, r8\n\
-        push {r7}\n\
-        movs r6, 0\n\
-        ldr r0, =gBattleControllerExecFlags\n\
-        ldr r0, [r0]\n\
-        cmp r0, 0\n\
-        beq _0804ACE2\n\
-        b _0804AF22\n\
-    _0804ACE2:\n\
-        ldr r0, =gBattleTypeFlags\n\
-        ldr r0, [r0]\n\
-        movs r1, 0x80\n\
-        lsls r1, 15\n\
-        ands r0, r1\n\
-        cmp r0, 0\n\
-        beq _0804AD48\n\
-        ldr r0, =gPartnerTrainerId\n\
-        ldrh r1, [r0]\n\
-        ldr r0, =0x00000c03\n\
-        cmp r1, r0\n\
-        bne _0804AD48\n\
-        movs r5, 0\n\
-    _0804ACFC:\n\
-        movs r0, 0x64\n\
-        adds r1, r5, 0\n\
-        muls r1, r0\n\
-        ldr r0, =gPlayerParty\n\
-        adds r4, r1, r0\n\
-        adds r0, r4, 0\n\
-        movs r1, 0xB\n\
-        bl GetMonData\n\
-        cmp r0, 0\n\
-        beq _0804AD2C\n\
-        adds r0, r4, 0\n\
-        movs r1, 0x2D\n\
-        bl GetMonData\n\
-        cmp r0, 0\n\
-        bne _0804AD2C\n\
-        adds r0, r4, 0\n\
-        movs r1, 0x39\n\
-        bl GetMonData\n\
-        adds r0, r6, r0\n\
-        lsls r0, 16\n\
-        lsrs r6, r0, 16\n\
-    _0804AD2C:\n\
-        adds r5, 0x1\n\
-        cmp r5, 0x2\n\
-        ble _0804ACFC\n\
-        b _0804ADA8\n\
-        .pool\n\
-    _0804AD48:\n\
-        movs r5, 0\n\
-    _0804AD4A:\n\
-        movs r0, 0x64\n\
-        adds r1, r5, 0\n\
-        muls r1, r0\n\
-        ldr r0, =gPlayerParty\n\
-        adds r4, r1, r0\n\
-        adds r0, r4, 0\n\
-        movs r1, 0xB\n\
-        bl GetMonData\n\
-        cmp r0, 0\n\
-        beq _0804ADA2\n\
-        adds r0, r4, 0\n\
-        movs r1, 0x2D\n\
-        bl GetMonData\n\
-        cmp r0, 0\n\
-        bne _0804ADA2\n\
-        ldr r0, =gBattleTypeFlags\n\
-        ldr r0, [r0]\n\
-        movs r1, 0x80\n\
-        lsls r1, 11\n\
-        ands r0, r1\n\
-        cmp r0, 0\n\
-        beq _0804AD94\n\
-        ldr r0, =gBattleStruct\n\
-        ldr r0, [r0]\n\
-        movs r1, 0xA8\n\
-        lsls r1, 2\n\
-        adds r0, r1\n\
-        ldrb r1, [r0]\n\
-        ldr r2, =gBitTable\n\
-        lsls r0, r5, 2\n\
-        adds r0, r2\n\
-        ldr r0, [r0]\n\
-        ands r1, r0\n\
-        cmp r1, 0\n\
-        bne _0804ADA2\n\
-    _0804AD94:\n\
-        adds r0, r4, 0\n\
-        movs r1, 0x39\n\
-        bl GetMonData\n\
-        adds r0, r6, r0\n\
-        lsls r0, 16\n\
-        lsrs r6, r0, 16\n\
-    _0804ADA2:\n\
-        adds r5, 0x1\n\
-        cmp r5, 0x5\n\
-        ble _0804AD4A\n\
-    _0804ADA8:\n\
-        cmp r6, 0\n\
-        bne _0804ADB6\n\
-        ldr r0, =gBattleOutcome\n\
-        ldrb r1, [r0]\n\
-        movs r2, 0x2\n\
-        orrs r1, r2\n\
-        strb r1, [r0]\n\
-    _0804ADB6:\n\
-        movs r6, 0\n\
-        movs r5, 0\n\
-    _0804ADBA:\n\
-        movs r0, 0x64\n\
-        adds r1, r5, 0\n\
-        muls r1, r0\n\
-        ldr r0, =gEnemyParty\n\
-        adds r4, r1, r0\n\
-        adds r0, r4, 0\n\
-        movs r1, 0xB\n\
-        bl GetMonData\n\
-        cmp r0, 0\n\
-        beq _0804AE10\n\
-        adds r0, r4, 0\n\
-        movs r1, 0x2D\n\
-        bl GetMonData\n\
-        cmp r0, 0\n\
-        bne _0804AE10\n\
-        ldr r0, =gBattleTypeFlags\n\
-        ldr r0, [r0]\n\
-        movs r1, 0x80\n\
-        lsls r1, 11\n\
-        ands r0, r1\n\
-        cmp r0, 0\n\
-        beq _0804AE02\n\
-        ldr r0, =gBattleStruct\n\
-        ldr r0, [r0]\n\
-        ldr r1, =0x000002a1\n\
-        adds r0, r1\n\
-        ldrb r1, [r0]\n\
-        ldr r2, =gBitTable\n\
-        lsls r0, r5, 2\n\
-        adds r0, r2\n\
-        ldr r0, [r0]\n\
-        ands r1, r0\n\
-        cmp r1, 0\n\
-        bne _0804AE10\n\
-    _0804AE02:\n\
-        adds r0, r4, 0\n\
-        movs r1, 0x39\n\
-        bl GetMonData\n\
-        adds r0, r6, r0\n\
-        lsls r0, 16\n\
-        lsrs r6, r0, 16\n\
-    _0804AE10:\n\
-        adds r5, 0x1\n\
-        cmp r5, 0x5\n\
-        ble _0804ADBA\n\
-        ldr r2, =gBattleOutcome\n\
-        cmp r6, 0\n\
-        bne _0804AE24\n\
-        ldrb r0, [r2]\n\
-        movs r1, 0x1\n\
-        orrs r0, r1\n\
-        strb r0, [r2]\n\
-    _0804AE24:\n\
-        ldrb r0, [r2]\n\
-        cmp r0, 0\n\
-        bne _0804AF1A\n\
-        ldr r0, =gBattleTypeFlags\n\
-        ldr r1, [r0]\n\
-        ldr r2, =0x02000002\n\
-        ands r1, r2\n\
-        mov r8, r0\n\
-        cmp r1, 0\n\
-        beq _0804AF1A\n\
-        movs r3, 0\n\
-        movs r5, 0\n\
-        ldr r0, =gBattlersCount\n\
-        ldrb r1, [r0]\n\
-        mov r12, r0\n\
-        ldr r7, =gBattlescriptCurrInstr\n\
-        cmp r3, r1\n\
-        bge _0804AE70\n\
-        ldr r0, =gHitMarker\n\
-        movs r6, 0x80\n\
-        lsls r6, 21\n\
-        ldr r4, [r0]\n\
-        adds r2, r1, 0\n\
-        ldr r1, =gSpecialStatuses\n\
-    _0804AE54:\n\
-        adds r0, r6, 0\n\
-        lsls r0, r5\n\
-        ands r0, r4\n\
-        cmp r0, 0\n\
-        beq _0804AE68\n\
-        ldrb r0, [r1]\n\
-        lsls r0, 25\n\
-        cmp r0, 0\n\
-        blt _0804AE68\n\
-        adds r3, 0x1\n\
-    _0804AE68:\n\
-        adds r1, 0x28\n\
-        adds r5, 0x2\n\
-        cmp r5, r2\n\
-        blt _0804AE54\n\
-    _0804AE70:\n\
-        movs r2, 0\n\
-        movs r5, 0x1\n\
-        mov r4, r12\n\
-        ldrb r1, [r4]\n\
-        cmp r5, r1\n\
-        bge _0804AEAA\n\
-        ldr r0, =gHitMarker\n\
-        movs r4, 0x80\n\
-        lsls r4, 21\n\
-        mov r12, r4\n\
-        ldr r6, [r0]\n\
-        ldr r0, =gSpecialStatuses\n\
-        adds r4, r1, 0\n\
-        adds r1, r0, 0\n\
-        adds r1, 0x14\n\
-    _0804AE8E:\n\
-        mov r0, r12\n\
-        lsls r0, r5\n\
-        ands r0, r6\n\
-        cmp r0, 0\n\
-        beq _0804AEA2\n\
-        ldrb r0, [r1]\n\
-        lsls r0, 25\n\
-        cmp r0, 0\n\
-        blt _0804AEA2\n\
-        adds r2, 0x1\n\
-    _0804AEA2:\n\
-        adds r1, 0x28\n\
-        adds r5, 0x2\n\
-        cmp r5, r4\n\
-        blt _0804AE8E\n\
-    _0804AEAA:\n\
-        mov r1, r8\n\
-        ldr r0, [r1]\n\
-        movs r1, 0x40\n\
-        ands r0, r1\n\
-        cmp r0, 0\n\
-        beq _0804AEF0\n\
-        adds r0, r2, r3\n\
-        cmp r0, 0x1\n\
-        bgt _0804AEF8\n\
-        b _0804AF12\n\
-        .pool\n\
-    _0804AEF0:\n\
-        cmp r2, 0\n\
-        beq _0804AF12\n\
-        cmp r3, 0\n\
-        beq _0804AF12\n\
-    _0804AEF8:\n\
-        ldr r2, [r7]\n\
-        ldrb r1, [r2, 0x1]\n\
-        ldrb r0, [r2, 0x2]\n\
-        lsls r0, 8\n\
-        adds r1, r0\n\
-        ldrb r0, [r2, 0x3]\n\
-        lsls r0, 16\n\
-        adds r1, r0\n\
-        ldrb r0, [r2, 0x4]\n\
-        lsls r0, 24\n\
-        adds r1, r0\n\
-        str r1, [r7]\n\
-        b _0804AF22\n\
-    _0804AF12:\n\
-        ldr r0, [r7]\n\
-        adds r0, 0x5\n\
-        str r0, [r7]\n\
-        b _0804AF22\n\
-    _0804AF1A:\n\
-        ldr r1, =gBattlescriptCurrInstr\n\
-        ldr r0, [r1]\n\
-        adds r0, 0x5\n\
-        str r0, [r1]\n\
-    _0804AF22:\n\
-        pop {r3}\n\
-        mov r8, r3\n\
-        pop {r4-r7}\n\
-        pop {r0}\n\
-        bx r0\n\
-        .pool\n\
-        .syntax divided");
-}
-
-#endif // NONMATCHING
 
 static void MoveValuesCleanUp(void)
 {
@@ -5831,8 +5535,8 @@ static void Cmd_hitanimation(void)
 static u32 GetTrainerMoneyToGive(u16 trainerId)
 {
     u32 i = 0;
-    u32 lastMonLevel = 0;
-    u32 moneyReward = 0;
+    u32 moneyReward;
+    u8 lastMonLevel = 0;
 
     if (trainerId == TRAINER_SECRET_BASE)
     {


### PR DESCRIPTION
Although it may appear unrelated changes are in this PR, they are necessary for the matching. The reason why the first function was not matching was because this is the only function in which the problem wasn't the function itself, but the data it is accessing.

When I inputted the structs into Ghidra, Ghidra showed that the size of the struct in the actual Emerald Rom is too big for the current struct declaration. Adjusting it allowed me to get rid of implicit casts that caused the nonmatching in C. The only function affected by this change other than Cmd_unknown32 was the money function.