### PR TITLE
Make agb_flash stack func buffers volatile

### DIFF
--- a/src/agb_flash.c
+++ b/src/agb_flash.c
@@ -140,9 +140,9 @@ void ReadFlash(u16 sectorNum, u32 offset, u8 *dest, u32 size)
 {
     u8 *src;
     u16 i;
-    u16 readFlash_Core_Buffer[0x40];
-    u16 *funcSrc;
-    u16 *funcDest;
+    vu16 readFlash_Core_Buffer[0x40];
+    vu16 *funcSrc;
+    vu16 *funcDest;
     void (*readFlash_Core)(vu8 *, u8 *, u32);
 
     REG_WAITCNT = (REG_WAITCNT & ~WAITCNT_SRAM_MASK) | WAITCNT_SRAM_8;
@@ -153,8 +153,8 @@ void ReadFlash(u16 sectorNum, u32 offset, u8 *dest, u32 size)
         sectorNum %= SECTORS_PER_BANK;
     }
 
-    funcSrc = (u16 *)ReadFlash_Core;
-    funcSrc = (u16 *)((uintptr_t)funcSrc ^ 1);
+    funcSrc = (vu16 *)ReadFlash_Core;
+    funcSrc = (vu16 *)((uintptr_t)funcSrc ^ 1);
     funcDest = readFlash_Core_Buffer;
 
     i = ((uintptr_t)ReadFlash - (uintptr_t)ReadFlash_Core) >> 1;
@@ -186,9 +186,9 @@ u32 VerifyFlashSector_Core(u8 *src, u8 *tgt, u32 size)
 u32 VerifyFlashSector(u16 sectorNum, u8 *src)
 {
     u16 i;
-    u16 verifyFlashSector_Core_Buffer[0x80];
-    u16 *funcSrc;
-    u16 *funcDest;
+    vu16 verifyFlashSector_Core_Buffer[0x80];
+    vu16 *funcSrc;
+    vu16 *funcDest;
     u8 *tgt;
     u16 size;
     u32 (*verifyFlashSector_Core)(u8 *, u8 *, u32);
@@ -201,8 +201,8 @@ u32 VerifyFlashSector(u16 sectorNum, u8 *src)
         sectorNum %= SECTORS_PER_BANK;
     }
 
-    funcSrc = (u16 *)VerifyFlashSector_Core;
-    funcSrc = (u16 *)((uintptr_t)funcSrc ^ 1);
+    funcSrc = (vu16 *)VerifyFlashSector_Core;
+    funcSrc = (vu16 *)((uintptr_t)funcSrc ^ 1);
     funcDest = verifyFlashSector_Core_Buffer;
 
     i = (u16)(((uintptr_t)VerifyFlashSector - (uintptr_t)VerifyFlashSector_Core) >> 1);
@@ -224,9 +224,9 @@ u32 VerifyFlashSector(u16 sectorNum, u8 *src)
 u32 VerifyFlashSectorNBytes(u16 sectorNum, u8 *src, u32 n)
 {
     u16 i;
-    u16 verifyFlashSector_Core_Buffer[0x80];
-    u16 *funcSrc;
-    u16 *funcDest;
+    vu16 verifyFlashSector_Core_Buffer[0x80];
+    vu16 *funcSrc;
+    vu16 *funcDest;
     u8 *tgt;
     u32 (*verifyFlashSector_Core)(u8 *, u8 *, u32);
 
@@ -238,8 +238,8 @@ u32 VerifyFlashSectorNBytes(u16 sectorNum, u8 *src, u32 n)
 
     REG_WAITCNT = (REG_WAITCNT & ~WAITCNT_SRAM_MASK) | WAITCNT_SRAM_8;
 
-    funcSrc = (u16 *)VerifyFlashSector_Core;
-    funcSrc = (u16 *)((uintptr_t)funcSrc ^ 1);
+    funcSrc = (vu16 *)VerifyFlashSector_Core;
+    funcSrc = (vu16 *)((uintptr_t)funcSrc ^ 1);
     funcDest = verifyFlashSector_Core_Buffer;
 
     i = ((uintptr_t)VerifyFlashSector - (uintptr_t)VerifyFlashSector_Core) >> 1;


### PR DESCRIPTION
Fixes observed crash with modern gcc
Resolves #1171 