### PR TITLE
Update Audio Macros

### DIFF
--- a/asm/macros/music_voice.inc
+++ b/asm/macros/music_voice.inc
@@ -1,19 +1,19 @@
-	.macro voice_directsound base_midi_key, pan, sample_data_pointer, attack, decay, sustain, release
+	.macro voice_directsound base_midi_key:req, pan:req, sample_data_pointer:req, attack:req, decay:req, sustain:req, release:req
 	.byte 0
 	_voice_directsound \base_midi_key, \pan, \sample_data_pointer, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_directsound_no_resample base_midi_key, pan, sample_data_pointer, attack, decay, sustain, release
+	.macro voice_directsound_no_resample base_midi_key:req, pan:req, sample_data_pointer:req, attack:req, decay:req, sustain:req, release:req
 	.byte 8
 	_voice_directsound \base_midi_key, \pan, \sample_data_pointer, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_directsound_alt base_midi_key, pan, sample_data_pointer, attack, decay, sustain, release
+	.macro voice_directsound_alt base_midi_key:req, pan:req, sample_data_pointer:req, attack:req, decay:req, sustain:req, release:req
 	.byte 16
 	_voice_directsound \base_midi_key, \pan, \sample_data_pointer, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro _voice_directsound base_midi_key, pan, sample_data_pointer, attack, decay, sustain, release
+	.macro _voice_directsound base_midi_key:req, pan:req, sample_data_pointer:req, attack:req, decay:req, sustain:req, release:req
 	.byte \base_midi_key
 	.byte 0
 	.if \pan != 0
@@ -28,15 +28,15 @@
 	.byte \release
 	.endm
 
-	.macro voice_square_1 base_midi_key, pan, sweep, duty_cycle, attack, decay, sustain, release
+	.macro voice_square_1 base_midi_key:req, pan:req, sweep:req, duty_cycle:req, attack:req, decay:req, sustain:req, release:req
 	_voice_square_1 1, \base_midi_key, \pan, \sweep, \duty_cycle, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_square_1_alt base_midi_key, pan, sweep, duty_cycle, attack, decay, sustain, release
+	.macro voice_square_1_alt base_midi_key:req, pan:req, sweep:req, duty_cycle:req, attack:req, decay:req, sustain:req, release:req
 	_voice_square_1 9, \base_midi_key, \pan, \sweep, \duty_cycle, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro _voice_square_1 type, base_midi_key, pan, sweep, duty_cycle, attack, decay, sustain, release
+	.macro _voice_square_1 type:req, base_midi_key:req, pan:req, sweep:req, duty_cycle:req, attack:req, decay:req, sustain:req, release:req
 	.byte \type
 	.byte \base_midi_key
 	.if \pan != 0
@@ -53,15 +53,15 @@
 	.byte (\release & 0x7)
 	.endm
 
-	.macro voice_square_2 base_midi_key, pan, duty_cycle, attack, decay, sustain, release
+	.macro voice_square_2 base_midi_key:req, pan:req, duty_cycle:req, attack:req, decay:req, sustain:req, release:req
 	_voice_square_2 2, \base_midi_key, \pan, \duty_cycle, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_square_2_alt base_midi_key, pan, duty_cycle, attack, decay, sustain, release
+	.macro voice_square_2_alt base_midi_key:req, pan:req, duty_cycle:req, attack:req, decay:req, sustain:req, release:req
 	_voice_square_2 10, \base_midi_key, \pan, \duty_cycle, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro _voice_square_2 type, base_midi_key, pan, duty_cycle, attack, decay, sustain, release
+	.macro _voice_square_2 type:req, base_midi_key:req, pan:req, duty_cycle:req, attack:req, decay:req, sustain:req, release:req
 	.byte \type
 	.byte \base_midi_key
 	.if \pan != 0
@@ -78,15 +78,15 @@
 	.byte (\release & 0x7)
 	.endm
 
-	.macro voice_programmable_wave base_midi_key, pan, wave_samples_pointer, attack, decay, sustain, release
+	.macro voice_programmable_wave base_midi_key:req, pan:req, wave_samples_pointer:req, attack:req, decay:req, sustain:req, release:req
 	_voice_programmable_wave 3, \base_midi_key, \pan, \wave_samples_pointer, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_programmable_wave_alt base_midi_key, pan, wave_samples_pointer, attack, decay, sustain, release
+	.macro voice_programmable_wave_alt base_midi_key:req, pan:req, wave_samples_pointer:req, attack:req, decay:req, sustain:req, release:req
 	_voice_programmable_wave 11, \base_midi_key, \pan, \wave_samples_pointer, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro _voice_programmable_wave type, base_midi_key, pan, wave_samples_pointer, attack, decay, sustain, release
+	.macro _voice_programmable_wave type:req, base_midi_key:req, pan:req, wave_samples_pointer:req, attack:req, decay:req, sustain:req, release:req
 	.byte \type
 	.byte \base_midi_key
 	.if \pan != 0
@@ -102,15 +102,15 @@
 	.byte (\release & 0x7)
 	.endm
 
-	.macro voice_noise base_midi_key, pan, period, attack, decay, sustain, release
+	.macro voice_noise base_midi_key:req, pan:req, period:req, attack:req, decay:req, sustain:req, release:req
 	_voice_noise 4, \base_midi_key, \pan, \period, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_noise_alt base_midi_key, pan, period, attack, decay, sustain, release
+	.macro voice_noise_alt base_midi_key:req, pan:req, period:req, attack:req, decay:req, sustain:req, release:req
 	_voice_noise 12, \base_midi_key, \pan, \period, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro _voice_noise type, base_midi_key, pan, period, attack, decay, sustain, release
+	.macro _voice_noise type:req, base_midi_key:req, pan:req, period:req, attack:req, decay:req, sustain:req, release:req
 	.byte \type
 	.byte \base_midi_key
 	.if \pan != 0
@@ -127,25 +127,25 @@
 	.byte (\release & 0x7)
 	.endm
 
-	.macro voice_keysplit voice_group_pointer, keysplit_table_pointer
+	.macro voice_keysplit voice_group_pointer:req, keysplit_table_pointer:req
 	.byte 0x40, 0, 0, 0
 	.4byte \voice_group_pointer
 	.4byte \keysplit_table_pointer
 	.endm
 
-	.macro voice_keysplit_all voice_group_pointer
+	.macro voice_keysplit_all voice_group_pointer:req
 	.byte 0x80, 0, 0, 0
 	.4byte \voice_group_pointer
 	.4byte 0
 	.endm
 
-	.macro cry sample
+	.macro cry sample:req
 	.byte 0x20, 60, 0, 0
 	.4byte \sample
 	.byte 0xff, 0, 0xff, 0
 	.endm
 
-	.macro cry2 sample
+	.macro cry2 sample:req
 	.byte 0x30, 60, 0, 0
 	.4byte \sample
 	.byte 0xff, 0, 0xff, 0

--- a/asm/macros/music_voice.inc
+++ b/asm/macros/music_voice.inc
@@ -28,16 +28,22 @@
 	.byte \release
 	.endm
 
-	.macro voice_square_1 sweep, duty_cycle, attack, decay, sustain, release
-	_voice_square_1 1, \sweep, \duty_cycle, \attack, \decay, \sustain, \release
+	.macro voice_square_1 base_midi_key, pan, sweep, duty_cycle, attack, decay, sustain, release
+	_voice_square_1 1, \base_midi_key, \pan, \sweep, \duty_cycle, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_square_1_alt sweep, duty_cycle, attack, decay, sustain, release
-	_voice_square_1 9, \sweep, \duty_cycle, \attack, \decay, \sustain, \release
+	.macro voice_square_1_alt base_midi_key, pan, sweep, duty_cycle, attack, decay, sustain, release
+	_voice_square_1 9, \base_midi_key, \pan, \sweep, \duty_cycle, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro _voice_square_1 type, sweep, duty_cycle, attack, decay, sustain, release
-	.byte \type, 60, 0
+	.macro _voice_square_1 type, base_midi_key, pan, sweep, duty_cycle, attack, decay, sustain, release
+	.byte \type
+	.byte \base_midi_key
+	.if \pan != 0
+	.byte (0x80 | \pan)
+	.else
+	.byte 0
+	.endif
 	.byte \sweep
 	.byte (\duty_cycle & 0x3)
 	.byte 0, 0, 0
@@ -47,16 +53,23 @@
 	.byte (\release & 0x7)
 	.endm
 
-	.macro voice_square_2 duty_cycle, attack, decay, sustain, release
-	_voice_square_2 2, \duty_cycle, \attack, \decay, \sustain, \release
+	.macro voice_square_2 base_midi_key, pan, duty_cycle, attack, decay, sustain, release
+	_voice_square_2 2, \base_midi_key, \pan, \duty_cycle, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_square_2_alt duty_cycle, attack, decay, sustain, release
-	_voice_square_2 10, \duty_cycle, \attack, \decay, \sustain, \release
+	.macro voice_square_2_alt base_midi_key, pan, duty_cycle, attack, decay, sustain, release
+	_voice_square_2 10, \base_midi_key, \pan, \duty_cycle, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro _voice_square_2 type, duty_cycle, attack, decay, sustain, release
-	.byte \type, 60, 0, 0
+	.macro _voice_square_2 type, base_midi_key, pan, duty_cycle, attack, decay, sustain, release
+	.byte \type
+	.byte \base_midi_key
+	.if \pan != 0
+	.byte (0x80 | \pan)
+	.else
+	.byte 0
+	.endif
+	.byte 0
 	.byte (\duty_cycle & 0x3)
 	.byte 0, 0, 0
 	.byte (\attack  & 0x7)
@@ -65,16 +78,23 @@
 	.byte (\release & 0x7)
 	.endm
 
-	.macro voice_programmable_wave wave_samples_pointer, attack, decay, sustain, release
-	_voice_programmable_wave 3, \wave_samples_pointer, \attack, \decay, \sustain, \release
+	.macro voice_programmable_wave base_midi_key, pan, wave_samples_pointer, attack, decay, sustain, release
+	_voice_programmable_wave 3, \base_midi_key, \pan, \wave_samples_pointer, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_programmable_wave_alt wave_samples_pointer, attack, decay, sustain, release
-	_voice_programmable_wave 11, \wave_samples_pointer, \attack, \decay, \sustain, \release
+	.macro voice_programmable_wave_alt base_midi_key, pan, wave_samples_pointer, attack, decay, sustain, release
+	_voice_programmable_wave 11, \base_midi_key, \pan, \wave_samples_pointer, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro _voice_programmable_wave type, wave_samples_pointer, attack, decay, sustain, release
-	.byte \type, 60, 0, 0
+	.macro _voice_programmable_wave type, base_midi_key, pan, wave_samples_pointer, attack, decay, sustain, release
+	.byte \type
+	.byte \base_midi_key
+	.if \pan != 0
+	.byte (0x80 | \pan)
+	.else
+	.byte 0
+	.endif
+	.byte 0
 	.4byte \wave_samples_pointer
 	.byte (\attack  & 0x7)
 	.byte (\decay   & 0x7)
@@ -82,16 +102,23 @@
 	.byte (\release & 0x7)
 	.endm
 
-	.macro voice_noise period, attack, decay, sustain, release
-	_voice_noise 4, \period, \attack, \decay, \sustain, \release
+	.macro voice_noise base_midi_key, pan, period, attack, decay, sustain, release
+	_voice_noise 4, \base_midi_key, \pan, \period, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_noise_alt period, attack, decay, sustain, release
-	_voice_noise 12, \period, \attack, \decay, \sustain, \release
+	.macro voice_noise_alt base_midi_key, pan, period, attack, decay, sustain, release
+	_voice_noise 12, \base_midi_key, \pan, \period, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro _voice_noise type, period, attack, decay, sustain, release
-	.byte \type, 60, 0, 0
+	.macro _voice_noise type, base_midi_key, pan, period, attack, decay, sustain, release
+	.byte \type
+	.byte \base_midi_key
+	.if \pan != 0
+	.byte (0x80 | \pan)
+	.else
+	.byte 0
+	.endif
+	.byte 0
 	.byte (\period & 0x1)
 	.byte 0, 0, 0
 	.byte (\attack  & 0x7)

--- a/sound/voicegroups/voicegroup000.inc
+++ b/sound/voicegroups/voicegroup000.inc
@@ -2,64 +2,64 @@
 voicegroup000:: @ 8675D04
 	voice_keysplit_all voicegroup001  @ 8675D04
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8675D10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675D1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675D28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675D34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675D40
-	voice_square_2 2, 0, 0, 9, 2  @ 8675D4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675D58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675D40
+	voice_square_2 60, 0, 2, 0, 0, 9, 2  @ 8675D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675D64
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 165, 51, 235  @ 8675D70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675D7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675D88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675D94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675DA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675DAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675DB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675DC4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 127  @ 8675DD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675DDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675DE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675DF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675E00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675E0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675E18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675E24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675E30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675E3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675E48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675E54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675E60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675E6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675DDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675DE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675E24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675E30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675E3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675E48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675E54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675E60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675E78
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 149  @ 8675E84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675E90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675E9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675EA8
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 115  @ 8675EB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675EC0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8675ECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675ED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675EE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675EF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675EFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675F08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675F14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675F20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675F2C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 204, 193, 239  @ 8675F38
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8675F44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675F50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675F5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675F68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675F74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675F80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675F8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675F74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675F98
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8675FA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675FB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675FBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675FC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675FD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675FB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675FBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675FE0
 

--- a/sound/voicegroups/voicegroup001.inc
+++ b/sound/voicegroups/voicegroup001.inc
@@ -1,32 +1,32 @@
 	.align 2
 voicegroup001:: @ 8675FEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675FEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8675FF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867601C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676040
-	voice_square_1 0, 2, 0, 1, 6, 0  @ 867604C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676058
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676064
-	voice_programmable_wave ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 8676070
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867607C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86760A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86760AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86760B8
-	voice_square_2 2, 0, 1, 6, 0  @ 86760C4
-	voice_programmable_wave ProgrammableWaveData_86B4850, 0, 7, 15, 1  @ 86760D0
-	voice_square_1 0, 2, 0, 1, 6, 0  @ 86760DC
-	voice_square_2 3, 0, 1, 6, 0  @ 86760E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86760F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867610C
-	voice_square_1 0, 0, 0, 1, 6, 0  @ 8676118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8675FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867601C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676040
+	voice_square_1 60, 0, 0, 2, 0, 1, 6, 0  @ 867604C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676064
+	voice_programmable_wave 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 8676070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867607C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86760A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86760AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86760B8
+	voice_square_2 60, 0, 2, 0, 1, 6, 0  @ 86760C4
+	voice_programmable_wave 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 1  @ 86760D0
+	voice_square_1 60, 0, 0, 2, 0, 1, 6, 0  @ 86760DC
+	voice_square_2 60, 0, 3, 0, 1, 6, 0  @ 86760E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86760F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867610C
+	voice_square_1 60, 0, 0, 0, 0, 1, 6, 0  @ 8676118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676130
 	voice_directsound 60, 0, DirectSoundWaveData_classical_choir_voice_ahhs, 255, 0, 255, 0  @ 867613C
 

--- a/sound/voicegroups/voicegroup002.inc
+++ b/sound/voicegroups/voicegroup002.inc
@@ -8,33 +8,33 @@ voicegroup002:: @ 8676148
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_wood_block_low, 255, 0, 255, 0  @ 8676184
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_wood_block_high, 255, 0, 255, 0  @ 8676190
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_standard_kick, 255, 0, 255, 242  @ 867619C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86761A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86761A8
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_standard3_snare, 255, 0, 255, 242  @ 86761B4
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_standard_hand_clap, 255, 255, 255, 127  @ 86761C0
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_orchestra_snare, 255, 0, 255, 242  @ 86761CC
 	voice_directsound 48, 44, DirectSoundWaveData_unknown_tom, 255, 210, 77, 204  @ 86761D8
 	voice_directsound_no_resample 60, 79, DirectSoundWaveData_unknown_close_hihat, 255, 127, 0, 188  @ 86761E4
 	voice_directsound 51, 54, DirectSoundWaveData_unknown_tom, 255, 216, 77, 204  @ 86761F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86761FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86761FC
 	voice_directsound 54, 64, DirectSoundWaveData_unknown_tom, 255, 216, 77, 204  @ 8676208
 	voice_directsound_no_resample 60, 79, DirectSoundWaveData_unknown_open_hihat, 255, 242, 141, 0  @ 8676214
 	voice_directsound 57, 69, DirectSoundWaveData_unknown_tom, 255, 210, 77, 204  @ 8676220
 	voice_directsound 60, 79, DirectSoundWaveData_unknown_tom, 255, 204, 77, 204  @ 867622C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676238
 	voice_directsound 62, 84, DirectSoundWaveData_unknown_tom, 255, 204, 77, 204  @ 8676244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867625C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867625C
 	voice_directsound_no_resample 70, 49, DirectSoundWaveData_unknown_bell, 255, 165, 103, 231  @ 8676268
 	voice_directsound_no_resample 32, 34, DirectSoundWaveData_unknown_tambourine, 255, 127, 77, 204  @ 8676274
 	voice_directsound_no_resample 60, 14, DirectSoundWaveData_trinity_cymbal_crash, 255, 235, 0, 165  @ 8676280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867628C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867628C
 	voice_directsound_no_resample 30, 54, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 246, 0, 216  @ 8676298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86762A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86762A4
 	voice_directsound_no_resample 30, 54, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 246, 0, 216  @ 86762B0
 	voice_directsound_no_resample 30, 64, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 8, 0, 255, 216  @ 86762BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86762C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86762C8
 	voice_directsound_no_resample 72, 104, DirectSoundWaveData_sc88_bongo, 255, 0, 255, 0  @ 86762D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86762E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86762E0
 	voice_directsound_no_resample 72, 94, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 86762EC
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_drum_and_percussion_kick, 255, 0, 255, 0  @ 86762F8
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sd90_solo_snare, 255, 180, 175, 228  @ 8676304
@@ -51,7 +51,7 @@ voicegroup002:: @ 8676148
 	voice_directsound 80, 94, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 8676388
 	voice_directsound_no_resample 33, 89, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 8676394
 	voice_directsound 84, 104, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 235  @ 86763A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86763AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86763AC
 	voice_directsound 63, 64, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 86763B8
 	voice_directsound_no_resample 64, 24, DirectSoundWaveData_dance_drums_ride_bell, 255, 165, 103, 231  @ 86763C4
 

--- a/sound/voicegroups/voicegroup003.inc
+++ b/sound/voicegroups/voicegroup003.inc
@@ -4,34 +4,34 @@ voicegroup003:: @ 86763D0
 	voice_directsound_no_resample 64, 14, DirectSoundWaveData_trinity_cymbal_crash, 255, 231, 0, 188  @ 86763DC
 	voice_directsound_no_resample 64, 89, DirectSoundWaveData_unknown_cowbell, 255, 0, 255, 242  @ 86763E8
 	voice_directsound_no_resample 64, 29, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 86763F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676400
 	voice_directsound_no_resample 64, 54, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 867640C
 	voice_directsound_no_resample 64, 54, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 8, 0, 255, 216  @ 8676418
 	voice_directsound_no_resample 64, 94, DirectSoundWaveData_unknown_djembe, 255, 0, 255, 0  @ 8676424
 	voice_directsound_no_resample 64, 34, DirectSoundWaveData_sc88_bongo, 255, 0, 255, 0  @ 8676430
 	voice_directsound_no_resample 64, 34, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 867643C
 	voice_directsound_no_resample 64, 90, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 8676448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867646C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867649C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86764A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86764B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86764C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86764CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86764D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86764E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86764F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86764FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867646C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867649C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86764A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86764B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86764C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86764CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86764D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86764E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86764F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86764FC
 	voice_directsound_no_resample 64, 39, DirectSoundWaveData_unknown_anvil_high, 255, 242, 103, 188  @ 8676508
 	voice_directsound_no_resample 64, 79, DirectSoundWaveData_unknown_anvil_high, 255, 242, 103, 188  @ 8676514
 	voice_directsound_no_resample 64, 39, DirectSoundWaveData_unknown_anvil_high, 255, 165, 103, 188  @ 8676520
 	voice_directsound_no_resample 64, 24, DirectSoundWaveData_sc88_standard_bells, 255, 0, 255, 0  @ 867652C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676544
 	voice_directsound_no_resample 64, 104, DirectSoundWaveData_unknown_anvil_low, 255, 0, 255, 0  @ 8676550
 	voice_directsound 63, 64, DirectSoundWaveData_unknown_ethnic_drum, 255, 0, 255, 0  @ 867655C
 	voice_directsound 50, 84, DirectSoundWaveData_unknown_tsuzumi, 255, 0, 255, 0  @ 8676568
@@ -46,12 +46,12 @@ voicegroup003:: @ 86763D0
 	voice_directsound 68, 34, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 86765D4
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_standard3_snare, 255, 0, 255, 242  @ 86765E0
 	voice_directsound 72, 44, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 86765EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86765F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86765F8
 	voice_directsound 76, 84, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 8676604
 	voice_directsound 80, 94, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 8676610
 	voice_directsound_no_resample 33, 89, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 867661C
 	voice_directsound 64, 104, DirectSoundWaveData_unknown_ethnic_drum, 255, 0, 255, 235  @ 8676628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676634
 	voice_directsound 63, 64, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 8676640
 	voice_directsound_no_resample 64, 24, DirectSoundWaveData_dance_drums_ride_bell, 255, 165, 103, 231  @ 867664C
 

--- a/sound/voicegroups/voicegroup004.inc
+++ b/sound/voicegroups/voicegroup004.inc
@@ -4,34 +4,34 @@ voicegroup004:: @ 8676658
 	voice_directsound_no_resample 64, 14, DirectSoundWaveData_trinity_cymbal_crash, 255, 231, 0, 188  @ 8676664
 	voice_directsound_no_resample 64, 89, DirectSoundWaveData_unknown_cowbell, 255, 0, 255, 242  @ 8676670
 	voice_directsound_no_resample 64, 29, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 867667C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676688
 	voice_directsound_no_resample 64, 54, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 8676694
 	voice_directsound_no_resample 64, 54, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 8, 0, 255, 216  @ 86766A0
 	voice_directsound_no_resample 64, 94, DirectSoundWaveData_unknown_djembe, 255, 0, 255, 0  @ 86766AC
 	voice_directsound_no_resample 64, 34, DirectSoundWaveData_sc88_bongo, 255, 0, 255, 0  @ 86766B8
 	voice_directsound_no_resample 64, 34, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 86766C4
 	voice_directsound_no_resample 64, 90, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 86766D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86766DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86766E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86766F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867670C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867673C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86766DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86766E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86766F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867670C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867673C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676748
 	voice_directsound_no_resample 61, 84, DirectSoundWaveData_unknown_wood_block_high, 255, 0, 255, 0  @ 8676754
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_unknown_wood_block_low, 255, 0, 255, 0  @ 8676760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867676C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867676C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676784
 	voice_directsound_no_resample 64, 39, DirectSoundWaveData_unknown_anvil_high, 255, 242, 103, 188  @ 8676790
 	voice_directsound_no_resample 64, 79, DirectSoundWaveData_unknown_anvil_high, 255, 242, 103, 188  @ 867679C
 	voice_directsound_no_resample 64, 39, DirectSoundWaveData_unknown_anvil_high, 255, 165, 103, 188  @ 86767A8
 	voice_directsound_no_resample 64, 24, DirectSoundWaveData_sc88_standard_bells, 255, 0, 255, 0  @ 86767B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86767C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86767CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86767C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86767CC
 	voice_directsound_no_resample 64, 104, DirectSoundWaveData_unknown_anvil_low, 255, 0, 255, 0  @ 86767D8
 	voice_directsound 63, 64, DirectSoundWaveData_unknown_ethnic_drum, 255, 0, 255, 0  @ 86767E4
 	voice_directsound 50, 84, DirectSoundWaveData_unknown_tsuzumi, 255, 0, 255, 0  @ 86767F0
@@ -46,46 +46,46 @@ voicegroup004:: @ 8676658
 	voice_directsound 68, 34, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 867685C
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_standard3_snare, 255, 0, 255, 242  @ 8676868
 	voice_directsound 72, 44, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 8676874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676880
 	voice_directsound 76, 84, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 867688C
 	voice_directsound 80, 94, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 8676898
 	voice_directsound 56, 89, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 86768A4
 	voice_directsound 64, 104, DirectSoundWaveData_unknown_ethnic_drum, 255, 0, 255, 235  @ 86768B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86768BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86768BC
 	voice_directsound 63, 64, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 86768C8
 	voice_directsound_no_resample 64, 24, DirectSoundWaveData_dance_drums_ride_bell, 255, 165, 103, 231  @ 86768D4
 	voice_directsound_no_resample 66, 34, DirectSoundWaveData_unknown_tambourine, 255, 127, 77, 204  @ 86768E0
 	voice_directsound 64, 14, DirectSoundWaveData_trinity_cymbal_crash, 255, 231, 0, 188  @ 86768EC
 	voice_directsound 64, 89, DirectSoundWaveData_unknown_cowbell, 255, 0, 255, 242  @ 86768F8
 	voice_directsound 60, 29, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 8676904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676910
 	voice_directsound 58, 54, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 867691C
 	voice_directsound 62, 54, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 8, 0, 255, 216  @ 8676928
 	voice_directsound 64, 94, DirectSoundWaveData_unknown_djembe, 255, 0, 255, 0  @ 8676934
 	voice_directsound 64, 34, DirectSoundWaveData_sc88_bongo, 255, 0, 255, 0  @ 8676940
 	voice_directsound 64, 34, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 867694C
 	voice_directsound 64, 90, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 8676958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867697C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86769A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86769AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86769B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86769C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86769D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867697C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86769A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86769AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86769B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86769C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86769D0
 	voice_directsound 61, 84, DirectSoundWaveData_unknown_wood_block_high, 255, 0, 255, 0  @ 86769DC
 	voice_directsound 64, 64, DirectSoundWaveData_unknown_wood_block_low, 255, 0, 255, 0  @ 86769E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86769F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676A00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86769F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676A0C
 	voice_directsound 64, 39, DirectSoundWaveData_unknown_anvil_high, 255, 242, 103, 188  @ 8676A18
 	voice_directsound 64, 79, DirectSoundWaveData_unknown_anvil_high, 255, 242, 103, 188  @ 8676A24
 	voice_directsound 64, 39, DirectSoundWaveData_unknown_anvil_high, 255, 165, 103, 188  @ 8676A30
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88_standard_bells, 255, 0, 255, 0  @ 8676A3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676A48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676A54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676A48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676A54
 	voice_directsound 64, 104, DirectSoundWaveData_unknown_anvil_low, 255, 0, 255, 0  @ 8676A60
 	voice_directsound 63, 64, DirectSoundWaveData_unknown_ethnic_drum, 255, 0, 255, 0  @ 8676A6C
 	voice_directsound 50, 84, DirectSoundWaveData_unknown_tsuzumi, 255, 0, 255, 0  @ 8676A78

--- a/sound/voicegroups/voicegroup007.inc
+++ b/sound/voicegroups/voicegroup007.inc
@@ -3,132 +3,132 @@ voicegroup007:: @ 8676AE4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_trumpet_60, 255, 0, 193, 127  @ 8676AE4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_trumpet_72, 255, 0, 193, 127  @ 8676AF0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_trumpet_84, 255, 0, 193, 127  @ 8676AFC
-	voice_square_1_alt 38, 2, 1, 0, 0, 0  @ 8676B08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676B14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676B20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676B2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676B38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676B44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676B50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676B5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676B68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676B74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676B80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676B8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676B98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676BA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676BB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676BBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676BC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676BD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676BE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676BEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676BF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676C04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676C10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676C1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676C28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676C34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676C40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676C4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676C58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676C64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676C70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676C7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676C88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676C94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676CA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676CAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676CB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676CC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676CD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676CDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676CE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676CF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676D00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676D0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676D18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676D24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676D30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676D3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676D48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676D54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676D60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676D6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676D78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676D84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676D90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676D9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676DA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676DB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676DC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676DCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676DD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676DE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676DF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676DFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676E08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676E14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676E20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676E2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676E38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676E44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676E50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676E5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676E68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676E74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676E80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676E8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676E98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676EA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676EB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676EBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676EC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676ED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676EE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676EEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676EF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676F04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676F10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676F1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676F28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676F34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676F40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676F4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676F58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676F64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676F70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676F7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676F88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676F94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676FA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676FAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676FB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676FC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676FD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676FDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676FE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8676FF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867700C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677030
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867703C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867706C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867709C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86770A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86770B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86770C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86770CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86770D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86770E4
-	voice_square_1_alt 36, 2, 0, 1, 4, 2  @ 86770F0
-	voice_square_1_alt 21, 2, 0, 0, 15, 2  @ 86770FC
+	voice_square_1_alt 60, 0, 38, 2, 1, 0, 0, 0  @ 8676B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676C58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676C70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676C7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676C88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676CA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676E2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676E44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676E50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676E5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676E74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676E80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676EA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676EBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676EEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676F34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676F40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676F64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676F88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8676FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867700C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867703C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867706C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867709C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86770A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86770B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86770C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86770CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86770D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86770E4
+	voice_square_1_alt 60, 0, 36, 2, 0, 1, 4, 2  @ 86770F0
+	voice_square_1_alt 60, 0, 21, 2, 0, 0, 15, 2  @ 86770FC
 

--- a/sound/voicegroups/voicegroup010.inc
+++ b/sound/voicegroups/voicegroup010.inc
@@ -1,87 +1,87 @@
 	.align 2
 voicegroup010:: @ 8677138
 	voice_keysplit_all voicegroup031  @ 8677138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867715C
-	voice_square_2 3, 0, 4, 0, 1  @ 8677168
-	voice_square_1 0, 3, 0, 4, 0, 1  @ 8677174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867718C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86771A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86771B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86771BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86771C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86771D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867715C
+	voice_square_2 60, 0, 3, 0, 4, 0, 1  @ 8677168
+	voice_square_1 60, 0, 0, 3, 0, 4, 0, 1  @ 8677174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867718C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86771A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86771B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86771BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86771C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86771D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 216, 90, 242  @ 86771E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86771EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86771F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867721C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677234
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867724C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677258
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867727C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86772A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86772AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86772B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86772C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86772D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86772DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86772E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86772F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867730C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867733C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86771EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86771F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867721C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867724C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867727C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86772A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86772AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86772B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86772C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86772D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86772DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86772E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86772F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867730C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867733C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677354
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 204  @ 8677360
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 867736C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8677378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867739C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86773A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86773B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86773C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86773CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867739C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86773A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86773B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86773C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86773CC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86773D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86773E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86773E4
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86773F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86773FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86773FC
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8677408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867742C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867745C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677468
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867748C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677498
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86774A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86774B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86774BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86774C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86774D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86774E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86774EC
-	voice_square_2 3, 0, 1, 7, 1  @ 86774F8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 2  @ 8677504
-	voice_square_1 0, 3, 0, 1, 7, 1  @ 8677510
-	voice_square_1 0, 3, 0, 0, 7, 1  @ 867751C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867742C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867745C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867748C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86774A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86774B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86774BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86774C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86774D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86774E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86774EC
+	voice_square_2 60, 0, 3, 0, 1, 7, 1  @ 86774F8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 2  @ 8677504
+	voice_square_1 60, 0, 0, 3, 0, 1, 7, 1  @ 8677510
+	voice_square_1 60, 0, 0, 3, 0, 0, 7, 1  @ 867751C
 

--- a/sound/voicegroups/voicegroup011.inc
+++ b/sound/voicegroups/voicegroup011.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup011:: @ 8677528
 	voice_keysplit_all voicegroup022  @ 8677528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867754C
-	voice_square_1_alt 0, 3, 0, 2, 4, 0  @ 8677558
-	voice_square_2_alt 3, 0, 2, 4, 0  @ 8677564
-	voice_square_2_alt 2, 0, 3, 0, 0  @ 8677570
-	voice_square_2_alt 2, 0, 3, 0, 0  @ 867757C
-	voice_square_1_alt 0, 2, 0, 3, 0, 0  @ 8677588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86775A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86775AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86775B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86775C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86775D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86775DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86775E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86775F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867760C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677618
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677630
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867763C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867754C
+	voice_square_1_alt 60, 0, 0, 3, 0, 2, 4, 0  @ 8677558
+	voice_square_2_alt 60, 0, 3, 0, 2, 4, 0  @ 8677564
+	voice_square_2_alt 60, 0, 2, 0, 3, 0, 0  @ 8677570
+	voice_square_2_alt 60, 0, 2, 0, 3, 0, 0  @ 867757C
+	voice_square_1_alt 60, 0, 0, 2, 0, 3, 0, 0  @ 8677588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86775A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86775AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86775B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86775C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86775D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86775DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86775E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86775F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867760C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867763C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 149  @ 8677648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867766C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867769C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86776A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86776B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86776C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867766C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867769C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86776A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86776B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86776C0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 149  @ 86776CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86776D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86776E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86776F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86776FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867772C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867775C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86776D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86776E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86776F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86776FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867772C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867775C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8677768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867778C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86777A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86777B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86777BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86777C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86777D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86777E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86777EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86777F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867781C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677828
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867784C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867787C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867778C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86777A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86777B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86777BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86777C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86777D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86777E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86777EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86777F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867781C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867784C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867787C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677888
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 8677894
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 86778A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86778AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86778B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86778C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86778D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86778DC
-	voice_square_2_alt 2, 1, 1, 7, 1  @ 86778E8
-	voice_square_1_alt 0, 2, 1, 1, 7, 1  @ 86778F4
-	voice_square_1_alt 0, 2, 0, 0, 7, 1  @ 8677900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867790C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867793C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867796C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867799C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86779A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86779B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86779C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86779CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86779D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86779E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86779F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86779FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677A08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677A14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677A20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677A2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677A38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677A44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677A50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677A5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677A68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677A74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677A80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677A8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677A98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677AA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677AB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677ABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677AC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677AD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677AE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677AEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677AF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677B04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677B10
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8677B1C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 86778A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86778AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86778B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86778C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86778D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86778DC
+	voice_square_2_alt 60, 0, 2, 1, 1, 7, 1  @ 86778E8
+	voice_square_1_alt 60, 0, 0, 2, 1, 1, 7, 1  @ 86778F4
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 7, 1  @ 8677900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867790C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867793C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867796C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867799C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86779A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86779B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86779C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86779CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86779D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86779E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86779F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86779FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677A50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677A5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677A74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677B10
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8677B1C
 

--- a/sound/voicegroups/voicegroup012.inc
+++ b/sound/voicegroups/voicegroup012.inc
@@ -3,103 +3,103 @@ voicegroup012:: @ 8677B28
 	voice_keysplit_all voicegroup001  @ 8677B28
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8677B34
 	voice_directsound 60, 0, DirectSoundWaveData_unused_acid_bass, 255, 178, 180, 165  @ 8677B40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677B4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677B58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677B64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677B70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677B7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677B64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677B88
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 165, 51, 235  @ 8677B94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677BA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677BAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677BB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677BB8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 8677BC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677BD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677BDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677BE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677BF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677C00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677C0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677C18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677C24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677C30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677C3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677C48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677C54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677C60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677C6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677C78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677C84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677C90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677C9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677CA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677CB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677CC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677CCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677CD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677BDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677BE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677BF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677C00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677C18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677C30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677C3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677C48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677C54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677C60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677C78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677C84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677C90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677CA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677CB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677CE4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8677CF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677CFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677D08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677D14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677D20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677D2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677D38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677D14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677D44
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 204  @ 8677D50
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 8677D5C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8677D68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677D74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677D80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677D8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677D98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677DA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677DB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677D98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677DBC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8677DC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677DD4
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8677DE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677DEC
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8677DF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677E04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677E10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677E1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677E28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677E34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677E40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677E4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677E58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677E64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677E70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677E7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677E88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677E28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677E34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677E4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677E58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677E7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677E88
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 8677E94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677EA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677EAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677EB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677EC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677ED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677EDC
-	voice_square_2_alt 2, 0, 1, 7, 1  @ 8677EE8
-	voice_square_1_alt 0, 2, 0, 1, 7, 1  @ 8677EF4
-	voice_square_2_alt 3, 0, 1, 7, 1  @ 8677F00
-	voice_square_1_alt 0, 3, 0, 1, 7, 1  @ 8677F0C
-	voice_square_2_alt 2, 0, 1, 4, 1  @ 8677F18
-	voice_square_1_alt 0, 2, 0, 1, 4, 1  @ 8677F24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677F30
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 2  @ 8677F3C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 2  @ 8677F48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677F54
-	voice_square_2 2, 0, 1, 4, 1  @ 8677F60
-	voice_square_1 0, 2, 0, 1, 4, 1  @ 8677F6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677F78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677F84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677F90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677F9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677FA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677FB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677FC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677FCC
-	voice_square_1_alt 29, 2, 0, 2, 0, 0  @ 8677FD8
-	voice_square_1_alt 22, 2, 0, 2, 0, 0  @ 8677FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677EA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677EDC
+	voice_square_2_alt 60, 0, 2, 0, 1, 7, 1  @ 8677EE8
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 7, 1  @ 8677EF4
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 1  @ 8677F00
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 7, 1  @ 8677F0C
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 1  @ 8677F18
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1  @ 8677F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677F30
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 2  @ 8677F3C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 2  @ 8677F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677F54
+	voice_square_2 60, 0, 2, 0, 1, 4, 1  @ 8677F60
+	voice_square_1 60, 0, 0, 2, 0, 1, 4, 1  @ 8677F6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677F78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677F90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677FB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677FC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677FCC
+	voice_square_1_alt 60, 0, 29, 2, 0, 2, 0, 0  @ 8677FD8
+	voice_square_1_alt 60, 0, 22, 2, 0, 2, 0, 0  @ 8677FE4
 

--- a/sound/voicegroups/voicegroup013.inc
+++ b/sound/voicegroups/voicegroup013.inc
@@ -1,93 +1,93 @@
 	.align 2
 voicegroup013:: @ 8677FF0
 	voice_keysplit_all voicegroup001  @ 8677FF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8677FFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867802C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867805C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867808C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86780A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86780B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86780BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86780C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86780D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86780E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86780EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86780F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867811C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867814C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867817C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86781A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86781AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86781B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86781C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86781D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86781DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86781E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86781F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867820C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8677FFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867802C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867805C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867808C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86780A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86780B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86780BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86780C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86780D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86780E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86780EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86780F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867811C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867814C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867817C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86781A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86781AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86781B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86781C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86781D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86781DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86781E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86781F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867820C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678218
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 8678224
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8678230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867823C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867826C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867823C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867826C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678284
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8678290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867829C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86782A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86782B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867829C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86782A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86782B4
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86782C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86782CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86782D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86782E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86782F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86782FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867832C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867835C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867838C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86783A4
-	voice_square_2_alt 1, 0, 1, 7, 1  @ 86783B0
-	voice_square_1_alt 0, 1, 0, 1, 7, 1  @ 86783BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86783C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86783D4
-	voice_square_2_alt 3, 0, 1, 7, 1  @ 86783E0
-	voice_square_1_alt 0, 3, 0, 1, 7, 1  @ 86783EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86783F8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 8678404
-	voice_square_1_alt 0, 1, 0, 0, 7, 1  @ 8678410
-	voice_square_1_alt 0, 3, 0, 0, 7, 1  @ 867841C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86782CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86782D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86782E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86782F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86782FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867832C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867835C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867838C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86783A4
+	voice_square_2_alt 60, 0, 1, 0, 1, 7, 1  @ 86783B0
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 7, 1  @ 86783BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86783C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86783D4
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 1  @ 86783E0
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 7, 1  @ 86783EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86783F8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 8678404
+	voice_square_1_alt 60, 0, 0, 1, 0, 0, 7, 1  @ 8678410
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 7, 1  @ 867841C
 

--- a/sound/voicegroups/voicegroup014.inc
+++ b/sound/voicegroups/voicegroup014.inc
@@ -2,87 +2,87 @@
 voicegroup014:: @ 8678428
 	voice_keysplit_all voicegroup001  @ 8678428
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8678434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867844C
-	voice_square_2_alt 3, 0, 1, 6, 1  @ 8678458
-	voice_square_1_alt 0, 3, 0, 1, 6, 1  @ 8678464
-	voice_square_2_alt 2, 0, 1, 6, 1  @ 8678470
-	voice_square_1_alt 0, 2, 0, 1, 6, 1  @ 867847C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86784A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86784AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86784B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86784C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86784D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86784DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86784E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86784F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867850C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867853C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867844C
+	voice_square_2_alt 60, 0, 3, 0, 1, 6, 1  @ 8678458
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 6, 1  @ 8678464
+	voice_square_2_alt 60, 0, 2, 0, 1, 6, 1  @ 8678470
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 6, 1  @ 867847C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86784A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86784AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86784B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86784C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86784D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86784DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86784E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86784F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867850C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867853C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 149  @ 8678548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867856C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867859C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86785A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86785B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86785C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86785CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86785D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86785E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86785F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86785FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867862C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867856C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867859C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86785A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86785B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86785C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86785CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86785D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86785E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86785F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86785FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867862C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678644
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 8678650
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 867865C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8678668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867868C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86786A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86786B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86786BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867868C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86786A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86786B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86786BC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86786C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86786D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86786E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86786EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86786D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86786E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86786EC
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86786F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867871C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867874C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867877C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867871C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867874C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867877C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678788
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 8678794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86787A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86787AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86787B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86787C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86787D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86787DC
-	voice_square_2_alt 3, 0, 1, 7, 1  @ 86787E8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 86787F4
-	voice_square_1_alt 0, 3, 0, 1, 7, 1  @ 8678800
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 867880C
-	voice_square_1_alt 0, 3, 0, 0, 7, 0  @ 8678818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86787A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86787AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86787B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86787C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86787D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86787DC
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 1  @ 86787E8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 86787F4
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 7, 1  @ 8678800
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 867880C
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 7, 0  @ 8678818
 

--- a/sound/voicegroups/voicegroup015.inc
+++ b/sound/voicegroups/voicegroup015.inc
@@ -2,94 +2,94 @@
 voicegroup015:: @ 8678824
 	voice_keysplit_all voicegroup016  @ 8678824
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8678830
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867883C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678848
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867886C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867889C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86788A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86788B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86788C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86788CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86788D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86788E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86788F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86788FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867892C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678938
-	voice_square_2 3, 0, 2, 0, 0  @ 8678944
-	voice_square_1 0, 3, 0, 2, 0, 0  @ 8678950
-	voice_square_2 3, 0, 6, 0, 0  @ 867895C
-	voice_square_1 0, 3, 0, 6, 0, 0  @ 8678968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867898C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86789A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86789B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86789BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867883C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867886C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867889C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86788A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86788B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86788C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86788CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86788D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86788E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86788F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86788FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867892C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678938
+	voice_square_2 60, 0, 3, 0, 2, 0, 0  @ 8678944
+	voice_square_1 60, 0, 0, 3, 0, 2, 0, 0  @ 8678950
+	voice_square_2 60, 0, 3, 0, 6, 0, 0  @ 867895C
+	voice_square_1 60, 0, 0, 3, 0, 6, 0, 0  @ 8678968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867898C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86789A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86789B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86789BC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 149  @ 86789C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86789D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86789E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86789EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86789F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678A04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678A10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678A1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678A28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678A34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678A40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678A4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678A58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86789D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86789E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86789EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86789F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678A1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678A34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678A40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678A4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678A58
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8678A64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678A70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678A7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678A88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678A94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678AA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678AAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678AB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678A70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678A7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678A88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678A94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678AA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678AAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678AB8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 255, 0, 255, 165  @ 8678AC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678AD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678ADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678AE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678AF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678B00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678B0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678B18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678B24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678B30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678B3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678B48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678B54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678B60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678B6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678B78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678ADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678AF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678B18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678B30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678B3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678B60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678B6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678B84
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 8678B90
-	voice_programmable_wave ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 8678B9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678BA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678BB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678BC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678BCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678BD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678BE4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 8678BF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678BFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678C08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678C14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678C20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678C2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678C38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678C44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678C50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678C5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678C68
+	voice_programmable_wave 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 8678B9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678BA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678BB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678BC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678BE4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 8678BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678BFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678C08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678C14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678C20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678C2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678C38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678C44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678C50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678C5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678C68
 

--- a/sound/voicegroups/voicegroup016.inc
+++ b/sound/voicegroups/voicegroup016.inc
@@ -1,68 +1,68 @@
 	.align 2
 voicegroup016:: @ 8678C74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678C74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678C80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678C8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678C98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678CA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678CB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678CBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678CC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678CD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678CE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678CEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678CF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678D04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678D10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678D1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678D28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678D34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678D40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678D4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678D58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678D64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678D70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678D7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678D88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678D94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678DA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678DAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678DB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678DC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678DD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678DDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678DE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678DF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678E00
-	voice_noise_alt 0, 0, 2, 0, 2  @ 8678E0C
-	voice_noise_alt 0, 0, 1, 0, 1  @ 8678E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678C74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678C80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678C98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678CBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678DDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678DE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678E00
+	voice_noise_alt 60, 0, 0, 0, 2, 0, 2  @ 8678E0C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 1  @ 8678E18
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_standard_kick, 255, 0, 255, 242  @ 8678E24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678E30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678E30
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_standard3_snare, 255, 0, 255, 242  @ 8678E3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678E48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678E48
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_orchestra_snare, 255, 0, 255, 242  @ 8678E54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678E60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678E6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678E78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678E84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678E90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678E9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678EA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678EB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678EC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678ECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678ED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678EE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678E60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678EF0
 	voice_directsound_no_resample 32, 74, DirectSoundWaveData_unknown_tambourine, 255, 127, 77, 204  @ 8678EFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678F08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678F14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678F20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678F2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678F38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678F44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678F50
 	voice_directsound_no_resample 72, 66, DirectSoundWaveData_sc88_bongo, 255, 0, 255, 0  @ 8678F5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678F68
 	voice_directsound_no_resample 72, 62, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 8678F74
 

--- a/sound/voicegroups/voicegroup017.inc
+++ b/sound/voicegroups/voicegroup017.inc
@@ -1,94 +1,94 @@
 	.align 2
 voicegroup017:: @ 8678F80
 	voice_keysplit_all voicegroup001  @ 8678F80
-	voice_square_2_alt 2, 0, 3, 3, 1  @ 8678F8C
-	voice_square_1_alt 0, 2, 0, 3, 3, 1  @ 8678F98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678FA4
-	voice_square_2_alt 2, 0, 1, 7, 2  @ 8678FB0
-	voice_square_1_alt 0, 2, 0, 1, 7, 2  @ 8678FBC
-	voice_square_2_alt 2, 1, 1, 0, 0  @ 8678FC8
-	voice_square_1_alt 0, 2, 1, 1, 0, 0  @ 8678FD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678FE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678FEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8678FF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867901C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867904C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679058
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679064
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679070
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867907C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86790A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86790AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86790B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86790C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86790D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86790DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86790E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86790F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867910C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867913C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867916C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679190
+	voice_square_2_alt 60, 0, 2, 0, 3, 3, 1  @ 8678F8C
+	voice_square_1_alt 60, 0, 0, 2, 0, 3, 3, 1  @ 8678F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678FA4
+	voice_square_2_alt 60, 0, 2, 0, 1, 7, 2  @ 8678FB0
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 7, 2  @ 8678FBC
+	voice_square_2_alt 60, 0, 2, 1, 1, 0, 0  @ 8678FC8
+	voice_square_1_alt 60, 0, 0, 2, 1, 1, 0, 0  @ 8678FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8678FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867901C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867904C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867907C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86790A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86790AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86790B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86790C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86790D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86790DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86790E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86790F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867910C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867913C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867916C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679190
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 216, 0, 165  @ 867919C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 204  @ 86791A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86791B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86791B4
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86791C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86791CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86791D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86791E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86791F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86791FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867922C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86791CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86791D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86791E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86791F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86791FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867922C
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8679238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679244
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8679250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867925C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679268
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867928C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86792A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86792B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86792BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86792C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86792D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86792E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867925C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867928C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86792A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86792B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86792BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86792C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86792D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86792E0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86792EC
-	voice_programmable_wave ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86792F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867931C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679334
-	voice_square_2_alt 2, 1, 1, 7, 2  @ 8679340
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 2  @ 867934C
-	voice_square_1_alt 0, 2, 1, 1, 7, 2  @ 8679358
-	voice_square_2_alt 3, 1, 1, 7, 2  @ 8679364
-	voice_square_1_alt 0, 3, 1, 1, 7, 2  @ 8679370
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 3  @ 867937C
-	voice_square_1_alt 0, 2, 0, 0, 7, 2  @ 8679388
-	voice_square_1_alt 0, 3, 0, 0, 7, 2  @ 8679394
-	voice_square_2_alt 1, 1, 2, 6, 2  @ 86793A0
-	voice_square_1_alt 0, 1, 1, 2, 6, 2  @ 86793AC
-	voice_square_1_alt 0, 1, 0, 0, 6, 2  @ 86793B8
+	voice_programmable_wave 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86792F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867931C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679334
+	voice_square_2_alt 60, 0, 2, 1, 1, 7, 2  @ 8679340
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 2  @ 867934C
+	voice_square_1_alt 60, 0, 0, 2, 1, 1, 7, 2  @ 8679358
+	voice_square_2_alt 60, 0, 3, 1, 1, 7, 2  @ 8679364
+	voice_square_1_alt 60, 0, 0, 3, 1, 1, 7, 2  @ 8679370
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 3  @ 867937C
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 7, 2  @ 8679388
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 7, 2  @ 8679394
+	voice_square_2_alt 60, 0, 1, 1, 2, 6, 2  @ 86793A0
+	voice_square_1_alt 60, 0, 0, 1, 1, 2, 6, 2  @ 86793AC
+	voice_square_1_alt 60, 0, 0, 1, 0, 0, 6, 2  @ 86793B8
 

--- a/sound/voicegroups/voicegroup018.inc
+++ b/sound/voicegroups/voicegroup018.inc
@@ -2,130 +2,130 @@
 voicegroup018:: @ 86793C4
 	voice_keysplit_all voicegroup001  @ 86793C4
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86793D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86793DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86793E8
-	voice_square_2_alt 0, 0, 1, 7, 1  @ 86793F4
-	voice_square_1_alt 0, 0, 0, 1, 7, 1  @ 8679400
-	voice_square_1_alt 0, 0, 0, 0, 7, 1  @ 867940C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679430
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867943C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867946C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867949C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86794A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86794B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86794C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86794CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86794D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86794E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86794F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86794FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867952C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867955C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867958C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86795A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86795B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86795BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86795C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86795D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86793DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86793E8
+	voice_square_2_alt 60, 0, 0, 0, 1, 7, 1  @ 86793F4
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 7, 1  @ 8679400
+	voice_square_1_alt 60, 0, 0, 0, 0, 0, 7, 1  @ 867940C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867943C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867946C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867949C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86794A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86794B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86794C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86794CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86794D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86794E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86794F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86794FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867952C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867955C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867958C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86795A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86795B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86795BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86795C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86795D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 216, 0, 165  @ 86795E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86795EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86795F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86795EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86795F8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8679604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867961C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867964C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867967C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86796A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86796AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86796B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86796C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86796D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86796DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86796E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86796F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867970C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867961C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867964C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867967C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86796A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86796AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86796B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86796C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86796D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86796DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86796E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86796F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867970C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679724
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 8679730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867973C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867976C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679778
-	voice_square_2_alt 2, 0, 1, 7, 1  @ 8679784
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 2  @ 8679790
-	voice_square_1_alt 0, 2, 0, 1, 7, 1  @ 867979C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86797A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86797B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86797C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86797CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86797D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86797E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86797F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86797FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679808
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867982C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679850
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867985C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679868
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867988C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679898
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86798A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86798B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86798BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86798C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86798D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86798E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86798EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86798F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867991C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867994C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867997C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86799A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86799AC
-	voice_noise_alt 1, 0, 1, 0, 3  @ 86799B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867973C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867976C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679778
+	voice_square_2_alt 60, 0, 2, 0, 1, 7, 1  @ 8679784
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 2  @ 8679790
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 7, 1  @ 867979C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86797A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86797B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86797C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86797CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86797D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86797E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86797F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86797FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867982C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867985C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867988C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86798A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86798B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86798BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86798C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86798D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86798E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86798EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86798F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867991C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867994C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867997C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86799A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86799AC
+	voice_noise_alt 60, 0, 1, 0, 1, 0, 3  @ 86799B8
 

--- a/sound/voicegroups/voicegroup019.inc
+++ b/sound/voicegroups/voicegroup019.inc
@@ -1,88 +1,88 @@
 	.align 2
 voicegroup019:: @ 86799C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86799C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86799D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86799DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86799E8
-	voice_square_2_alt 1, 0, 1, 7, 1  @ 86799F4
-	voice_square_1_alt 0, 1, 0, 1, 7, 1  @ 8679A00
-	voice_square_2_alt 2, 0, 2, 6, 1  @ 8679A0C
-	voice_square_1_alt 0, 2, 0, 2, 6, 1  @ 8679A18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679A24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679A30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679A3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679A48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679A54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679A60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679A6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679A78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679A84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679A90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679A9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679AA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679AB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679AC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679ACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679AD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679AE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679AF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679AFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679B08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679B14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679B20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679B2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679B38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679B44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679B50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679B5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679B68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679B74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679B80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679B8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679B98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679BA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679BB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679BBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679BC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86799C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86799D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86799DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86799E8
+	voice_square_2_alt 60, 0, 1, 0, 1, 7, 1  @ 86799F4
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 7, 1  @ 8679A00
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 1  @ 8679A0C
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 6, 1  @ 8679A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679A24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679A30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679A3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679A48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679A54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679A6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679A84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679BD4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 216, 0, 165  @ 8679BE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679BEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679BF8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8679C04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679C10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679C1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679C28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679C34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679C40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679C4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679C58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679C64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679C70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679C58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679C70
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8679C7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679C88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679C88
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8679C94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679CA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679CAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679CB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679CC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679CD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679CDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679CE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679CF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679D00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679D0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679D18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679CA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679D24
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 8679D30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679D3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679D48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679D54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679D60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679D6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679D78
-	voice_square_2_alt 2, 0, 1, 7, 1  @ 8679D84
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 2  @ 8679D90
-	voice_square_1_alt 0, 2, 0, 1, 7, 1  @ 8679D9C
-	voice_square_1_alt 0, 2, 0, 0, 7, 1  @ 8679DA8
-	voice_square_1_alt 0, 1, 0, 0, 7, 1  @ 8679DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679D78
+	voice_square_2_alt 60, 0, 2, 0, 1, 7, 1  @ 8679D84
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 2  @ 8679D90
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 7, 1  @ 8679D9C
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 7, 1  @ 8679DA8
+	voice_square_1_alt 60, 0, 0, 1, 0, 0, 7, 1  @ 8679DB4
 

--- a/sound/voicegroups/voicegroup020.inc
+++ b/sound/voicegroups/voicegroup020.inc
@@ -1,90 +1,90 @@
 	.align 2
 voicegroup020:: @ 8679DC0
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8679DC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679DCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679DD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679DE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679DF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679DFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679E08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679E14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679E20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679E2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679E38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679E44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679E50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679E5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679E68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679E74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679E80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679E8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679E98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679EA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679EB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679EBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679EC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679ED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679EE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679EEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679EF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679F04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679F10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679F1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679F28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679F34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679F40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679F4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679F58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679F64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679F70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679F7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679F88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679F94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679FA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679FAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679FB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679FC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679E2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679E44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679E50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679E5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679E74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679E80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679EA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679EBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679EEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679F34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679F40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679F64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679F88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679FD0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 216, 0, 165  @ 8679FDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679FE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8679FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8679FF4
 	voice_keysplit voicegroup006, KeySplitTable2  @ 867A000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A00C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A030
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A03C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A06C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A00C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A03C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A06C
 	voice_keysplit voicegroup008, KeySplitTable4  @ 867A078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A09C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A0A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A0B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A0C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A0CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A0D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A0E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A0F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A0FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A12C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A15C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A174
-	voice_square_2 2, 0, 1, 7, 1  @ 867A180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A18C
-	voice_square_1 0, 2, 0, 1, 7, 1  @ 867A198
-	voice_square_2_alt 1, 0, 1, 6, 2  @ 867A1A4
-	voice_square_1_alt 0, 1, 0, 1, 6, 2  @ 867A1B0
-	voice_square_1_alt 0, 1, 0, 0, 6, 2  @ 867A1BC
-	voice_square_1 0, 2, 0, 0, 7, 1  @ 867A1C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A09C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A0A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A0B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A0C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A0CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A0D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A0E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A0F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A0FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A12C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A15C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A174
+	voice_square_2 60, 0, 2, 0, 1, 7, 1  @ 867A180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A18C
+	voice_square_1 60, 0, 0, 2, 0, 1, 7, 1  @ 867A198
+	voice_square_2_alt 60, 0, 1, 0, 1, 6, 2  @ 867A1A4
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 6, 2  @ 867A1B0
+	voice_square_1_alt 60, 0, 0, 1, 0, 0, 6, 2  @ 867A1BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 7, 1  @ 867A1C8
 

--- a/sound/voicegroups/voicegroup021.inc
+++ b/sound/voicegroups/voicegroup021.inc
@@ -1,54 +1,54 @@
 	.align 2
 voicegroup021:: @ 867A1D4
 	voice_keysplit_all voicegroup001  @ 867A1D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A1E0
-	voice_square_2_alt 3, 0, 2, 0, 0  @ 867A1EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A1F8
-	voice_square_2_alt 3, 0, 1, 6, 0  @ 867A204
-	voice_square_1_alt 0, 3, 0, 1, 6, 0  @ 867A210
-	voice_square_1_alt 0, 3, 0, 0, 6, 0  @ 867A21C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A234
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A24C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A258
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A27C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A2A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A2AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A2B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A2C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A2D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A2DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A2E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A2F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A30C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A33C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A36C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A39C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A3A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A3B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A3C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A3CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A3D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A3E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A3F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A3FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A1E0
+	voice_square_2_alt 60, 0, 3, 0, 2, 0, 0  @ 867A1EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A1F8
+	voice_square_2_alt 60, 0, 3, 0, 1, 6, 0  @ 867A204
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 6, 0  @ 867A210
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 6, 0  @ 867A21C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A24C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A27C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A2A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A2AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A2B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A2C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A2D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A2DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A2E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A2F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A30C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A33C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A36C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A39C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A3A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A3B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A3C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A3CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A3D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A3E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A3F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A3FC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 867A408
 	voice_keysplit voicegroup006, KeySplitTable2  @ 867A414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A42C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A42C
 

--- a/sound/voicegroups/voicegroup022.inc
+++ b/sound/voicegroups/voicegroup022.inc
@@ -1,68 +1,68 @@
 	.align 2
 voicegroup022:: @ 867A438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A45C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A45C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A468
 	voice_keysplit voicegroup007, KeySplitTable3  @ 867A474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A480
 	voice_keysplit voicegroup008, KeySplitTable4  @ 867A48C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A498
 	voice_keysplit voicegroup009, KeySplitTable5  @ 867A4A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A4B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A4BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A4C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A4D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A4E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A4EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A4F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A510
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A51C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A4B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A4BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A4C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A4D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A4E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A4EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A4F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A51C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A534
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 867A540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A54C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A57C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A588
-	voice_square_2_alt 0, 0, 1, 7, 0  @ 867A594
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 867A5A0
-	voice_square_1_alt 0, 0, 0, 1, 7, 0  @ 867A5AC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 867A5B8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 867A5C4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 1  @ 867A5D0
-	voice_square_1_alt 0, 0, 0, 0, 7, 0  @ 867A5DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A54C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A57C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A588
+	voice_square_2_alt 60, 0, 0, 0, 1, 7, 0  @ 867A594
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 867A5A0
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 7, 0  @ 867A5AC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 867A5B8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 867A5C4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 1  @ 867A5D0
+	voice_square_1_alt 60, 0, 0, 0, 0, 0, 7, 0  @ 867A5DC
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_standard_kick, 255, 0, 255, 242  @ 867A5E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A5F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A5F4
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_standard3_snare, 255, 0, 255, 242  @ 867A600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A60C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A60C
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_orchestra_snare, 255, 0, 255, 242  @ 867A618
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A630
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A63C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A66C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A69C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A6A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A6B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A63C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A66C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A69C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A6A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A6B4
 	voice_directsound_no_resample 32, 34, DirectSoundWaveData_unknown_tambourine, 255, 127, 77, 204  @ 867A6C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A6CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A6D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A6E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A6F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A6FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A6CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A6D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A6E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A6F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A6FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A714
 	voice_directsound_no_resample 72, 67, DirectSoundWaveData_sc88_bongo, 255, 0, 255, 0  @ 867A720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A72C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A72C
 	voice_directsound_no_resample 72, 61, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 867A738
 

--- a/sound/voicegroups/voicegroup023.inc
+++ b/sound/voicegroups/voicegroup023.inc
@@ -2,91 +2,91 @@
 voicegroup023:: @ 867A744
 	voice_keysplit voicegroup005, KeySplitTable1  @ 867A744
 	voice_keysplit_all voicegroup001  @ 867A750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A75C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A78C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A7A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A7B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A7BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A7C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A7D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A7E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A7EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A7F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A81C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A828
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A84C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A87C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A8A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A8AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A8B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A8C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A8D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A8DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A75C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A78C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A7A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A7B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A7BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A7C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A7D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A7E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A7EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A7F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A81C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A84C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A87C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A8A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A8AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A8B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A8C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A8D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A8DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 149  @ 867A8E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A8F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A90C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A93C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A8F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A90C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A93C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A960
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 867A96C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A978
 	voice_keysplit voicegroup006, KeySplitTable2  @ 867A984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A99C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A9A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A9B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A9C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A9CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A9D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A99C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A9A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A9B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A9C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A9CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A9D8
 	voice_keysplit voicegroup007, KeySplitTable3  @ 867A9E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A9F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867A9FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AA08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AA14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AA20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AA2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AA38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AA44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AA50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AA5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AA68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AA74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AA80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AA8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AA98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AAA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AAB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AAC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AAD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AAE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AAEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AAF8
-	voice_square_2_alt 2, 0, 1, 7, 0  @ 867AB04
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 867AB10
-	voice_square_1_alt 0, 2, 0, 1, 7, 0  @ 867AB1C
-	voice_square_2_alt 2, 0, 1, 6, 1  @ 867AB28
-	voice_square_1_alt 0, 2, 0, 1, 6, 1  @ 867AB34
-	voice_square_2_alt 3, 0, 1, 7, 0  @ 867AB40
-	voice_square_1_alt 0, 3, 0, 1, 7, 0  @ 867AB4C
-	voice_square_1_alt 0, 2, 0, 0, 7, 0  @ 867AB58
-	voice_square_1_alt 0, 3, 0, 0, 7, 0  @ 867AB64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A9F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867A9FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AA08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AA14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AA20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AA2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AA38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AA44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AA50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AA5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AA68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AA74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AA80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AA8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AA98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AAA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AAB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AAC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AAD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AAE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AAEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AAF8
+	voice_square_2_alt 60, 0, 2, 0, 1, 7, 0  @ 867AB04
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 867AB10
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 7, 0  @ 867AB1C
+	voice_square_2_alt 60, 0, 2, 0, 1, 6, 1  @ 867AB28
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 6, 1  @ 867AB34
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 0  @ 867AB40
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 7, 0  @ 867AB4C
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 7, 0  @ 867AB58
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 7, 0  @ 867AB64
 

--- a/sound/voicegroups/voicegroup024.inc
+++ b/sound/voicegroups/voicegroup024.inc
@@ -1,94 +1,94 @@
 	.align 2
 voicegroup024:: @ 867AB70
 	voice_keysplit_all voicegroup001  @ 867AB70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AB7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AB88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AB94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ABA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ABAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ABB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ABC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ABD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ABDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ABE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ABF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AC00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AC0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AC18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AC24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AC30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AC3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AC48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AC54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AC60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AC6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AC78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AC84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AC90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AC9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ACA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ACB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ACC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ACCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ACD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ACE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ACF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ACFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AD08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AD14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AD20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AD2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AD38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AD44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AD50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AD5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AD68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AD74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AD80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AB7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AB88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AB94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ABA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ABAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ABB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ABC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ABD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ABDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ABE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ABF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AC00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AC0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AC18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AC24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AC30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AC3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AC48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AC54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AC60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AC6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AC78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AC84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AC90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AC9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ACA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ACB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ACC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ACCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ACD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ACE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ACF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ACFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AD08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AD14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AD20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AD2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AD38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AD44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AD50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AD5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AD68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AD74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AD80
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 216, 0, 165  @ 867AD8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AD98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AD98
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 867ADA4
 	voice_keysplit voicegroup006, KeySplitTable2  @ 867ADB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ADBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ADC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ADD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ADE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ADEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ADF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AE04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ADBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ADC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ADD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ADE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ADEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ADF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AE04
 	voice_keysplit voicegroup007, KeySplitTable3  @ 867AE10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AE1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AE28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AE34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AE1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AE28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AE34
 	voice_keysplit voicegroup009, KeySplitTable5  @ 867AE40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AE4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AE58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AE64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AE70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AE7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AE88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AE94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AEA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AEAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AEB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AEC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AE4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AE58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AE64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AE70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AE7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AE88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AE94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AEA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AEAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AEB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AEC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AED0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 867AEDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AEE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AEF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AF00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AF0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AF18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AF24
-	voice_square_2_alt 2, 0, 1, 7, 0  @ 867AF30
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 867AF3C
-	voice_square_1_alt 0, 2, 0, 1, 7, 0  @ 867AF48
-	voice_square_2_alt 2, 0, 2, 0, 0  @ 867AF54
-	voice_square_2_alt 3, 0, 1, 7, 0  @ 867AF60
-	voice_square_1_alt 0, 3, 0, 1, 7, 0  @ 867AF6C
-	voice_square_1_alt 0, 2, 0, 2, 0, 0  @ 867AF78
-	voice_square_1_alt 0, 3, 0, 0, 7, 0  @ 867AF84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AF90
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 867AF9C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 867AFA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AEE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AEF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AF00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AF0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AF18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AF24
+	voice_square_2_alt 60, 0, 2, 0, 1, 7, 0  @ 867AF30
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 867AF3C
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 7, 0  @ 867AF48
+	voice_square_2_alt 60, 0, 2, 0, 2, 0, 0  @ 867AF54
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 0  @ 867AF60
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 7, 0  @ 867AF6C
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 0, 0  @ 867AF78
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 7, 0  @ 867AF84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AF90
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 867AF9C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 867AFA8
 

--- a/sound/voicegroups/voicegroup025.inc
+++ b/sound/voicegroups/voicegroup025.inc
@@ -1,87 +1,87 @@
 	.align 2
 voicegroup025:: @ 867AFB4
 	voice_keysplit_all voicegroup001  @ 867AFB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AFC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AFCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AFD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AFE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AFF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867AFFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B02C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B05C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B08C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B0A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B0B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B0BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B0C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B0D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B0E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B0EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B0F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B11C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B14C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B17C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B1A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B1AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B1B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B1C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B1D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B1DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AFC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AFCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AFD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AFE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AFF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867AFFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B02C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B05C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B08C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B0A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B0B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B0BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B0C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B0D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B0E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B0EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B0F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B11C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B14C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B17C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B1A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B1AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B1B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B1C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B1D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B1DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 867B1E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B1F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B20C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B23C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B1F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B20C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B23C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B248
 	voice_keysplit voicegroup007, KeySplitTable3  @ 867B254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B260
 	voice_keysplit voicegroup008, KeySplitTable4  @ 867B26C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B29C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B2A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B2B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B2C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B2CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B2D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B2E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B2F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B2FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B29C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B2A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B2B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B2C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B2CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B2D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B2E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B2F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B2FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B314
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 867B320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B32C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B35C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B368
-	voice_square_2_alt 1, 0, 1, 7, 1  @ 867B374
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 867B380
-	voice_square_1_alt 0, 1, 0, 1, 7, 1  @ 867B38C
-	voice_square_2_alt 2, 0, 1, 0, 0  @ 867B398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B32C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B35C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B368
+	voice_square_2_alt 60, 0, 1, 0, 1, 7, 1  @ 867B374
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 867B380
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 7, 1  @ 867B38C
+	voice_square_2_alt 60, 0, 2, 0, 1, 0, 0  @ 867B398
 

--- a/sound/voicegroups/voicegroup026.inc
+++ b/sound/voicegroups/voicegroup026.inc
@@ -1,88 +1,88 @@
 	.align 2
 voicegroup026:: @ 867B3A4
 	voice_keysplit_all voicegroup001  @ 867B3A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B3B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B3BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B3C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B3D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B3E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B3EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B3F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B41C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B428
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B44C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B458
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B470
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B47C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B4A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B4AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B4B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B4C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B4D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B4DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B4E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B4F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B50C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B53C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B56C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B59C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B5A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B5B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B5C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B5CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B3B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B3BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B3C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B3D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B3E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B3EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B3F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B41C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B44C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B47C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B4A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B4AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B4B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B4C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B4D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B4DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B4E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B4F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B50C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B53C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B56C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B59C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B5A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B5B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B5C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B5CC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 867B5D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B5E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B5F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B5FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B62C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B65C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B5E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B5F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B5FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B62C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B65C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B668
 	voice_keysplit voicegroup009, KeySplitTable5  @ 867B674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B68C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B6A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B6B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B6BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B6C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B6D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B6E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B6EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B6F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B71C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B74C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B758
-	voice_square_2_alt 2, 0, 1, 9, 0  @ 867B764
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 867B770
-	voice_square_1_alt 0, 2, 0, 1, 9, 0  @ 867B77C
-	voice_square_2_alt 3, 0, 1, 7, 0  @ 867B788
-	voice_square_1_alt 0, 3, 0, 1, 7, 0  @ 867B794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B68C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B6A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B6B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B6BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B6C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B6D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B6E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B6EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B6F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B71C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B74C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B758
+	voice_square_2_alt 60, 0, 2, 0, 1, 9, 0  @ 867B764
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 867B770
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 9, 0  @ 867B77C
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 0  @ 867B788
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 7, 0  @ 867B794
 

--- a/sound/voicegroups/voicegroup027.inc
+++ b/sound/voicegroups/voicegroup027.inc
@@ -2,130 +2,130 @@
 voicegroup027:: @ 867B7A0
 	voice_keysplit_all voicegroup001  @ 867B7A0
 	voice_keysplit voicegroup005, KeySplitTable1  @ 867B7AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B7B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B7C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B7D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B7DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B7E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B7F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B80C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B7B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B7C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B7D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B7DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B7E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B7F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B80C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B830
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 867B83C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B848
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B86C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B89C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B8A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B8B4
-	voice_square_2 1, 0, 2, 0, 0  @ 867B8C0
-	voice_square_1 0, 1, 0, 2, 0, 0  @ 867B8CC
-	voice_square_2 1, 0, 6, 0, 0  @ 867B8D8
-	voice_square_1 0, 1, 0, 6, 0, 0  @ 867B8E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B8F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B8FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B92C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B938
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B95C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B86C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B89C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B8A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B8B4
+	voice_square_2 60, 0, 1, 0, 2, 0, 0  @ 867B8C0
+	voice_square_1 60, 0, 0, 1, 0, 2, 0, 0  @ 867B8CC
+	voice_square_2 60, 0, 1, 0, 6, 0, 0  @ 867B8D8
+	voice_square_1 60, 0, 0, 1, 0, 6, 0, 0  @ 867B8E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B8F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B8FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B92C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B95C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 867B968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B98C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B9A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B9B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B9BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B9C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B9D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B9E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B9EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867B9F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BA04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BA10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BA1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BA28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BA34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BA40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BA4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BA58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BA64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BA70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BA7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BA88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BA94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BAA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BAAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BAB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BAC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BAD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BAE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BAF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BB00
-	voice_programmable_wave ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 867BB0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BB18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BB24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BB30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BB3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BB48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BB54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BB60
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 867BB6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BB78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BB84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BB90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BB9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BBA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BBB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BBC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BBCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BBD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BBE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BBF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BBFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BC08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BC14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BC20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BC2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BC38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BC44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BC50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BC5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BC68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BC74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BC80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BC8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BC98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BCA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BCB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BCBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BCC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BCD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BCE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BCEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BCF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BD04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BD10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BD1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BD28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BD34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BD40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BD4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BD58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BD64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BD70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BD7C
-	voice_noise_alt 0, 0, 4, 1, 4  @ 867BD88
-	voice_noise_alt 0, 0, 1, 0, 2  @ 867BD94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B98C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B9A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B9B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B9BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B9C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B9D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B9E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B9EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867B9F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BA04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BA10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BA1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BA28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BA34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BA40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BA4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BA58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BA64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BA70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BA7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BA88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BA94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BAA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BAAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BAB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BAC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BAD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BAE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BAF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BB00
+	voice_programmable_wave 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 867BB0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BB18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BB24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BB30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BB3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BB48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BB54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BB60
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 867BB6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BB78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BB84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BB90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BB9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BBA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BBB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BBC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BBCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BBD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BBE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BBF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BBFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BC08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BC14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BC20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BC2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BC38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BC44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BC50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BC5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BC68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BC74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BC80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BC8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BC98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BCA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BCB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BCBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BCC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BCD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BCE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BCEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BCF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BD04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BD10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BD1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BD28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BD34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BD40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BD4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BD58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BD64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BD70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BD7C
+	voice_noise_alt 60, 0, 0, 0, 4, 1, 4  @ 867BD88
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 2  @ 867BD94
 

--- a/sound/voicegroups/voicegroup028.inc
+++ b/sound/voicegroups/voicegroup028.inc
@@ -1,86 +1,86 @@
 	.align 2
 voicegroup028:: @ 867BDA0
 	voice_keysplit_all voicegroup001  @ 867BDA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BDAC
-	voice_square_1 0, 3, 0, 1, 0, 0  @ 867BDB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BDC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BDD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BDDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BDE8
-	voice_square_2 0, 0, 2, 0, 0  @ 867BDF4
-	voice_square_1 0, 0, 0, 2, 0, 0  @ 867BE00
-	voice_square_2 0, 0, 6, 0, 0  @ 867BE0C
-	voice_square_1 0, 0, 0, 6, 0, 0  @ 867BE18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BE24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BE30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BE3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BE48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BE54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BE60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BDAC
+	voice_square_1 60, 0, 0, 3, 0, 1, 0, 0  @ 867BDB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BDC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BDD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BDDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BDE8
+	voice_square_2 60, 0, 0, 0, 2, 0, 0  @ 867BDF4
+	voice_square_1 60, 0, 0, 0, 0, 2, 0, 0  @ 867BE00
+	voice_square_2 60, 0, 0, 0, 6, 0, 0  @ 867BE0C
+	voice_square_1 60, 0, 0, 0, 0, 6, 0, 0  @ 867BE18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BE24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BE30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BE3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BE48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BE54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BE60
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 127  @ 867BE6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BE78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BE84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BE90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BE9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BEA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BEB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BEC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BEE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BEF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BEFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BF08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BF14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BF20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BF2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BF38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BF44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BE78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BE84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BE90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BE9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BEA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BEB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BEC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BEE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BEF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BEFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BF08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BF14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BF20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BF2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BF38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BF44
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 867BF50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BF5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BF68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BF74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BF80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BF8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BF98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BFA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BFB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BFBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BFC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BFD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BFE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BFEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867BFF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C01C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BF5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BF68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BF74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BF80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BF8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BF98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BFA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BFB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BFBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BFC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BFD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BFE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BFEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867BFF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C01C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C034
 	voice_keysplit voicegroup007, KeySplitTable3  @ 867C040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C04C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C058
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C064
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C070
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C07C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C0A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C0AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C0B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C0C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C0D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C0DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C0E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C0F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C10C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C13C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C154
-	voice_square_2 2, 0, 2, 0, 0  @ 867C160
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 867C16C
-	voice_square_2 3, 0, 4, 0, 0  @ 867C178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C04C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C07C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C0A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C0AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C0B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C0C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C0D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C0DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C0E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C0F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C10C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C13C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C154
+	voice_square_2 60, 0, 2, 0, 2, 0, 0  @ 867C160
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 867C16C
+	voice_square_2 60, 0, 3, 0, 4, 0, 0  @ 867C178
 

--- a/sound/voicegroups/voicegroup029.inc
+++ b/sound/voicegroups/voicegroup029.inc
@@ -1,91 +1,91 @@
 	.align 2
 voicegroup029:: @ 867C184
 	voice_keysplit_all voicegroup001  @ 867C184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C190
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C19C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C1A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C1B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C1C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C1CC
-	voice_square_2_alt 1, 0, 2, 4, 0  @ 867C1D8
-	voice_square_1_alt 0, 1, 0, 2, 7, 0  @ 867C1E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C1F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C1FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C208
-	voice_square_2_alt 2, 0, 2, 0, 0  @ 867C214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C19C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C1A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C1B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C1C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C1CC
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 0  @ 867C1D8
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 7, 0  @ 867C1E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C1F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C1FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C208
+	voice_square_2_alt 60, 0, 2, 0, 2, 0, 0  @ 867C214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C220
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 216, 90, 242  @ 867C22C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C25C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C268
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C28C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C2A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C2B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C2BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C2C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C2D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C2E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C2EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C2F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C31C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C34C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C37C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C25C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C28C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C2A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C2B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C2BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C2C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C2D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C2E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C2EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C2F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C31C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C34C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C37C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C394
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 216, 0, 165  @ 867C3A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C3AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C3AC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 867C3B8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 867C3C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C3D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C3DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C3E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C3F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C40C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C3D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C3DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C3E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C3F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C40C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C418
 	voice_keysplit voicegroup007, KeySplitTable3  @ 867C424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C430
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C43C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C43C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C448
 	voice_keysplit voicegroup009, KeySplitTable5  @ 867C454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C46C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C49C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C4A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C4B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C4C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C4CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C4D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C4E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C46C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C49C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C4A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C4B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C4C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C4CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C4D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C4E4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 867C4F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C4FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C52C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C538
-	voice_square_2_alt 3, 0, 1, 7, 0  @ 867C544
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 867C550
-	voice_square_1_alt 0, 3, 0, 1, 7, 0  @ 867C55C
-	voice_square_2_alt 3, 0, 1, 0, 0  @ 867C568
-	voice_square_1_alt 0, 3, 0, 1, 0, 0  @ 867C574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C58C
-	voice_square_1_alt 0, 0, 0, 1, 7, 0  @ 867C598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C4FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C52C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C538
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 0  @ 867C544
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 867C550
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 7, 0  @ 867C55C
+	voice_square_2_alt 60, 0, 3, 0, 1, 0, 0  @ 867C568
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 0, 0  @ 867C574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C58C
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 7, 0  @ 867C598
 

--- a/sound/voicegroups/voicegroup030.inc
+++ b/sound/voicegroups/voicegroup030.inc
@@ -2,57 +2,57 @@
 voicegroup030:: @ 867C5A4
 	voice_keysplit_all voicegroup031  @ 867C5A4
 	voice_keysplit voicegroup005, KeySplitTable1  @ 867C5B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C5BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C5C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C5D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C5E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C5EC
-	voice_square_2_alt 3, 0, 2, 4, 0  @ 867C5F8
-	voice_square_1_alt 0, 3, 0, 2, 4, 0  @ 867C604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C61C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C5BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C5C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C5D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C5E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C5EC
+	voice_square_2_alt 60, 0, 3, 0, 2, 4, 0  @ 867C5F8
+	voice_square_1_alt 60, 0, 0, 3, 0, 2, 4, 0  @ 867C604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C61C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C640
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 216, 90, 242  @ 867C64C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C664
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 37, 165, 180, 127  @ 867C670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C67C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C6A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C6AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C6B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C6C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C6D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C6DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C6E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C6F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C70C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C73C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C76C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C790
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C79C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C7A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C7B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C7C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C67C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C6A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C6AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C6B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C6C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C6D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C6DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C6E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C6F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C70C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C73C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C76C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C79C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C7A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C7B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C7C0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 867C7CC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 867C7D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C7E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C7F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C7FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C808
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C82C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C7E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C7F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C7FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C82C
 

--- a/sound/voicegroups/voicegroup031.inc
+++ b/sound/voicegroups/voicegroup031.inc
@@ -1,68 +1,68 @@
 	.align 2
 voicegroup031:: @ 867C838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C850
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C85C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C85C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C868
 	voice_keysplit voicegroup009, KeySplitTable5  @ 867C874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C88C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C898
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C8A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C8B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C8BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C8C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C8D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C8E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C8EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C8F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C91C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C94C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C964
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 1  @ 867C970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C97C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C9A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C9AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C9B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C9C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C9D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C88C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C8A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C8B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C8BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C8C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C8D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C8E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C8EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C8F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C91C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C94C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C964
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 1  @ 867C970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C97C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C9A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C9AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C9B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C9C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C9D0
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_polysynth, 255, 165, 154, 127  @ 867C9DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C9E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867C9F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CA00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CA0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C9E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867C9F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CA00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CA0C
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_orchestra_snare, 255, 0, 255, 242  @ 867CA18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CA24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CA30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CA3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CA48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CA54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CA60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CA6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CA78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CA84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CA90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CA9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CAA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CAB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CA24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CA30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CA3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CA48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CA54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CA60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CA6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CA78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CA84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CA90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CA9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CAA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CAB4
 	voice_directsound_no_resample 32, 49, DirectSoundWaveData_unknown_tambourine, 255, 127, 77, 204  @ 867CAC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CAD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CAD8
 	voice_directsound_no_resample 30, 54, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 8, 0, 255, 216  @ 867CAE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CAF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CAF0
 	voice_directsound_no_resample 30, 54, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 246, 0, 216  @ 867CAFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CB08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CB14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CB08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CB14
 	voice_directsound_no_resample 72, 79, DirectSoundWaveData_sc88_bongo, 255, 0, 255, 0  @ 867CB20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CB2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CB2C
 	voice_directsound_no_resample 72, 74, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 867CB38
 

--- a/sound/voicegroups/voicegroup032.inc
+++ b/sound/voicegroups/voicegroup032.inc
@@ -2,130 +2,130 @@
 voicegroup032:: @ 867CB44
 	voice_keysplit_all voicegroup016  @ 867CB44
 	voice_keysplit voicegroup005, KeySplitTable1  @ 867CB50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CB5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CB68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CB74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CB80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CB8C
-	voice_square_2_alt 3, 0, 3, 4, 0  @ 867CB98
-	voice_square_1_alt 0, 3, 0, 3, 4, 0  @ 867CBA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CBB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CBBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CBC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CBD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CBE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CBEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CBF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CC04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CC10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CC1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CC28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CC34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CC40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CC4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CC58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CC64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CC70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CC7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CC88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CC94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CCA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CCAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CCB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CCC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CCD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CCDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CB5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CB68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CB74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CB80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CB8C
+	voice_square_2_alt 60, 0, 3, 0, 3, 4, 0  @ 867CB98
+	voice_square_1_alt 60, 0, 0, 3, 0, 3, 4, 0  @ 867CBA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CBB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CBBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CBC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CBD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CBE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CBEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CBF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CC04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CC10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CC1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CC28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CC34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CC40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CC4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CC58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CC64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CC70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CC7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CC88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CC94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CCA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CCAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CCB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CCC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CCD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CCDC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 250, 0, 149  @ 867CCE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CCF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CD00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CD0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CD18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CD24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CD30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CD3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CD48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CD54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CD60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CD6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CD78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CD84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CD90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CD9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CDA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CDB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CDC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CDCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CDD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CDE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CDF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CDFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CE08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CE14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CE20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CE2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CE38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CE44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CE50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CE5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CE68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CE74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CE80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CE8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CE98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CEA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CCF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CD00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CD0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CD18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CD24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CD30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CD3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CD48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CD54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CD60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CD6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CD78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CD84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CD90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CD9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CDA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CDB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CDC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CDCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CDD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CDE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CDF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CDFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CE08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CE14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CE20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CE2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CE38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CE44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CE50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CE5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CE68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CE74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CE80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CE8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CE98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CEA4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 867CEB0
-	voice_programmable_wave ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 867CEBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CEC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CEE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CEEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CEF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CF04
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 2  @ 867CF10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CF1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CF28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CF34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CF40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CF4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CF58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CF64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CF70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CF7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CF88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CF94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CFA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CFAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CFB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CFC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CFD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CFDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CFE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867CFF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D00C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D030
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D03C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D06C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D09C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D0A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D0B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D0C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D0CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D0D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D0E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D0F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D0FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D114
-	voice_noise_alt 0, 0, 1, 0, 0  @ 867D120
-	voice_noise_alt 0, 0, 4, 1, 4  @ 867D12C
-	voice_noise_alt 0, 0, 1, 0, 2  @ 867D138
+	voice_programmable_wave 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 867CEBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CEC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CEE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CEEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CEF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CF04
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 2  @ 867CF10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CF1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CF28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CF34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CF40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CF4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CF58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CF64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CF70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CF7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CF88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CF94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CFA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CFAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CFB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CFC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CFD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CFDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CFE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867CFF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D00C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D03C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D06C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D09C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D0A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D0B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D0C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D0CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D0D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D0E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D0F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D0FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D114
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 867D120
+	voice_noise_alt 60, 0, 0, 0, 4, 1, 4  @ 867D12C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 2  @ 867D138
 

--- a/sound/voicegroups/voicegroup033.inc
+++ b/sound/voicegroups/voicegroup033.inc
@@ -1,86 +1,86 @@
 	.align 2
 voicegroup033:: @ 867D144
 	voice_keysplit_all voicegroup001  @ 867D144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D15C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D18C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D1A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D1B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D1BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D1C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D1D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D1E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D1EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D1F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D21C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D234
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D24C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D258
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D27C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D2A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D2AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D2B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D2C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D2D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D2DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D15C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D18C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D1A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D1B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D1BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D1C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D1D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D1E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D1EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D1F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D21C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D24C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D27C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D2A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D2AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D2B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D2C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D2D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D2DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 149  @ 867D2E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D2F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D30C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D33C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D2F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D30C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D33C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D360
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 867D36C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D378
 	voice_keysplit voicegroup006, KeySplitTable2  @ 867D384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D39C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D3A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D3B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D3C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D3CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D3D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D3E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D3F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D3FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D39C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D3A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D3B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D3C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D3CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D3D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D3E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D3F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D3FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D408
 	voice_keysplit voicegroup009, KeySplitTable5  @ 867D414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D42C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D45C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D468
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D48C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D498
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D4A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D42C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D45C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D48C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D4A4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 867D4B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D4BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D4C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D4D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D4E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D4EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D4F8
-	voice_square_2_alt 2, 0, 1, 4, 1  @ 867D504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D510
-	voice_square_1_alt 0, 2, 0, 1, 4, 1  @ 867D51C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D4BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D4C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D4D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D4E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D4EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D4F8
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 1  @ 867D504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D510
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1  @ 867D51C
 

--- a/sound/voicegroups/voicegroup034.inc
+++ b/sound/voicegroups/voicegroup034.inc
@@ -2,86 +2,86 @@
 voicegroup034:: @ 867D528
 	voice_keysplit_all voicegroup001  @ 867D528
 	voice_keysplit voicegroup005, KeySplitTable1  @ 867D534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D54C
-	voice_square_2 2, 0, 1, 4, 2  @ 867D558
-	voice_square_1 0, 2, 0, 1, 4, 1  @ 867D564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D57C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D5A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D5AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D5B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D5C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D5D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D5DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D5E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D5F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D60C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D618
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D630
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D63C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D66C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D69C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D6A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D6B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D6C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D54C
+	voice_square_2 60, 0, 2, 0, 1, 4, 2  @ 867D558
+	voice_square_1 60, 0, 0, 2, 0, 1, 4, 1  @ 867D564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D57C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D5A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D5AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D5B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D5C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D5D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D5DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D5E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D5F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D60C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D63C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D66C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D69C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D6A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D6B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D6C0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 867D6CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D6D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D6E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D6F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D6FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D72C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D6D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D6E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D6F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D6FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D72C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D738
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 38  @ 867D744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D75C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D75C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 867D768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D78C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D7A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D7B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D7BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D7C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D7D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D7E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D7EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D7F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D81C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D828
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D84C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D87C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D78C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D7A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D7B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D7BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D7C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D7D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D7E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D7EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D7F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D81C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D84C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D87C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D888
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 867D894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D8A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D8AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D8B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D8C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D8D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D8DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D8E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D8F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D900
-	voice_programmable_wave ProgrammableWaveData_86B4920, 0, 7, 15, 2  @ 867D90C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D8A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D8AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D8B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D8C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D8D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D8DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D8E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D8F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D900
+	voice_programmable_wave 60, 0, ProgrammableWaveData_86B4920, 0, 7, 15, 2  @ 867D90C
 

--- a/sound/voicegroups/voicegroup035.inc
+++ b/sound/voicegroups/voicegroup035.inc
@@ -2,87 +2,87 @@
 voicegroup035:: @ 867D918
 	voice_keysplit_all voicegroup031  @ 867D918
 	voice_keysplit voicegroup005, KeySplitTable1  @ 867D924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D93C
-	voice_square_2_alt 2, 0, 1, 7, 1  @ 867D948
-	voice_square_1_alt 0, 2, 0, 1, 7, 1  @ 867D954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D96C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D99C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D9A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D9B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D9C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D9CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D9D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D9E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D9F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867D9FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DA08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DA14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DA20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DA2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DA38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DA44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DA50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DA5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DA68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DA74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DA80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DA8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DA98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DAA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DAB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DAC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DAD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DAE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DAEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DAF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DB04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DB10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DB1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DB28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DB34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DB40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D93C
+	voice_square_2_alt 60, 0, 2, 0, 1, 7, 1  @ 867D948
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 7, 1  @ 867D954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D96C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D99C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D9A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D9B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D9C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D9CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D9D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D9E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D9F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867D9FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DA08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DA14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DA20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DA2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DA38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DA44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DA50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DA5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DA68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DA74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DA80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DA8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DA98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DAA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DAB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DAC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DAD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DAE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DAEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DAF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DB04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DB10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DB1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DB28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DB34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DB40
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 867DB4C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 867DB58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DB64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DB70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DB7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DB88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DB94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DBA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DBAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DB64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DB70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DB7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DB88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DB94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DBA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DBAC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 867DBB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DBC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DBD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DBDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DBC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DBD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DBDC
 	voice_keysplit voicegroup009, KeySplitTable5  @ 867DBE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DBF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DC00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DC0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DC18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DC24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DC30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DC3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DC48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DC54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DC60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DC6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DC78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DC84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DC90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DC9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DCA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DCB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DCC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DCCC
-	voice_square_2_alt 3, 0, 1, 6, 1  @ 867DCD8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 2  @ 867DCE4
-	voice_square_1_alt 0, 3, 0, 1, 6, 1  @ 867DCF0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 867DCFC
-	voice_square_1_alt 0, 3, 0, 0, 6, 1  @ 867DD08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DBF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DC00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DC0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DC18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DC24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DC30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DC3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DC48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DC54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DC60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DC6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DC78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DC84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DC90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DC9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DCA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DCB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DCC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DCCC
+	voice_square_2_alt 60, 0, 3, 0, 1, 6, 1  @ 867DCD8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 2  @ 867DCE4
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 6, 1  @ 867DCF0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 867DCFC
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 6, 1  @ 867DD08
 

--- a/sound/voicegroups/voicegroup036.inc
+++ b/sound/voicegroups/voicegroup036.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup036:: @ 867DD14
 	voice_keysplit_all voicegroup001  @ 867DD14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DD20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DD2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DD38
-	voice_square_2_alt 2, 0, 1, 6, 1  @ 867DD44
-	voice_square_1_alt 0, 2, 0, 1, 6, 1  @ 867DD50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DD5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DD68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DD74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DD80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DD8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DD98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DDA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DDB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DDBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DDC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DDD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DDE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DDEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DDF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DE04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DE10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DE1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DE28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DE34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DE40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DE4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DE58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DE64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DE70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DE7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DE88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DE94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DD20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DD2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DD38
+	voice_square_2_alt 60, 0, 2, 0, 1, 6, 1  @ 867DD44
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 6, 1  @ 867DD50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DD5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DD68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DD74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DD80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DD8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DD98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DDA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DDB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DDBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DDC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DDD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DDE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DDEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DDF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DE04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DE10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DE1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DE28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DE34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DE40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DE4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DE58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DE64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DE70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DE7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DE88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DE94
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 253, 0, 149  @ 867DEA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DEAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DEB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DEC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DEDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DEE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DEF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DF00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DF0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DF18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DF24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DEAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DEB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DEC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DEDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DEE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DEF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DF00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DF0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DF18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DF24
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 216, 0, 165  @ 867DF30
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 867DF3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DF48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DF48
 	voice_keysplit voicegroup006, KeySplitTable2  @ 867DF54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DF60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DF6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DF78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DF84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DF90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DF9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DFA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DFB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DFC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DFCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DFD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DF60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DF6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DF78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DF84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DF90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DF9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DFA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DFB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DFC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DFCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DFD8
 	voice_keysplit voicegroup009, KeySplitTable5  @ 867DFE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DFF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867DFFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E02C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E05C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E074
-	voice_programmable_wave ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 867E080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E08C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E0A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E0B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E0BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E0C8
-	voice_square_2_alt 2, 0, 2, 4, 1  @ 867E0D4
-	voice_square_1_alt 0, 2, 0, 2, 4, 1  @ 867E0E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E0EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E0F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E11C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E14C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E17C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E1A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E1AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E1B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E1C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E1D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E1DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E1E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E1F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E20C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E23C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E26C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E29C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E2A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E2B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E2C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E2CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E2D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E2E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E2F0
-	voice_noise_alt 0, 0, 4, 1, 4  @ 867E2FC
-	voice_noise_alt 0, 0, 1, 0, 2  @ 867E308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DFF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867DFFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E02C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E05C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E074
+	voice_programmable_wave 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 867E080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E08C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E0A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E0B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E0BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E0C8
+	voice_square_2_alt 60, 0, 2, 0, 2, 4, 1  @ 867E0D4
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 4, 1  @ 867E0E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E0EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E0F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E11C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E14C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E17C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E1A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E1AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E1B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E1C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E1D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E1DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E1E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E1F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E20C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E23C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E26C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E29C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E2A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E2B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E2C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E2CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E2D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E2E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E2F0
+	voice_noise_alt 60, 0, 0, 0, 4, 1, 4  @ 867E2FC
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 2  @ 867E308
 

--- a/sound/voicegroups/voicegroup037.inc
+++ b/sound/voicegroups/voicegroup037.inc
@@ -1,92 +1,92 @@
 	.align 2
 voicegroup037:: @ 867E314
 	voice_keysplit_all voicegroup031  @ 867E314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E32C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E338
-	voice_square_2_alt 2, 0, 2, 4, 1  @ 867E344
-	voice_square_1_alt 0, 2, 0, 2, 4, 1  @ 867E350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E35C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E38C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E3A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E3B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E32C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E338
+	voice_square_2_alt 60, 0, 2, 0, 2, 4, 1  @ 867E344
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 4, 1  @ 867E350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E35C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E38C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E3A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E3B0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 216, 90, 242  @ 867E3BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E3C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E3D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E3E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E3EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E3F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E41C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E428
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E44C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E458
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E470
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E47C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E4A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E4AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E4B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E4C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E4D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E4DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E4E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E4F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E50C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E3C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E3D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E3E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E3EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E3F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E41C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E44C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E47C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E4A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E4AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E4B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E4C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E4D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E4DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E4E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E4F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E50C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E530
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 867E53C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 867E548
 	voice_keysplit voicegroup006, KeySplitTable2  @ 867E554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E56C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E59C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E5A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E5B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E5C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E56C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E59C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E5A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E5B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E5C0
 	voice_keysplit voicegroup008, KeySplitTable4  @ 867E5CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E5D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E5D8
 	voice_keysplit voicegroup009, KeySplitTable5  @ 867E5E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E5F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E5FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E62C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E65C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E68C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E6A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E6B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E6BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E6C8
-	voice_square_2_alt 0, 0, 1, 7, 1  @ 867E6D4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 867E6E0
-	voice_square_1_alt 0, 0, 0, 1, 7, 1  @ 867E6EC
-	voice_square_1_alt 0, 0, 0, 0, 7, 1  @ 867E6F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E71C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E728
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 2  @ 867E734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E5F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E5FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E62C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E65C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E68C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E6A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E6B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E6BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E6C8
+	voice_square_2_alt 60, 0, 0, 0, 1, 7, 1  @ 867E6D4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 867E6E0
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 7, 1  @ 867E6EC
+	voice_square_1_alt 60, 0, 0, 0, 0, 0, 7, 1  @ 867E6F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E71C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E728
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 2  @ 867E734
 

--- a/sound/voicegroups/voicegroup038.inc
+++ b/sound/voicegroups/voicegroup038.inc
@@ -1,85 +1,85 @@
 	.align 2
 voicegroup038:: @ 867E740
 	voice_keysplit_all voicegroup001  @ 867E740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E74C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E764
-	voice_square_2 2, 0, 1, 4, 1  @ 867E770
-	voice_square_1 0, 2, 0, 1, 4, 1  @ 867E77C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E788
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E7A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E7AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E7B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E7C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E7D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E7DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E7E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E7F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E74C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E764
+	voice_square_2 60, 0, 2, 0, 1, 4, 1  @ 867E770
+	voice_square_1 60, 0, 0, 2, 0, 1, 4, 1  @ 867E77C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E7A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E7AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E7B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E7C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E7D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E7DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E7E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E7F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E800
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 127  @ 867E80C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E830
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E83C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E848
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E86C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E89C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E8A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E8B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E8C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E8CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E8D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E8E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E8F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E8FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E83C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E86C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E89C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E8A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E8B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E8C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E8CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E8D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E8E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E8F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E8FC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 867E908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E92C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E938
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E95C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E98C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E9A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E9B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E9BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E9C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E9D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E9E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E9EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867E9F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EA04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EA10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EA1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EA28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EA34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EA40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EA4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EA58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EA64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EA70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EA7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EA88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EA94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EAA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EAAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EAB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EAC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EAD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EAE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EAF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EB00
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 0  @ 867EB0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E92C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E95C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E98C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E9A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E9B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E9BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E9C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E9D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E9E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E9EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867E9F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EA04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EA10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EA1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EA28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EA34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EA40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EA4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EA58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EA64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EA70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EA7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EA88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EA94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EAA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EAAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EAB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EAC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EAD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EAE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EAF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EB00
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 0  @ 867EB0C
 

--- a/sound/voicegroups/voicegroup039.inc
+++ b/sound/voicegroups/voicegroup039.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup039:: @ 867EB18
 	voice_keysplit_all voicegroup001  @ 867EB18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EB24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EB30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EB3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EB48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EB54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EB60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EB6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EB78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EB84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EB90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EB9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EBA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EBB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EBC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EBCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EBD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EB24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EB30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EB3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EB48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EB54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EB60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EB6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EB78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EB84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EB90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EB9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EBA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EBB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EBC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EBCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EBD8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 165  @ 867EBE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EBF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EBFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EC08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EC14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EC20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EC2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EBF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EBFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EC08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EC14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EC20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EC2C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 867EC38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EC44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EC50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EC5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EC68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EC74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EC80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EC8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EC98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ECA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ECB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ECBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EC44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EC50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EC5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EC68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EC74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EC80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EC8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EC98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ECA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ECB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ECBC
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 867ECC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ECD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ECE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ECEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ECF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ED04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ED10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ED1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ED28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ED34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ED40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ED4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ECD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ECE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ECEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ECF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ED04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ED10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ED1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ED28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ED34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ED40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ED4C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 867ED58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ED64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ED70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ED7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ED88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867ED94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EDA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EDAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ED64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ED70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ED7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ED88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867ED94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EDA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EDAC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 867EDB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EDC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EDD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EDDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EDC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EDD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EDDC
 	voice_keysplit voicegroup009, KeySplitTable5  @ 867EDE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EDF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EE00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EE0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EE18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EE24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EE30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EE3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EE48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EE54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EE60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EE6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EE78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EDF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EE00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EE0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EE18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EE24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EE30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EE3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EE48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EE54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EE60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EE6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EE78
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 867EE84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EE90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EE9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EEA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EEB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EEC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EECC
-	voice_square_1_alt 0, 2, 0, 2, 4, 0  @ 867EED8
-	voice_square_2_alt 1, 0, 2, 4, 0  @ 867EEE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EEF0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 867EEFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EF08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EF14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EF20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EF2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EF38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EF44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EF50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EF5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EF68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EF74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EF80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EF8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EF98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EFA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EFB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EFBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EFC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EFD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EFE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EFEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867EFF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F01C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F04C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F058
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F064
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F070
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F07C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F0A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F0AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F0B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F0C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F0D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F0DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F0E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F0F4
-	voice_noise_alt 0, 0, 1, 7, 1  @ 867F100
-	voice_noise_alt 0, 0, 1, 0, 0  @ 867F10C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EE90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EE9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EEA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EEB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EEC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EECC
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 4, 0  @ 867EED8
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 0  @ 867EEE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EEF0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 867EEFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EF08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EF14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EF20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EF2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EF38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EF44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EF50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EF5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EF68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EF74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EF80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EF8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EF98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EFA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EFB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EFBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EFC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EFD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EFE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EFEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867EFF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F01C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F04C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F07C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F0A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F0AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F0B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F0C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F0D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F0DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F0E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F0F4
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 867F100
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 867F10C
 

--- a/sound/voicegroups/voicegroup040.inc
+++ b/sound/voicegroups/voicegroup040.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup040:: @ 867F118
 	voice_keysplit_all voicegroup001  @ 867F118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F13C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F16C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F190
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F19C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F1A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F1B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F1C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F1CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F1D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F13C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F16C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F19C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F1A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F1B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F1C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F1CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F1D8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 165  @ 867F1E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F1F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F1FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F22C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F1F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F1FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F22C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 867F238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F25C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F268
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F28C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F2A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F2B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F2BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F25C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F28C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F2A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F2B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F2BC
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 867F2C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F2D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F2E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F2EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F2F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F31C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F34C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F2D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F2E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F2EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F2F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F31C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F34C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 867F358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F37C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F3A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F3AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F37C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F3A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F3AC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 867F3B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F3C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F3D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F3DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F3C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F3D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F3DC
 	voice_keysplit voicegroup009, KeySplitTable5  @ 867F3E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F3F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F40C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F430
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F43C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F46C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F3F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F40C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F43C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F46C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F478
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 867F484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F49C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F4A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F4B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F4C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F4CC
-	voice_square_1_alt 0, 2, 0, 2, 4, 0  @ 867F4D8
-	voice_square_2_alt 1, 0, 2, 4, 0  @ 867F4E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F4F0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 867F4FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F52C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F55C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F58C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F5A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F5B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F5BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F5C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F5D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F5E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F5EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F5F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F61C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F64C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F67C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F6A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F6AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F6B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F6C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F6D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F6DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F6E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F6F4
-	voice_noise_alt 0, 0, 1, 7, 1  @ 867F700
-	voice_noise_alt 0, 0, 1, 0, 0  @ 867F70C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F49C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F4A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F4B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F4C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F4CC
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 4, 0  @ 867F4D8
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 0  @ 867F4E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F4F0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 867F4FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F52C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F55C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F58C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F5A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F5B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F5BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F5C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F5D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F5E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F5EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F5F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F61C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F64C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F67C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F6A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F6AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F6B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F6C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F6D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F6DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F6E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F6F4
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 867F700
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 867F70C
 

--- a/sound/voicegroups/voicegroup041.inc
+++ b/sound/voicegroups/voicegroup041.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup041:: @ 867F718
 	voice_keysplit_all voicegroup001  @ 867F718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F73C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F76C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F790
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F79C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F7A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F7B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F7C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F7CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F7D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F73C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F76C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F79C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F7A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F7B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F7C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F7CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F7D8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 165  @ 867F7E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F7F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F7FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F808
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F82C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F7F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F7FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F82C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 867F838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F850
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F85C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F868
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F88C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F898
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F8A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F8B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F8BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F85C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F88C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F8A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F8B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F8BC
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 867F8C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F8D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F8E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F8EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F8F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F91C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F94C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F8D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F8E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F8EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F8F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F91C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F94C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 867F958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F97C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F9A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F9AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F97C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F9A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F9AC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 867F9B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F9C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F9D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F9DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F9C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F9D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F9DC
 	voice_keysplit voicegroup009, KeySplitTable5  @ 867F9E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867F9F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FA00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FA0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FA18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FA24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FA30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FA3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FA48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FA54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FA60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FA6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FA78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867F9F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FA00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FA0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FA18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FA24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FA30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FA3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FA48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FA54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FA60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FA6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FA78
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 867FA84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FA90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FA9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FAA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FAB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FAC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FACC
-	voice_square_1_alt 0, 2, 0, 2, 4, 0  @ 867FAD8
-	voice_square_2_alt 1, 0, 2, 4, 0  @ 867FAE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FAF0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 867FAFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FB08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FB14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FB20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FB2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FB38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FB44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FB50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FB5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FB68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FB74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FB80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FB8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FB98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FBA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FBB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FBBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FBC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FBD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FBE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FBEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FBF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FC04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FC10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FC1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FC28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FC34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FC40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FC4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FC58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FC64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FC70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FC7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FC88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FC94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FCA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FCAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FCB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FCC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FCD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FCDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FCE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FCF4
-	voice_noise_alt 0, 0, 1, 7, 1  @ 867FD00
-	voice_noise_alt 0, 0, 1, 0, 0  @ 867FD0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FA90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FA9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FAA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FAB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FAC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FACC
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 4, 0  @ 867FAD8
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 0  @ 867FAE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FAF0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 867FAFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FB08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FB14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FB20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FB2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FB38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FB44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FB50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FB5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FB68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FB74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FB80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FB8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FB98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FBA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FBB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FBBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FBC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FBD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FBE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FBEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FBF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FC04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FC10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FC1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FC28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FC34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FC40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FC4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FC58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FC64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FC70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FC7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FC88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FC94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FCA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FCAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FCB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FCC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FCD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FCDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FCE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FCF4
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 867FD00
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 867FD0C
 

--- a/sound/voicegroups/voicegroup042.inc
+++ b/sound/voicegroups/voicegroup042.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup042:: @ 867FD18
 	voice_keysplit_all voicegroup001  @ 867FD18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FD24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FD30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FD3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FD48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FD54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FD60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FD6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FD78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FD84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FD90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FD9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FDA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FDB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FDC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FDCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FDD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FD24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FD30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FD3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FD48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FD54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FD60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FD6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FD78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FD84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FD90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FD9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FDA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FDB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FDC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FDCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FDD8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 165  @ 867FDE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FDF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FDFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FE08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FE14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FE20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FE2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FDF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FDFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FE08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FE14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FE20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FE2C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 867FE38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FE44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FE50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FE5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FE68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FE74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FE80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FE8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FE98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FEA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FEB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FEBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FE44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FE50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FE5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FE68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FE74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FE80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FE8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FE98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FEA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FEB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FEBC
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 867FEC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FEE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FEEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FEF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FF04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FF10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FF1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FF28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FF34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FF40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FF4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FEE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FEEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FEF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FF04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FF10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FF1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FF28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FF34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FF40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FF4C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 867FF58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FF64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FF70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FF7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FF88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FF94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FFA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FFAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FF64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FF70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FF7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FF88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FF94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FFA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FFAC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 867FFB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FFC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FFD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FFDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FFC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FFD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FFDC
 	voice_keysplit voicegroup009, KeySplitTable5  @ 867FFE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 867FFF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868000C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680030
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868003C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868006C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 867FFF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868000C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868003C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868006C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680078
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 8680084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868009C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86800A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86800B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86800C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86800CC
-	voice_square_1_alt 0, 2, 0, 2, 4, 0  @ 86800D8
-	voice_square_2_alt 1, 0, 2, 4, 0  @ 86800E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86800F0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 86800FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868012C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868015C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868018C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86801A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86801B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86801BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86801C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86801D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86801E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86801EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86801F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868021C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680234
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868024C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680258
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868027C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86802A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86802AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86802B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86802C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86802D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86802DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86802E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86802F4
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8680300
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868030C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868009C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86800A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86800B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86800C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86800CC
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 4, 0  @ 86800D8
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 0  @ 86800E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86800F0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 86800FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868012C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868015C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868018C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86801A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86801B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86801BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86801C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86801D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86801E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86801EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86801F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868021C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868024C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868027C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86802A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86802AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86802B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86802C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86802D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86802DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86802E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86802F4
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8680300
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868030C
 

--- a/sound/voicegroups/voicegroup043.inc
+++ b/sound/voicegroups/voicegroup043.inc
@@ -1,84 +1,84 @@
 	.align 2
 voicegroup043:: @ 8680318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680318
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8680324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868033C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868036C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868039C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86803A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86803B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86803C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86803CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86803D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86803E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86803F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86803FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868042C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868045C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680468
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868048C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868033C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868036C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868039C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86803A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86803B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86803C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86803CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86803D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86803E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86803F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86803FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868042C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868045C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868048C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 149  @ 8680498
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86804A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86804B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86804BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86804C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86804D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86804E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86804EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86804F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680510
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868051C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868054C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86804A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86804B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86804BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86804C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86804D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86804E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86804EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86804F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868051C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868054C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8680558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868057C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86805A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86805AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86805B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86805C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868057C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86805A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86805AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86805B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86805C4
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86805D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86805DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86805E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86805F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868060C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680618
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680630
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868063C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868066C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86805DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86805E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86805F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868060C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868063C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868066C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680678
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 8680684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868069C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86806A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86806B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86806C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86806CC
-	voice_square_2_alt 1, 0, 2, 4, 0  @ 86806D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868069C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86806A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86806B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86806C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86806CC
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 0  @ 86806D8
 

--- a/sound/voicegroups/voicegroup044.inc
+++ b/sound/voicegroups/voicegroup044.inc
@@ -1,84 +1,84 @@
 	.align 2
 voicegroup044:: @ 86806E4
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86806E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86806F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86806FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680708
-	voice_square_1_alt 0, 2, 0, 5, 1, 7  @ 8680714
-	voice_square_2_alt 3, 0, 4, 3, 6  @ 8680720
-	voice_square_2_alt 2, 1, 1, 4, 0  @ 868072C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868075C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868078C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86807A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86807B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86807BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86807C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86807D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86807E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86807EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86807F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868081C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680828
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868084C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868087C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86806F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86806FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680708
+	voice_square_1_alt 60, 0, 0, 2, 0, 5, 1, 7  @ 8680714
+	voice_square_2_alt 60, 0, 3, 0, 4, 3, 6  @ 8680720
+	voice_square_2_alt 60, 0, 2, 1, 1, 4, 0  @ 868072C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868075C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868078C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86807A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86807B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86807BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86807C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86807D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86807E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86807EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86807F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868081C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868084C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868087C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 224  @ 8680888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86808A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86808AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86808B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86808C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86808D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86808DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86808E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86808F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86808A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86808AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86808B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86808C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86808D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86808DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86808E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86808F4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 38  @ 8680900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868090C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868090C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680918
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8680924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868093C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868096C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868099C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86809A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86809B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86809C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86809CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86809D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86809E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86809F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86809FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680A08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680A14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680A20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680A2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680A38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868093C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868096C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868099C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86809A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86809B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86809C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86809CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86809D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86809E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86809F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86809FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680A44
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 8680A50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680A5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680A68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680A74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680A80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680A8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680A98
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 8680AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680A5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680A74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680A98
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 8680AA4
 

--- a/sound/voicegroups/voicegroup045.inc
+++ b/sound/voicegroups/voicegroup045.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup045:: @ 8680AB0
 	voice_keysplit_all voicegroup001  @ 8680AB0
-	voice_square_1_alt 0, 1, 0, 2, 0, 1  @ 8680ABC
-	voice_square_1_alt 0, 3, 1, 2, 6, 0  @ 8680AC8
-	voice_square_2_alt 3, 1, 2, 6, 0  @ 8680AD4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 8680AE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680AEC
-	voice_square_2_alt 1, 0, 2, 0, 1  @ 8680AF8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4860, 1, 7, 15, 1  @ 8680B04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680B10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680B1C
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 0, 1  @ 8680ABC
+	voice_square_1_alt 60, 0, 0, 3, 1, 2, 6, 0  @ 8680AC8
+	voice_square_2_alt 60, 0, 3, 1, 2, 6, 0  @ 8680AD4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 8680AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680AEC
+	voice_square_2_alt 60, 0, 1, 0, 2, 0, 1  @ 8680AF8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4860, 1, 7, 15, 1  @ 8680B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680B1C
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8680B28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680B34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680B40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680B4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680B58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680B64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680B64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680B70
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 8680B7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680B88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680B94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680BA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680BAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680BB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680BC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680BD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680BDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680BE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680BF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680C00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680C0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680C18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680C24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680C30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680C3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680C48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680C54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680C60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680B94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680BB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680BC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680BDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680BE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680BF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680C00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680C18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680C30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680C3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680C48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680C54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680C60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680C6C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 216  @ 8680C78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680C84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680C90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680C9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680CA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680CB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680CC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680CCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680CD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680C84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680C90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680CA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680CB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680CE4
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8680CF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680CFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680D08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680D14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680D20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680D2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680D38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680D44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680D50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680D5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680D68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680D74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680D80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680D8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680D98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680DA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680DB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680DBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680DC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680DD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680DE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680DEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680DF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680E04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680D14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680D98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680DF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680E10
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 8680E1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680E28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680E34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680E40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680E4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680E58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680E64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680E70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680E7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680E88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680E94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680EA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680EAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680EB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680EC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680ED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680EDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680EE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680EF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680F00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680F0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680F18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680F24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680F30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680F3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680F48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680F54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680F60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680F6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680F78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680F84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680F90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680F9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680FA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680FB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680FC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680FCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680FD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680FE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680FF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8680FFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868102C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868105C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868108C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681098
-	voice_noise_alt 0, 0, 1, 0, 0  @ 86810A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680E28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680E34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680E4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680E58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680E7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680E88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680EA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680EF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680F00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680F18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680F30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680F60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680F6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680F78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680F90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680FB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680FC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680FCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680FF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8680FFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868102C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868105C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868108C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681098
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 86810A4
 

--- a/sound/voicegroups/voicegroup046.inc
+++ b/sound/voicegroups/voicegroup046.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup046:: @ 86810B0
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86810B0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4900, 0, 1, 12, 0  @ 86810BC
-	voice_square_1_alt 0, 0, 1, 1, 9, 0  @ 86810C8
-	voice_square_2_alt 2, 0, 2, 6, 3  @ 86810D4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 1  @ 86810E0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4900, 0, 1, 12, 0  @ 86810BC
+	voice_square_1_alt 60, 0, 0, 0, 1, 1, 9, 0  @ 86810C8
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 3  @ 86810D4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 1  @ 86810E0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 216  @ 86810EC
-	voice_square_2_alt 1, 0, 2, 6, 3  @ 86810F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868111C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868114C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868117C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86811A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86811AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86811B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86811C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86811D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86811DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86811E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86811F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868120C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868123C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868126C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868129C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86812A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86812B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86812C0
+	voice_square_2_alt 60, 0, 1, 0, 2, 6, 3  @ 86810F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868111C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868114C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868117C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86811A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86811AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86811B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86811C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86811D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86811DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86811E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86811F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868120C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868123C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868126C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868129C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86812A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86812B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86812C0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 165  @ 86812CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86812D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86812E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86812D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86812E4
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86812F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86812FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868132C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868135C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868138C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86813A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86813B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86813BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86813C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86813D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86813E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86813EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86813F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86812FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868132C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868135C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868138C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86813A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86813B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86813BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86813C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86813D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86813E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86813EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86813F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681410
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 868141C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681428
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868144C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681458
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681470
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868147C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86814A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86814AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86814B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86814C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86814D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86814DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86814E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86814F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868150C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868153C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868156C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868159C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86815A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86815B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86815C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86815CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86815D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86815E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86815F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86815FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868162C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868165C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868168C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681698
-	voice_noise_alt 0, 0, 1, 0, 0  @ 86816A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868144C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868147C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86814A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86814AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86814B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86814C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86814D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86814DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86814E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86814F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868150C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868153C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868156C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868159C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86815A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86815B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86815C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86815CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86815D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86815E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86815F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86815FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868162C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868165C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868168C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681698
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 86816A4
 

--- a/sound/voicegroups/voicegroup047.inc
+++ b/sound/voicegroups/voicegroup047.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup047:: @ 86816B0
 	voice_keysplit_all voicegroup001  @ 86816B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86816BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86816C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86816D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86816E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86816EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86816F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868171C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868174C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868177C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681788
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86817A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86817AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86817B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86817C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86817D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86817DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86817E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86817F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868180C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681830
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868183C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681848
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868186C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86816BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86816C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86816D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86816E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86816EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86816F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868171C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868174C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868177C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86817A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86817AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86817B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86817C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86817D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86817DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86817E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86817F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868180C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868183C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868186C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8681878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868189C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86818A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86818B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86818C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86818CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868189C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86818A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86818B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86818C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86818CC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 204  @ 86818D8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 204, 193, 239  @ 86818E4
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86818F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86818FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868192C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681938
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86818FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868192C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681944
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8681950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868195C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868195C
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8681968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681974
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8681980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868198C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86819A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86819B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86819BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86819C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86819D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86819E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86819EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86819F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681A04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681A10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681A1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681A28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681A34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681A40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681A4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681A58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681A64
-	voice_square_2_alt 2, 0, 1, 6, 2  @ 8681A70
-	voice_programmable_wave_alt ProgrammableWaveData_86B4920, 0, 7, 15, 0  @ 8681A7C
-	voice_square_2_alt 3, 0, 1, 4, 1  @ 8681A88
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 1, 7, 15, 2  @ 8681A94
-	voice_square_2_alt 1, 1, 1, 4, 1  @ 8681AA0
-	voice_square_1_alt 0, 1, 1, 2, 4, 1  @ 8681AAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681AB8
-	voice_square_2_alt 2, 0, 1, 6, 1  @ 8681AC4
-	voice_square_1_alt 0, 2, 0, 1, 6, 1  @ 8681AD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681ADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681AE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681AF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681B00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681B0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681B18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681B24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681B30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681B3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681B48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681B54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681B60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681B6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681B78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681B84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681B90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681B9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681BA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681BB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681BC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681BCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681BD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681BE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681BF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681BFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681C08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681C14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681C20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681C2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681C38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681C44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681C50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681C5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681C68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681C74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681C80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681C8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681C98
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8681CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868198C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86819A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86819B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86819BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86819C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86819D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86819E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86819EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86819F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681A1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681A34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681A40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681A4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681A58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681A64
+	voice_square_2_alt 60, 0, 2, 0, 1, 6, 2  @ 8681A70
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4920, 0, 7, 15, 0  @ 8681A7C
+	voice_square_2_alt 60, 0, 3, 0, 1, 4, 1  @ 8681A88
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 1, 7, 15, 2  @ 8681A94
+	voice_square_2_alt 60, 0, 1, 1, 1, 4, 1  @ 8681AA0
+	voice_square_1_alt 60, 0, 0, 1, 1, 2, 4, 1  @ 8681AAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681AB8
+	voice_square_2_alt 60, 0, 2, 0, 1, 6, 1  @ 8681AC4
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 6, 1  @ 8681AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681ADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681AF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681B18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681B30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681B3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681B60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681B6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681B90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681B9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681BA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681BB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681BC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681BE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681BFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681C08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681C14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681C20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681C2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681C38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681C44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681C50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681C5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681C68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681C74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681C80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681C98
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8681CA4
 

--- a/sound/voicegroups/voicegroup048.inc
+++ b/sound/voicegroups/voicegroup048.inc
@@ -1,91 +1,91 @@
 	.align 2
 voicegroup048:: @ 8681CB0
 	voice_keysplit_all voicegroup001  @ 8681CB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681CBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681CC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681CD4
-	voice_square_1_alt 0, 2, 0, 7, 3, 3  @ 8681CE0
-	voice_square_1_alt 0, 2, 0, 1, 4, 1  @ 8681CEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681CF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681D04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681CBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681CD4
+	voice_square_1_alt 60, 0, 0, 2, 0, 7, 3, 3  @ 8681CE0
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1  @ 8681CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681D10
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 204, 51, 242  @ 8681D1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681D28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681D34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681D40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681D4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681D58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681D64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681D70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681D7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681D88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681D94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681DA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681DAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681DB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681DC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681DD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681DDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681DE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681DF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681E00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681E0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681E18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681E24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681E30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681E3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681E48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681E54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681E60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681E6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681E78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681E84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681E90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681E9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681EA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681EB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681EC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681DDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681DE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681E24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681E30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681E3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681E48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681E54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681E60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681ECC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 242  @ 8681ED8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 193, 239  @ 8681EE4
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8681EF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681EFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681F08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681F14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681F20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681F2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681F38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681F44
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8681F50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681F5C
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8681F68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681F74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681F74
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8681F80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681F8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681F98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681FA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681FB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681FBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681FC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681FD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681FE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681FEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8681FF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682010
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 868201C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868204C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682058
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682064
-	voice_square_2_alt 3, 0, 4, 4, 0  @ 8682070
-	voice_square_1_alt 0, 3, 0, 3, 6, 0  @ 868207C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682088
-	voice_square_1_alt 0, 0, 0, 3, 3, 0  @ 8682094
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 12, 1  @ 86820A0
-	voice_square_2_alt 1, 0, 1, 4, 3  @ 86820AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86820B8
-	voice_square_2_alt 0, 0, 2, 4, 0  @ 86820C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681FA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681FB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681FBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8681FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682010
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 868201C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868204C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682064
+	voice_square_2_alt 60, 0, 3, 0, 4, 4, 0  @ 8682070
+	voice_square_1_alt 60, 0, 0, 3, 0, 3, 6, 0  @ 868207C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682088
+	voice_square_1_alt 60, 0, 0, 0, 0, 3, 3, 0  @ 8682094
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 12, 1  @ 86820A0
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 3  @ 86820AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86820B8
+	voice_square_2_alt 60, 0, 0, 0, 2, 4, 0  @ 86820C4
 

--- a/sound/voicegroups/voicegroup049.inc
+++ b/sound/voicegroups/voicegroup049.inc
@@ -2,130 +2,130 @@
 voicegroup049:: @ 86820D0
 	voice_keysplit_all voicegroup001  @ 86820D0
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86820DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86820E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86820F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868210C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86820E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86820F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868210C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682130
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 165, 51, 242  @ 868213C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868216C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682190
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868219C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86821A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86821B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86821C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86821CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86821D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86821E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86821F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86821FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868222C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868225C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868216C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868219C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86821A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86821B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86821C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86821CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86821D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86821E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86821F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86821FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868222C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868225C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682268
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 8682274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868228C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86822A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86822B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86822BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86822C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86822D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86822E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868228C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86822A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86822B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86822BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86822C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86822D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86822E0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 38  @ 86822EC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 242  @ 86822F8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 193, 226  @ 8682304
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8682310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868231C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868234C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868231C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868234C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682364
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8682370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868237C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868237C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682394
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86823A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86823AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86823B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86823C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86823D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86823DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86823E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86823F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868240C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86823AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86823B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86823C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86823D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86823DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86823E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86823F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868240C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682430
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 868243C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868246C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682484
-	voice_square_1_alt 0, 2, 0, 2, 4, 1  @ 8682490
-	voice_square_2_alt 1, 1, 3, 4, 2  @ 868249C
-	voice_square_1_alt 0, 3, 0, 1, 4, 1  @ 86824A8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 1, 7, 15, 0  @ 86824B4
-	voice_square_2_alt 2, 0, 2, 4, 2  @ 86824C0
-	voice_square_2_alt 1, 1, 3, 4, 2  @ 86824CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86824D8
-	voice_square_1_alt 0, 2, 1, 4, 4, 2  @ 86824E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86824F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86824FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868252C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868255C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868258C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86825A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86825B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86825BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86825C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86825D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86825E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86825EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86825F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868261C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868264C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868267C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86826A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86826AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86826B8
-	voice_noise_alt 0, 0, 1, 0, 0  @ 86826C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868246C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682484
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 4, 1  @ 8682490
+	voice_square_2_alt 60, 0, 1, 1, 3, 4, 2  @ 868249C
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 4, 1  @ 86824A8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 1, 7, 15, 0  @ 86824B4
+	voice_square_2_alt 60, 0, 2, 0, 2, 4, 2  @ 86824C0
+	voice_square_2_alt 60, 0, 1, 1, 3, 4, 2  @ 86824CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86824D8
+	voice_square_1_alt 60, 0, 0, 2, 1, 4, 4, 2  @ 86824E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86824F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86824FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868252C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868255C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868258C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86825A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86825B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86825BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86825C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86825D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86825E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86825EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86825F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868261C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868264C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868267C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86826A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86826AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86826B8
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 86826C4
 

--- a/sound/voicegroups/voicegroup050.inc
+++ b/sound/voicegroups/voicegroup050.inc
@@ -2,130 +2,130 @@
 voicegroup050:: @ 86826D0
 	voice_keysplit_all voicegroup001  @ 86826D0
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86826DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86826E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86826F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868270C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868273C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868276C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86826E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86826F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868270C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868273C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868276C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682790
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 868279C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86827A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86827B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86827C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86827CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86827D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86827E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86827F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86827FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682808
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868282C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682850
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868285C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86827A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86827B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86827C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86827CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86827D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86827E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86827F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86827FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868282C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868285C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682868
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 8682874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868288C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682898
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86828A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86828B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86828BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86828C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86828D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86828E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86828EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868288C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86828A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86828B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86828BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86828C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86828D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86828E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86828EC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 242  @ 86828F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868291C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868294C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868297C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86829A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86829AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86829B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86829C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86829D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86829DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86829E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86829F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682A00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682A0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682A18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682A24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682A30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682A3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682A48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682A54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682A60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682A6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682A78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682A84
-	voice_square_2_alt 3, 0, 1, 4, 1  @ 8682A90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682A9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682AA8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 8682AB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682AC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682ACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682AD8
-	voice_square_1_alt 0, 1, 0, 2, 4, 1  @ 8682AE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682AF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682AFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682B08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682B14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682B20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682B2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682B38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682B44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682B50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682B5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682B68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682B74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682B80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682B8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682B98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682BA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682BB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682BBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682BC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682BD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682BE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682BEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682BF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682C04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682C10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682C1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682C28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682C34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682C40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682C4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682C58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682C64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682C70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682C7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682C88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682C94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682CA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682CAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682CB8
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8682CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868291C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868294C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868297C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86829A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86829AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86829B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86829C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86829D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86829DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86829E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86829F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682A24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682A30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682A3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682A48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682A54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682A6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682A84
+	voice_square_2_alt 60, 0, 3, 0, 1, 4, 1  @ 8682A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682AA8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 8682AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682AD8
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 4, 1  @ 8682AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682C58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682C70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682C7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682C88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682CA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682CB8
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8682CC4
 

--- a/sound/voicegroups/voicegroup051.inc
+++ b/sound/voicegroups/voicegroup051.inc
@@ -2,76 +2,76 @@
 voicegroup051:: @ 8682CD0
 	voice_keysplit_all voicegroup001  @ 8682CD0
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8682CDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682CE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682CF4
-	voice_square_2_alt 2, 1, 4, 4, 2  @ 8682D00
-	voice_square_1_alt 0, 2, 0, 3, 4, 1  @ 8682D0C
-	voice_square_2_alt 2, 1, 3, 4, 2  @ 8682D18
-	voice_square_1_alt 0, 2, 0, 3, 4, 1  @ 8682D24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682D30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682D3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682D48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682D54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682D60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682D6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682D78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682D84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682D90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682D9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682DA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682DB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682DC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682DCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682DD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682DE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682DF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682DFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682E08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682E14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682E20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682E2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682E38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682E44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682E50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682E5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682CF4
+	voice_square_2_alt 60, 0, 2, 1, 4, 4, 2  @ 8682D00
+	voice_square_1_alt 60, 0, 0, 2, 0, 3, 4, 1  @ 8682D0C
+	voice_square_2_alt 60, 0, 2, 1, 3, 4, 2  @ 8682D18
+	voice_square_1_alt 60, 0, 0, 2, 0, 3, 4, 1  @ 8682D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682E2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682E44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682E50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682E5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682E68
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 8682E74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682E80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682E8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682E98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682EA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682EB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682EBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682EC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682ED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682E80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682EA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682EBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682EE0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 99  @ 8682EEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682EF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682F04
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8682F10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682F1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682F28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682F34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682F40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682F4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682F58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682F64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682F70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682F7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682F88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682F94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682FA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682FAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682FB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682FC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682FD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682FDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682FE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8682FF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868300C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682F34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682F40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682F64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682F88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8682FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868300C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683030
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 868303C
 

--- a/sound/voicegroups/voicegroup052.inc
+++ b/sound/voicegroups/voicegroup052.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup052:: @ 8683048
 	voice_keysplit_all voicegroup001  @ 8683048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683054
-	voice_square_1 0, 3, 1, 2, 6, 0  @ 8683060
-	voice_square_2 3, 1, 2, 6, 0  @ 868306C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868309C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86830A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86830B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86830C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86830CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86830D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86830E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86830F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86830FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868312C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868315C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868318C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683198
-	voice_programmable_wave_alt ProgrammableWaveData_86B4860, 0, 7, 15, 0  @ 86831A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86831B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86831BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86831C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86831D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86831E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86831EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86831F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868321C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683234
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868324C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683258
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683054
+	voice_square_1 60, 0, 0, 3, 1, 2, 6, 0  @ 8683060
+	voice_square_2 60, 0, 3, 1, 2, 6, 0  @ 868306C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868309C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86830A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86830B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86830C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86830CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86830D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86830E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86830F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86830FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868312C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868315C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868318C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683198
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4860, 0, 7, 15, 0  @ 86831A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86831B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86831BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86831C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86831D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86831E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86831EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86831F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868321C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868324C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683270
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 193, 226  @ 868327C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8683288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86832A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86832AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86832B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86832C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86832D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86832DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86832A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86832AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86832B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86832C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86832D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86832DC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86832E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86832F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86832F4
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8683300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868330C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868330C
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8683318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868333C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868336C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868339C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86833A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86833B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86833C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86833CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86833D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86833E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86833F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86833FC
-	voice_square_2_alt 1, 0, 1, 6, 1  @ 8683408
-	voice_square_1_alt 0, 0, 0, 1, 7, 1  @ 8683414
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 1  @ 8683420
-	voice_square_2_alt 0, 0, 1, 4, 2  @ 868342C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 8683438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683450
-	voice_square_1_alt 0, 1, 0, 7, 6, 1  @ 868345C
-	voice_square_2_alt 2, 0, 1, 6, 1  @ 8683468
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868348C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683498
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86834A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86834B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86834BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86834C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86834D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86834E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86834EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86834F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683510
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868351C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868354C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868357C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86835A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86835AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86835B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86835C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86835D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86835DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86835E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86835F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868360C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683618
-	voice_noise_alt 0, 0, 1, 9, 4  @ 8683624
-	voice_noise_alt 0, 3, 1, 10, 0  @ 8683630
-	voice_noise_alt 0, 0, 2, 0, 0  @ 868363C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868333C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868336C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868339C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86833A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86833B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86833C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86833CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86833D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86833E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86833F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86833FC
+	voice_square_2_alt 60, 0, 1, 0, 1, 6, 1  @ 8683408
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 7, 1  @ 8683414
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 1  @ 8683420
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 2  @ 868342C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 8683438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683450
+	voice_square_1_alt 60, 0, 0, 1, 0, 7, 6, 1  @ 868345C
+	voice_square_2_alt 60, 0, 2, 0, 1, 6, 1  @ 8683468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868348C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86834A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86834B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86834BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86834C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86834D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86834E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86834EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86834F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868351C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868354C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868357C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86835A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86835AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86835B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86835C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86835D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86835DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86835E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86835F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868360C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683618
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 4  @ 8683624
+	voice_noise_alt 60, 0, 0, 3, 1, 10, 0  @ 8683630
+	voice_noise_alt 60, 0, 0, 0, 2, 0, 0  @ 868363C
 

--- a/sound/voicegroups/voicegroup053.inc
+++ b/sound/voicegroups/voicegroup053.inc
@@ -2,130 +2,130 @@
 voicegroup053:: @ 8683648
 	voice_keysplit_all voicegroup001  @ 8683648
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8683654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868366C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868369C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86836A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86836B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86836C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86836CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86836D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86836E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86836F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86836FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868372C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868375C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868378C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86837A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86837B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86837BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86837C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86837D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86837E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868366C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868369C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86836A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86836B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86836C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86836CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86836D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86836E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86836F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86836FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868372C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868375C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868378C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86837A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86837B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86837BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86837C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86837D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86837E0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 86837EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86837F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868381C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683828
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868384C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86837F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868381C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868384C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683858
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 38  @ 8683864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868387C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868387C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8683888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86838A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86838AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86838B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86838C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86838D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86838DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86838E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86838F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868390C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868393C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868396C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868399C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86839A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86838A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86838AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86838B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86838C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86838D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86838DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86838E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86838F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868390C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868393C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868396C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868399C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86839A8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 86839B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86839C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86839CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86839D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86839E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86839F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86839FC
-	voice_square_2_alt 2, 0, 1, 4, 2  @ 8683A08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683A14
-	voice_square_1_alt 0, 3, 0, 1, 4, 1  @ 8683A20
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 12, 0  @ 8683A2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683A38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683A44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683A50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683A5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683A68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683A74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683A80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683A8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683A98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683AA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683AB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683ABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683AC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683AD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683AE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683AEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683AF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683B04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683B10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683B1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683B28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683B34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683B40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683B4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683B58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683B64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683B70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683B7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683B88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683B94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683BA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683BAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683BB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683BC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683BD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683BDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683BE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683BF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683C00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683C0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683C18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683C24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683C30
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8683C3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86839C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86839CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86839D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86839E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86839F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86839FC
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 2  @ 8683A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683A14
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 4, 1  @ 8683A20
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 12, 0  @ 8683A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683A50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683A5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683A74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683B64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683B94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683BB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683BC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683BDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683BE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683BF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683C00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683C18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683C30
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8683C3C
 

--- a/sound/voicegroups/voicegroup054.inc
+++ b/sound/voicegroups/voicegroup054.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup054:: @ 8683C48
 	voice_keysplit_all voicegroup001  @ 8683C48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683C54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683C60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683C6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683C78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683C84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683C90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683C9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683CA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683CB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683CC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683CCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683CD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683CE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683CF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683CFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683D08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683D14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683D20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683D2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683D38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683D44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683D50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683D5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683D68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683D74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683D80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683D8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683D98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683DA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683DB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683DBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683DC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683DD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683DE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683DEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683DF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683E04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683E10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683E1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683E28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683E34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683E40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683E4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683E58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683C54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683C60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683C78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683C84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683C90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683CA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683CB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683CF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683D14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683D98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683DF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683E28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683E34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683E4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683E58
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 38  @ 8683E64
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 242  @ 8683E70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683E7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683E7C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8683E88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683E94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683EA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683EAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683EB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683EC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683ED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683EDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683EE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683EF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683EA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683EF4
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8683F00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683F0C
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8683F18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683F24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683F30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683F3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683F48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683F54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683F60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683F6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683F78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683F84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683F90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683F9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683F30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683F60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683F6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683F78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683F90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683FA8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 8683FB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683FC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683FCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683FD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683FE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683FF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8683FFC
-	voice_square_2_alt 2, 0, 1, 5, 2  @ 8684008
-	voice_square_1_alt 0, 3, 0, 1, 4, 1  @ 8684014
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 8684020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868402C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868405C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868408C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86840A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86840B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86840BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86840C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86840D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86840E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86840EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86840F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868411C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868414C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868417C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86841A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86841AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86841B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86841C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86841D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86841DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86841E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86841F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868420C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684230
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868423C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683FC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683FCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683FF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8683FFC
+	voice_square_2_alt 60, 0, 2, 0, 1, 5, 2  @ 8684008
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 4, 1  @ 8684014
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 8684020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868402C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868405C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868408C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86840A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86840B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86840BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86840C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86840D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86840E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86840EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86840F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868411C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868414C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868417C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86841A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86841AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86841B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86841C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86841D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86841DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86841E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86841F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868420C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684230
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868423C
 

--- a/sound/voicegroups/voicegroup055.inc
+++ b/sound/voicegroups/voicegroup055.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup055:: @ 8684248
 	voice_keysplit_all voicegroup001  @ 8684248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868426C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868429C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86842A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86842B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86842C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86842CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86842D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86842E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86842F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86842FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868432C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868435C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868438C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86843A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86843B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86843BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86843C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86843D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86843E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86843EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86843F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868426C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868429C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86842A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86842B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86842C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86842CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86842D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86842E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86842F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86842FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868432C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868435C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868438C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86843A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86843B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86843BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86843C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86843D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86843E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86843EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86843F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684404
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8684410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868441C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684428
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868444C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684458
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868441C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868444C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684464
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 204  @ 8684470
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 204, 193, 239  @ 868447C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8684488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86844A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86844AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86844B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86844C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86844D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86844DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86844A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86844AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86844B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86844C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86844D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86844DC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86844E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86844F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86844F4
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8684500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868450C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868450C
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8684518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868453C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868456C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868459C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86845A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86845B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86845C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86845CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86845D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86845E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86845F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86845FC
-	voice_square_2_alt 2, 0, 1, 4, 1  @ 8684608
-	voice_square_1_alt 0, 3, 0, 1, 6, 0  @ 8684614
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8684620
-	voice_programmable_wave_alt ProgrammableWaveData_86B4860, 0, 7, 15, 2  @ 868462C
-	voice_square_2_alt 1, 1, 1, 4, 1  @ 8684638
-	voice_square_1_alt 0, 1, 0, 1, 4, 2  @ 8684644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684650
-	voice_square_2_alt 2, 0, 1, 6, 1  @ 868465C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868468C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86846A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86846B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86846BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86846C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86846D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86846E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86846EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86846F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868471C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868474C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868477C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684788
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86847A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86847AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86847B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86847C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86847D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86847DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86847E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86847F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868480C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684830
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868483C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868453C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868456C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868459C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86845A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86845B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86845C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86845CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86845D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86845E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86845F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86845FC
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 1  @ 8684608
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 6, 0  @ 8684614
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8684620
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4860, 0, 7, 15, 2  @ 868462C
+	voice_square_2_alt 60, 0, 1, 1, 1, 4, 1  @ 8684638
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 2  @ 8684644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684650
+	voice_square_2_alt 60, 0, 2, 0, 1, 6, 1  @ 868465C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868468C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86846A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86846B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86846BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86846C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86846D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86846E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86846EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86846F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868471C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868474C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868477C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86847A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86847AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86847B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86847C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86847D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86847DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86847E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86847F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868480C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684830
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868483C
 

--- a/sound/voicegroups/voicegroup056.inc
+++ b/sound/voicegroups/voicegroup056.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup056:: @ 8684848
 	voice_keysplit_all voicegroup001  @ 8684848
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868486C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868489C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86848A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86848B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86848C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86848CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86848D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86848E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86848F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86848FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868492C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684938
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868495C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868498C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86849A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86849B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86849BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86849C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86849D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86849E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86849EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86849F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868486C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868489C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86848A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86848B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86848C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86848CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86848D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86848E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86848F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86848FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868492C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868495C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868498C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86849A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86849B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86849BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86849C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86849D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86849E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86849EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86849F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684A04
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8684A10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684A1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684A28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684A34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684A40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684A4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684A58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684A64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684A70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684A7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684A1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684A34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684A40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684A4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684A58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684A64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684A70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684A7C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8684A88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684A94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684AA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684AAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684AB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684AC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684AD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684ADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684AE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684AF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684B00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684A94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684AA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684AAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684AB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684AC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684ADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684AF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684B0C
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8684B18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684B24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684B30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684B3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684B48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684B54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684B60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684B6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684B78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684B84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684B90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684B9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684BA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684B30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684B3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684B60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684B6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684B90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684B9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684BA8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 8684BB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684BC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684BCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684BD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684BE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684BF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684BFC
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 8684C08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684C14
-	voice_square_1_alt 0, 0, 0, 1, 4, 1  @ 8684C20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684C2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684C38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684C44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684C50
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 8684C5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684C68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684C74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684C80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684C8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684C98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684CA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684CB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684CBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684CC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684CD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684CE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684CEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684CF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684D04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684D10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684D1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684D28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684D34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684D40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684D4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684D58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684D64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684D70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684D7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684D88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684D94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684DA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684DAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684DB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684DC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684DD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684DDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684DE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684DF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684E00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684E0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684E18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684E24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684E30
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8684E3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684BC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684BE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684BFC
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 8684C08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684C14
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1  @ 8684C20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684C2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684C38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684C44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684C50
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 8684C5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684C68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684C74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684C80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684C98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684CBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684DDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684DE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684E24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684E30
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8684E3C
 

--- a/sound/voicegroups/voicegroup057.inc
+++ b/sound/voicegroups/voicegroup057.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup057:: @ 8684E48
 	voice_keysplit_all voicegroup001  @ 8684E48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684E54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684E60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684E6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684E78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684E84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684E90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684E9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684E54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684E60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684EA8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 188, 51, 242  @ 8684EB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684EC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684ECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684ED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684EE4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 128, 165, 90, 216  @ 8684EF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684EFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684F08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684F14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684F20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684F2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684F38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684F44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684F50
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_bubbles, 255, 0, 255, 127  @ 8684F5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684F68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684F74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684F80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684F8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684F98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684FA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684FB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684FBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684FC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684FD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684F74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684FA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684FB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684FBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684FE0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 8684FEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8684FF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868501C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868504C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8684FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868501C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868504C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685058
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 38  @ 8685064
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 242  @ 8685070
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 193, 226  @ 868507C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8685088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86850A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86850AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86850B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86850C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86850D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86850DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86850E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86850F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868510C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868513C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868516C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685190
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868519C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86851A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86850A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86850AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86850B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86850C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86850D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86850DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86850E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86850F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868510C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868513C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868516C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868519C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86851A8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 86851B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86851C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86851CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86851D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86851E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86851F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86851FC
-	voice_square_1_alt 0, 2, 0, 1, 4, 1  @ 8685208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685214
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 1, 4, 10, 1  @ 8685220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868522C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868525C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685268
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868528C
-	voice_square_2_alt 2, 1, 5, 9, 1  @ 8685298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86852A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86852B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86852BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86852C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86852D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86852E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86852EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86852F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868531C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868534C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868537C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86853A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86853AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86853B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86853C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86853D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86853DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86853E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86853F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868540C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685424
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8685430
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868543C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86851C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86851CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86851D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86851E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86851F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86851FC
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1  @ 8685208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685214
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 1, 4, 10, 1  @ 8685220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868522C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868525C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868528C
+	voice_square_2_alt 60, 0, 2, 1, 5, 9, 1  @ 8685298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86852A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86852B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86852BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86852C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86852D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86852E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86852EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86852F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868531C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868534C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868537C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86853A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86853AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86853B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86853C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86853D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86853DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86853E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86853F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868540C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685424
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8685430
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868543C
 

--- a/sound/voicegroups/voicegroup058.inc
+++ b/sound/voicegroups/voicegroup058.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup058:: @ 8685448
 	voice_keysplit_all voicegroup001  @ 8685448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868546C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868549C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86854A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86854B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86854C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86854CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86854D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86854E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86854F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86854FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868546C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868549C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86854A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86854B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86854C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86854CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86854D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86854E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86854F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86854FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685508
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 8685514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868552C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868555C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868558C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86855A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86855B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86855BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86855C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86855D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86855E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868552C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868555C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868558C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86855A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86855B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86855BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86855C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86855D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86855E0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 86855EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86855F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868561C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868564C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868567C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86856A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86856AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86856B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86856C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86856D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86856DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86855F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868561C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868564C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868567C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86856A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86856AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86856B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86856C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86856D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86856DC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86856E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86856F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86856F4
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8685700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868570C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868573C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868576C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685790
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868579C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86857A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86857B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86857C0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 86857CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86857D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86857E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86857F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86857FC
-	voice_square_1_alt 0, 2, 0, 1, 4, 1  @ 8685808
-	voice_square_2_alt 2, 0, 1, 4, 1  @ 8685814
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 8685820
-	voice_square_1_alt 0, 0, 0, 1, 4, 1  @ 868582C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685850
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868585C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685868
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868588C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685898
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86858A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86858B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86858BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86858C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86858D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86858E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86858EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86858F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868591C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868594C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868597C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86859A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86859AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86859B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86859C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86859D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86859DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86859E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86859F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685A00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685A0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685A18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685A24
-	voice_noise_alt 0, 0, 2, 4, 0  @ 8685A30
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8685A3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868570C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868573C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868576C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868579C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86857A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86857B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86857C0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 86857CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86857D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86857E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86857F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86857FC
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1  @ 8685808
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 1  @ 8685814
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 8685820
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1  @ 868582C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868585C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868588C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86858A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86858B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86858BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86858C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86858D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86858E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86858EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86858F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868591C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868594C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868597C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86859A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86859AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86859B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86859C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86859D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86859DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86859E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86859F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685A24
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0  @ 8685A30
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8685A3C
 

--- a/sound/voicegroups/voicegroup059.inc
+++ b/sound/voicegroups/voicegroup059.inc
@@ -2,91 +2,91 @@
 voicegroup059:: @ 8685A48
 	voice_keysplit_all voicegroup001  @ 8685A48
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8685A54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685A60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685A6C
-	voice_square_2_alt 1, 1, 1, 6, 2  @ 8685A78
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 8685A84
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 8685A90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685A9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685A6C
+	voice_square_2_alt 60, 0, 1, 1, 1, 6, 2  @ 8685A78
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 8685A84
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 8685A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685AA8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 165, 51, 242  @ 8685AB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685AC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685ACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685AD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685AE4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 8685AF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685AFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685B08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685B14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685B20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685B2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685B38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685B44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685B50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685B5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685B68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685B74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685B80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685B8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685B98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685BA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685BB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685BBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685BC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685BD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685BE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685BEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685BF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685C04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685C10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685C1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685C28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685C34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685C40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685C4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685C58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685C58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685C64
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 8685C70
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 239  @ 8685C7C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8685C88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685C94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685CA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685CAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685CB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685CC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685CD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685CA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685CDC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8685CE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685CF4
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8685D00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685D0C
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8685D18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685D24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685D30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685D3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685D48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685D54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685D60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685D6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685D78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685D84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685D90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685D9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685DA8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 8685DB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685DC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685DCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685DD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685DE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685DF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685DFC
-	voice_square_1_alt 0, 2, 0, 1, 6, 2  @ 8685E08
-	voice_square_2_alt 2, 0, 1, 6, 0  @ 8685E14
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8685E20
-	voice_square_1_alt 0, 1, 0, 1, 4, 1  @ 8685E2C
-	voice_square_1_alt 0, 1, 1, 2, 4, 0  @ 8685E38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685E44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685E50
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8685E5C
-	voice_square_2_alt 3, 0, 1, 6, 2  @ 8685E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685DFC
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 6, 2  @ 8685E08
+	voice_square_2_alt 60, 0, 2, 0, 1, 6, 0  @ 8685E14
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8685E20
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 1  @ 8685E2C
+	voice_square_1_alt 60, 0, 0, 1, 1, 2, 4, 0  @ 8685E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685E44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685E50
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8685E5C
+	voice_square_2_alt 60, 0, 3, 0, 1, 6, 2  @ 8685E68
 

--- a/sound/voicegroups/voicegroup060.inc
+++ b/sound/voicegroups/voicegroup060.inc
@@ -2,130 +2,130 @@
 voicegroup060:: @ 8685E74
 	voice_keysplit_all voicegroup001  @ 8685E74
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8685E80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685E8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685E98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685EA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685EB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685EBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685EC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685ED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685EE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685EEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685EF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685EA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685EBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685EEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685F04
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 8685F10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685F1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685F28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685F34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685F40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685F4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685F58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685F64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685F70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685F7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685F88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685F94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685FA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685FAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685FB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685FC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685FD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685FDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685FE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8685FF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868600C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686030
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868603C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868606C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685F34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685F40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685F64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685F88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8685FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868600C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868603C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868606C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686084
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 128, 226, 0, 38  @ 8686090
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 868609C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 86860A8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86860B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86860C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86860CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86860D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86860E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86860F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86860FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86860C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86860CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86860D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86860E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86860F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86860FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686108
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8686114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686120
 	voice_keysplit voicegroup008, KeySplitTable4  @ 868612C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686138
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8686144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868615C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868618C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86861A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86861B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86861BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86861C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86861D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868615C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868618C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86861A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86861B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86861BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86861C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86861D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 86861E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86861EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86861F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868621C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686228
-	voice_square_2_alt 1, 1, 1, 6, 1  @ 8686234
-	voice_square_1_alt 0, 1, 0, 4, 4, 1  @ 8686240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868624C
-	voice_square_2_alt 2, 0, 7, 3, 3  @ 8686258
-	voice_square_1_alt 0, 2, 0, 7, 3, 3  @ 8686264
-	voice_square_1_alt 0, 3, 2, 2, 7, 0  @ 8686270
-	voice_square_2_alt 1, 1, 2, 3, 0  @ 868627C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86862A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86862AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86862B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86862C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86862D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86862DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86862E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86862F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868630C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868633C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868636C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868639C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86863A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86863B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86863C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86863CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86863D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86863E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86863F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86863FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868642C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868645C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8686468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86861EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86861F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868621C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686228
+	voice_square_2_alt 60, 0, 1, 1, 1, 6, 1  @ 8686234
+	voice_square_1_alt 60, 0, 0, 1, 0, 4, 4, 1  @ 8686240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868624C
+	voice_square_2_alt 60, 0, 2, 0, 7, 3, 3  @ 8686258
+	voice_square_1_alt 60, 0, 0, 2, 0, 7, 3, 3  @ 8686264
+	voice_square_1_alt 60, 0, 0, 3, 2, 2, 7, 0  @ 8686270
+	voice_square_2_alt 60, 0, 1, 1, 2, 3, 0  @ 868627C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86862A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86862AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86862B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86862C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86862D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86862DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86862E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86862F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868630C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868633C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868636C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868639C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86863A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86863B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86863C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86863CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86863D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86863E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86863F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86863FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868642C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868645C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8686468
 

--- a/sound/voicegroups/voicegroup061.inc
+++ b/sound/voicegroups/voicegroup061.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup061:: @ 8686474
 	voice_keysplit_all voicegroup001  @ 8686474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868648C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686498
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86864A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86864B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86864BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86864C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86864D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86864E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86864EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86864F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686510
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868651C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868648C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86864A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86864B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86864BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86864C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86864D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86864E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86864EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86864F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868651C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686534
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 8686540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868654C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868657C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86865A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86865AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86865B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86865C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86865D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86865DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86865E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86865F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868660C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868654C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868657C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86865A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86865AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86865B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86865C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86865D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86865DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86865E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86865F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868660C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686618
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 115  @ 8686624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686630
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868663C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868666C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868669C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86866A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86866B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86866C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86866CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86866D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86866E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86866F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86866FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868663C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868666C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868669C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86866A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86866B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86866C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86866CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86866D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86866E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86866F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86866FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686708
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8686714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868672C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868675C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868678C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86867A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86867B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86867BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86867C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86867D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868672C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868675C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868678C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86867A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86867B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86867BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86867C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86867D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 86867E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86867EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86867F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868681C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686828
-	voice_square_1_alt 0, 2, 0, 1, 4, 1  @ 8686834
-	voice_square_2_alt 2, 0, 1, 4, 1  @ 8686840
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 868684C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8686858
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8686864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868687C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86868A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86868AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86868B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86868C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86868D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86868DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86868E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86868F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868690C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868693C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868696C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868699C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86869A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86869B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86869C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86869CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86869D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86869E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86869F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86869FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686A08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686A14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686A20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686A2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686A38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686A44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686A50
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8686A5C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8686A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86867EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86867F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868681C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686828
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1  @ 8686834
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 1  @ 8686840
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 868684C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8686858
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8686864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868687C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86868A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86868AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86868B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86868C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86868D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86868DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86868E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86868F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868690C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868693C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868696C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868699C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86869A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86869B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86869C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86869CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86869D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86869E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86869F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86869FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686A50
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8686A5C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8686A68
 

--- a/sound/voicegroups/voicegroup062.inc
+++ b/sound/voicegroups/voicegroup062.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup062:: @ 8686A74
 	voice_keysplit_all voicegroup001  @ 8686A74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686A80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686A8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686A98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686AA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686AB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686ABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686AC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686AD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686AE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686AEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686AF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686B04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686B10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686B1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686B28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686B34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686B40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686B4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686B58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686B64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686B70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686B7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686B88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686B94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686BA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686BAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686BB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686BC4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4910, 0, 7, 15, 0  @ 8686BD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686BDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686BE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686BF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686C00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686C0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686C18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686C24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686C30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686B64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686B94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686BB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686BC4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4910, 0, 7, 15, 0  @ 8686BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686BDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686BE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686BF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686C00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686C18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686C30
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8686C3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686C48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686C54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686C60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686C6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686C78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686C84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686C90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686C9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686CA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686CB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686CC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686CCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686CD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686CE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686CF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686CFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686C48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686C54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686C60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686C78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686C84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686C90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686CA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686CB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686CF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686D08
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8686D14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686D20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686D2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686D38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686D44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686D50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686D5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686D68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686D74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686D80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686D8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686D98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686DA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686DB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686DBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686DC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686DD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686DE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686DEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686DF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686E04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686E10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686E1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686E28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686E34
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 8686E40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686E4C
-	voice_square_1_alt 0, 1, 0, 1, 4, 1  @ 8686E58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686E64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686E70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686E7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686E88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686E94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686EA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686EAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686EB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686EC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686ED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686EDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686EE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686EF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686F00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686F0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686F18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686F24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686F30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686F3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686F48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686F54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686F60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686F6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686F78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686F84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686F90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686F9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686FA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686FB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686FC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686FCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686FD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686FE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686FF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8686FFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868702C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687050
-	voice_noise_alt 0, 0, 1, 7, 1  @ 868705C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8687068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686D98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686DF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686E28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686E34
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 8686E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686E4C
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 1  @ 8686E58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686E7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686E88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686EA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686EF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686F00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686F18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686F30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686F60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686F6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686F78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686F90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686FB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686FC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686FCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686FF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8686FFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868702C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687050
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 868705C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8687068
 

--- a/sound/voicegroups/voicegroup063.inc
+++ b/sound/voicegroups/voicegroup063.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup063:: @ 8687074
 	voice_keysplit_all voicegroup001  @ 8687074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868708C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86870A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86870B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86870BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86870C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86870D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86870E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86870EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86870F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868711C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868708C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86870A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86870B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86870BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86870C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86870D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86870E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86870EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86870F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868711C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687134
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 165  @ 8687140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868714C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868717C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86871A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86871AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86871B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86871C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86871D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86871DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86871E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86871F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868720C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868714C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868717C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86871A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86871AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86871B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86871C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86871D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86871DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86871E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86871F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868720C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687218
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 8687224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868723C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868726C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868729C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86872A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86872B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86872C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86872CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86872D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86872E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86872F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86872FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868723C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868726C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868729C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86872A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86872B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86872C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86872CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86872D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86872E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86872F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86872FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687308
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8687314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868732C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868735C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868738C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86873A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86873B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86873BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86873C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86873D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86873E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86873EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86873F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868741C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687428
-	voice_square_1_alt 0, 1, 0, 1, 4, 1  @ 8687434
-	voice_square_2_alt 1, 0, 1, 4, 1  @ 8687440
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 868744C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8687458
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8687464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687470
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868747C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86874A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86874AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86874B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86874C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86874D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86874DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86874E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86874F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868750C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868753C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868756C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868759C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86875A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86875B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86875C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86875CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86875D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86875E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86875F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86875FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868762C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687650
-	voice_noise_alt 0, 0, 1, 7, 1  @ 868765C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8687668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868732C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868735C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868738C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86873A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86873B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86873BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86873C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86873D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86873E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86873EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86873F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868741C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687428
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 1  @ 8687434
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 1  @ 8687440
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 868744C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8687458
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8687464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868747C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86874A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86874AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86874B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86874C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86874D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86874DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86874E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86874F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868750C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868753C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868756C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868759C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86875A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86875B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86875C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86875CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86875D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86875E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86875F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86875FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868762C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687650
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 868765C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8687668
 

--- a/sound/voicegroups/voicegroup064.inc
+++ b/sound/voicegroups/voicegroup064.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup064:: @ 8687674
 	voice_keysplit_all voicegroup001  @ 8687674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868768C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86876A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86876B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86876BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86876C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86876D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86876E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86876EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86876F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868771C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868774C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868777C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868768C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86876A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86876B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86876BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86876C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86876D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86876E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86876EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86876F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868771C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868774C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868777C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687788
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 8687794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86877A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86877AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86877B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86877C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86877D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86877DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86877E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86877F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868780C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687830
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868783C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687848
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868786C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86877A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86877AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86877B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86877C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86877D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86877DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86877E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86877F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868780C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868783C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868786C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687890
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 868789C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 86878A8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86878B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86878C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86878CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86878D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86878E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86878F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86878FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868792C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86878C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86878CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86878D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86878E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86878F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86878FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868792C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687938
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8687944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868795C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868798C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86879A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86879B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86879BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86879C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86879D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868795C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868798C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86879A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86879B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86879BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86879C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86879D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 86879E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86879EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86879F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687A04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687A10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687A1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687A28
-	voice_square_1_alt 0, 0, 0, 1, 4, 1  @ 8687A34
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 8687A40
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 8687A4C
-	voice_square_2_alt 3, 0, 1, 4, 1  @ 8687A58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687A64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687A70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687A7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687A88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687A94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687AA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687AAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687AB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687AC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687AD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687ADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687AE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687AF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687B00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687B0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687B18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687B24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687B30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687B3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687B48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687B54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687B60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687B6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687B78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687B84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687B90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687B9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687BA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687BB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687BC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687BCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687BD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687BE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687BF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687BFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687C08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687C14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687C20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687C2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687C38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687C44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687C50
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8687C5C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8687C68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86879EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86879F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687A1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687A28
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1  @ 8687A34
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 8687A40
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 8687A4C
+	voice_square_2_alt 60, 0, 3, 0, 1, 4, 1  @ 8687A58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687A64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687A70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687A7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687A88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687A94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687AA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687AAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687AB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687AC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687ADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687AF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687B18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687B30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687B3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687B60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687B6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687B90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687B9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687BA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687BB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687BC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687BE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687BFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687C08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687C14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687C20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687C2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687C38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687C44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687C50
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8687C5C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8687C68
 

--- a/sound/voicegroups/voicegroup065.inc
+++ b/sound/voicegroups/voicegroup065.inc
@@ -2,130 +2,130 @@
 voicegroup065:: @ 8687C74
 	voice_keysplit_all voicegroup001  @ 8687C74
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8687C80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687C8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687C98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687CA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687CB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687CBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687CC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687CD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687CE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687CEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687CF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687D04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687D10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687D1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687D28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687C98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687CBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687D34
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 165  @ 8687D40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687D4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687D58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687D64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687D70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687D7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687D88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687D94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687DA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687DAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687DB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687DC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687DD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687DDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687DE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687DF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687E00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687E0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687DDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687DE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687E18
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 8687E24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687E30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687E3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687E48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687E54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687E60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687E6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687E78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687E84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687E90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687E9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687EA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687EB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687EC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687ECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687ED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687EE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687EF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687EFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687E30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687E3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687E48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687E54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687E60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687F08
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8687F14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687F20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687F2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687F38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687F44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687F50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687F5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687F68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687F74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687F80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687F8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687F98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687FA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687FB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687FBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687FC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687FD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687FE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687FEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8687FF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868801C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688028
-	voice_square_1_alt 0, 1, 0, 1, 4, 1  @ 8688034
-	voice_square_2_alt 1, 0, 1, 4, 1  @ 8688040
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 868804C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 0  @ 8688058
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8688064
-	voice_square_1_alt 0, 2, 0, 1, 4, 1  @ 8688070
-	voice_square_2_alt 2, 0, 1, 4, 1  @ 868807C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4920, 0, 7, 15, 0  @ 8688088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86880A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86880AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86880B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86880C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86880D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86880DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86880E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86880F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868810C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868813C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868816C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688190
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868819C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86881A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86881B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86881C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86881CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86881D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86881E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86881F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86881FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868822C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688250
-	voice_noise_alt 0, 0, 1, 7, 1  @ 868825C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8688268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687F74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687FA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687FB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687FBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8687FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868801C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688028
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 1  @ 8688034
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 1  @ 8688040
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 868804C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 0  @ 8688058
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8688064
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1  @ 8688070
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 1  @ 868807C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4920, 0, 7, 15, 0  @ 8688088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86880A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86880AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86880B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86880C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86880D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86880DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86880E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86880F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868810C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868813C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868816C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868819C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86881A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86881B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86881C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86881CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86881D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86881E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86881F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86881FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868822C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688250
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 868825C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8688268
 

--- a/sound/voicegroups/voicegroup066.inc
+++ b/sound/voicegroups/voicegroup066.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup066:: @ 8688274
 	voice_keysplit_all voicegroup001  @ 8688274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868828C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86882A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86882B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86882BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86882C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86882D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86882E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86882EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86882F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868831C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868834C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868837C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868828C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86882A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86882B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86882BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86882C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86882D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86882E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86882EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86882F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868831C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868834C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868837C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688388
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 8688394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86883A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86883AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86883B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86883C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86883D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86883DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86883E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86883F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868840C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86883A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86883AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86883B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86883C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86883D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86883DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86883E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86883F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868840C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 8688418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688430
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 868843C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868846C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868846C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688484
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 38  @ 8688490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868849C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86884A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86884B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86884C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86884CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86884D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86884E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86884F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86884FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868852C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868855C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868858C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86885A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86885B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86885BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86885C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86885D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868849C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86884A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86884B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86884C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86884CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86884D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86884E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86884F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86884FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868852C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868855C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868858C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86885A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86885B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86885BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86885C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86885D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 86885E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86885EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86885F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868861C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688628
-	voice_square_1 0, 1, 0, 1, 4, 1  @ 8688634
-	voice_square_2_alt 1, 0, 1, 4, 1  @ 8688640
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 3  @ 868864C
-	voice_square_2_alt 3, 0, 1, 4, 1  @ 8688658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868867C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86886A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86886AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86886B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86886C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86886D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86886DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86886E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86886F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868870C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868873C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868876C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688790
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868879C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86887A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86887B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86887C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86887CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86887D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86887E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86887F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86887FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688808
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868882C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688850
-	voice_noise_alt 0, 0, 1, 7, 1  @ 868885C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8688868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86885EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86885F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868861C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688628
+	voice_square_1 60, 0, 0, 1, 0, 1, 4, 1  @ 8688634
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 1  @ 8688640
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 3  @ 868864C
+	voice_square_2_alt 60, 0, 3, 0, 1, 4, 1  @ 8688658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868867C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86886A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86886AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86886B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86886C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86886D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86886DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86886E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86886F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868870C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868873C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868876C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868879C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86887A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86887B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86887C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86887CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86887D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86887E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86887F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86887FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868882C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688850
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 868885C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8688868
 

--- a/sound/voicegroups/voicegroup067.inc
+++ b/sound/voicegroups/voicegroup067.inc
@@ -2,130 +2,130 @@
 voicegroup067:: @ 8688874
 	voice_keysplit_all voicegroup001  @ 8688874
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8688880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868888C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688898
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86888A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86888B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86888BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86888C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86888D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86888E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86888EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86888F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868891C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868888C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86888A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86888B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86888BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86888C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86888D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86888E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86888EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86888F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868891C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688934
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 8688940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868894C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868897C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868894C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868897C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688988
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 8688994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86889A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86889AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86889B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86889C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86889D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86889DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86889E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86889F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688A00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688A0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688A18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688A24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688A30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86889A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86889AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86889B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86889C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86889D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86889DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86889E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86889F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688A24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688A30
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8688A3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688A48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688A54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688A60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688A6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688A78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688A84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688A90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688A9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688AA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688AB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688AC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688ACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688AD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688AE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688AF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688AFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688A48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688A54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688A6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688A84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688B08
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8688B14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688B20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688B2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688B38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688B44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688B50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688B5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688B68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688B74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688B80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688B8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688B98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688BA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688BB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688BBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688BC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688BD4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 8688BE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688BEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688BF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688C04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688C10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688C1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688C28
-	voice_square_1_alt 0, 1, 0, 1, 4, 1  @ 8688C34
-	voice_square_2_alt 1, 0, 1, 4, 1  @ 8688C40
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 8688C4C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8688C58
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8688C64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688C70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688C7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688C88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688C94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688CA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688CAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688CB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688CC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688CD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688CDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688CE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688CF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688D00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688D0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688D18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688D24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688D30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688D3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688D48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688D54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688D60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688D6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688D78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688D84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688D90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688D9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688DA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688DB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688DC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688DCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688DD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688DE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688DF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688DFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688E08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688E14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688E20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688E2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688E38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688E44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688E50
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8688E5C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8688E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688C28
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 1  @ 8688C34
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 1  @ 8688C40
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 8688C4C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8688C58
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8688C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688C70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688C7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688C88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688CA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688E2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688E44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688E50
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8688E5C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8688E68
 

--- a/sound/voicegroups/voicegroup068.inc
+++ b/sound/voicegroups/voicegroup068.inc
@@ -2,130 +2,130 @@
 voicegroup068:: @ 8688E74
 	voice_keysplit_all voicegroup001  @ 8688E74
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8688E80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688E8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688E98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688EA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688EB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688EBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688EC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688ED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688EE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688EEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688EF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688F04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688EA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688EBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688EEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688F10
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 8688F1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688F28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688F34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688F34
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 8688F40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688F4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688F58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688F64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688F70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688F7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688F88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688F64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688F88
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 8688F94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688FA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688FAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688FB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688FC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688FD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688FDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688FE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8688FF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868900C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8688FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868900C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 8689018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689030
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 868903C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868906C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868909C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86890A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86890B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86890C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86890CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86890D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86890E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86890F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86890FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868906C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868909C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86890A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86890B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86890C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86890CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86890D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86890E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86890F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86890FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689108
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8689114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868912C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868915C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868918C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86891A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86891B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86891BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86891C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86891D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868912C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868915C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868918C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86891A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86891B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86891BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86891C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86891D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 86891E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86891EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86891F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868921C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689228
-	voice_square_1 0, 2, 0, 2, 3, 1  @ 8689234
-	voice_square_2_alt 2, 0, 2, 3, 1  @ 8689240
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 868924C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8689258
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8689264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868927C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86892A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86892AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86892B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86892C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86892D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86892DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86892E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86892F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868930C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868933C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868936C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868939C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86893A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86893B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86893C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86893CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86893D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86893E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86893F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86893FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868942C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689450
-	voice_noise_alt 0, 0, 1, 7, 1  @ 868945C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8689468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86891EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86891F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868921C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689228
+	voice_square_1 60, 0, 0, 2, 0, 2, 3, 1  @ 8689234
+	voice_square_2_alt 60, 0, 2, 0, 2, 3, 1  @ 8689240
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 868924C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8689258
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8689264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868927C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86892A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86892AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86892B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86892C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86892D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86892DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86892E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86892F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868930C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868933C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868936C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868939C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86893A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86893B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86893C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86893CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86893D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86893E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86893F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86893FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868942C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689450
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 868945C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8689468
 

--- a/sound/voicegroups/voicegroup069.inc
+++ b/sound/voicegroups/voicegroup069.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup069:: @ 8689474
 	voice_keysplit_all voicegroup001  @ 8689474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868948C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689498
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86894A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86894B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86894BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86894C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86894D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86894E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86894EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86894F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689510
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868951C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868948C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86894A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86894B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86894BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86894C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86894D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86894E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86894EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86894F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868951C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689534
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 8689540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868954C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868957C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868954C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868957C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689588
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 8689594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86895A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86895AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86895B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86895C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86895D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86895DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86895E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86895F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868960C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86895A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86895AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86895B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86895C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86895D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86895DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86895E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86895F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868960C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 8689618
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689630
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 868963C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868966C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868966C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689684
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 38  @ 8689690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868969C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86896A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868969C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86896A8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86896B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86896C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86896CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86896D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86896E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86896F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86896FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86896C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86896CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86896D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86896E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86896F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86896FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689720
 	voice_keysplit voicegroup008, KeySplitTable4  @ 868972C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868975C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868978C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86897A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86897B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86897BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86897C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86897D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868975C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868978C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86897A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86897B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86897BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86897C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86897D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 86897E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86897EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86897F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868981C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689828
-	voice_square_1_alt 0, 0, 0, 1, 4, 1  @ 8689834
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 8689840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868984C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 3  @ 8689858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868987C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86898A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86898AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86898B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86898C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86898D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86898DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86898E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86898F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868990C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868993C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868996C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868999C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86899A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86899B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86899C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86899CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86899D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86899E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86899F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86899FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689A08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689A14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689A20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689A2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689A38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689A44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689A50
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8689A5C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8689A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86897EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86897F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868981C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689828
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1  @ 8689834
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 8689840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868984C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 3  @ 8689858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868987C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86898A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86898AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86898B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86898C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86898D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86898DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86898E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86898F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868990C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868993C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868996C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868999C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86899A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86899B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86899C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86899CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86899D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86899E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86899F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86899FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689A50
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8689A5C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8689A68
 

--- a/sound/voicegroups/voicegroup070.inc
+++ b/sound/voicegroups/voicegroup070.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup070:: @ 8689A74
 	voice_keysplit_all voicegroup001  @ 8689A74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689A80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689A8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689A98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689AA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689AB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689ABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689AC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689AD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689AE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689AEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689AF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689B04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689B10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689B1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689B28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689B34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689B40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689B4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689B58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689B64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689B70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689B7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689B64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689B88
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 8689B94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689BA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689BAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689BB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689BC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689BD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689BDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689BE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689BF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689C00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689BB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689BC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689BDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689BE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689BF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689C00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689C0C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 8689C18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689C24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689C30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689C3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689C48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689C54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689C60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689C6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689C78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689C84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689C90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689C30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689C3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689C48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689C54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689C60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689C78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689C84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689C90
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 8689C9C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 8689CA8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8689CB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689CC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689CCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689CD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689CE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689CF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689CFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689CF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689D08
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8689D14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689D20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689D2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689D38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689D44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689D50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689D5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689D68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689D74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689D80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689D8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689D98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689DA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689DB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689DBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689DC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689DD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689DE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689DEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689DF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689E04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689E10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689E1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689E28
-	voice_square_1_alt 0, 0, 0, 1, 4, 1  @ 8689E34
-	voice_square_2_alt 2, 0, 1, 4, 1  @ 8689E40
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 8689E4C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8689E58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689E64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689E70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689E7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689E88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689E94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689EA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689EAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689EB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689EC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689ED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689EDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689EE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689EF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689F00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689F0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689F18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689F24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689F30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689F3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689F48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689F54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689F60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689F6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689F78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689F84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689F90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689F9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689FA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689FB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689FC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689FCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689FD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689FE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689FF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8689FFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A02C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A050
-	voice_noise_alt 0, 0, 2, 4, 0  @ 868A05C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868A068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689D98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689DF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689E28
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1  @ 8689E34
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 1  @ 8689E40
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 8689E4C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8689E58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689E7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689E88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689EA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689EF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689F00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689F18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689F30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689F60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689F6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689F78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689F90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689FB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689FC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689FCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689FF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8689FFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A02C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A050
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0  @ 868A05C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868A068
 

--- a/sound/voicegroups/voicegroup071.inc
+++ b/sound/voicegroups/voicegroup071.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup071:: @ 868A074
 	voice_keysplit_all voicegroup001  @ 868A074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A08C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A0A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A0B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A0BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A0C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A0D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A0E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A0EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A0F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A11C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A14C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A17C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A1A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A1AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A1B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A1C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A1D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A1DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A1E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A1F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A20C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A23C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A26C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A29C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A2A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A2B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A2C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A2CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A2D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A2E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A2F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A2FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A08C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A0A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A0B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A0BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A0C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A0D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A0E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A0EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A0F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A11C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A14C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A17C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A1A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A1AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A1B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A1C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A1D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A1DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A1E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A1F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A20C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A23C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A26C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A29C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A2A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A2B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A2C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A2CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A2D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A2E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A2F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A2FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A308
 	voice_keysplit voicegroup007, KeySplitTable3  @ 868A314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A320
 	voice_keysplit voicegroup008, KeySplitTable4  @ 868A32C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A338
 	voice_keysplit voicegroup009, KeySplitTable5  @ 868A344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A35C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A38C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A3A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A3B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A3BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A3C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A3D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A3E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A3EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A3F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A41C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A428
-	voice_square_1_alt 0, 0, 0, 1, 4, 1  @ 868A434
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 868A440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A44C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 2  @ 868A458
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A470
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A47C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A4A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A4AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A4B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A4C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A4D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A4DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A4E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A4F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A50C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A53C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A56C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A59C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A5A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A5B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A5C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A5CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A5D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A5E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A5F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A5FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A62C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A65C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868A668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A35C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A38C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A3A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A3B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A3BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A3C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A3D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A3E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A3EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A3F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A41C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A428
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1  @ 868A434
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 868A440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A44C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 2  @ 868A458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A47C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A4A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A4AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A4B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A4C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A4D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A4DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A4E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A4F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A50C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A53C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A56C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A59C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A5A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A5B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A5C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A5CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A5D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A5E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A5F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A5FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A62C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A65C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868A668
 

--- a/sound/voicegroups/voicegroup072.inc
+++ b/sound/voicegroups/voicegroup072.inc
@@ -2,130 +2,130 @@
 voicegroup072:: @ 868A674
 	voice_keysplit_all voicegroup001  @ 868A674
 	voice_keysplit voicegroup005, KeySplitTable1  @ 868A680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A68C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A6A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A6B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A6BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A6C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A6D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A6E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A6EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A6F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A68C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A6A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A6B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A6BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A6C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A6D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A6E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A6EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A6F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A704
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 868A710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A71C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A71C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A734
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 868A740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A74C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A77C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A74C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A77C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A788
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 868A794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A7A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A7AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A7B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A7C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A7D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A7DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A7E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A7F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A80C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A7A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A7AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A7B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A7C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A7D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A7DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A7E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A7F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A80C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 868A818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A830
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A83C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A848
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A86C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A83C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A86C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A890
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 868A89C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A8A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A8A8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 868A8B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A8C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A8CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A8D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A8E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A8F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A8FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A8C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A8CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A8D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A8E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A8F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A8FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A908
 	voice_keysplit voicegroup007, KeySplitTable3  @ 868A914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A92C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A92C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A938
 	voice_keysplit voicegroup009, KeySplitTable5  @ 868A944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A95C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A98C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A9A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A9B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A9BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A9C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A9D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A9E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A9EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868A9F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AA04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AA10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AA1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AA28
-	voice_square_1_alt 0, 2, 0, 1, 4, 1  @ 868AA34
-	voice_square_2_alt 2, 0, 1, 4, 1  @ 868AA40
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 868AA4C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 868AA58
-	voice_square_2_alt 0, 0, 1, 4, 0  @ 868AA64
-	voice_square_1_alt 0, 0, 0, 1, 4, 0  @ 868AA70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AA7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AA88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AA94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AAA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AAAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AAB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AAC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AAD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AAE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AAF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AB00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AB0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AB18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AB24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AB30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AB3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AB48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AB54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AB60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AB6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AB78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AB84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AB90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AB9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ABA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ABB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ABC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ABCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ABD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ABE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ABF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ABFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AC08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AC14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AC20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AC2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AC38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AC44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AC50
-	voice_noise_alt 0, 0, 2, 4, 0  @ 868AC5C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868AC68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A95C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A98C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A9A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A9B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A9BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A9C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A9D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A9E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A9EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868A9F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AA04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AA10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AA1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AA28
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1  @ 868AA34
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 1  @ 868AA40
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 868AA4C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 868AA58
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 0  @ 868AA64
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 0  @ 868AA70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AA7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AA88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AA94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AAA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AAAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AAB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AAC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AAD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AAE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AAF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AB00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AB0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AB18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AB24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AB30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AB3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AB48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AB54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AB60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AB6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AB78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AB84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AB90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AB9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ABA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ABB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ABC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ABCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ABD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ABE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ABF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ABFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AC08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AC14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AC20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AC2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AC38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AC44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AC50
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0  @ 868AC5C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868AC68
 

--- a/sound/voicegroups/voicegroup073.inc
+++ b/sound/voicegroups/voicegroup073.inc
@@ -2,130 +2,130 @@
 voicegroup073:: @ 868AC74
 	voice_keysplit_all voicegroup001  @ 868AC74
 	voice_keysplit voicegroup005, KeySplitTable1  @ 868AC80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AC8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AC98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ACA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ACB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ACBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ACC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ACD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ACE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ACEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ACF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AD04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AC8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AC98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ACA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ACB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ACBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ACC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ACD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ACE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ACEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ACF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AD04
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 868AD10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AD1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AD28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AD34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AD1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AD28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AD34
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 868AD40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AD4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AD58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AD64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AD70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AD7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AD88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AD4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AD58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AD64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AD70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AD7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AD88
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 868AD94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ADA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ADAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ADB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ADC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ADD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ADDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ADE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ADF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AE00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AE0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ADA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ADAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ADB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ADC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ADD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ADDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ADE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ADF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AE00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AE0C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 868AE18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AE24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AE30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AE24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AE30
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 868AE3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AE48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AE54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AE60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AE6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AE78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AE84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AE90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AE48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AE54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AE60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AE6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AE78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AE84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AE90
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 868AE9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AEA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AEA8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 868AEB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AEC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AEE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AEF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AEFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AF08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AEC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AEE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AEF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AEFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AF08
 	voice_keysplit voicegroup007, KeySplitTable3  @ 868AF14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AF20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AF2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AF38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AF20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AF2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AF38
 	voice_keysplit voicegroup009, KeySplitTable5  @ 868AF44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AF50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AF5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AF68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AF74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AF80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AF8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AF98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AFA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AFB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AFBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AFC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AFD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AF50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AF5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AF68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AF74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AF80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AF8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AF98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AFA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AFB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AFBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AFC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AFD4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 868AFE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AFEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868AFF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B01C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B028
-	voice_square_1_alt 0, 2, 0, 2, 4, 1  @ 868B034
-	voice_square_2_alt 2, 0, 2, 4, 1  @ 868B040
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 868B04C
-	voice_square_2_alt 0, 0, 1, 4, 0  @ 868B058
-	voice_square_1_alt 0, 0, 0, 1, 4, 0  @ 868B064
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B070
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B07C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B0A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B0AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B0B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B0C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B0D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B0DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B0E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B0F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B10C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B13C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B16C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B190
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B19C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B1A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B1B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B1C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B1CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B1D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B1E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B1F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B1FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B22C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B250
-	voice_noise_alt 0, 0, 2, 4, 0  @ 868B25C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868B268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AFEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868AFF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B01C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B028
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 4, 1  @ 868B034
+	voice_square_2_alt 60, 0, 2, 0, 2, 4, 1  @ 868B040
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 868B04C
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 0  @ 868B058
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 0  @ 868B064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B07C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B0A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B0AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B0B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B0C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B0D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B0DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B0E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B0F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B10C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B13C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B16C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B19C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B1A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B1B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B1C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B1CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B1D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B1E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B1F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B1FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B22C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B250
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0  @ 868B25C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868B268
 

--- a/sound/voicegroups/voicegroup074.inc
+++ b/sound/voicegroups/voicegroup074.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup074:: @ 868B274
 	voice_keysplit_all voicegroup001  @ 868B274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B28C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B2A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B2B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B2BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B2C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B2D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B2E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B2EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B2F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B28C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B2A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B2B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B2BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B2C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B2D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B2E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B2EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B2F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B304
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 868B310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B31C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B34C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B37C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B3A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B3AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B3B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B3C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B3D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B3DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B3E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B3F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B40C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B31C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B34C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B37C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B3A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B3AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B3B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B3C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B3D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B3DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B3E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B3F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B40C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 868B418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B430
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B43C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B46C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B49C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B43C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B46C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B49C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 216  @ 868B4A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B4B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B4C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B4CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B4D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B4E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B4F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B4FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B52C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B55C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B58C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B5A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B5B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B5BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B5C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B5D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B5E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B5EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B5F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B61C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B628
-	voice_square_1_alt 0, 2, 0, 1, 4, 0  @ 868B634
-	voice_square_2_alt 2, 0, 1, 4, 0  @ 868B640
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 868B64C
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 868B658
-	voice_square_1_alt 0, 1, 0, 1, 4, 1  @ 868B664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B67C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 868B688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B6A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B6AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B6B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B6C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B6D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B6DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B6E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B6F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B70C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B73C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B76C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B790
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B79C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B7A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B7B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B7C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B7CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B7D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B7E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B7F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B7FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B808
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B82C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B850
-	voice_noise_alt 0, 0, 2, 4, 0  @ 868B85C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868B868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B4B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B4C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B4CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B4D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B4E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B4F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B4FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B52C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B55C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B58C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B5A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B5B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B5BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B5C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B5D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B5E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B5EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B5F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B61C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B628
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 0  @ 868B634
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 0  @ 868B640
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 868B64C
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 868B658
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 1  @ 868B664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B67C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 868B688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B6A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B6AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B6B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B6C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B6D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B6DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B6E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B6F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B70C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B73C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B76C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B79C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B7A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B7B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B7C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B7CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B7D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B7E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B7F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B7FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B82C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B850
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0  @ 868B85C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868B868
 

--- a/sound/voicegroups/voicegroup075.inc
+++ b/sound/voicegroups/voicegroup075.inc
@@ -2,130 +2,130 @@
 voicegroup075:: @ 868B874
 	voice_keysplit_all voicegroup001  @ 868B874
 	voice_keysplit voicegroup005, KeySplitTable1  @ 868B880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B88C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B898
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B8A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B8B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B8BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B8C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B8D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B8E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B8EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B8F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B88C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B8A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B8B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B8BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B8C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B8D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B8E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B8EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B8F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B910
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 868B91C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B94C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B97C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B9A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B9AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B9B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B9C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B9D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B9DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B9E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868B9F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BA00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BA0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B94C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B97C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B9A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B9AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B9B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B9C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B9D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B9DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B9E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868B9F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BA00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BA0C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 868BA18
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 868BA24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BA30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BA3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BA48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BA54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BA60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BA6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BA78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BA84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BA90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BA9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BA30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BA3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BA48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BA54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BA60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BA6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BA78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BA84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BA90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BA9C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 868BAA8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 868BAB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BAC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BAD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BAE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BAF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BAFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BB08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BAC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BAD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BAE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BAF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BAFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BB08
 	voice_keysplit voicegroup007, KeySplitTable3  @ 868BB14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BB20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BB20
 	voice_keysplit voicegroup008, KeySplitTable4  @ 868BB2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BB38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BB38
 	voice_keysplit voicegroup009, KeySplitTable5  @ 868BB44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BB50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BB5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BB68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BB74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BB80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BB8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BB98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BBA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BBB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BBBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BBC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BBD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BB50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BB5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BB68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BB74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BB80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BB8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BB98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BBA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BBB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BBBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BBC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BBD4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 868BBE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BBEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BBF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BC04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BC10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BC1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BC28
-	voice_square_1_alt 0, 1, 0, 2, 3, 1  @ 868BC34
-	voice_square_2_alt 2, 0, 1, 4, 1  @ 868BC40
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 868BC4C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 868BC58
-	voice_square_2_alt 1, 0, 1, 4, 1  @ 868BC64
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 1  @ 868BC70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BC7C
-	voice_square_1_alt 0, 0, 0, 2, 3, 1  @ 868BC88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BC94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BCA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BCAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BCB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BCC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BCD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BCDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BCE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BCF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BD00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BD0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BD18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BD24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BD30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BD3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BD48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BD54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BD60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BD6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BD78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BD84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BD90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BD9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BDA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BDB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BDC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BDCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BDD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BDE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BDF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BDFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BE08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BE14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BE20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BE2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BE38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BE44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BE50
-	voice_noise_alt 0, 0, 3, 4, 0  @ 868BE5C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868BE68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BBEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BBF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BC04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BC10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BC1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BC28
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 3, 1  @ 868BC34
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 1  @ 868BC40
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 868BC4C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 868BC58
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 1  @ 868BC64
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 1  @ 868BC70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BC7C
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 3, 1  @ 868BC88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BC94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BCA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BCAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BCB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BCC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BCD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BCDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BCE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BCF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BD00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BD0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BD18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BD24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BD30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BD3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BD48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BD54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BD60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BD6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BD78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BD84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BD90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BD9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BDA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BDB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BDC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BDCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BDD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BDE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BDF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BDFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BE08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BE14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BE20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BE2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BE38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BE44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BE50
+	voice_noise_alt 60, 0, 0, 0, 3, 4, 0  @ 868BE5C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868BE68
 

--- a/sound/voicegroups/voicegroup076.inc
+++ b/sound/voicegroups/voicegroup076.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup076:: @ 868BE74
 	voice_keysplit_all voicegroup001  @ 868BE74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BE80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BE8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BE98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BEA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BEB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BEBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BEC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BEE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BEEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BEF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BF04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BF10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BF1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BF28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BF34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BE80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BE8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BE98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BEA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BEB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BEBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BEC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BEE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BEEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BEF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BF04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BF10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BF1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BF28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BF34
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 165  @ 868BF40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BF4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BF58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BF64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BF70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BF7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BF88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BF94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BFA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BFAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BFB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BFC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BFD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BFDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BFE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868BFF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C00C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BF4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BF58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BF64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BF70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BF7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BF88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BF94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BFA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BFAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BFB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BFC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BFD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BFDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BFE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868BFF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C00C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 868C018
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 868C024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C030
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C03C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C06C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C09C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C0A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C0B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C0C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C0CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C0D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C0E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C0F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C0FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C03C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C06C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C09C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C0A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C0B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C0C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C0CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C0D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C0E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C0F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C0FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C108
 	voice_keysplit voicegroup007, KeySplitTable3  @ 868C114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C12C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C15C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C18C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C1A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C1B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C1BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C1C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C1D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C1E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C1EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C1F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C21C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C228
-	voice_square_1_alt 0, 1, 0, 1, 4, 1  @ 868C234
-	voice_square_2_alt 1, 0, 1, 4, 1  @ 868C240
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 868C24C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4910, 0, 7, 15, 0  @ 868C258
-	voice_square_1_alt 0, 0, 0, 1, 4, 1  @ 868C264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C27C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C2A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C2AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C2B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C2C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C2D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C2DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C2E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C2F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C30C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C33C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C36C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C39C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C3A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C3B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C3C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C3CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C3D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C3E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C3F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C3FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C42C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C450
-	voice_noise_alt 0, 0, 1, 7, 1  @ 868C45C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868C468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C12C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C15C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C18C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C1A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C1B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C1BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C1C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C1D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C1E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C1EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C1F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C21C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C228
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 1  @ 868C234
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 1  @ 868C240
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 868C24C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4910, 0, 7, 15, 0  @ 868C258
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1  @ 868C264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C27C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C2A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C2AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C2B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C2C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C2D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C2DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C2E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C2F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C30C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C33C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C36C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C39C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C3A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C3B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C3C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C3CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C3D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C3E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C3F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C3FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C42C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C450
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 868C45C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868C468
 

--- a/sound/voicegroups/voicegroup077.inc
+++ b/sound/voicegroups/voicegroup077.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup077:: @ 868C474
 	voice_keysplit_all voicegroup001  @ 868C474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C48C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C498
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C4A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C4B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C4BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C4C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C4D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C4E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C4EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C4F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C48C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C4A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C4B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C4BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C4C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C4D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C4E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C4EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C4F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C504
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 868C510
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C51C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C51C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C534
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 868C540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C54C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C57C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C54C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C57C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C588
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 868C594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C5A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C5AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C5B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C5C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C5D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C5DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C5E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C5F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C60C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C5A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C5AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C5B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C5C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C5D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C5DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C5E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C5F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C60C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 196  @ 868C618
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C630
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C63C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C66C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C63C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C66C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C690
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 868C69C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C6A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C6A8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 868C6B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C6C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C6CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C6D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C6E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C6F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C6FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C72C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C75C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C78C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C7A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C7B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C7BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C7C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C7D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C6C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C6CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C6D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C6E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C6F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C6FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C72C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C75C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C78C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C7A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C7B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C7BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C7C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C7D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 868C7E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C7EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C7F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C81C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C828
-	voice_square_1_alt 0, 1, 0, 1, 4, 1  @ 868C834
-	voice_square_2_alt 1, 0, 1, 4, 1  @ 868C840
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 868C84C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C87C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C8A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C8AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C8B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C8C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C8D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C8DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C8E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C8F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C90C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C93C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C96C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C99C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C9A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C9B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C9C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C9CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C9D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C9E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C9F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868C9FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CA08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CA14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CA20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CA2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CA38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CA44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CA50
-	voice_noise_alt 0, 0, 2, 4, 0  @ 868CA5C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868CA68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C7EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C7F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C81C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C828
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 1  @ 868C834
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 1  @ 868C840
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 868C84C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C87C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C8A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C8AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C8B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C8C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C8D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C8DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C8E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C8F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C90C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C93C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C96C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C99C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C9A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C9B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C9C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C9CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C9D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C9E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C9F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868C9FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CA08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CA14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CA20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CA2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CA38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CA44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CA50
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0  @ 868CA5C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868CA68
 

--- a/sound/voicegroups/voicegroup078.inc
+++ b/sound/voicegroups/voicegroup078.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup078:: @ 868CA74
 	voice_keysplit_all voicegroup001  @ 868CA74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CA80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CA8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CA98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CAA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CAB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CAC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CAD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CAE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CAEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CAF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CB04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CB10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CA80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CA8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CA98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CAA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CAB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CAC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CAD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CAE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CAEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CAF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CB04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CB10
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 868CB1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CB28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CB34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CB40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CB4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CB58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CB64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CB70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CB7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CB88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CB28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CB34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CB40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CB4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CB58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CB64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CB70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CB7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CB88
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 868CB94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CBA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CBAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CBB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CBC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CBD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CBDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CBE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CBF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CC00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CC0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CBA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CBAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CBB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CBC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CBD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CBDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CBE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CBF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CC00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CC0C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 196  @ 868CC18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CC24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CC30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CC3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CC48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CC54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CC60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CC6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CC78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CC84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CC24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CC30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CC3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CC48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CC54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CC60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CC6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CC78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CC84
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 38  @ 868CC90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CC9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CC9C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 868CCA8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 868CCB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CCC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CCCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CCD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CCE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CCF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CCFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CD08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CD14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CD20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CD2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CD38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CCC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CCCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CCD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CCE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CCF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CCFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CD08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CD14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CD20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CD2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CD38
 	voice_keysplit voicegroup009, KeySplitTable5  @ 868CD44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CD50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CD5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CD68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CD74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CD80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CD8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CD98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CDA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CDB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CDBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CDC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CDD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CDE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CDEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CDF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CE04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CE10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CE1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CE28
-	voice_square_1_alt 0, 1, 0, 1, 4, 1  @ 868CE34
-	voice_square_2_alt 1, 0, 1, 4, 1  @ 868CE40
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 868CE4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CE58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CE64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CE70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CE7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CE88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CE94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CEA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CEAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CEB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CEC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CEDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CEE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CEF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CF00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CF0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CF18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CF24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CF30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CF3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CF48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CF54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CF60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CF6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CF78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CF84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CF90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CF9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CFA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CFB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CFC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CFCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CFD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CFE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CFF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868CFFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D02C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D050
-	voice_noise_alt 0, 0, 2, 4, 0  @ 868D05C
-	voice_noise_alt 0, 0, 2, 0, 2  @ 868D068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CD50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CD5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CD68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CD74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CD80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CD8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CD98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CDA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CDB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CDBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CDC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CDD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CDE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CDEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CDF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CE04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CE10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CE1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CE28
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 1  @ 868CE34
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 1  @ 868CE40
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 868CE4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CE58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CE64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CE70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CE7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CE88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CE94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CEA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CEAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CEB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CEC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CEDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CEE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CEF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CF00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CF0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CF18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CF24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CF30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CF3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CF48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CF54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CF60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CF6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CF78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CF84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CF90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CF9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CFA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CFB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CFC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CFCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CFD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CFE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CFF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868CFFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D02C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D050
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0  @ 868D05C
+	voice_noise_alt 60, 0, 0, 0, 2, 0, 2  @ 868D068
 

--- a/sound/voicegroups/voicegroup079.inc
+++ b/sound/voicegroups/voicegroup079.inc
@@ -2,130 +2,130 @@
 voicegroup079:: @ 868D074
 	voice_keysplit_all voicegroup001  @ 868D074
 	voice_keysplit voicegroup005, KeySplitTable1  @ 868D080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D08C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D0A4
-	voice_square_2_alt 3, 0, 2, 4, 1  @ 868D0B0
-	voice_square_2_alt 0, 0, 1, 6, 2  @ 868D0BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D0C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D0D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D0E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D0EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D0F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D08C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D0A4
+	voice_square_2_alt 60, 0, 3, 0, 2, 4, 1  @ 868D0B0
+	voice_square_2_alt 60, 0, 0, 0, 1, 6, 2  @ 868D0BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D0C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D0D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D0E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D0EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D0F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D110
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 868D11C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D134
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 868D140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D14C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D17C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D14C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D17C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D188
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 868D194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D1A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D1AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D1B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D1C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D1D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D1DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D1E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D1F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D20C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D23C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 6, 2  @ 868D248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D26C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D1A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D1AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D1B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D1C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D1D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D1DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D1E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D1F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D20C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D23C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 6, 2  @ 868D248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D26C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D284
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 38  @ 868D290
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 868D29C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D2A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D2A8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 868D2B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D2C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D2CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D2D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D2E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D2F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D2FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D32C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D35C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D38C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D3A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D3B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D3BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D3C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D3D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D2C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D2CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D2D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D2E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D2F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D2FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D32C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D35C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D38C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D3A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D3B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D3BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D3C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D3D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 868D3E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D3EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D3F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D41C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D428
-	voice_square_1_alt 0, 3, 0, 2, 4, 1  @ 868D434
-	voice_square_2_alt 3, 0, 1, 6, 2  @ 868D440
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 868D44C
-	voice_square_1_alt 0, 2, 0, 2, 6, 5  @ 868D458
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 4, 4  @ 868D464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D470
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D47C
-	voice_square_2_alt 2, 0, 1, 6, 2  @ 868D488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D4A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D4AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D4B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D4C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D4D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D4DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D4E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D4F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D50C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D53C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D56C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D59C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D5A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D5B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D5C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D5CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D5D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D5E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D5F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D5FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D62C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D650
-	voice_noise_alt 0, 0, 1, 7, 1  @ 868D65C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868D668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D3EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D3F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D41C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D428
+	voice_square_1_alt 60, 0, 0, 3, 0, 2, 4, 1  @ 868D434
+	voice_square_2_alt 60, 0, 3, 0, 1, 6, 2  @ 868D440
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 868D44C
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 6, 5  @ 868D458
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 4, 4  @ 868D464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D47C
+	voice_square_2_alt 60, 0, 2, 0, 1, 6, 2  @ 868D488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D4A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D4AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D4B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D4C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D4D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D4DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D4E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D4F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D50C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D53C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D56C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D59C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D5A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D5B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D5C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D5CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D5D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D5E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D5F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D5FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D62C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D650
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 868D65C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868D668
 

--- a/sound/voicegroups/voicegroup080.inc
+++ b/sound/voicegroups/voicegroup080.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup080:: @ 868D674
 	voice_keysplit_all voicegroup001  @ 868D674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D68C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D6A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D6B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D6BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D6C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D6D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D6E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D6EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D6F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D71C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D74C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D77C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D68C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D6A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D6B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D6BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D6C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D6D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D6E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D6EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D6F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D71C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D74C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D77C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D788
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 868D794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D7A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D7AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D7B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D7C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D7D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D7DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D7E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D7F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D80C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D7A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D7AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D7B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D7C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D7D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D7DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D7E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D7F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D80C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D830
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 868D83C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D848
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D86C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D86C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D884
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 38  @ 868D890
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 868D89C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 868D8A8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 868D8B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D8C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D8CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D8D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D8E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D8F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D8FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D92C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D8C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D8CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D8D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D8E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D8F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D8FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D92C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D938
 	voice_keysplit voicegroup009, KeySplitTable5  @ 868D944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D95C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D98C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D9A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D9B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D9BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D9C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D9D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D95C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D98C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D9A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D9B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D9BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D9C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D9D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 868D9E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D9EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868D9F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DA04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DA10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DA1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DA28
-	voice_square_1_alt 0, 1, 0, 1, 4, 1  @ 868DA34
-	voice_square_2_alt 1, 0, 1, 4, 1  @ 868DA40
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 868DA4C
-	voice_square_2_alt 3, 0, 1, 4, 1  @ 868DA58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DA64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DA70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DA7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DA88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DA94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DAA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DAAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DAB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DAC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DAD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DAE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DAF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DB00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DB0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DB18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DB24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DB30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DB3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DB48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DB54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DB60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DB6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DB78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DB84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DB90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DB9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DBA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DBB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DBC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DBCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DBD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DBE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DBF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DBFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DC08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DC14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DC20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DC2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DC38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DC44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DC50
-	voice_noise_alt 0, 0, 1, 7, 1  @ 868DC5C
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868DC68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D9EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868D9F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DA04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DA10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DA1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DA28
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 1  @ 868DA34
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 1  @ 868DA40
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 868DA4C
+	voice_square_2_alt 60, 0, 3, 0, 1, 4, 1  @ 868DA58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DA64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DA70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DA7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DA88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DA94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DAA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DAAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DAB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DAC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DAD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DAE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DAF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DB00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DB0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DB18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DB24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DB30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DB3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DB48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DB54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DB60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DB6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DB78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DB84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DB90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DB9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DBA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DBB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DBC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DBCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DBD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DBE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DBF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DBFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DC08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DC14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DC20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DC2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DC38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DC44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DC50
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 868DC5C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868DC68
 

--- a/sound/voicegroups/voicegroup081.inc
+++ b/sound/voicegroups/voicegroup081.inc
@@ -1,5 +1,5 @@
 	.align 2
 voicegroup081:: @ 868DC74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DC74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DC74
 	voice_keysplit voicegroup005, KeySplitTable1  @ 868DC80
 

--- a/sound/voicegroups/voicegroup082.inc
+++ b/sound/voicegroups/voicegroup082.inc
@@ -2,130 +2,130 @@
 voicegroup082:: @ 868DC8C
 	voice_keysplit_all voicegroup001  @ 868DC8C
 	voice_keysplit voicegroup005, KeySplitTable1  @ 868DC98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DCA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DCB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DCBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DCC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DCD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DCE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DCEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DCF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DD04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DD10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DD1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DD28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DCA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DCB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DCBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DCC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DCD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DCE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DCEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DCF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DD04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DD10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DD1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DD28
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 868DD34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DD40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DD4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DD58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DD64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DD70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DD7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DD88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DD94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DDA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DD40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DD4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DD58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DD64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DD70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DD7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DD88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DD94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DDA0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 868DDAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DDB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DDC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DDD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DDDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DDE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DDF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DE00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DE0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DE18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DE24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DE30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DE3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DE48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DE54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DE60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DE6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DE78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DE84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DE90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DE9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DEA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DEB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DDB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DDC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DDD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DDDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DDE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DDF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DE00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DE0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DE18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DE24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DE30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DE3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DE48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DE54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DE60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DE6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DE78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DE84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DE90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DE9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DEA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DEB4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 868DEC0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 868DECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DEE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DEF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DEFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DF08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DF14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DF20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DEE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DEF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DEFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DF08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DF14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DF20
 	voice_keysplit voicegroup007, KeySplitTable3  @ 868DF2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DF38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DF44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DF50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DF38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DF44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DF50
 	voice_keysplit voicegroup009, KeySplitTable5  @ 868DF5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DF68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DF74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DF80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DF8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DF98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DFA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DFB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DFBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DFC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DFD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DFE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DFEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868DFF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E01C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E040
-	voice_square_1_alt 0, 3, 0, 2, 4, 1  @ 868E04C
-	voice_square_2_alt 3, 0, 1, 6, 2  @ 868E058
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 868E064
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 4, 4  @ 868E070
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E07C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E0A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E0AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E0B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E0C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E0D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E0DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E0E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E0F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E10C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E13C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E16C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E190
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E19C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E1A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E1B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E1C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E1CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E1D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E1E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E1F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E1FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E22C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E25C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E268
-	voice_noise_alt 0, 0, 1, 7, 1  @ 868E274
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868E280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DF68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DF74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DF80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DF8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DF98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DFA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DFB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DFBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DFC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DFD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DFE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DFEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868DFF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E01C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E040
+	voice_square_1_alt 60, 0, 0, 3, 0, 2, 4, 1  @ 868E04C
+	voice_square_2_alt 60, 0, 3, 0, 1, 6, 2  @ 868E058
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 868E064
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 4, 4  @ 868E070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E07C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E0A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E0AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E0B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E0C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E0D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E0DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E0E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E0F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E10C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E13C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E16C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E19C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E1A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E1B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E1C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E1CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E1D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E1E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E1F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E1FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E22C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E25C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E268
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 868E274
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868E280
 

--- a/sound/voicegroups/voicegroup083.inc
+++ b/sound/voicegroups/voicegroup083.inc
@@ -2,86 +2,86 @@
 voicegroup083:: @ 868E28C
 	voice_keysplit_all voicegroup001  @ 868E28C
 	voice_keysplit voicegroup005, KeySplitTable1  @ 868E298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E2A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E2B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E2BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E2C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E2D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E2E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E2EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E2A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E2B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E2BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E2C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E2D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E2E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E2EC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 165, 72, 249  @ 868E2F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E31C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E34C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E37C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E3A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E31C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E34C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E37C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E3A0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 76  @ 868E3AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E3B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E3C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E3D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E3DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E3E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E3F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E40C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E3B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E3C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E3D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E3DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E3E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E3F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E40C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E424
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 868E430
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E43C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E46C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E49C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E43C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E46C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E49C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 38  @ 868E4A8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 242  @ 868E4B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E4C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E4C0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 868E4CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E4D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E4E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E4F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E4FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E52C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E4D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E4E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E4F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E4FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E52C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E538
 	voice_keysplit voicegroup008, KeySplitTable4  @ 868E544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E550
 	voice_keysplit voicegroup009, KeySplitTable5  @ 868E55C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E58C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E5A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E5B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E5BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E5C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E5D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E5E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E5EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E58C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E5A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E5B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E5BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E5C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E5D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E5E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E5EC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 868E5F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E61C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E640
-	voice_square_1_alt 0, 2, 0, 1, 4, 1  @ 868E64C
-	voice_square_2_alt 2, 0, 1, 4, 2  @ 868E658
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 6, 4  @ 868E664
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 2, 6, 1  @ 868E670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E61C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E640
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1  @ 868E64C
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 2  @ 868E658
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 6, 4  @ 868E664
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 2, 6, 1  @ 868E670
 

--- a/sound/voicegroups/voicegroup084.inc
+++ b/sound/voicegroups/voicegroup084.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup084:: @ 868E67C
 	voice_keysplit_all voicegroup001  @ 868E67C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E6A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E6AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E6B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E6C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E6D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E6DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E6E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E6F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E70C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E6A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E6AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E6B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E6C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E6D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E6DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E6E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E6F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E70C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E718
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 868E724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E73C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E76C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E73C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E76C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E790
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 868E79C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E7A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E7B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E7C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E7CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E7D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E7E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E7F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E7FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E808
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E82C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E850
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E85C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E868
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E88C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E7A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E7B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E7C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E7CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E7D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E7E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E7F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E7FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E82C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E85C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E88C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E898
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 868E8A4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 868E8B0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 868E8BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E8C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E8D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E8E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E8EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E8F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E91C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E8C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E8D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E8E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E8EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E8F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E91C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E940
 	voice_keysplit voicegroup009, KeySplitTable5  @ 868E94C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E97C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E9A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E9AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E9B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E9C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E9D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E9DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E97C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E9A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E9AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E9B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E9C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E9D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E9DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 868E9E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868E9F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EA00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EA0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EA18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EA24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EA30
-	voice_square_1_alt 0, 1, 0, 2, 4, 0  @ 868EA3C
-	voice_square_2_alt 1, 0, 2, 4, 0  @ 868EA48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EA54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EA60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EA6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EA78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EA84
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 868EA90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EA9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EAA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EAB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EAC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EAD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EAE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EAF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EAFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EB08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EB14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EB20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EB2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EB38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EB44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EB50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EB5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EB68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EB74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EB80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EB8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EB98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EBA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EBB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EBBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EBC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EBD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EBE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EBEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EBF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EC04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EC10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EC1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EC28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EC34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EC40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EC4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EC58
-	voice_noise_alt 0, 0, 1, 7, 1  @ 868EC64
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868EC70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868E9F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EA00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EA0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EA18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EA24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EA30
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 4, 0  @ 868EA3C
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 0  @ 868EA48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EA54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EA60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EA6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EA78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EA84
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 868EA90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EA9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EAA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EAB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EAC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EAD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EAE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EAF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EAFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EB08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EB14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EB20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EB2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EB38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EB44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EB50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EB5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EB68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EB74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EB80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EB8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EB98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EBA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EBB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EBBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EBC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EBD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EBE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EBEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EBF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EC04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EC10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EC1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EC28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EC34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EC40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EC4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EC58
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 868EC64
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868EC70
 

--- a/sound/voicegroups/voicegroup085.inc
+++ b/sound/voicegroups/voicegroup085.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup085:: @ 868EC7C
 	voice_keysplit_all voicegroup001  @ 868EC7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EC88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EC94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ECA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ECAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ECB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ECC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ECD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ECDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ECE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ECF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ED00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ED0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ED18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ED24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ED30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ED3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ED48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ED54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ED60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ED6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ED78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ED84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868ED90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EC88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EC94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ECA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ECAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ECB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ECC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ECD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ECDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ECE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ECF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ED00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ED0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ED18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ED24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ED30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ED3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ED48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ED54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ED60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ED6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ED78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ED84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868ED90
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 868ED9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EDA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EDB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EDC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EDCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EDD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EDE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EDF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EDFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EE08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EE14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EE20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EE2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EE38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EE44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EE50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EE5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EE68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EE74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EE80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EE8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EE98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EDA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EDB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EDC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EDCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EDD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EDE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EDF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EDFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EE08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EE14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EE20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EE2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EE38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EE44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EE50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EE5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EE68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EE74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EE80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EE8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EE98
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 868EEA4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 868EEB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EEBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EEC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EEE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EEEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EEF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EF04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EF10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EEBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EEC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EEE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EEEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EEF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EF04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EF10
 	voice_keysplit voicegroup007, KeySplitTable3  @ 868EF1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EF28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EF34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EF40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EF4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EF58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EF64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EF70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EF7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EF88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EF94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EFA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EFAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EFB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EFC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EFD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EFDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EF28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EF34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EF40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EF4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EF58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EF64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EF70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EF7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EF88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EF94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EFA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EFAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EFB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EFC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EFD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EFDC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 868EFE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868EFF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F00C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F030
-	voice_square_1_alt 0, 2, 1, 2, 4, 0  @ 868F03C
-	voice_square_2_alt 1, 0, 2, 4, 0  @ 868F048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F054
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 868F060
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 13, 1  @ 868F06C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F09C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F0A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F0B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F0C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F0CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F0D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F0E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F0F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F0FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F12C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F15C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F18C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F1A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F1B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F1BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F1C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F1D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F1E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F1EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F1F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F21C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F234
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F24C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F258
-	voice_noise_alt 0, 0, 1, 7, 1  @ 868F264
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868F270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868EFF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F00C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F030
+	voice_square_1_alt 60, 0, 0, 2, 1, 2, 4, 0  @ 868F03C
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 0  @ 868F048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F054
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 868F060
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 13, 1  @ 868F06C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F09C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F0A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F0B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F0C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F0CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F0D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F0E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F0F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F0FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F12C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F15C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F18C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F1A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F1B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F1BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F1C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F1D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F1E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F1EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F1F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F21C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F24C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F258
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 868F264
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868F270
 

--- a/sound/voicegroups/voicegroup086.inc
+++ b/sound/voicegroups/voicegroup086.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup086:: @ 868F27C
 	voice_keysplit_all voicegroup001  @ 868F27C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F2A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F2AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F2B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F2C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F2D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F2DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F2E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F2F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F30C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F2A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F2AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F2B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F2C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F2D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F2DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F2E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F2F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F30C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F318
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 868F324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F33C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F33C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 165  @ 868F348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F36C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F36C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F390
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 868F39C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F3A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F3B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F3C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F3CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F3D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F3E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F3F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F3FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F3A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F3B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F3C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F3CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F3D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F3E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F3F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F3FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F414
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 868F420
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 868F42C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F45C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F468
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F48C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F45C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F48C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F498
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 868F4A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F4B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F4B0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 868F4BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F4C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F4D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F4E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F4EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F4F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F4C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F4D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F4E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F4EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F4F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F510
 	voice_keysplit voicegroup007, KeySplitTable3  @ 868F51C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F540
 	voice_keysplit voicegroup009, KeySplitTable5  @ 868F54C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F57C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F5A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F5AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F5B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F5C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F5D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F5DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F57C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F5A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F5AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F5B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F5C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F5D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F5DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 868F5E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F5F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F60C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F618
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F630
-	voice_square_1_alt 0, 2, 0, 2, 4, 0  @ 868F63C
-	voice_square_2_alt 1, 0, 2, 4, 0  @ 868F648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F654
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 868F660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F66C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F69C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F6A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F6B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F6C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F6CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F6D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F6E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F6F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F6FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F72C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F75C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F78C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F7A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F7B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F7BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F7C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F7D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F7E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F7EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F7F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F81C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F828
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F84C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F858
-	voice_noise_alt 0, 0, 1, 7, 1  @ 868F864
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868F870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F5F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F60C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F630
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 4, 0  @ 868F63C
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 0  @ 868F648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F654
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 868F660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F66C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F69C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F6A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F6B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F6C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F6CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F6D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F6E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F6F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F6FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F72C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F75C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F78C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F7A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F7B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F7BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F7C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F7D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F7E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F7EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F7F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F81C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F84C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F858
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 868F864
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868F870
 

--- a/sound/voicegroups/voicegroup087.inc
+++ b/sound/voicegroups/voicegroup087.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup087:: @ 868F87C
 	voice_keysplit_all voicegroup001  @ 868F87C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F8A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F8AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F8B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F8C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F8D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F8DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F8E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F8F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F90C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F93C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F96C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F99C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F9A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F9B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F9C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F9CC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4910, 0, 7, 15, 0  @ 868F9D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F9E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F9F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868F9FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FA08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FA14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FA20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F8A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F8AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F8B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F8C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F8D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F8DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F8E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F8F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F90C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F93C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F96C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F99C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F9A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F9B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F9C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F9CC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4910, 0, 7, 15, 0  @ 868F9D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F9E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F9F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868F9FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FA08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FA14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FA20
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 868FA2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FA38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FA38
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 868FA44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FA50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FA5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FA68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FA74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FA80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FA8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FA98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FAA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FA50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FA5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FA68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FA74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FA80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FA8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FA98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FAA4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 868FAB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FAC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FAD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FAE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FAEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FAF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FB04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FB10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FAC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FAD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FAE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FAEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FAF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FB04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FB10
 	voice_keysplit voicegroup007, KeySplitTable3  @ 868FB1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FB28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FB34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FB40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FB28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FB34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FB40
 	voice_keysplit voicegroup009, KeySplitTable5  @ 868FB4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FB58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FB64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FB70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FB7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FB88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FB94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FBA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FBAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FBB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FBC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FBD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FBDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FBE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FBF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FC00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FC0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FC18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FC24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FC30
-	voice_square_1_alt 0, 0, 0, 1, 4, 1  @ 868FC3C
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 868FC48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FC54
-	voice_programmable_wave_alt ProgrammableWaveData_86B4920, 0, 7, 15, 0  @ 868FC60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FC6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FC78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FC84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FC90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FC9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FCA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FCB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FCC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FCCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FCD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FCE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FCF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FCFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FD08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FD14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FD20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FD2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FD38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FD44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FD50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FD5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FD68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FD74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FD80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FD8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FD98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FDA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FDB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FDBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FDC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FDD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FDE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FDEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FDF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FE04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FE10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FE1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FE28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FE34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FE40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FE4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FE58
-	voice_noise_alt 0, 0, 1, 7, 1  @ 868FE64
-	voice_noise_alt 0, 0, 1, 0, 0  @ 868FE70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FB58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FB64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FB70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FB7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FB88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FB94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FBA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FBAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FBB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FBC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FBD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FBDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FBE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FBF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FC00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FC0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FC18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FC24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FC30
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1  @ 868FC3C
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 868FC48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FC54
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4920, 0, 7, 15, 0  @ 868FC60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FC6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FC78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FC84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FC90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FC9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FCA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FCB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FCC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FCCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FCD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FCE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FCF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FCFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FD08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FD14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FD20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FD2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FD38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FD44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FD50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FD5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FD68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FD74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FD80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FD8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FD98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FDA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FDB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FDBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FDC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FDD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FDE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FDEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FDF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FE04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FE10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FE1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FE28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FE34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FE40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FE4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FE58
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 868FE64
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 868FE70
 

--- a/sound/voicegroups/voicegroup088.inc
+++ b/sound/voicegroups/voicegroup088.inc
@@ -2,130 +2,130 @@
 voicegroup088:: @ 868FE7C
 	voice_keysplit_all voicegroup001  @ 868FE7C
 	voice_keysplit voicegroup005, KeySplitTable1  @ 868FE88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FE94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FEA0
-	voice_square_2_alt 1, 1, 1, 6, 2  @ 868FEAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FEB8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 868FEC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FEDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FEE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FEF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FF00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FF0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FF18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FE94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FEA0
+	voice_square_2_alt 60, 0, 1, 1, 1, 6, 2  @ 868FEAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FEB8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 868FEC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FEDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FEE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FEF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FF00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FF0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FF18
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 868FF24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FF30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FF3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FF48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FF54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FF60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FF6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FF78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FF84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FF90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FF9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FFA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FFB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FFC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FFCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FFD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FFE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FFF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 868FFFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869002C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869005C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869008C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FF30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FF3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FF48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FF54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FF60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FF6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FF78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FF84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FF90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FF9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FFA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FFB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FFC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FFCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FFD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FFE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FFF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 868FFFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869002C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869005C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869008C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690098
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 86900A4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 239  @ 86900B0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86900BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86900C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86900D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86900E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86900EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86900F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86900C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86900D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86900E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86900EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86900F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690110
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869011C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690128
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8690134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690140
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869014C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869017C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86901A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86901AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86901B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86901C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86901D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86901DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869017C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86901A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86901AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86901B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86901C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86901D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86901DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 86901E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86901F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869020C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690230
-	voice_square_1_alt 0, 1, 0, 1, 6, 2  @ 869023C
-	voice_square_2_alt 1, 0, 2, 4, 0  @ 8690248
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8690254
-	voice_square_1_alt 0, 1, 0, 1, 4, 1  @ 8690260
-	voice_square_1_alt 0, 1, 1, 1, 6, 0  @ 869026C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690284
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 8690290
-	voice_square_2_alt 3, 0, 1, 6, 2  @ 869029C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86902A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86902B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86902C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86902CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86902D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86902E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86902F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86902FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869032C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869035C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869038C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86903A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86903B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86903BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86903C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86903D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86903E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86903EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86903F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869041C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690428
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869044C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690458
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690464
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8690470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86901F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869020C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690230
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 6, 2  @ 869023C
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 0  @ 8690248
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8690254
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 1  @ 8690260
+	voice_square_1_alt 60, 0, 0, 1, 1, 1, 6, 0  @ 869026C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690284
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 0  @ 8690290
+	voice_square_2_alt 60, 0, 3, 0, 1, 6, 2  @ 869029C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86902A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86902B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86902C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86902CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86902D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86902E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86902F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86902FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869032C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869035C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869038C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86903A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86903B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86903BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86903C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86903D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86903E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86903EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86903F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869041C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869044C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690464
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8690470
 

--- a/sound/voicegroups/voicegroup089.inc
+++ b/sound/voicegroups/voicegroup089.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup089:: @ 869047C
 	voice_keysplit_all voicegroup001  @ 869047C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86904A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86904AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86904B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86904C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86904D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86904DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86904E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86904F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869050C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86904A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86904AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86904B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86904C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86904D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86904DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86904E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86904F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869050C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690518
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 8690524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869053C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869056C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869059C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86905A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86905B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86905C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86905CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86905D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86905E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86905F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86905FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869062C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869065C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869068C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86906A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86906B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869053C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869056C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869059C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86905A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86905B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86905C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86905CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86905D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86905E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86905F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86905FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869062C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869065C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869068C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86906A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86906B0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86906BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86906C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86906D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86906E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86906EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86906F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869071C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86906C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86906D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86906E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86906EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86906F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869071C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690740
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869074C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869077C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690788
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86907A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86907AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86907B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86907C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86907D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86907DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869077C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86907A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86907AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86907B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86907C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86907D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86907DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 86907E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86907F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869080C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690830
-	voice_square_1_alt 0, 1, 0, 2, 4, 3  @ 869083C
-	voice_square_2_alt 2, 0, 2, 4, 0  @ 8690848
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 8690854
-	voice_programmable_wave_alt ProgrammableWaveData_86B4920, 0, 7, 15, 0  @ 8690860
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 869086C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869089C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86908A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86908B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86908C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86908CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86908D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86908E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86908F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86908FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869092C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690938
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869095C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869098C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86909A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86909B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86909BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86909C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86909D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86909E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86909EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86909F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690A04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690A10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690A1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690A28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690A34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690A40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690A4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690A58
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8690A64
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8690A70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86907F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869080C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690830
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 4, 3  @ 869083C
+	voice_square_2_alt 60, 0, 2, 0, 2, 4, 0  @ 8690848
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 8690854
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4920, 0, 7, 15, 0  @ 8690860
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 869086C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869089C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86908A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86908B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86908C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86908CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86908D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86908E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86908F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86908FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869092C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869095C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869098C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86909A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86909B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86909BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86909C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86909D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86909E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86909EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86909F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690A1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690A34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690A40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690A4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690A58
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8690A64
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8690A70
 

--- a/sound/voicegroups/voicegroup090.inc
+++ b/sound/voicegroups/voicegroup090.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup090:: @ 8690A7C
 	voice_keysplit_all voicegroup001  @ 8690A7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690A88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690A94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690AA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690AAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690AB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690AC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690AD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690ADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690AE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690AF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690B00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690B0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690B18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690B24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690B30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690B3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690B48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690B54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690B60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690B6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690B78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690B84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690B90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690B9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690BA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690BB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690BC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690BCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690BD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690BE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690BF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690BFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690C08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690C14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690C20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690C2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690C38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690C44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690C50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690C5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690C68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690C74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690C80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690C8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690C98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690CA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690CB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690CBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690CC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690CD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690CE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690CEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690CF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690D04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690D10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690D1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690D28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690D34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690D40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690D4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690D58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690D64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690D70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690D7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690D88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690D94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690DA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690DAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690DB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690DC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690DD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690DDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690DE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690DF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690E00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690E0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690E18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690E24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690E30
-	voice_square_1_alt 0, 0, 0, 2, 4, 1  @ 8690E3C
-	voice_square_2_alt 0, 0, 2, 4, 1  @ 8690E48
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8690E54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690E60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690E6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690E78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690E84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690E90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690E9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690EA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690EB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690EC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690ECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690ED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690EE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690EF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690EFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690F08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690F14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690F20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690F2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690F38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690F44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690F50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690F5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690F68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690F74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690F80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690F8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690F98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690FA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690FB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690FBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690FC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690FD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690FE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690FEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8690FF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869101C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869104C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691058
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8691064
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8691070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690A88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690A94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690AA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690AAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690AB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690AC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690ADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690AF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690B18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690B30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690B3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690B60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690B6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690B90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690B9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690BA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690BB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690BC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690BE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690BFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690C08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690C14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690C20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690C2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690C38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690C44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690C50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690C5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690C68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690C74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690C80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690C98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690CBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690DDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690DE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690E24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690E30
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 4, 1  @ 8690E3C
+	voice_square_2_alt 60, 0, 0, 0, 2, 4, 1  @ 8690E48
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8690E54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690E60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690F74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690FA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690FB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690FBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8690FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869101C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869104C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691058
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8691064
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8691070
 

--- a/sound/voicegroups/voicegroup091.inc
+++ b/sound/voicegroups/voicegroup091.inc
@@ -2,130 +2,130 @@
 voicegroup091:: @ 869107C
 	voice_keysplit_all voicegroup001  @ 869107C
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8691088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86910A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86910AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86910B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86910C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86910D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86910DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86910A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86910AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86910B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86910C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86910D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86910DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 165, 72, 249  @ 86910E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86910F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869110C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86910F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869110C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 8691118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869113C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869113C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 165  @ 8691148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869116C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869116C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691190
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 76  @ 869119C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86911A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86911B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86911C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86911CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86911D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86911E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86911F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86911FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86911A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86911B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86911C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86911CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86911D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86911E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86911F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86911FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691214
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 8691220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869122C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869125C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691268
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869128C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869122C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869125C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869128C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 226, 0, 38  @ 8691298
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 242  @ 86912A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86912B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86912B0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86912BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86912C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86912D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86912E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86912EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86912F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869131C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86912C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86912D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86912E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86912EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86912F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869131C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691328
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8691334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691340
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869134C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869137C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86913A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86913AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86913B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86913C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86913D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86913DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869137C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86913A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86913AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86913B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86913C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86913D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86913DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 86913E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86913F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869140C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691430
-	voice_square_1_alt 0, 2, 0, 1, 5, 2  @ 869143C
-	voice_square_2_alt 2, 0, 1, 5, 2  @ 8691448
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 7, 0  @ 8691454
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 2, 6, 1  @ 8691460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869146C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869149C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86914A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86914B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86914C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86914CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86914D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86914E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86914F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86914FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869152C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869155C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869158C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86915A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86915B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86915BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86915C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86915D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86915E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86915EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86915F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869161C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869164C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691658
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8691664
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8691670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86913F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869140C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691430
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 5, 2  @ 869143C
+	voice_square_2_alt 60, 0, 2, 0, 1, 5, 2  @ 8691448
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 7, 0  @ 8691454
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 2, 6, 1  @ 8691460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869146C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869149C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86914A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86914B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86914C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86914CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86914D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86914E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86914F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86914FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869152C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869155C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869158C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86915A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86915B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86915BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86915C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86915D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86915E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86915EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86915F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869161C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869164C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691658
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8691664
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8691670
 

--- a/sound/voicegroups/voicegroup092.inc
+++ b/sound/voicegroups/voicegroup092.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup092:: @ 869167C
 	voice_keysplit_all voicegroup001  @ 869167C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86916A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86916AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86916B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86916C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86916D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86916DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86916E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86916F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869170C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86916A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86916AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86916B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86916C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86916D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86916DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86916E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86916F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869170C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 8691718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869173C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869176C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869173C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869176C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691790
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 76  @ 869179C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86917A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86917B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86917C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86917CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86917D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86917E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86917F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86917FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691808
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869182C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86917A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86917B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86917C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86917CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86917D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86917E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86917F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86917FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869182C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691838
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8691844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691850
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869185C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691868
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869188C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869185C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869188C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691898
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 242  @ 86918A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86918B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86918BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86918C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86918D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86918E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86918EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86918F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869191C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869194C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869197C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86919A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86919AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86919B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86919C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86919D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86919DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86919E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86919F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691A00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691A0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691A18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691A24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691A30
-	voice_square_1_alt 0, 2, 0, 1, 4, 1  @ 8691A3C
-	voice_square_2_alt 2, 0, 1, 4, 2  @ 8691A48
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 7, 0  @ 8691A54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691A60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691A6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691A78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691A84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691A90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691A9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691AA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691AB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691AC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691ACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691AD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691AE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691AF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691AFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691B08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691B14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691B20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691B2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691B38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691B44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691B50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691B5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691B68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691B74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691B80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691B8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691B98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691BA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691BB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691BBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691BC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691BD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691BE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691BEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691BF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691C04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691C10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691C1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691C28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691C34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691C40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691C4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691C58
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8691C64
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8691C70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86918B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86918BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86918C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86918D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86918E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86918EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86918F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869191C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869194C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869197C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86919A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86919AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86919B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86919C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86919D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86919DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86919E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86919F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691A24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691A30
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1  @ 8691A3C
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 2  @ 8691A48
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 7, 0  @ 8691A54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691A6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691A84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691C58
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8691C64
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8691C70
 

--- a/sound/voicegroups/voicegroup093.inc
+++ b/sound/voicegroups/voicegroup093.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup093:: @ 8691C7C
 	voice_keysplit_all voicegroup001  @ 8691C7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691C88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691C94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691CA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691CAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691CB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691CC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691CD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691CDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691CE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691CF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691D00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691C88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691CA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691D0C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 8691D18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691D24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691D30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691D3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691D48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691D54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691D60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691D6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691D78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691D84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691D90
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 76  @ 8691D9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691DA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691DB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691DC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691DCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691DD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691DE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691DF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691DFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691E08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691E14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691E20
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 8691E2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691E38
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8691E44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691E50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691E5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691E68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691E74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691E80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691E8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691E50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691E5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691E74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691E80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691E98
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 242  @ 8691EA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691EB0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8691EBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691EC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691ED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691EE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691EEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691EF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691F04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691F10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691F1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691EEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691F28
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8691F34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691F40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691F40
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8691F4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691F58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691F64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691F70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691F7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691F88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691F94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691FA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691FAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691FB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691FC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691FD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691F64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691F88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691FDC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 8691FE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8691FF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869200C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692030
-	voice_square_1_alt 0, 1, 0, 1, 4, 1  @ 869203C
-	voice_square_2_alt 1, 0, 1, 4, 1  @ 8692048
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 7, 0  @ 8692054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869206C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869209C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86920A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86920B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86920C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86920CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86920D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86920E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86920F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86920FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869212C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869215C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869218C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86921A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86921B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86921BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86921C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86921D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86921E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86921EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86921F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869221C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692234
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869224C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692258
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8692264
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8692270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8691FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869200C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692030
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 1  @ 869203C
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 1  @ 8692048
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 7, 0  @ 8692054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869206C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869209C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86920A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86920B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86920C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86920CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86920D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86920E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86920F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86920FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869212C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869215C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869218C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86921A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86921B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86921BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86921C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86921D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86921E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86921EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86921F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869221C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869224C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692258
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8692264
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8692270
 

--- a/sound/voicegroups/voicegroup094.inc
+++ b/sound/voicegroups/voicegroup094.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup094:: @ 869227C
 	voice_keysplit_all voicegroup001  @ 869227C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86922A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86922AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86922B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86922C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86922D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86922DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86922A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86922AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86922B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86922C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86922D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86922DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 165, 72, 249  @ 86922E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86922F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869230C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86922F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869230C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 8692318
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 8692324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869233C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869233C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 8692348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869236C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869236C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 255, 0, 255, 165  @ 8692378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692390
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 76  @ 869239C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86923A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86923B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86923C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86923CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86923D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86923E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86923F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86923FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869242C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869245C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692468
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869248C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692498
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86924A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86923A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86923B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86923C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86923CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86923D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86923E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86923F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86923FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869242C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869245C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869248C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86924A4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 86924B0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86924BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86924C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86924D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86924E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86924EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86924F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86924C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86924D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86924E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86924EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86924F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692510
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869251C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692540
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869254C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869257C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86925A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86925AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86925B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86925C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86925D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86925DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869257C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86925A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86925AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86925B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86925C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86925D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86925DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 86925E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86925F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869260C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692618
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692630
-	voice_square_1_alt 0, 0, 0, 1, 4, 1  @ 869263C
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 8692648
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 7, 0  @ 8692654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869266C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869269C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86926A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86926B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86926C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86926CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86926D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86926E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86926F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86926FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869272C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869275C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869278C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86927A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86927B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86927BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86927C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86927D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86927E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86927EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86927F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869281C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692828
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869284C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692858
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8692864
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8692870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86925F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869260C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692630
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1  @ 869263C
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 8692648
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 7, 0  @ 8692654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869266C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869269C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86926A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86926B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86926C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86926CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86926D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86926E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86926F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86926FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869272C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869275C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869278C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86927A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86927B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86927BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86927C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86927D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86927E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86927EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86927F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869281C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869284C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692858
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8692864
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8692870
 

--- a/sound/voicegroups/voicegroup095.inc
+++ b/sound/voicegroups/voicegroup095.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup095:: @ 869287C
 	voice_keysplit_all voicegroup001  @ 869287C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86928A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86928AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86928B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86928C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86928D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86928DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86928E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86928F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869290C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869293C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86928A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86928AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86928B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86928C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86928D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86928DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86928E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86928F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869290C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869293C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 8692948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869296C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869296C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692990
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 869299C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86929A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86929B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86929C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86929CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86929D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86929E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86929F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86929FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692A08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692A14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692A20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692A2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86929A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86929B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86929C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86929CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86929D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86929E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86929F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86929FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692A38
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8692A44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692A50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692A5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692A68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692A74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692A80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692A8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692A98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692AA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692AB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692ABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692AC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692AD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692AE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692AEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692AF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692B04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692B10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692B1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692B28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692B34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692B40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692B4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692B58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692B64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692B70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692B7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692B88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692B94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692BA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692BAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692BB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692BC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692BD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692BDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692A50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692A5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692A74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692B64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692B94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692BB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692BC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692BDC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 8692BE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692BF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692C00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692C0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692C18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692C24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692C30
-	voice_square_1_alt 0, 1, 0, 1, 4, 1  @ 8692C3C
-	voice_square_2_alt 1, 0, 1, 4, 1  @ 8692C48
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 3  @ 8692C54
-	voice_square_2_alt 3, 0, 1, 4, 1  @ 8692C60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692C6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692C78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692C84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692C90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692C9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692CA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692CB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692CC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692CCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692CD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692CE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692CF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692CFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692D08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692D14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692D20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692D2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692D38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692D44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692D50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692D5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692D68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692D74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692D80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692D8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692D98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692DA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692DB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692DBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692DC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692DD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692DE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692DEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692DF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692E04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692E10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692E1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692E28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692E34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692E40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692E4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692E58
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8692E64
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8692E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692BF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692C00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692C18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692C30
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 1  @ 8692C3C
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 1  @ 8692C48
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 3  @ 8692C54
+	voice_square_2_alt 60, 0, 3, 0, 1, 4, 1  @ 8692C60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692C78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692C84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692C90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692CA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692CB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692CF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692D14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692D98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692DF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692E28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692E34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692E4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692E58
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8692E64
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8692E70
 

--- a/sound/voicegroups/voicegroup096.inc
+++ b/sound/voicegroups/voicegroup096.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup096:: @ 8692E7C
 	voice_keysplit_all voicegroup001  @ 8692E7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692E88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692E94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692EA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692EAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692EB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692EC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692ED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692EDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692EE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692EF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692F00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692E88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692EA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692EF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692F00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692F0C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 8692F18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692F24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692F30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692F30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692F3C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 8692F48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692F54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692F60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692F6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692F78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692F84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692F90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692F60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692F6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692F78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692F90
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 8692F9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692FA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692FB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692FC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692FCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692FD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692FE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692FF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8692FFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692FB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692FC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692FCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692FF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8692FFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693020
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 869302C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693038
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8693044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869305C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869308C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86930A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869305C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869308C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86930A4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 86930B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86930BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86930C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86930D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86930E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86930EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86930F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86930BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86930C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86930D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86930E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86930EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86930F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693110
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869311C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869314C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869317C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86931A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86931AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86931B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86931C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86931D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86931DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86931E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86931F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869320C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869323C
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 8693248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693254
-	voice_square_1_alt 0, 0, 0, 1, 4, 1  @ 8693260
-	voice_programmable_wave_alt ProgrammableWaveData_86B4910, 0, 7, 15, 0  @ 869326C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869329C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86932A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86932B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86932C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86932CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86932D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86932E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86932F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86932FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869332C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869335C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869338C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86933A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86933B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86933BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86933C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86933D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86933E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86933EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86933F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869341C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693428
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869344C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693458
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8693464
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8693470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869314C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869317C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86931A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86931AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86931B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86931C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86931D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86931DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86931E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86931F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869320C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869323C
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 8693248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693254
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1  @ 8693260
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4910, 0, 7, 15, 0  @ 869326C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869329C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86932A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86932B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86932C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86932CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86932D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86932E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86932F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86932FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869332C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869335C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869338C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86933A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86933B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86933BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86933C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86933D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86933E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86933EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86933F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869341C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869344C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693458
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8693464
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8693470
 

--- a/sound/voicegroups/voicegroup097.inc
+++ b/sound/voicegroups/voicegroup097.inc
@@ -2,130 +2,130 @@
 voicegroup097:: @ 869347C
 	voice_keysplit_all voicegroup001  @ 869347C
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8693488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86934A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86934AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86934B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86934C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86934D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86934DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86934E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86934F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869350C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86934A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86934AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86934B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86934C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86934D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86934DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86934E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86934F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869350C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693518
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 8693524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869353C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869356C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869359C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86935A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86935B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86935C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86935CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86935D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86935E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86935F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86935FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869362C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869365C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869368C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86936A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869353C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869356C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869359C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86935A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86935B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86935C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86935CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86935D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86935E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86935F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86935FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869362C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869365C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869368C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86936A4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 249  @ 86936B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86936BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86936C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86936D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86936E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86936EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86936F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869371C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86936BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86936C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86936D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86936E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86936EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86936F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869371C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693728
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8693734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693740
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869374C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869377C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693788
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86937A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86937AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86937B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86937C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86937D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86937DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86937E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86937F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869380C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693830
-	voice_square_1_alt 0, 3, 0, 1, 4, 1  @ 869383C
-	voice_square_2_alt 3, 0, 1, 4, 1  @ 8693848
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 7, 0  @ 8693854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869386C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869389C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86938A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86938B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86938C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86938CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86938D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86938E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86938F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86938FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869392C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693938
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869395C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869398C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86939A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86939B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86939BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86939C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86939D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86939E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86939EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86939F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693A04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693A10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693A1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693A28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693A34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693A40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693A4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693A58
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8693A64
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8693A70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869377C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86937A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86937AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86937B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86937C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86937D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86937DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86937E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86937F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869380C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693830
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 4, 1  @ 869383C
+	voice_square_2_alt 60, 0, 3, 0, 1, 4, 1  @ 8693848
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 7, 0  @ 8693854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869386C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869389C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86938A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86938B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86938C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86938CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86938D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86938E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86938F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86938FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869392C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869395C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869398C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86939A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86939B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86939BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86939C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86939D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86939E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86939EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86939F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693A1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693A34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693A40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693A4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693A58
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8693A64
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8693A70
 

--- a/sound/voicegroups/voicegroup098.inc
+++ b/sound/voicegroups/voicegroup098.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup098:: @ 8693A7C
 	voice_keysplit_all voicegroup001  @ 8693A7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693A88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693A94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693AA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693AAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693AB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693AC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693AD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693ADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693AE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693AF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693B00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693B0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693B18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693B24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693B30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693B3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693B48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693B54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693B60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693B6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693B78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693B84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693B90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693B9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693BA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693BB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693BC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693BCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693BD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693BE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693BF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693BFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693C08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693C14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693C20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693C2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693C38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693C44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693C50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693C5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693C68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693C74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693C80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693C8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693C98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693CA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693CB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693CBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693CC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693CD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693CE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693CEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693CF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693D04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693A88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693A94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693AA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693AAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693AB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693AC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693ADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693AF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693B18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693B30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693B3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693B60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693B6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693B90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693B9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693BA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693BB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693BC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693BE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693BFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693C08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693C14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693C20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693C2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693C38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693C44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693C50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693C5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693C68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693C74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693C80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693C98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693CBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693D10
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8693D1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693D28
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8693D34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693D40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693D4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693D58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693D64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693D70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693D7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693D88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693D94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693DA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693DAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693DB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693DC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693DD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693DDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693DDC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 8693DE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693DF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693E00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693E0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693E18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693E24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693E30
-	voice_square_1_alt 0, 0, 0, 1, 4, 0  @ 8693E3C
-	voice_square_2_alt 0, 0, 1, 4, 0  @ 8693E48
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 7, 0  @ 8693E54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693E60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693E6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693E78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693E84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693E90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693E9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693EA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693EB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693EC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693ECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693ED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693EE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693EF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693EFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693F08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693F14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693F20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693F2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693F38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693F44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693F50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693F5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693F68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693F74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693F80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693F8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693F98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693FA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693FB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693FBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693FC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693FD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693FE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693FEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8693FF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869401C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869404C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693E24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693E30
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 0  @ 8693E3C
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 0  @ 8693E48
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 7, 0  @ 8693E54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693E60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693F74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693FA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693FB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693FBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8693FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869401C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869404C
 	voice_directsound 60, 0, DirectSoundWaveData_873ECD8, 255, 255, 255, 127  @ 8694058
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_standard_hand_clap, 255, 255, 255, 127  @ 8694064
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8694070
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8694070
 

--- a/sound/voicegroups/voicegroup099.inc
+++ b/sound/voicegroups/voicegroup099.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup099:: @ 869407C
 	voice_keysplit_all voicegroup001  @ 869407C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86940A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86940AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86940B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86940C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86940D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86940DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86940E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86940F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869410C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86940A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86940AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86940B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86940C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86940D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86940DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86940E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86940F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869410C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 8694118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869413C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869416C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694190
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869419C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86941A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86941B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86941C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86941CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86941D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86941E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86941F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86941FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869413C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869416C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869419C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86941A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86941B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86941C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86941CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86941D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86941E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86941F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86941FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694220
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 869422C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694238
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8694244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869425C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694268
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869428C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86942A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86942B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86942BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86942C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86942D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86942E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86942EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86942F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869425C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869428C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86942A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86942B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86942BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86942C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86942D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86942E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86942EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86942F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694310
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869431C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869434C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869437C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86943A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86943AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86943B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86943C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86943D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86943DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86943E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86943F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869440C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694430
-	voice_square_1_alt 0, 0, 0, 1, 4, 0  @ 869443C
-	voice_square_2_alt 0, 0, 1, 4, 0  @ 8694448
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 7, 0  @ 8694454
-	voice_square_1_alt 0, 1, 2, 1, 5, 0  @ 8694460
-	voice_square_2_alt 1, 2, 1, 5, 0  @ 869446C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869449C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86944A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86944B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86944C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86944CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86944D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86944E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86944F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86944FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869452C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869455C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869458C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86945A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86945B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86945BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86945C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86945D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86945E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86945EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86945F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869461C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869464C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694658
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8694664
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8694670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869434C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869437C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86943A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86943AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86943B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86943C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86943D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86943DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86943E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86943F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869440C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694430
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 0  @ 869443C
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 0  @ 8694448
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 7, 0  @ 8694454
+	voice_square_1_alt 60, 0, 0, 1, 2, 1, 5, 0  @ 8694460
+	voice_square_2_alt 60, 0, 1, 2, 1, 5, 0  @ 869446C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869449C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86944A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86944B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86944C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86944CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86944D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86944E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86944F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86944FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869452C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869455C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869458C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86945A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86945B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86945BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86945C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86945D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86945E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86945EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86945F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869461C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869464C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694658
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8694664
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8694670
 

--- a/sound/voicegroups/voicegroup100.inc
+++ b/sound/voicegroups/voicegroup100.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup100:: @ 869467C
 	voice_keysplit_all voicegroup001  @ 869467C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86946A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86946AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86946B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86946C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86946D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86946DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86946E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86946F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869470C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86946A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86946AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86946B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86946C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86946D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86946DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86946E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86946F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869470C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 8694718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869473C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869473C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 8694748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869476C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869476C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694790
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 869479C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86947A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86947B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86947C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86947CC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4910, 0, 7, 15, 0  @ 86947D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86947E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86947F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86947FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694808
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86947A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86947B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86947C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86947CC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4910, 0, 7, 15, 0  @ 86947D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86947E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86947F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86947FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694820
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 869482C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694838
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8694844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694850
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869485C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694868
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869488C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694898
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86948A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869485C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869488C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86948A4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 86948B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86948BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86948C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86948D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86948E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86948EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86948F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86948BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86948C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86948D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86948E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86948EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86948F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694910
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869491C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869494C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869497C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86949A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86949AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86949B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86949C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86949D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86949DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869494C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869497C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86949A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86949AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86949B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86949C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86949D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86949DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 86949E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86949F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694A00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694A0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694A18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694A24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694A30
-	voice_square_1_alt 0, 0, 0, 1, 4, 1  @ 8694A3C
-	voice_square_1_alt 0, 2, 1, 1, 4, 1  @ 8694A48
-	voice_square_2_alt 2, 1, 1, 4, 1  @ 8694A54
-	voice_square_2_alt 1, 0, 1, 4, 1  @ 8694A60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694A6C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 8694A78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694A84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694A90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694A9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694AA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694AB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694AC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694ACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694AD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694AE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694AF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694AFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694B08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694B14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694B20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694B2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694B38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694B44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694B50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694B5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694B68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694B74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694B80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694B8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694B98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694BA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694BB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694BBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694BC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694BD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694BE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694BEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694BF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694C04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694C10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694C1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694C28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694C34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694C40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694C4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694C58
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8694C64
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8694C70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86949F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694A24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694A30
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1  @ 8694A3C
+	voice_square_1_alt 60, 0, 0, 2, 1, 1, 4, 1  @ 8694A48
+	voice_square_2_alt 60, 0, 2, 1, 1, 4, 1  @ 8694A54
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 1  @ 8694A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694A6C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 8694A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694A84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694C58
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8694C64
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8694C70
 

--- a/sound/voicegroups/voicegroup101.inc
+++ b/sound/voicegroups/voicegroup101.inc
@@ -2,112 +2,112 @@
 voicegroup101:: @ 8694C7C
 	voice_keysplit_all voicegroup001  @ 8694C7C
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8694C88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694C94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694CA0
-	voice_square_1_alt 0, 1, 1, 5, 2, 4  @ 8694CAC
-	voice_square_2_alt 1, 1, 5, 2, 4  @ 8694CB8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 8694CC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694CD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694CDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694CE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694CF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694D00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694D0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694CA0
+	voice_square_1_alt 60, 0, 0, 1, 1, 5, 2, 4  @ 8694CAC
+	voice_square_2_alt 60, 0, 1, 1, 5, 2, 4  @ 8694CB8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 8694CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694D18
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 8694D24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694D30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694D3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694D48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694D54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694D60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694D6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694D78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694D84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694D90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694D9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694DA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694DB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694DC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694DCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694DD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694DE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694DF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694DFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694E08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694E14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694E20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694E2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694E38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694E44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694E50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694E5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694E68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694E74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694E80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694E8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694E2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694E44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694E50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694E5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694E74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694E80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694E98
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 8694EA4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 239  @ 8694EB0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8694EBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694EC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694ED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694EE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694EEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694EF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694F04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694EEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694F10
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8694F1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694F28
 	voice_keysplit voicegroup008, KeySplitTable4  @ 8694F34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694F40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694F40
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8694F4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694F58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694F64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694F70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694F7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694F88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694F94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694FA0
-	voice_square_1_alt 0, 1, 1, 2, 4, 1  @ 8694FAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694FB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694FC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694FD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8694FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694F64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694F88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694FA0
+	voice_square_1_alt 60, 0, 0, 1, 1, 2, 4, 1  @ 8694FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8694FDC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 8694FE8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8694FF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869500C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695030
-	voice_square_2_alt 1, 1, 1, 6, 0  @ 869503C
-	voice_square_1_alt 0, 0, 0, 4, 6, 2  @ 8695048
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8695054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695060
-	voice_square_1_alt 0, 0, 0, 1, 6, 0  @ 869506C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695078
-	voice_square_2_alt 1, 1, 4, 6, 1  @ 8695084
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8695090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869509C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86950A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86950B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86950C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86950CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86950D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86950E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86950F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86950FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869512C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869515C
-	voice_square_2_alt 0, 1, 2, 4, 1  @ 8695168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869518C
-	voice_square_2_alt 0, 1, 1, 6, 1  @ 8695198
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8694FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869500C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695030
+	voice_square_2_alt 60, 0, 1, 1, 1, 6, 0  @ 869503C
+	voice_square_1_alt 60, 0, 0, 0, 0, 4, 6, 2  @ 8695048
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8695054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695060
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 6, 0  @ 869506C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695078
+	voice_square_2_alt 60, 0, 1, 1, 4, 6, 1  @ 8695084
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8695090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869509C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86950A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86950B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86950C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86950CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86950D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86950E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86950F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86950FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869512C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869515C
+	voice_square_2_alt 60, 0, 0, 1, 2, 4, 1  @ 8695168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869518C
+	voice_square_2_alt 60, 0, 0, 1, 1, 6, 1  @ 8695198
 

--- a/sound/voicegroups/voicegroup102.inc
+++ b/sound/voicegroups/voicegroup102.inc
@@ -1,85 +1,85 @@
 	.align 2
 voicegroup102:: @ 86951A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86951A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86951B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86951BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86951C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86951D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86951E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86951EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86951F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869521C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695234
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869524C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695258
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869527C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86952A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86952AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86952B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86951A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86951B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86951BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86951C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86951D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86951E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86951EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86951F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869521C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869524C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869527C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86952A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86952AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86952B8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 248  @ 86952C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86952D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86952DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86952E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86952F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869530C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869533C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869536C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869539C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86953A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86953B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86953C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86952D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86952DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86952E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86952F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869530C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869533C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869536C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869539C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86953A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86953B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86953C0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 165  @ 86953CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86953D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86953E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86953F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86953FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869542C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869545C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695468
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869548C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695498
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86954A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86954B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86954BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86954C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86954D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86954E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86954EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86954F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695510
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869551C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869554C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695558
-	voice_square_1_alt 0, 2, 0, 6, 0, 6  @ 8695564
-	voice_square_2_alt 2, 0, 6, 0, 6  @ 8695570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86953D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86953E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86953F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86953FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869542C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869545C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869548C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86954A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86954B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86954BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86954C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86954D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86954E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86954EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86954F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869551C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869554C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695558
+	voice_square_1_alt 60, 0, 0, 2, 0, 6, 0, 6  @ 8695564
+	voice_square_2_alt 60, 0, 2, 0, 6, 0, 6  @ 8695570
 

--- a/sound/voicegroups/voicegroup103.inc
+++ b/sound/voicegroups/voicegroup103.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup103:: @ 869557C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869557C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869557C
 	voice_keysplit_all voicegroup002  @ 8695588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86955A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86955AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86955B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86955C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86955D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86955DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86955E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86955F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869560C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86955A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86955AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86955B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86955C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86955D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86955DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86955E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86955F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869560C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695618
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 8695624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695630
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869563C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869566C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869563C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869566C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695690
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 869569C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86956A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86956B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86956C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86956CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86956D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86956E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86956F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86956FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869572C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869575C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869578C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86956A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86956B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86956C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86956CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86956D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86956E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86956F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86956FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869572C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869575C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869578C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695798
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 86957A4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 239  @ 86957B0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86957BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86957C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86957D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86957E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86957EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86957F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86957C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86957D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86957E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86957EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86957F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695810
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869581C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695828
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695840
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869584C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869587C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86958A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86958AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86958B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86958C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86958D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86958DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86958E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86958F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869590C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695930
-	voice_square_1_alt 0, 1, 1, 1, 6, 0  @ 869593C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695954
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 8695960
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 1  @ 869596C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695984
-	voice_square_2_alt 1, 0, 0, 10, 1  @ 8695990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869599C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86959A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86959B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86959C0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 86959CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86959D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86959E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86959F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86959FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695A08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695A14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695A20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695A2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695A38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695A44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695A50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695A5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695A68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695A74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695A80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695A8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695A98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695AA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695AB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695ABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695AC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695AD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695AE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695AEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695AF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695B04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695B10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695B1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695B28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695B34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695B40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695B4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695B58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695B64
-	voice_noise_alt 0, 0, 2, 6, 1  @ 8695B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869587C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86958A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86958AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86958B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86958C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86958D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86958DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86958E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86958F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869590C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695930
+	voice_square_1_alt 60, 0, 0, 1, 1, 1, 6, 0  @ 869593C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695954
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 8695960
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 1  @ 869596C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695984
+	voice_square_2_alt 60, 0, 1, 0, 0, 10, 1  @ 8695990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869599C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86959A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86959B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86959C0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 86959CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86959D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86959E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86959F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86959FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695A50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695A5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695A74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695B64
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 1  @ 8695B70
 

--- a/sound/voicegroups/voicegroup104.inc
+++ b/sound/voicegroups/voicegroup104.inc
@@ -1,111 +1,111 @@
 	.align 2
 voicegroup104:: @ 8695B7C
 	voice_keysplit_all voicegroup003  @ 8695B7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695B88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695B94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695B94
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_koto_high, 255, 0, 206, 242  @ 8695BA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695BAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695BB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695BC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695BD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695BDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695BE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695BF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695C00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695C0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695C18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695C24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695C30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695C3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695C48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695C54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695C60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695C6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695C78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695C84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695C90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695C9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695CA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695CB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695CC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695CCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695CD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695CE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695CF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695CFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695D08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695D14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695D20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695D2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695D38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695D44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695D50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695D5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695D68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695D74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695D80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695D8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695D98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695BB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695BC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695BDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695BE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695BF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695C00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695C18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695C30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695C3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695C48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695C54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695C60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695C78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695C84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695C90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695CA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695CB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695CF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695D14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695D98
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 8695DA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695DB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695DBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695DC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695DD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695DE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695DEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695DF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695E04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695E10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695E1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695E28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695E34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695E40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695E4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695E58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695E64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695E70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695E7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695E88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695E94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695EA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695EAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695EB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695EC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695ED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695EDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695EE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695EF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695F00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695DF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695E28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695E34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695E4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695E58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695E7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695E88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695EA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695EF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695F00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695F0C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_shakuhachi, 255, 0, 255, 204  @ 8695F18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695F24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695F30
-	voice_square_1_alt 0, 1, 2, 0, 12, 5  @ 8695F3C
-	voice_square_2_alt 0, 0, 0, 10, 4  @ 8695F48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695F54
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 0, 15, 0  @ 8695F60
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8695F6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695F78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695F84
-	voice_square_2_alt 1, 2, 0, 12, 5  @ 8695F90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695F9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695FA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695FB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695FC0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 0, 15, 0  @ 8695FCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695FD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695FE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695FF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8695FFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869602C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869605C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695F30
+	voice_square_1_alt 60, 0, 0, 1, 2, 0, 12, 5  @ 8695F3C
+	voice_square_2_alt 60, 0, 0, 0, 0, 10, 4  @ 8695F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695F54
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 0, 15, 0  @ 8695F60
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 8695F6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695F78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695F84
+	voice_square_2_alt 60, 0, 1, 2, 0, 12, 5  @ 8695F90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695FB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695FC0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 0, 15, 0  @ 8695FCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695FF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8695FFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869602C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869605C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696074
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_koto_low, 255, 0, 206, 242  @ 8696080
 

--- a/sound/voicegroups/voicegroup105.inc
+++ b/sound/voicegroups/voicegroup105.inc
@@ -1,86 +1,86 @@
 	.align 2
 voicegroup105:: @ 869608C
 	voice_keysplit_all voicegroup002  @ 869608C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86960A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86960B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86960BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86960C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86960D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86960E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86960EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86960F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869611C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86960A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86960B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86960BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86960C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86960D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86960E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86960EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86960F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869611C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 216  @ 8696128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869614C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869617C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86961A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86961AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86961B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86961C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86961D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86961DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86961E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86961F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869620C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869623C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869626C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869629C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86962A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86962B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86962C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86962CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86962D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86962E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86962F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86962FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869632C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869635C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869638C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86963A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86963B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86963BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86963C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86963D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86963E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86963EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86963F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869641C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696428
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696440
-	voice_square_1_alt 0, 2, 0, 2, 9, 4  @ 869644C
-	voice_square_2_alt 2, 0, 2, 9, 4  @ 8696458
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 8696464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869614C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869617C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86961A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86961AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86961B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86961C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86961D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86961DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86961E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86961F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869620C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869623C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869626C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869629C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86962A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86962B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86962C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86962CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86962D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86962E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86962F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86962FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869632C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869635C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869638C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86963A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86963B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86963BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86963C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86963D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86963E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86963EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86963F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869641C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696440
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 9, 4  @ 869644C
+	voice_square_2_alt 60, 0, 2, 0, 2, 9, 4  @ 8696458
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 8696464
 

--- a/sound/voicegroups/voicegroup106.inc
+++ b/sound/voicegroups/voicegroup106.inc
@@ -2,130 +2,130 @@
 voicegroup106:: @ 8696470
 	voice_keysplit_all voicegroup002  @ 8696470
 	voice_keysplit voicegroup005, KeySplitTable1  @ 869647C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86964A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86964AC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86964B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86964C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86964D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86964DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86964E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86964F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869650C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86964A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86964AC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86964B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86964C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86964D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86964DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86964E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86964F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869650C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 8696518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696530
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 64, 38, 128, 226  @ 869653C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869656C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869656C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696584
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 76  @ 8696590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869659C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86965A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86965B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86965C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869659C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86965A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86965B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86965C0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127  @ 86965CC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 127  @ 86965D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86965E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86965F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86965FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869662C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86965E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86965F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86965FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869662C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8696638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869665C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869668C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869665C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869668C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 8696698
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 86966A4
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86966B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86966BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86966C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86966D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86966E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86966EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86966F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86966BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86966C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86966D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86966E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86966EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86966F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696704
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8696710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869671C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869671C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696734
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8696740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869674C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869674C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 127  @ 8696758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869677C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696788
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86967A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86967AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86967B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86967C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86967D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869677C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86967A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86967AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86967B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86967C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86967D0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 86967DC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 86967E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86967F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869680C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696824
-	voice_square_1_alt 0, 2, 0, 1, 4, 1  @ 8696830
-	voice_square_2_alt 2, 0, 1, 4, 1  @ 869683C
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 8696848
-	voice_square_1_alt 0, 0, 0, 1, 4, 1  @ 8696854
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 0  @ 8696860
-	voice_square_1_alt 0, 3, 0, 1, 4, 1  @ 869686C
-	voice_square_2_alt 3, 0, 1, 4, 1  @ 8696878
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 8696884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869689C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86968A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86968B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86968C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86968CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86968D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86968E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86968F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86968FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869692C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696938
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869695C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869698C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86969A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86969B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86969BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86969C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86969D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86969E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86969EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86969F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696A04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696A10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696A1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696A28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696A34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696A40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696A4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696A58
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8696A64
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 86967E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86967F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869680C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696824
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1  @ 8696830
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 1  @ 869683C
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 8696848
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1  @ 8696854
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 0  @ 8696860
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 4, 1  @ 869686C
+	voice_square_2_alt 60, 0, 3, 0, 1, 4, 1  @ 8696878
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 8696884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869689C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86968A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86968B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86968C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86968CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86968D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86968E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86968F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86968FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869692C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869695C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869698C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86969A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86969B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86969BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86969C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86969D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86969E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86969EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86969F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696A1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696A34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696A40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696A4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696A58
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8696A64
 

--- a/sound/voicegroups/voicegroup107.inc
+++ b/sound/voicegroups/voicegroup107.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup107:: @ 8696A70
 	voice_keysplit_all voicegroup002  @ 8696A70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696A7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696A88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696A94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696AA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696AAC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 8696AB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696AC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696AD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696ADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696AE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696AF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696B00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696A7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696A88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696A94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696AA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696AAC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 8696AB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696AC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696ADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696AF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696B0C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 8696B18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696B24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696B30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696B3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696B48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696B54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696B60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696B6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696B78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696B30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696B3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696B60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696B6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696B84
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 76  @ 8696B90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696B9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696BA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696BB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696BC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696BCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696BD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696BE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696BF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696BFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696C08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696C14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696C20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696C2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696C38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696C44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696C50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696C5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696C68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696C74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696C80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696B9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696BA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696BB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696BC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696BE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696BFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696C08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696C14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696C20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696C2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696C38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696C44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696C50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696C5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696C68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696C74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696C80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696C8C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 8696C98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696CA4
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8696CB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696CBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696CC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696CD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696CBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696CE0
 	voice_directsound 60, 0, DirectSoundWaveData_classical_choir_voice_ahhs, 255, 0, 255, 0  @ 8696CEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696CF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696D04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696D10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696D1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696D28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696D34
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8696D40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696D4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696D58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696D64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696D70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696D7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696D88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696D94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696DA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696DAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696DB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696DC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696DD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696DDC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8696DE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696DF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696E00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696E0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696E18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696E24
-	voice_square_1_alt 0, 2, 0, 1, 4, 1  @ 8696E30
-	voice_square_2_alt 2, 0, 1, 4, 1  @ 8696E3C
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 8696E48
-	voice_square_1_alt 0, 0, 0, 1, 4, 1  @ 8696E54
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 0  @ 8696E60
-	voice_square_1_alt 0, 3, 0, 1, 4, 1  @ 8696E6C
-	voice_square_2_alt 3, 0, 1, 4, 1  @ 8696E78
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 8696E84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696E90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696E9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696EA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696EB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696EC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696ECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696ED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696EE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696EF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696EFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696F08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696F14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696F20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696F2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696F38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696F44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696F50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696F5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696F68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696F74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696F80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696F8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696F98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696FA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696FB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696FBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696FC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696FD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696FE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696FEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8696FF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869701C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869704C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697058
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8697064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696DDC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 8696DE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696E24
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1  @ 8696E30
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 1  @ 8696E3C
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 8696E48
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1  @ 8696E54
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 0  @ 8696E60
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 4, 1  @ 8696E6C
+	voice_square_2_alt 60, 0, 3, 0, 1, 4, 1  @ 8696E78
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 8696E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696F74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696FA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696FB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696FBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8696FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869701C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869704C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697058
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8697064
 

--- a/sound/voicegroups/voicegroup108.inc
+++ b/sound/voicegroups/voicegroup108.inc
@@ -2,130 +2,130 @@
 voicegroup108:: @ 8697070
 	voice_keysplit_all voicegroup004  @ 8697070
 	voice_keysplit voicegroup005, KeySplitTable1  @ 869707C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86970A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86970AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86970B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86970C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86970D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86970DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86970A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86970AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86970B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86970C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86970D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86970DC
 	voice_directsound 60, 0, DirectSoundWaveData_heart_of_asia_gamelan, 255, 188, 139, 239  @ 86970E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86970F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869710C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869713C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869716C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86970F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869710C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869713C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869716C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697184
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 76  @ 8697190
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869719C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86971A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86971B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86971C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86971CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86971D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86971E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86971F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86971FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869719C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86971A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86971B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86971C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86971CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86971D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86971E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86971F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86971FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697208
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 8697214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869722C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869725C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697268
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869728C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869722C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869725C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869728C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 8697298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86972A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86972B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86972BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86972C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86972D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86972E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86972EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86972F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869731C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869734C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869737C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86973A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86973AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86973B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86973C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86973D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86973DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86973E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86973F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869740C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697424
-	voice_square_1_alt 0, 0, 0, 1, 13, 4  @ 8697430
-	voice_square_2_alt 0, 0, 0, 9, 2  @ 869743C
-	voice_square_2_alt 1, 0, 0, 7, 1  @ 8697448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697454
-	voice_programmable_wave_alt ProgrammableWaveData_86B4860, 0, 7, 15, 1  @ 8697460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869746C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697478
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 0, 15, 0  @ 8697484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869749C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86974A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86974B4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 86974C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86974CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86974D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86974E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86974F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86974FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869752C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869755C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869758C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86975A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86975B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86975BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86975C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86975D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86975E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86975EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86975F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869761C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869764C
-	voice_noise_alt 0, 0, 1, 7, 1  @ 8697658
-	voice_noise_alt 0, 0, 1, 0, 0  @ 8697664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86972A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86972B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86972BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86972C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86972D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86972E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86972EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86972F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869731C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869734C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869737C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86973A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86973AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86973B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86973C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86973D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86973DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86973E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86973F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869740C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697424
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 13, 4  @ 8697430
+	voice_square_2_alt 60, 0, 0, 0, 0, 9, 2  @ 869743C
+	voice_square_2_alt 60, 0, 1, 0, 0, 7, 1  @ 8697448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697454
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4860, 0, 7, 15, 1  @ 8697460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869746C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697478
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 0, 15, 0  @ 8697484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869749C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86974A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86974B4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 86974C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86974CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86974D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86974E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86974F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86974FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869752C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869755C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869758C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86975A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86975B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86975BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86975C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86975D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86975E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86975EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86975F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869761C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869764C
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 8697658
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 8697664
 

--- a/sound/voicegroups/voicegroup109.inc
+++ b/sound/voicegroups/voicegroup109.inc
@@ -1,86 +1,86 @@
 	.align 2
 voicegroup109:: @ 8697670
 	voice_keysplit_all voicegroup004  @ 8697670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869767C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86976A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86976AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86976B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86976C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86976D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86976DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86976E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86976F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869770C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869773C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869767C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86976A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86976AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86976B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86976C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86976D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86976DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86976E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86976F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869770C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869773C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697748
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_church_organ, 255, 76, 154, 188  @ 8697754
 	voice_directsound 60, 0, DirectSoundWaveData_emu_ii_pipe_organ, 255, 76, 154, 188  @ 8697760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869776C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697790
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869779C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86977A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86977B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86977C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86977CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86977D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86977E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86977F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86977FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869776C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869779C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86977A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86977B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86977C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86977CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86977D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86977E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86977F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86977FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697808
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 8697814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869782C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697850
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869785C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697868
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869788C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697898
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86978A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86978B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86978BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86978C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86978D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86978E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86978EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86978F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869791C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869794C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869797C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86979A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86979AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86979B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86979C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86979D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86979DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86979E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86979F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697A00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697A0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697A18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697A24
-	voice_square_1_alt 0, 0, 0, 0, 13, 1  @ 8697A30
-	voice_square_2_alt 0, 0, 0, 12, 1  @ 8697A3C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4920, 0, 7, 15, 0  @ 8697A48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869782C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869785C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869788C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86978A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86978B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86978BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86978C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86978D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86978E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86978EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86978F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869791C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869794C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869797C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86979A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86979AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86979B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86979C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86979D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86979DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86979E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86979F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697A24
+	voice_square_1_alt 60, 0, 0, 0, 0, 0, 13, 1  @ 8697A30
+	voice_square_2_alt 60, 0, 0, 0, 0, 12, 1  @ 8697A3C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4920, 0, 7, 15, 0  @ 8697A48
 

--- a/sound/voicegroups/voicegroup110.inc
+++ b/sound/voicegroups/voicegroup110.inc
@@ -2,130 +2,130 @@
 voicegroup110:: @ 8697A54
 	voice_keysplit_all voicegroup002  @ 8697A54
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8697A60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697A6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697A78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697A84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697A90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697A9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697AA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697AB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697AC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697ACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697AD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697AE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697A6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697A84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697AF0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 8697AFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697B08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697B14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697B20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697B2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697B38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697B44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697B50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697B5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697B68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697B74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697B80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697B8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697B98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697BA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697BB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697BBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697BC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697BD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697BE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697BEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697BF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697C04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697C10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697C1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697C28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697C34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697C40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697C4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697C58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697C64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697C70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697C58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697C70
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 8697C7C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 239  @ 8697C88
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8697C94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697CA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697CAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697CB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697CC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697CD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697CDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697CA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697CE8
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8697CF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697D00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697D0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697D18
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8697D24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697D30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697D3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697D48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697D54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697D60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697D6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697D78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697D84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697D90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697D9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697DA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697DB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697DC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697DCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697DD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697DE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697DF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697DFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697E08
-	voice_square_1_alt 0, 1, 1, 1, 6, 0  @ 8697E14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697E20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697E2C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 8697E38
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 1  @ 8697E44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697E50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697E5C
-	voice_square_2_alt 3, 0, 0, 10, 1  @ 8697E68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697E74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697E80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697E8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697E98
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 8697EA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697EB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697EBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697EC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697ED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697EE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697EEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697EF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697F04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697F10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697F1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697F28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697F34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697F40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697F4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697F58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697F64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697F70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697F7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697F88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697F94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697FA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697FAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697FB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697FC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697FD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697FDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697FE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8697FF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869800C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698030
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869803C
-	voice_noise_alt 0, 0, 2, 6, 1  @ 8698048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697E08
+	voice_square_1_alt 60, 0, 0, 1, 1, 1, 6, 0  @ 8697E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697E2C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 8697E38
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 1  @ 8697E44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697E50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697E5C
+	voice_square_2_alt 60, 0, 3, 0, 0, 10, 1  @ 8697E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697E74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697E80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697E98
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 8697EA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697EBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697EEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697F34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697F40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697F64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697F88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8697FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869800C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869803C
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 1  @ 8698048
 

--- a/sound/voicegroups/voicegroup111.inc
+++ b/sound/voicegroups/voicegroup111.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup111:: @ 8698054
 	voice_keysplit_all voicegroup002  @ 8698054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869806C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869809C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86980A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86980B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86980C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86980CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86980D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86980E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86980F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86980FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869806C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869809C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86980A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86980B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86980C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86980CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86980D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86980E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86980F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86980FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698114
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 127  @ 8698120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869812C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869815C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869818C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86981A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869812C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869815C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869818C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86981A4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 226  @ 86981B0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 195  @ 86981BC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 195  @ 86981C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86981D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86981E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86981EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86981F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869821C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698234
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869824C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698258
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869827C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86982A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86982AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86982B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86982C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86982D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86982DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86982E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86982F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869830C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86981D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86981E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86981EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86981F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869821C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869824C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869827C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86982A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86982AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86982B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86982C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86982D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86982DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86982E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86982F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869830C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698330
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 195  @ 869833C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869836C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869839C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86983A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86983B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86983C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86983CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86983D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86983E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86983F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86983FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698408
-	voice_square_1_alt 0, 1, 0, 1, 7, 1  @ 8698414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869842C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 8698438
-	voice_programmable_wave_alt ProgrammableWaveData_86B4910, 0, 7, 15, 1  @ 8698444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869845C
-	voice_square_2_alt 3, 0, 1, 7, 1  @ 8698468
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869848C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698498
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 86984A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86984B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86984BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86984C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86984D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86984E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86984EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86984F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698510
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869851C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869854C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869857C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86985A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86985AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86985B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86985C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86985D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86985DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86985E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86985F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869860C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698618
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698630
-	voice_noise_alt 0, 0, 1, 7, 1  @ 869863C
-	voice_noise_alt 0, 0, 2, 6, 1  @ 8698648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869836C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869839C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86983A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86983B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86983C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86983CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86983D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86983E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86983F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86983FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698408
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 7, 1  @ 8698414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869842C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 8698438
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4910, 0, 7, 15, 1  @ 8698444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869845C
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 1  @ 8698468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869848C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698498
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 86984A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86984B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86984BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86984C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86984D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86984E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86984EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86984F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869851C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869854C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869857C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86985A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86985AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86985B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86985C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86985D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86985DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86985E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86985F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869860C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698630
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 869863C
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 1  @ 8698648
 

--- a/sound/voicegroups/voicegroup112.inc
+++ b/sound/voicegroups/voicegroup112.inc
@@ -2,130 +2,130 @@
 voicegroup112:: @ 8698654
 	voice_keysplit_all voicegroup003  @ 8698654
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8698660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869866C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698678
-	voice_programmable_wave_alt ProgrammableWaveData_86B4970, 0, 7, 15, 1  @ 8698684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869869C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86986A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86986B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86986C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86986CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86986D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86986E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86986F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869866C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698678
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4970, 0, 7, 15, 1  @ 8698684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869869C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86986A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86986B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86986C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86986CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86986D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86986E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86986F0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86986FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698714
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 8698720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869872C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869875C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869872C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869875C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698768
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 76  @ 8698774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869878C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86987A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86987B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86987BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86987C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86987D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86987E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86987EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869878C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86987A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86987B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86987BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86987C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86987D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86987E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86987EC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 86987F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698810
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 128, 252, 0, 115  @ 869881C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698828
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869884C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869884C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698870
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 869887C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698888
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8698894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86988A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86988AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86988B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86988A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86988AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86988B8
 	voice_directsound 60, 0, DirectSoundWaveData_classical_choir_voice_ahhs, 128, 165, 128, 188  @ 86988C4
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_female_voice, 128, 165, 128, 204  @ 86988D0
 	voice_directsound 60, 0, DirectSoundWaveData_unused_unknown_male_voice, 128, 165, 128, 188  @ 86988DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86988E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86988F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869890C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86988E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86988F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869890C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698918
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8698924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869893C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869896C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869899C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86989A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86989B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86989C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86989CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86989D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86989E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86989F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86989FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698A08
-	voice_square_1_alt 0, 1, 0, 0, 7, 0  @ 8698A14
-	voice_square_2_alt 1, 0, 0, 6, 0  @ 8698A20
-	voice_square_2_alt 3, 0, 0, 6, 0  @ 8698A2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698A38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698A44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698A50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698A5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698A68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698A74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698A80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698A8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698A98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698AA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698AB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698ABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698AC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698AD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698AE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698AEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698AF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698B04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698B10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698B1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698B28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698B34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698B40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698B4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698B58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698B64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698B70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698B7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698B88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698B94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698BA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698BAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698BB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698BC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698BD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698BDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698BE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698BF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698C00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698C0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698C18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698C24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698C30
-	voice_noise_alt 0, 0, 7, 10, 1  @ 8698C3C
-	voice_noise_alt 0, 0, 2, 6, 1  @ 8698C48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869893C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869896C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869899C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86989A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86989B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86989C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86989CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86989D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86989E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86989F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86989FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698A08
+	voice_square_1_alt 60, 0, 0, 1, 0, 0, 7, 0  @ 8698A14
+	voice_square_2_alt 60, 0, 1, 0, 0, 6, 0  @ 8698A20
+	voice_square_2_alt 60, 0, 3, 0, 0, 6, 0  @ 8698A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698A50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698A5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698A74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698B64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698B94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698BB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698BC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698BDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698BE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698BF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698C00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698C18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698C30
+	voice_noise_alt 60, 0, 0, 0, 7, 10, 1  @ 8698C3C
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 1  @ 8698C48
 

--- a/sound/voicegroups/voicegroup113.inc
+++ b/sound/voicegroups/voicegroup113.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup113:: @ 8698C54
 	voice_keysplit_all voicegroup002  @ 8698C54
-	voice_programmable_wave_alt ProgrammableWaveData_86B4990, 0, 7, 15, 1  @ 8698C60
-	voice_programmable_wave_alt ProgrammableWaveData_86B49B0, 0, 7, 15, 1  @ 8698C6C
-	voice_programmable_wave_alt ProgrammableWaveData_86B49A0, 0, 7, 15, 1  @ 8698C78
-	voice_programmable_wave_alt ProgrammableWaveData_86B4970, 0, 7, 15, 1  @ 8698C84
-	voice_programmable_wave_alt ProgrammableWaveData_86B4980, 0, 7, 15, 1  @ 8698C90
-	voice_programmable_wave_alt ProgrammableWaveData_86B48B0, 0, 7, 15, 1  @ 8698C9C
-	voice_programmable_wave_alt ProgrammableWaveData_86B48C0, 0, 7, 15, 1  @ 8698CA8
-	voice_programmable_wave_alt ProgrammableWaveData_86B48D0, 0, 7, 15, 1  @ 8698CB4
-	voice_programmable_wave_alt ProgrammableWaveData_86B48E0, 0, 7, 15, 1  @ 8698CC0
-	voice_programmable_wave_alt ProgrammableWaveData_86B48F0, 0, 7, 15, 1  @ 8698CCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698CD8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4990, 0, 7, 15, 1  @ 8698C60
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B49B0, 0, 7, 15, 1  @ 8698C6C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B49A0, 0, 7, 15, 1  @ 8698C78
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4970, 0, 7, 15, 1  @ 8698C84
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4980, 0, 7, 15, 1  @ 8698C90
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B48B0, 0, 7, 15, 1  @ 8698C9C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B48C0, 0, 7, 15, 1  @ 8698CA8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B48D0, 0, 7, 15, 1  @ 8698CB4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B48E0, 0, 7, 15, 1  @ 8698CC0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B48F0, 0, 7, 15, 1  @ 8698CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698CD8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 8698CE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698CF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698CF0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 8698CFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698D08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698D14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698D20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698D2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698D38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698D44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698D50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698D5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698D68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698D74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698D80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698D8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698D98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698D14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698D98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698DA4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 195  @ 8698DB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698DBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698DC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698DD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698DE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698DEC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 8698DF8
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 8698E04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698E10
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 8698E1C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4920, 0, 7, 15, 1  @ 8698E28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698E34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698E40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698E4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698E58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698E64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698E70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698E7C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4920, 0, 7, 15, 1  @ 8698E28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698E34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698E4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698E58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698E7C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 180, 246  @ 8698E88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698E94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698EA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698EAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698EB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698EC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698ED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698EDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698EA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698EE8
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8698EF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698F00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698F0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698F18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698F00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698F18
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8698F24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698F30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698F3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698F48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698F54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698F60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698F6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698F78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698F84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698F90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698F9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698FA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698FB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698F30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698F60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698F6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698F78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698F90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698FB4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 127  @ 8698FC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698FCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698FD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698FE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698FF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8698FFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699008
-	voice_square_1_alt 0, 2, 0, 7, 7, 0  @ 8699014
-	voice_square_2_alt 2, 0, 7, 7, 0  @ 8699020
-	voice_square_2_alt 1, 0, 7, 7, 0  @ 869902C
-	voice_square_2_alt 0, 0, 7, 7, 0  @ 8699038
-	voice_square_2_alt 3, 0, 7, 7, 0  @ 8699044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869905C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4910, 0, 7, 15, 1  @ 8699068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869908C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699098
-	voice_square_1_alt 0, 1, 0, 7, 7, 0  @ 86990A4
-	voice_square_1_alt 0, 0, 0, 7, 7, 0  @ 86990B0
-	voice_square_1_alt 0, 3, 0, 7, 7, 0  @ 86990BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86990C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86990D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86990E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86990EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86990F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869911C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869914C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869917C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86991A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86991AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86991B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86991C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86991D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86991DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86991E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86991F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869920C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699230
-	voice_noise_alt 0, 0, 1, 7, 1  @ 869923C
-	voice_noise_alt 0, 0, 2, 6, 1  @ 8699248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698FCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698FF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8698FFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699008
+	voice_square_1_alt 60, 0, 0, 2, 0, 7, 7, 0  @ 8699014
+	voice_square_2_alt 60, 0, 2, 0, 7, 7, 0  @ 8699020
+	voice_square_2_alt 60, 0, 1, 0, 7, 7, 0  @ 869902C
+	voice_square_2_alt 60, 0, 0, 0, 7, 7, 0  @ 8699038
+	voice_square_2_alt 60, 0, 3, 0, 7, 7, 0  @ 8699044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869905C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4910, 0, 7, 15, 1  @ 8699068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869908C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699098
+	voice_square_1_alt 60, 0, 0, 1, 0, 7, 7, 0  @ 86990A4
+	voice_square_1_alt 60, 0, 0, 0, 0, 7, 7, 0  @ 86990B0
+	voice_square_1_alt 60, 0, 0, 3, 0, 7, 7, 0  @ 86990BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86990C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86990D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86990E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86990EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86990F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869911C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869914C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869917C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86991A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86991AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86991B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86991C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86991D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86991DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86991E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86991F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869920C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699230
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 869923C
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 1  @ 8699248
 

--- a/sound/voicegroups/voicegroup114.inc
+++ b/sound/voicegroups/voicegroup114.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup114:: @ 8699254
 	voice_keysplit_all voicegroup001  @ 8699254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869926C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869929C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86992A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86992B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86992C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86992CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86992D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86992E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86992F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869926C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869929C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86992A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86992B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86992C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86992CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86992D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86992E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86992F0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 216, 90, 242  @ 86992FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869932C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869935C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869938C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86993A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86993B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86993BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86993C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86993D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869932C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869935C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869938C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86993A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86993B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86993BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86993C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86993D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 253, 0, 149  @ 86993E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86993EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86993F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869941C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699428
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869944C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699458
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699470
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869947C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86993EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86993F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869941C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869944C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869947C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 8699488
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8699494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86994A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86994AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86994B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86994C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86994D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86994DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86994E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86994A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86994AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86994B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86994C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86994D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86994DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86994E8
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86994F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869950C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869950C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699518
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8699524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869953C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869956C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869959C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86995A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86995B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869953C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869956C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869959C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86995A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86995B4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 86995C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86995CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86995D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86995E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86995F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86995FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699608
-	voice_square_2 3, 0, 1, 7, 1  @ 8699614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699620
-	voice_square_1 0, 3, 0, 1, 7, 1  @ 869962C
-	voice_square_1 0, 3, 0, 0, 7, 1  @ 8699638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869965C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869968C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86996A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86996B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86996BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86996C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86996D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86996E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86996EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86996F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869971C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869974C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869977C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699788
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86997A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86997AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86997B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86997C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86997D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86997DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86997E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86997F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869980C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699830
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869983C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86995CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86995D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86995E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86995F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86995FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699608
+	voice_square_2 60, 0, 3, 0, 1, 7, 1  @ 8699614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699620
+	voice_square_1 60, 0, 0, 3, 0, 1, 7, 1  @ 869962C
+	voice_square_1 60, 0, 0, 3, 0, 0, 7, 1  @ 8699638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869965C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869968C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86996A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86996B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86996BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86996C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86996D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86996E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86996EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86996F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869971C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869974C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869977C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86997A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86997AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86997B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86997C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86997D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86997DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86997E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86997F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869980C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869983C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 246, 0, 216  @ 8699848
 

--- a/sound/voicegroups/voicegroup115.inc
+++ b/sound/voicegroups/voicegroup115.inc
@@ -2,130 +2,130 @@
 voicegroup115:: @ 8699854
 	voice_keysplit_all voicegroup002  @ 8699854
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8699860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869986C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869986C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699878
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 128, 249, 0, 188  @ 8699884
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 188, 103, 165  @ 8699890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869989C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86998A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86998B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86998C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86998CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86998D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86998E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86998F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869989C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86998A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86998B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86998C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86998CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86998D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86998E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86998F0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86998FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699914
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 127  @ 8699920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869992C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699938
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869995C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869992C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869995C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699968
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 204  @ 8699974
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 165, 128, 204  @ 8699980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869998C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86999A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869998C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86999A4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127  @ 86999B0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 165, 154, 165  @ 86999BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86999C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86999D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86999C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86999D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 253, 0, 149  @ 86999E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86999EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86999EC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 198  @ 86999F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699A04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699A10
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 146  @ 8699A1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699A28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699A34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699A40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699A4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699A58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699A64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699A34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699A40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699A4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699A58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699A64
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 216, 0, 165  @ 8699A70
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 8699A7C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 8699A88
 	voice_keysplit voicegroup006, KeySplitTable2  @ 8699A94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699AA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699AAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699AB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699AC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699AD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699ADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699AA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699AAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699AB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699AC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699ADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699AE8
 	voice_keysplit voicegroup007, KeySplitTable3  @ 8699AF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699B00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699B0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699B18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699B18
 	voice_keysplit voicegroup009, KeySplitTable5  @ 8699B24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699B30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699B30
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 165, 180, 165  @ 8699B3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699B48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699B54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699B60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699B6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699B78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699B84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699B90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699B9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699BA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699BB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699BC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699BCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699BD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699BE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699BF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699BFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699C08
-	voice_square_1_alt 0, 1, 0, 2, 7, 2  @ 8699C14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699C20
-	voice_square_2_alt 0, 0, 1, 6, 0  @ 8699C2C
-	voice_square_2_alt 3, 0, 3, 6, 2  @ 8699C38
-	voice_square_2_alt 0, 0, 2, 6, 5  @ 8699C44
-	voice_square_1_alt 0, 0, 0, 1, 6, 0  @ 8699C50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699C5C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4970, 0, 7, 15, 1  @ 8699C68
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 8699C74
-	voice_programmable_wave_alt ProgrammableWaveData_86B4910, 0, 1, 9, 2  @ 8699C80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699C8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699C98
-	voice_square_2_alt 2, 0, 2, 6, 3  @ 8699CA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699CB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699CBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699CC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699CD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699CE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699CEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699CF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699D04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699D10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699D1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699D28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699D34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699D40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699D4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699D58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699D64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699D70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699D7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699D88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699D94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699DA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699DAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699DB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699DC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699DD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699DDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699DE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699B60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699B6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699B90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699B9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699BA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699BB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699BC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699BE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699BFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699C08
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 7, 2  @ 8699C14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699C20
+	voice_square_2_alt 60, 0, 0, 0, 1, 6, 0  @ 8699C2C
+	voice_square_2_alt 60, 0, 3, 0, 3, 6, 2  @ 8699C38
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5  @ 8699C44
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 6, 0  @ 8699C50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699C5C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4970, 0, 7, 15, 1  @ 8699C68
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 8699C74
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4910, 0, 1, 9, 2  @ 8699C80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699C98
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 3  @ 8699CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699CBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699DDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699DE8
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165  @ 8699DF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699E00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699E0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699E18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699E24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699E30
-	voice_noise_alt 0, 0, 2, 6, 2  @ 8699E3C
-	voice_noise_alt 0, 0, 1, 6, 0  @ 8699E48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699E24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699E30
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 2  @ 8699E3C
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0  @ 8699E48
 

--- a/sound/voicegroups/voicegroup116.inc
+++ b/sound/voicegroups/voicegroup116.inc
@@ -2,130 +2,130 @@
 voicegroup116:: @ 8699E54
 	voice_keysplit_all voicegroup002  @ 8699E54
 	voice_keysplit voicegroup005, KeySplitTable1  @ 8699E60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699E6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699E78
-	voice_square_2_alt 3, 0, 2, 6, 5  @ 8699E84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699E90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699E9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699EA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699EB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699EC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699ECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699ED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699EE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699EF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699EFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699F08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699E78
+	voice_square_2_alt 60, 0, 3, 0, 2, 6, 5  @ 8699E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699F14
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 128, 146, 190, 115  @ 8699F20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699F2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699F38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699F44
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 255, 0, 255, 165  @ 8699F50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699F5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699F68
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 165, 128, 216  @ 8699F74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699F80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699F8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699F98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699FA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699FA4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127  @ 8699FB0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 127  @ 8699FBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699FC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699FD4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 253, 0, 149  @ 8699FE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699FEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 8699FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 8699FF8
 	voice_directsound 60, 0, DirectSoundWaveData_unused_sc88_unison_slap, 255, 165, 180, 216  @ 869A004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A010
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 869A01C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A04C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A058
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A064
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A070
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A07C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A04C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A07C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A088
 	voice_keysplit voicegroup006, KeySplitTable2  @ 869A094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A0A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A0AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A0B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A0C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A0D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A0DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A0E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A0A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A0AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A0B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A0C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A0D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A0DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A0E8
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869A0F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A10C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A10C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A118
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869A124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A130
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 127  @ 869A13C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A16C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A190
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A19C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A1A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A1B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A1C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A1CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A1D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A1E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A1F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A1FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A208
-	voice_square_1_alt 0, 1, 0, 2, 7, 2  @ 869A214
-	voice_square_2_alt 3, 0, 3, 3, 0  @ 869A220
-	voice_programmable_wave_alt ProgrammableWaveData_86B4970, 0, 3, 6, 5  @ 869A22C
-	voice_square_1_alt 0, 0, 0, 2, 7, 2  @ 869A238
-	voice_programmable_wave_alt ProgrammableWaveData_86B4970, 0, 7, 15, 0  @ 869A244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A25C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 869A268
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A28C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A298
-	voice_square_2_alt 2, 0, 2, 6, 3  @ 869A2A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A2B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A2BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A2C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A2D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A2E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A2EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A2F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A31C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A34C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A37C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A3A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A3AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A3B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A3C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A3D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A3DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A3E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A3F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A40C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A430
-	voice_noise_alt 0, 0, 2, 6, 0  @ 869A43C
-	voice_noise_alt 0, 0, 1, 6, 1  @ 869A448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A16C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A19C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A1A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A1B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A1C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A1CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A1D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A1E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A1F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A1FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A208
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 7, 2  @ 869A214
+	voice_square_2_alt 60, 0, 3, 0, 3, 3, 0  @ 869A220
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4970, 0, 3, 6, 5  @ 869A22C
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 7, 2  @ 869A238
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4970, 0, 7, 15, 0  @ 869A244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A25C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 869A268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A28C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A298
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 3  @ 869A2A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A2B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A2BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A2C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A2D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A2E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A2EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A2F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A31C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A34C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A37C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A3A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A3AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A3B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A3C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A3D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A3DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A3E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A3F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A40C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A430
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 869A43C
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1  @ 869A448
 

--- a/sound/voicegroups/voicegroup117.inc
+++ b/sound/voicegroups/voicegroup117.inc
@@ -1,85 +1,85 @@
 	.align 2
 voicegroup117:: @ 869A454
 	voice_keysplit_all voicegroup001  @ 869A454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A46C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A478
-	voice_square_2 2, 0, 1, 1, 1  @ 869A484
-	voice_square_1 0, 2, 0, 1, 1, 1  @ 869A490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A49C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A4A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A4B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A4C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A4CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A4D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A4E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A4F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A4FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A52C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A55C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A58C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A5A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A5B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A5BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A5C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A5D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A46C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A478
+	voice_square_2 60, 0, 2, 0, 1, 1, 1  @ 869A484
+	voice_square_1 60, 0, 0, 2, 0, 1, 1, 1  @ 869A490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A49C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A4A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A4B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A4C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A4CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A4D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A4E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A4F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A4FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A52C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A55C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A58C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A5A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A5B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A5BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A5C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A5D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 253, 0, 149  @ 869A5E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A5EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A5F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A61C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A64C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A5EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A5F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A61C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A64C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A670
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 869A67C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 869A688
 	voice_keysplit voicegroup006, KeySplitTable2  @ 869A694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A6A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A6AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A6B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A6C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A6D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A6DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A6E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A6A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A6AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A6B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A6C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A6D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A6DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A6E8
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869A6F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A700
 	voice_keysplit voicegroup008, KeySplitTable4  @ 869A70C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A718
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869A724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A73C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A76C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A790
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A79C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A7A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A7B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A7C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A7CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A7D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A7E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A7F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A7FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A808
-	voice_square_2 3, 0, 1, 7, 1  @ 869A814
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 869A820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A73C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A76C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A79C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A7A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A7B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A7C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A7CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A7D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A7E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A7F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A7FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A808
+	voice_square_2 60, 0, 3, 0, 1, 7, 1  @ 869A814
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 869A820
 

--- a/sound/voicegroups/voicegroup118.inc
+++ b/sound/voicegroups/voicegroup118.inc
@@ -1,94 +1,94 @@
 	.align 2
 voicegroup118:: @ 869A82C
 	voice_keysplit_all voicegroup001  @ 869A82C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A850
-	voice_square_2 0, 0, 1, 7, 1  @ 869A85C
-	voice_square_1 0, 0, 0, 1, 7, 1  @ 869A868
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A88C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A898
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A8A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A8B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A8BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A8C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A850
+	voice_square_2 60, 0, 0, 0, 1, 7, 1  @ 869A85C
+	voice_square_1 60, 0, 0, 0, 0, 1, 7, 1  @ 869A868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A88C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A8A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A8B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A8BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A8C8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 250, 0, 242  @ 869A8D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A8E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A8EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A8E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A8EC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 127  @ 869A8F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A91C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A91C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 255, 0, 255, 165  @ 869A928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A94C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A97C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A9A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A9AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A94C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A97C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A9A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A9AC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 253, 0, 149  @ 869A9B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A9C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A9D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A9DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869A9E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A9C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A9D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A9DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869A9E8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 869A9F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AA00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AA0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AA18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AA24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AA30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AA3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AA48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AA00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AA0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AA18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AA24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AA30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AA3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AA48
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 869AA54
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 869AA60
 	voice_keysplit voicegroup006, KeySplitTable2  @ 869AA6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AA78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AA84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AA90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AA9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AAA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AAB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AAC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AAD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AA78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AA84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AA90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AA9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AAA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AAB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AAC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AAD8
 	voice_keysplit voicegroup008, KeySplitTable4  @ 869AAE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AAF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AAF0
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869AAFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AB08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AB14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AB20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AB2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AB38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AB44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AB50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AB5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AB68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AB74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AB80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AB8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AB98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ABA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ABB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ABBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ABC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ABD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ABE0
-	voice_square_2 2, 0, 1, 7, 1  @ 869ABEC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 869ABF8
-	voice_square_1 0, 2, 0, 1, 7, 1  @ 869AC04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AC10
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 2  @ 869AC1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AC28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AC34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AC40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AC4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AC58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AB08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AB14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AB20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AB2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AB38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AB44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AB50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AB5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AB68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AB74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AB80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AB8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AB98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ABA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ABB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ABBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ABC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ABD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ABE0
+	voice_square_2 60, 0, 2, 0, 1, 7, 1  @ 869ABEC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 869ABF8
+	voice_square_1 60, 0, 0, 2, 0, 1, 7, 1  @ 869AC04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AC10
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 2  @ 869AC1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AC28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AC34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AC40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AC4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AC58
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_polysynth, 255, 0, 255, 127  @ 869AC64
 

--- a/sound/voicegroups/voicegroup119.inc
+++ b/sound/voicegroups/voicegroup119.inc
@@ -2,93 +2,93 @@
 voicegroup119:: @ 869AC70
 	voice_keysplit_all voicegroup001  @ 869AC70
 	voice_keysplit voicegroup005, KeySplitTable1  @ 869AC7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AC88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AC94
-	voice_square_2 0, 0, 2, 4, 1  @ 869ACA0
-	voice_square_1 0, 0, 0, 2, 4, 1  @ 869ACAC
-	voice_square_2 3, 0, 1, 7, 1  @ 869ACB8
-	voice_square_1 0, 3, 0, 1, 7, 1  @ 869ACC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ACD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ACDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ACE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ACF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AD00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AD0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AD18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AD24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AD30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AC88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AC94
+	voice_square_2 60, 0, 0, 0, 2, 4, 1  @ 869ACA0
+	voice_square_1 60, 0, 0, 0, 0, 2, 4, 1  @ 869ACAC
+	voice_square_2 60, 0, 3, 0, 1, 7, 1  @ 869ACB8
+	voice_square_1 60, 0, 0, 3, 0, 1, 7, 1  @ 869ACC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ACD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ACDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ACE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ACF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AD00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AD0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AD18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AD24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AD30
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 127  @ 869AD3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AD48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AD54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AD60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AD6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AD78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AD84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AD90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AD9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ADA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ADB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ADC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ADCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ADD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ADE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869ADF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AD48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AD54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AD60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AD6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AD78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AD84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AD90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AD9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ADA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ADB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ADC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ADCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ADD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ADE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869ADF0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 253, 0, 149  @ 869ADFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AE08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AE14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AE20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AE2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AE38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AE44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AE50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AE5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AE68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AE74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AE80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AE8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AE08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AE14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AE20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AE2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AE38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AE44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AE50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AE5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AE68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AE74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AE80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AE8C
 	voice_directsound_no_resample 60, 0, DirectSoundWaveData_sc88_timpani_with_snare, 255, 246, 0, 226  @ 869AE98
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 869AEA4
 	voice_keysplit voicegroup006, KeySplitTable2  @ 869AEB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AEBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AEC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AEE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AEEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AEF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AF04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AEBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AEC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AEE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AEEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AEF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AF04
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869AF10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AF1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AF28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AF34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AF1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AF28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AF34
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869AF40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AF4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AF58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AF64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AF70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AF7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AF88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AF94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AFA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AFAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AFB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AFC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AFD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AFDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AFE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869AFF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B00C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B024
-	voice_square_2 2, 0, 1, 7, 1  @ 869B030
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 2  @ 869B03C
-	voice_square_1 0, 2, 0, 1, 7, 1  @ 869B048
-	voice_square_2 1, 0, 1, 9, 1  @ 869B054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B06C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B09C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 2  @ 869B0A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AF4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AF58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AF64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AF70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AF7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AF88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AF94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AFA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AFAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AFB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AFC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AFD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AFDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AFE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869AFF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B00C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B024
+	voice_square_2 60, 0, 2, 0, 1, 7, 1  @ 869B030
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 2  @ 869B03C
+	voice_square_1 60, 0, 0, 2, 0, 1, 7, 1  @ 869B048
+	voice_square_2 60, 0, 1, 0, 1, 9, 1  @ 869B054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B06C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B09C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 2  @ 869B0A8
 

--- a/sound/voicegroups/voicegroup120.inc
+++ b/sound/voicegroups/voicegroup120.inc
@@ -2,93 +2,93 @@
 voicegroup120:: @ 869B0B4
 	voice_keysplit_all voicegroup001  @ 869B0B4
 	voice_keysplit voicegroup005, KeySplitTable1  @ 869B0C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B0CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B0D8
-	voice_square_2 2, 0, 2, 6, 1  @ 869B0E4
-	voice_square_1 0, 2, 0, 2, 6, 1  @ 869B0F0
-	voice_square_2 3, 0, 2, 4, 1  @ 869B0FC
-	voice_square_1 0, 3, 0, 2, 4, 1  @ 869B108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B12C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B15C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B18C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B1A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B1B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B1BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B1C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B1D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B1E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B1EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B1F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B21C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B0CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B0D8
+	voice_square_2 60, 0, 2, 0, 2, 6, 1  @ 869B0E4
+	voice_square_1 60, 0, 0, 2, 0, 2, 6, 1  @ 869B0F0
+	voice_square_2 60, 0, 3, 0, 2, 4, 1  @ 869B0FC
+	voice_square_1 60, 0, 0, 3, 0, 2, 4, 1  @ 869B108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B12C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B15C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B18C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B1A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B1B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B1BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B1C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B1D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B1E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B1EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B1F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B21C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B234
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 253, 0, 149  @ 869B240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B24C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B258
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B27C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B2A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B2AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B2B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B2C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B24C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B27C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B2A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B2AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B2B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B2C4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 216, 0, 165  @ 869B2D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B2DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B2DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 869B2E8
 	voice_keysplit voicegroup006, KeySplitTable2  @ 869B2F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B30C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B33C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B30C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B33C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B348
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869B354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B36C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B36C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B378
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869B384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B39C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B3A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B3B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B3C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B3CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B3D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B3E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B3F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B3FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B42C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B45C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B468
-	voice_square_2 2, 0, 1, 7, 1  @ 869B474
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 869B480
-	voice_square_1 0, 2, 0, 1, 7, 1  @ 869B48C
-	voice_square_1 0, 2, 0, 0, 7, 1  @ 869B498
-	voice_square_2 3, 0, 1, 7, 1  @ 869B4A4
-	voice_square_1 0, 3, 0, 1, 7, 1  @ 869B4B0
-	voice_square_1 0, 3, 0, 0, 7, 1  @ 869B4BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B4C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B4D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B4E0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 2  @ 869B4EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B39C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B3A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B3B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B3C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B3CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B3D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B3E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B3F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B3FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B42C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B45C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B468
+	voice_square_2 60, 0, 2, 0, 1, 7, 1  @ 869B474
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 869B480
+	voice_square_1 60, 0, 0, 2, 0, 1, 7, 1  @ 869B48C
+	voice_square_1 60, 0, 0, 2, 0, 0, 7, 1  @ 869B498
+	voice_square_2 60, 0, 3, 0, 1, 7, 1  @ 869B4A4
+	voice_square_1 60, 0, 0, 3, 0, 1, 7, 1  @ 869B4B0
+	voice_square_1 60, 0, 0, 3, 0, 0, 7, 1  @ 869B4BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B4C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B4D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B4E0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 2  @ 869B4EC
 

--- a/sound/voicegroups/voicegroup121.inc
+++ b/sound/voicegroups/voicegroup121.inc
@@ -2,88 +2,88 @@
 voicegroup121:: @ 869B4F8
 	voice_keysplit_all voicegroup001  @ 869B4F8
 	voice_keysplit voicegroup005, KeySplitTable1  @ 869B504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B510
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B51C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B54C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B57C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B5A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B5AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B5B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B5C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B5D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B5DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B5E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B5F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B60C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B618
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B630
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B63C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B66C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B51C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B54C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B57C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B5A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B5AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B5B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B5C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B5D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B5DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B5E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B5F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B60C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B63C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B66C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B678
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 253, 0, 149  @ 869B684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B69C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B6A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B6B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B6C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B6CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B6D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B6E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B6F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B6FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B69C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B6A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B6B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B6C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B6CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B6D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B6E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B6F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B6FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B708
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 216, 0, 165  @ 869B714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B720
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 869B72C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 869B738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B75C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B78C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B75C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B78C
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869B798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B7A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B7B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B7BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B7A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B7B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B7BC
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869B7C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B7D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B7E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B7EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B7F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B81C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B828
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B84C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B7D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B7E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B7EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B7F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B81C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B84C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B858
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 869B864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B87C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B8A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B8AC
-	voice_square_2 2, 0, 1, 7, 1  @ 869B8B8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 2  @ 869B8C4
-	voice_square_1 0, 2, 0, 1, 7, 1  @ 869B8D0
-	voice_square_2 0, 0, 1, 7, 1  @ 869B8DC
-	voice_square_1 0, 0, 0, 1, 7, 1  @ 869B8E8
-	voice_square_1 0, 0, 0, 0, 7, 1  @ 869B8F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B87C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B8A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B8AC
+	voice_square_2 60, 0, 2, 0, 1, 7, 1  @ 869B8B8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 2  @ 869B8C4
+	voice_square_1 60, 0, 0, 2, 0, 1, 7, 1  @ 869B8D0
+	voice_square_2 60, 0, 0, 0, 1, 7, 1  @ 869B8DC
+	voice_square_1 60, 0, 0, 0, 0, 1, 7, 1  @ 869B8E8
+	voice_square_1 60, 0, 0, 0, 0, 0, 7, 1  @ 869B8F4
 

--- a/sound/voicegroups/voicegroup122.inc
+++ b/sound/voicegroups/voicegroup122.inc
@@ -1,87 +1,87 @@
 	.align 2
 voicegroup122:: @ 869B900
 	voice_keysplit_all voicegroup001  @ 869B900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B90C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B924
-	voice_square_2 1, 0, 1, 6, 1  @ 869B930
-	voice_square_1 0, 1, 0, 1, 6, 1  @ 869B93C
-	voice_square_2 2, 0, 1, 6, 1  @ 869B948
-	voice_square_1 0, 2, 0, 1, 6, 1  @ 869B954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B96C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B99C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B9A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B9B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B9C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B9CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B9D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B9E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B9F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869B9FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BA08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BA14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BA20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BA2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BA38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BA44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BA50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BA5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BA68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BA74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BA80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BA8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BA98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BAA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B90C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B924
+	voice_square_2 60, 0, 1, 0, 1, 6, 1  @ 869B930
+	voice_square_1 60, 0, 0, 1, 0, 1, 6, 1  @ 869B93C
+	voice_square_2 60, 0, 2, 0, 1, 6, 1  @ 869B948
+	voice_square_1 60, 0, 0, 2, 0, 1, 6, 1  @ 869B954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B96C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B99C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B9A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B9B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B9C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B9CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B9D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B9E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B9F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869B9FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BA08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BA14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BA20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BA2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BA38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BA44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BA50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BA5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BA68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BA74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BA80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BA8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BA98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BAA4
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 869BAB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BAC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BAD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BAE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BAEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BAF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BB04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BB10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BAC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BAD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BAE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BAEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BAF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BB04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BB10
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 216, 0, 165  @ 869BB1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BB28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BB28
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 869BB34
 	voice_keysplit voicegroup006, KeySplitTable2  @ 869BB40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BB4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BB58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BB64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BB70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BB7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BB88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BB94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BB4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BB58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BB64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BB70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BB7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BB88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BB94
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_polysynth, 255, 165, 154, 127  @ 869BBA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BBAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BBB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BBC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BBAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BBB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BBC4
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869BBD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BBDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BBE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BBF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BC00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BC0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BC18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BC24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BC30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BC3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BC48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BC54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BC60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BC6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BC78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BC84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BC90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BC9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BCA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BCB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BCC0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 869BCCC
-	voice_square_1 0, 3, 0, 1, 9, 1  @ 869BCD8
-	voice_square_1 0, 3, 0, 0, 9, 1  @ 869BCE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BBDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BBE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BBF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BC00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BC0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BC18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BC24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BC30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BC3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BC48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BC54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BC60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BC6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BC78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BC84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BC90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BC9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BCA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BCB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BCC0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 869BCCC
+	voice_square_1 60, 0, 0, 3, 0, 1, 9, 1  @ 869BCD8
+	voice_square_1 60, 0, 0, 3, 0, 0, 9, 1  @ 869BCE4
 

--- a/sound/voicegroups/voicegroup123.inc
+++ b/sound/voicegroups/voicegroup123.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup123:: @ 869BCF0
 	voice_keysplit_all voicegroup001  @ 869BCF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BCFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BD08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BD14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BD20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BD2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BD38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BD44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BD50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BD5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BD68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BD74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BD80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BD8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BCFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BD08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BD14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BD20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BD2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BD38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BD44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BD50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BD5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BD68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BD74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BD80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BD8C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 216, 90, 242  @ 869BD98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BDA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BDB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BDBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BDC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BDD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BDE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BDEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BDF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BE04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BE10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BE1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BE28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BE34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BE40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BE4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BE58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BE64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BE70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BDA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BDB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BDBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BDC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BDD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BDE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BDEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BDF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BE04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BE10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BE1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BE28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BE34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BE40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BE4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BE58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BE64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BE70
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 253, 0, 149  @ 869BE7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BE88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BE94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BEA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BEAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BEB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BEC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BEDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BEE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BEF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BF00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BF0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BF18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BE88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BE94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BEA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BEAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BEB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BEC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BEDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BEE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BEF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BF00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BF0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BF18
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 869BF24
 	voice_keysplit voicegroup006, KeySplitTable2  @ 869BF30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BF3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BF48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BF54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BF60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BF6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BF78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BF84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BF3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BF48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BF54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BF60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BF6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BF78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BF84
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869BF90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BF9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BFA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BFB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BF9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BFA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BFB4
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869BFC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BFCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BFD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BFE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BFF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869BFFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C02C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BFCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BFD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BFE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BFF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869BFFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C02C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C050
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 869C05C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C08C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C0A4
-	voice_square_2 3, 0, 1, 7, 1  @ 869C0B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C0BC
-	voice_square_1 0, 3, 0, 1, 7, 1  @ 869C0C8
-	voice_square_1 0, 3, 0, 0, 7, 1  @ 869C0D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C0E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C0EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C0F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C11C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C14C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C17C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C1A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C1AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C1B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C1C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C1D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C1DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C1E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C1F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C20C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C23C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C26C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C29C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C2A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C2B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C2C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C2CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C2D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C08C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C0A4
+	voice_square_2 60, 0, 3, 0, 1, 7, 1  @ 869C0B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C0BC
+	voice_square_1 60, 0, 0, 3, 0, 1, 7, 1  @ 869C0C8
+	voice_square_1 60, 0, 0, 3, 0, 0, 7, 1  @ 869C0D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C0E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C0EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C0F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C11C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C14C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C17C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C1A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C1AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C1B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C1C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C1D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C1DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C1E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C1F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C20C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C23C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C26C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C29C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C2A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C2B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C2C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C2CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C2D8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 246, 0, 216  @ 869C2E4
 

--- a/sound/voicegroups/voicegroup124.inc
+++ b/sound/voicegroups/voicegroup124.inc
@@ -2,89 +2,89 @@
 voicegroup124:: @ 869C2F0
 	voice_keysplit_all voicegroup001  @ 869C2F0
 	voice_keysplit voicegroup005, KeySplitTable1  @ 869C2FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C314
-	voice_square_2 2, 0, 2, 3, 1  @ 869C320
-	voice_square_1 0, 2, 0, 2, 3, 1  @ 869C32C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C35C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C38C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C3A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C3B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C3BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C3C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C3D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C3E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C3EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C3F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C41C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C428
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C44C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C458
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C314
+	voice_square_2 60, 0, 2, 0, 2, 3, 1  @ 869C320
+	voice_square_1 60, 0, 0, 2, 0, 2, 3, 1  @ 869C32C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C35C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C38C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C3A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C3B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C3BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C3C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C3D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C3E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C3EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C3F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C41C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C44C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C470
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 253, 0, 149  @ 869C47C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C4A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C4AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C4B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C4C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C4D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C4DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C4E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C4F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C50C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C4A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C4AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C4B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C4C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C4D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C4DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C4E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C4F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C50C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 869C518
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 869C524
 	voice_keysplit voicegroup006, KeySplitTable2  @ 869C530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C53C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C56C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C53C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C56C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C584
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869C590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C59C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C5A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C5B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C59C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C5A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C5B4
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869C5C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C5CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C5D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C5E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C5F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C5FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C62C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C65C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C68C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C6A4
-	voice_square_2 3, 0, 1, 7, 1  @ 869C6B0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 869C6BC
-	voice_square_1 0, 3, 0, 1, 7, 1  @ 869C6C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C6D4
-	voice_square_2 2, 0, 1, 7, 1  @ 869C6E0
-	voice_square_1 0, 2, 0, 1, 7, 1  @ 869C6EC
-	voice_square_2 3, 0, 2, 7, 1  @ 869C6F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C5CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C5D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C5E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C5F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C5FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C62C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C65C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C68C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C6A4
+	voice_square_2 60, 0, 3, 0, 1, 7, 1  @ 869C6B0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 869C6BC
+	voice_square_1 60, 0, 0, 3, 0, 1, 7, 1  @ 869C6C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C6D4
+	voice_square_2 60, 0, 2, 0, 1, 7, 1  @ 869C6E0
+	voice_square_1 60, 0, 0, 2, 0, 1, 7, 1  @ 869C6EC
+	voice_square_2 60, 0, 3, 0, 2, 7, 1  @ 869C6F8
 

--- a/sound/voicegroups/voicegroup125.inc
+++ b/sound/voicegroups/voicegroup125.inc
@@ -1,87 +1,87 @@
 	.align 2
 voicegroup125:: @ 869C704
 	voice_keysplit_all voicegroup001  @ 869C704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C71C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C728
-	voice_square_2 2, 0, 2, 3, 1  @ 869C734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C74C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C77C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C788
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C7A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C7AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C7B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C7C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C7D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C7DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C7E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C7F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C80C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C830
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C83C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C848
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C86C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C89C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C8A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C8B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C8C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C71C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C728
+	voice_square_2 60, 0, 2, 0, 2, 3, 1  @ 869C734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C74C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C77C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C7A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C7AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C7B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C7C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C7D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C7DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C7E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C7F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C80C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C83C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C86C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C89C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C8A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C8B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C8C0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 869C8CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C8D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C8E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C8F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C8FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C92C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C8D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C8E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C8F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C8FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C92C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 869C938
 	voice_keysplit voicegroup006, KeySplitTable2  @ 869C944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C95C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C98C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C95C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C98C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C998
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869C9A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C9B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C9BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C9C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C9B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C9BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C9C8
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869C9D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C9E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C9EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869C9F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CA04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CA10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CA1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CA28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CA34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CA40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CA4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CA58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CA64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CA70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CA7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CA88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CA94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CAA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CAAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CAB8
-	voice_square_2 3, 0, 1, 7, 1  @ 869CAC4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 869CAD0
-	voice_square_1 0, 3, 0, 1, 7, 1  @ 869CADC
-	voice_square_1 0, 3, 0, 0, 7, 1  @ 869CAE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C9E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C9EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869C9F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CA04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CA10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CA1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CA28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CA34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CA40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CA4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CA58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CA64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CA70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CA7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CA88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CA94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CAA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CAAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CAB8
+	voice_square_2 60, 0, 3, 0, 1, 7, 1  @ 869CAC4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 869CAD0
+	voice_square_1 60, 0, 0, 3, 0, 1, 7, 1  @ 869CADC
+	voice_square_1 60, 0, 0, 3, 0, 0, 7, 1  @ 869CAE8
 

--- a/sound/voicegroups/voicegroup126.inc
+++ b/sound/voicegroups/voicegroup126.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup126:: @ 869CAF4
 	voice_keysplit_all voicegroup001  @ 869CAF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CB00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CB0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CB18
-	voice_square_2 0, 1, 1, 7, 1  @ 869CB24
-	voice_square_1 0, 0, 1, 1, 7, 1  @ 869CB30
-	voice_square_1 0, 0, 0, 0, 7, 1  @ 869CB3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CB48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CB54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CB60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CB6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CB78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CB84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CB90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CB9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CBA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CBB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CBC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CBCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CBD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CBE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CBF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CBFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CC08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CC14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CC20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CC2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CC38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CC44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CC50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CC5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CC68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CC74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CB00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CB0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CB18
+	voice_square_2 60, 0, 0, 1, 1, 7, 1  @ 869CB24
+	voice_square_1 60, 0, 0, 0, 1, 1, 7, 1  @ 869CB30
+	voice_square_1 60, 0, 0, 0, 0, 0, 7, 1  @ 869CB3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CB48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CB54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CB60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CB6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CB78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CB84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CB90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CB9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CBA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CBB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CBC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CBCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CBD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CBE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CBF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CBFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CC08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CC14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CC20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CC2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CC38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CC44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CC50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CC5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CC68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CC74
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 235, 128, 99  @ 869CC80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CC8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CC98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CCA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CCB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CCBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CCC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CCD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CCE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CCEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CCF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CD04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CD10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CD1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CC8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CC98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CCA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CCB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CCBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CCC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CCD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CCE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CCEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CCF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CD04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CD10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CD1C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 869CD28
 	voice_keysplit voicegroup006, KeySplitTable2  @ 869CD34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CD40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CD4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CD58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CD64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CD70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CD7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CD88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CD40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CD4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CD58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CD64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CD70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CD7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CD88
 	voice_keysplit voicegroup007, KeySplitTable3  @ 869CD94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CDA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CDAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CDB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CDA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CDAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CDB8
 	voice_keysplit voicegroup009, KeySplitTable5  @ 869CDC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CDD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CDDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CDE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CDF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CE00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CE0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CE18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CE24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CE30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CE3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CE48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CE54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CE60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CE6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CE78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CE84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CE90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CE9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CEA8
-	voice_square_2 3, 1, 1, 6, 1  @ 869CEB4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 869CEC0
-	voice_square_1 0, 3, 1, 1, 6, 1  @ 869CECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CEE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CEF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CEFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CF08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CF14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CF20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CF2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CF38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CF44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CF50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CF5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CF68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CF74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CF80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CF8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CF98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CFA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CFB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CFBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CFC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CFD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CFE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CFEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869CFF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D01C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D04C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D058
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D064
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D070
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D07C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D0A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D0AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D0B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D0C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D0D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CDD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CDDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CDE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CDF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CE00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CE0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CE18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CE24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CE30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CE3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CE48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CE54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CE60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CE6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CE78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CE84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CE90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CE9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CEA8
+	voice_square_2 60, 0, 3, 1, 1, 6, 1  @ 869CEB4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 2  @ 869CEC0
+	voice_square_1 60, 0, 0, 3, 1, 1, 6, 1  @ 869CECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CEE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CEF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CEFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CF08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CF14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CF20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CF2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CF38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CF44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CF50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CF5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CF68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CF74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CF80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CF8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CF98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CFA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CFB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CFBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CFC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CFD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CFE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CFEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869CFF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D01C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D04C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D07C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D0A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D0AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D0B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D0C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D0D0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 216  @ 869D0DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 246, 0, 216  @ 869D0E8
 

--- a/sound/voicegroups/voicegroup127.inc
+++ b/sound/voicegroups/voicegroup127.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup127:: @ 869D0F4
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_synth_snare, 255, 249, 103, 165  @ 869D0F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D10C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D118
-	voice_square_1_alt 0, 2, 0, 2, 0, 0  @ 869D124
-	voice_square_1_alt 0, 0, 0, 2, 0, 1  @ 869D130
-	voice_square_1_alt 0, 2, 0, 4, 0, 1  @ 869D13C
-	voice_square_1_alt 44, 2, 0, 4, 0, 0  @ 869D148
-	voice_square_1_alt 38, 0, 0, 4, 0, 0  @ 869D154
-	voice_square_1_alt 0, 0, 0, 7, 0, 0  @ 869D160
-	voice_square_1_alt 0, 2, 2, 0, 15, 0  @ 869D16C
-	voice_square_1_alt 0, 1, 2, 0, 15, 0  @ 869D178
-	voice_square_1_alt 23, 1, 0, 1, 9, 0  @ 869D184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D10C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D118
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 0, 0  @ 869D124
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 0, 1  @ 869D130
+	voice_square_1_alt 60, 0, 0, 2, 0, 4, 0, 1  @ 869D13C
+	voice_square_1_alt 60, 0, 44, 2, 0, 4, 0, 0  @ 869D148
+	voice_square_1_alt 60, 0, 38, 0, 0, 4, 0, 0  @ 869D154
+	voice_square_1_alt 60, 0, 0, 0, 0, 7, 0, 0  @ 869D160
+	voice_square_1_alt 60, 0, 0, 2, 2, 0, 15, 0  @ 869D16C
+	voice_square_1_alt 60, 0, 0, 1, 2, 0, 15, 0  @ 869D178
+	voice_square_1_alt 60, 0, 23, 1, 0, 1, 9, 0  @ 869D184
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_square_wave, 255, 0, 255, 165  @ 869D190
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_square_wave, 255, 226, 0, 165  @ 869D19C
-	voice_square_1_alt 0, 2, 0, 6, 0, 1  @ 869D1A8
-	voice_square_1_alt 36, 0, 0, 2, 0, 0  @ 869D1B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D1C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D1CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D1D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D1E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D1F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D1FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D22C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D25C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D268
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D28C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D2A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D2B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D2BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D2C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D2D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D2E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D2EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D2F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D31C
+	voice_square_1_alt 60, 0, 0, 2, 0, 6, 0, 1  @ 869D1A8
+	voice_square_1_alt 60, 0, 36, 0, 0, 2, 0, 0  @ 869D1B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D1C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D1CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D1D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D1E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D1F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D1FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D22C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D25C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D28C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D2A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D2B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D2BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D2C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D2D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D2E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D2EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D2F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D31C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 869D328
 	voice_keysplit voicegroup006, KeySplitTable2  @ 869D334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D34C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D37C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D3A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D3AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D3B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D3C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D3D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D3DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D3E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D3F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D40C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D430
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D43C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D46C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D49C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D4A8
-	voice_square_2_alt 3, 0, 1, 0, 1  @ 869D4B4
-	voice_square_1_alt 0, 3, 0, 1, 0, 1  @ 869D4C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D4CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D4D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D4E4
-	voice_square_1_alt 46, 2, 0, 4, 0, 0  @ 869D4F0
-	voice_square_1_alt 38, 2, 0, 4, 0, 0  @ 869D4FC
-	voice_square_1_alt 119, 2, 0, 0, 15, 1  @ 869D508
-	voice_square_1_alt 0, 2, 0, 0, 15, 1  @ 869D514
-	voice_square_1_alt 106, 2, 0, 2, 0, 0  @ 869D520
-	voice_square_1_alt 23, 2, 0, 1, 9, 0  @ 869D52C
-	voice_square_1_alt 21, 2, 0, 1, 9, 0  @ 869D538
-	voice_square_1_alt 0, 0, 0, 0, 15, 1  @ 869D544
-	voice_square_1_alt 47, 2, 0, 2, 6, 0  @ 869D550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D55C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D58C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D5A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D5B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D5BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D5C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D5D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D5E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D5EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D5F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D61C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D64C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D67C
-	voice_noise 0, 0, 7, 15, 0  @ 869D688
-	voice_noise 0, 2, 7, 15, 0  @ 869D694
-	voice_noise_alt 0, 2, 0, 15, 0  @ 869D6A0
-	voice_noise_alt 1, 0, 0, 15, 0  @ 869D6AC
-	voice_noise_alt 0, 0, 0, 15, 0  @ 869D6B8
-	voice_noise_alt 0, 0, 3, 0, 0  @ 869D6C4
-	voice_noise_alt 0, 0, 2, 0, 0  @ 869D6D0
-	voice_noise_alt 0, 0, 1, 0, 0  @ 869D6DC
-	voice_noise_alt 0, 0, 1, 0, 1  @ 869D6E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D34C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D37C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D3A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D3AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D3B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D3C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D3D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D3DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D3E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D3F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D40C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D43C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D46C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D49C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D4A8
+	voice_square_2_alt 60, 0, 3, 0, 1, 0, 1  @ 869D4B4
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 0, 1  @ 869D4C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D4CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D4D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D4E4
+	voice_square_1_alt 60, 0, 46, 2, 0, 4, 0, 0  @ 869D4F0
+	voice_square_1_alt 60, 0, 38, 2, 0, 4, 0, 0  @ 869D4FC
+	voice_square_1_alt 60, 0, 119, 2, 0, 0, 15, 1  @ 869D508
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 15, 1  @ 869D514
+	voice_square_1_alt 60, 0, 106, 2, 0, 2, 0, 0  @ 869D520
+	voice_square_1_alt 60, 0, 23, 2, 0, 1, 9, 0  @ 869D52C
+	voice_square_1_alt 60, 0, 21, 2, 0, 1, 9, 0  @ 869D538
+	voice_square_1_alt 60, 0, 0, 0, 0, 0, 15, 1  @ 869D544
+	voice_square_1_alt 60, 0, 47, 2, 0, 2, 6, 0  @ 869D550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D55C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D58C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D5A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D5B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D5BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D5C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D5D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D5E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D5EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D5F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D61C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D64C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D67C
+	voice_noise 60, 0, 0, 0, 7, 15, 0  @ 869D688
+	voice_noise 60, 0, 0, 2, 7, 15, 0  @ 869D694
+	voice_noise_alt 60, 0, 0, 2, 0, 15, 0  @ 869D6A0
+	voice_noise_alt 60, 0, 1, 0, 0, 15, 0  @ 869D6AC
+	voice_noise_alt 60, 0, 0, 0, 0, 15, 0  @ 869D6B8
+	voice_noise_alt 60, 0, 0, 0, 3, 0, 0  @ 869D6C4
+	voice_noise_alt 60, 0, 0, 0, 2, 0, 0  @ 869D6D0
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 869D6DC
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 1  @ 869D6E8
 

--- a/sound/voicegroups/voicegroup128.inc
+++ b/sound/voicegroups/voicegroup128.inc
@@ -4,35 +4,35 @@ voicegroup128:: @ 869D6F4
 	voice_directsound_alt 60, 0, DirectSoundWaveData_bicycle_bell, 255, 0, 255, 165  @ 869D700
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_synth_snare, 255, 0, 255, 165  @ 869D70C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 242, 0, 127  @ 869D718
-	voice_noise_alt 0, 0, 1, 0, 1  @ 869D724
-	voice_noise_alt 1, 0, 1, 0, 1  @ 869D730
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 1  @ 869D724
+	voice_noise_alt 60, 0, 1, 0, 1, 0, 1  @ 869D730
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 255, 165  @ 869D73C
-	voice_square_1_alt 0, 2, 0, 2, 0, 1  @ 869D748
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 0, 1  @ 869D748
 	voice_directsound 60, 0, DirectSoundWaveData_8725A2C, 255, 0, 255, 165  @ 869D754
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 0, 255, 127  @ 869D760
 	voice_directsound 60, 0, DirectSoundWaveData_872762C, 255, 0, 255, 127  @ 869D76C
-	voice_noise_alt 1, 0, 2, 0, 0  @ 869D778
-	voice_square_1 103, 3, 2, 7, 0, 0  @ 869D784
-	voice_square_2 3, 2, 7, 0, 0  @ 869D790
+	voice_noise_alt 60, 0, 1, 0, 2, 0, 0  @ 869D778
+	voice_square_1 60, 0, 103, 3, 2, 7, 0, 0  @ 869D784
+	voice_square_2 60, 0, 3, 2, 7, 0, 0  @ 869D790
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_square_wave, 255, 226, 0, 127  @ 869D79C
 	voice_directsound 60, 0, DirectSoundWaveData_872921C, 255, 0, 255, 0  @ 869D7A8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_square_wave, 255, 204, 0, 127  @ 869D7B4
-	voice_square_1_alt 0, 2, 0, 2, 0, 1  @ 869D7C0
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 0, 1  @ 869D7C0
 	voice_directsound 60, 0, DirectSoundWaveData_872A5D0, 255, 0, 255, 127  @ 869D7CC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_square_wave, 255, 0, 255, 127  @ 869D7D8
-	voice_square_1 103, 0, 0, 7, 0, 0  @ 869D7E4
+	voice_square_1 60, 0, 103, 0, 0, 7, 0, 0  @ 869D7E4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_orchestra_snare, 255, 0, 255, 127  @ 869D7F0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_wind, 255, 0, 255, 127  @ 869D7FC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_bubbles, 255, 0, 255, 127  @ 869D808
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_standard3_snare, 255, 0, 255, 127  @ 869D814
-	voice_noise_alt 0, 0, 7, 15, 1  @ 869D820
+	voice_noise_alt 60, 0, 0, 0, 7, 15, 1  @ 869D820
 	voice_directsound 60, 0, DirectSoundWaveData_872EEA8, 255, 0, 255, 127  @ 869D82C
-	voice_noise_alt 1, 0, 7, 15, 1  @ 869D838
+	voice_noise_alt 60, 0, 1, 0, 7, 15, 1  @ 869D838
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 246, 0, 127  @ 869D844
 	voice_directsound 60, 0, DirectSoundWaveData_87301B0, 255, 0, 255, 127  @ 869D850
-	voice_square_1_alt 19, 2, 0, 2, 0, 0  @ 869D85C
+	voice_square_1_alt 60, 0, 19, 2, 0, 2, 0, 0  @ 869D85C
 	voice_directsound 60, 0, DirectSoundWaveData_unused_acid_bass, 255, 0, 255, 127  @ 869D868
-	voice_square_1 103, 0, 0, 0, 15, 0  @ 869D874
+	voice_square_1 60, 0, 103, 0, 0, 0, 15, 0  @ 869D874
 	voice_directsound_alt 60, 0, DirectSoundWaveData_87301B0, 255, 0, 255, 127  @ 869D880
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 255, 255, 127  @ 869D88C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 0, 255, 127  @ 869D898
@@ -42,86 +42,86 @@ voicegroup128:: @ 869D6F4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 869D8C8
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_close_hihat, 255, 127, 0, 188  @ 869D8D4
 	voice_directsound 60, 0, DirectSoundWaveData_87385E4, 255, 249, 0, 165  @ 869D8E0
-	voice_square_1 0, 0, 4, 6, 0, 0  @ 869D8EC
+	voice_square_1 60, 0, 0, 0, 4, 6, 0, 0  @ 869D8EC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 13, 0, 255, 127  @ 869D8F8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 13, 0, 255, 127  @ 869D904
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_polysynth, 255, 0, 255, 127  @ 869D910
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 252, 0, 204  @ 869D91C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869D928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869D928
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 869D934
-	voice_square_1 0, 0, 4, 0, 15, 0  @ 869D940
+	voice_square_1 60, 0, 0, 0, 4, 0, 15, 0  @ 869D940
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 188, 0, 0  @ 869D94C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 226, 0, 127  @ 869D958
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 26, 0, 255, 127  @ 869D964
-	voice_square_1_alt 0, 2, 0, 1, 0, 0  @ 869D970
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 0, 0  @ 869D970
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 252, 0, 127  @ 869D97C
-	voice_square_1_alt 0, 1, 0, 2, 0, 0  @ 869D988
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 0, 0  @ 869D988
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 127, 0, 127  @ 869D994
-	voice_noise_alt 0, 1, 6, 0, 0  @ 869D9A0
+	voice_noise_alt 60, 0, 0, 1, 6, 0, 0  @ 869D9A0
 	voice_directsound 60, 0, DirectSoundWaveData_jv1080_slap_bass, 255, 255, 255, 127  @ 869D9AC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_standard_hand_clap, 255, 255, 255, 127  @ 869D9B8
 	voice_directsound 60, 0, DirectSoundWaveData_873ECD8, 255, 255, 255, 127  @ 869D9C4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_french_horn_72, 11, 242, 0, 127  @ 869D9D0
-	voice_square_1_alt 0, 2, 4, 6, 0, 0  @ 869D9DC
+	voice_square_1_alt 60, 0, 0, 2, 4, 6, 0, 0  @ 869D9DC
 	voice_directsound 60, 0, DirectSoundWaveData_8740818, 255, 255, 255, 127  @ 869D9E8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 255, 0, 255, 165  @ 869D9F4
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_tom, 255, 0, 255, 165  @ 869DA00
-	voice_noise_alt 0, 5, 7, 15, 1  @ 869DA0C
+	voice_noise_alt 60, 0, 0, 5, 7, 15, 1  @ 869DA0C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_square_wave, 128, 242, 0, 165  @ 869DA18
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_string_ensemble_72, 255, 0, 255, 165  @ 869DA24
-	voice_square_1 0, 0, 1, 5, 0, 0  @ 869DA30
-	voice_noise_alt 0, 6, 6, 0, 1  @ 869DA3C
-	voice_noise_alt 0, 3, 6, 0, 1  @ 869DA48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DA54
+	voice_square_1 60, 0, 0, 0, 1, 5, 0, 0  @ 869DA30
+	voice_noise_alt 60, 0, 0, 6, 6, 0, 1  @ 869DA3C
+	voice_noise_alt 60, 0, 0, 3, 6, 0, 1  @ 869DA48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DA54
 	voice_directsound 60, 0, DirectSoundWaveData_unused_acid_bass, 15, 127, 231, 127  @ 869DA60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DA6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DA78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DA84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DA90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DA9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DAA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DAB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DAC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DAD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DAE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DAF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DAFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DB08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DB14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DB20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DB2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DB38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DB44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DB50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DB5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DB68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DB74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DB80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DB8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DB98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DBA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DBB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DBBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DBC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DBD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DBE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DBEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DBF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DC04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DC10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DC1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DC28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DC34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DC40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DC4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DC58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DC64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DC70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DC7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DC88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DC94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 869DCA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DA6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DA78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DA84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DA90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DA9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DAA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DAB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DAC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DAD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DAE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DAF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DAFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DB08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DB14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DB20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DB2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DB38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DB44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DB50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DB5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DB68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DB74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DB80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DB8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DB98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DBA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DBB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DBBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DBC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DBD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DBE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DBEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DBF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DC04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DC10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DC1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DC28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DC34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DC40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DC4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DC58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DC64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DC70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DC7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DC88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DC94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 869DCA0
 	voice_directsound 60, 0, DirectSoundWaveData_87424B0, 255, 0, 255, 165  @ 869DCAC
 	voice_directsound 60, 0, DirectSoundWaveData_87430C0, 255, 0, 255, 165  @ 869DCB8
 	voice_directsound 60, 0, DirectSoundWaveData_8743C50, 255, 0, 255, 165  @ 869DCC4

--- a/sound/voicegroups/voicegroup129.inc
+++ b/sound/voicegroups/voicegroup129.inc
@@ -1,10 +1,10 @@
 	.align 2
 voicegroup129:: @ 86A0154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0154
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_bongo, 255, 0, 255, 0  @ 86A0160
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 86A016C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_standard_hand_clap, 255, 226, 25, 0  @ 86A0178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0184
 	voice_directsound 60, 0, DirectSoundWaveData_8725A2C, 255, 0, 255, 165  @ 86A0190
 	voice_directsound 60, 0, DirectSoundWaveData_dance_drums_ride_bell, 255, 165, 103, 231  @ 86A019C
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_anvil_high, 255, 204, 128, 249  @ 86A01A8
@@ -12,120 +12,120 @@ voicegroup129:: @ 86A0154
 	voice_directsound 60, 0, DirectSoundWaveData_88D6978, 255, 0, 206, 204  @ 86A01C0
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_wood_block_low, 255, 0, 206, 38  @ 86A01CC
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_wood_block_high, 255, 0, 206, 0  @ 86A01D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A01E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A01E4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 216  @ 86A01F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A01FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A022C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A025C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A01FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A022C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A025C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0268
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 165, 128, 204  @ 86A0274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A028C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A02A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A02B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A02BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A028C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A02A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A02B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A02BC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165  @ 86A02C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A02D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A02E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A02EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A02F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A02D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A02E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A02EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A02F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0310
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 86A031C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A034C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A034C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0370
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 252, 0, 204  @ 86A037C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 255, 0, 255, 165  @ 86A0388
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_square_wave, 255, 204, 0, 127  @ 86A0394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A03A0
-	voice_square_1_alt 0, 2, 0, 0, 15, 0  @ 86A03AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A03B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A03C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A03D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A03DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A03E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A03F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A03A0
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 15, 0  @ 86A03AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A03B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A03C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A03D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A03DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A03E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A03F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0400
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86A040C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0430
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A043C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A046C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A049C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A04A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A04B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A04C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A04CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A04D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A04E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A04F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A04FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0508
-	voice_square_1_alt 0, 2, 0, 0, 10, 4  @ 86A0514
-	voice_square_1_alt 0, 3, 0, 0, 10, 3  @ 86A0520
-	voice_square_1_alt 0, 2, 0, 0, 10, 1  @ 86A052C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A055C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A058C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0598
-	voice_square_1_alt 0, 0, 0, 0, 15, 1  @ 86A05A4
-	voice_square_1_alt 0, 0, 0, 2, 5, 6  @ 86A05B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A05BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A05C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A05D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A05E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A05EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A05F8
-	voice_square_1_alt 29, 2, 0, 2, 0, 0  @ 86A0604
-	voice_square_1_alt 22, 2, 0, 2, 0, 0  @ 86A0610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A061C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A064C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A067C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A06A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A06AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A06B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A043C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A046C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A049C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A04A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A04B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A04C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A04CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A04D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A04E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A04F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A04FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0508
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 10, 4  @ 86A0514
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 10, 3  @ 86A0520
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 10, 1  @ 86A052C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A055C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A058C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0598
+	voice_square_1_alt 60, 0, 0, 0, 0, 0, 15, 1  @ 86A05A4
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 5, 6  @ 86A05B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A05BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A05C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A05D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A05E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A05EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A05F8
+	voice_square_1_alt 60, 0, 29, 2, 0, 2, 0, 0  @ 86A0604
+	voice_square_1_alt 60, 0, 22, 2, 0, 2, 0, 0  @ 86A0610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A061C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A064C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A067C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A06A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A06AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A06B8
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_ethnic_drum, 255, 0, 255, 0  @ 86A06C4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 86A06D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A06DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A06E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A06F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A070C
-	voice_noise_alt 0, 0, 1, 9, 2  @ 86A0718
-	voice_noise_alt 0, 0, 4, 3, 1  @ 86A0724
-	voice_noise_alt 0, 0, 1, 12, 0  @ 86A0730
-	voice_noise_alt 1, 0, 1, 9, 0  @ 86A073C
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86A0748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A06DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A06E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A06F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A070C
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 2  @ 86A0718
+	voice_noise_alt 60, 0, 0, 0, 4, 3, 1  @ 86A0724
+	voice_noise_alt 60, 0, 0, 0, 1, 12, 0  @ 86A0730
+	voice_noise_alt 60, 0, 1, 0, 1, 9, 0  @ 86A073C
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86A0748
 

--- a/sound/voicegroups/voicegroup130.inc
+++ b/sound/voicegroups/voicegroup130.inc
@@ -52,131 +52,131 @@ voicegroup130:: @ 86A0754
 	voice_directsound 60, 0, DirectSoundWaveData_88F5FCC, 255, 0, 255, 0  @ 86A09A0
 	voice_directsound 60, 0, DirectSoundWaveData_88F6498, 255, 0, 255, 0  @ 86A09AC
 	voice_keysplit_all voicegroup001  @ 86A09B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A09C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A09D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A09DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A09E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A09F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0A00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0A0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0A18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0A24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0A30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0A3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0A48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0A54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0A60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0A6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0A78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0A84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0A90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0A9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A09C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A09D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A09DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A09E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A09F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0A24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0A30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0A3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0A48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0A54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0A6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0A84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0AA8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion_duplicate, 255, 249, 25, 248  @ 86A0AB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0AC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0ACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0AD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0AE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0AF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0AFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0B08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0B14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0B20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0B2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0B38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0B44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0B50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0B5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0B68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0B74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0B80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0B8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0B98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0BA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0BB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0BBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0BC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0BD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0BE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0BEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0BF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0C04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0C10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0C1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0C28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0C34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0C40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0C4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0C58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0C64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0C70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0C7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0C88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0C94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0CA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0CAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0CB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0CC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0CD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0CDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0CE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0CF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0D00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0D0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0D18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0D24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0D30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0D3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0D48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0D54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0D60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0D6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0D78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0D84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0D90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0D9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0DA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0DB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0DC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0DCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0DD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0DE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0DF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0DFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0E08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0E14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0E20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0E2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0E38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0E44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0E50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0E5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0E68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0E74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0E80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0E8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0E98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0EA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0EB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0EBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0EC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0ED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0EE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0EEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0EF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0F04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0F10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0F1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0F28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0F34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0F40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0F4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0F58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0F64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0F70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0F7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0F88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0F94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0FA0
-	voice_noise_alt 0, 0, 1, 7, 1  @ 86A0FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0C58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0C70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0C7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0C88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0CA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0E2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0E44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0E50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0E5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0E74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0E80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0EA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0EBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0EEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0F34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0F40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0F64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0F88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0FA0
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1  @ 86A0FAC
 

--- a/sound/voicegroups/voicegroup131.inc
+++ b/sound/voicegroups/voicegroup131.inc
@@ -3,129 +3,129 @@ voicegroup131:: @ 86A0FB8
 	voice_keysplit_all voicegroup002  @ 86A0FB8
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A0FC4
 	voice_directsound 60, 0, DirectSoundWaveData_steinway_b_piano, 128, 204, 51, 242  @ 86A0FD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0FDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0FE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A0FF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A100C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1030
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A103C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A106C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A109C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A10A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A10B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A10C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A10CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A0FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A100C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A103C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A106C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A109C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A10A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A10B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A10C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A10CC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 204, 103, 226  @ 86A10D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A10E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A10F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A10FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A112C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A115C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A118C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A11A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A11B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A11BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A11C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A11D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A11E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A11EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A11F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A121C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1234
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A124C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1258
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A127C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A12A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A12AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A12B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A12C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A12D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A12DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A12E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A12F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A130C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A133C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A136C
-	voice_square_1_alt 0, 1, 0, 2, 3, 5  @ 86A1378
-	voice_square_2_alt 3, 0, 2, 6, 5  @ 86A1384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A139C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A13A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A13B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A13C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A13CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A13D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A13E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A13F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A13FC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 9, 1  @ 86A1408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A142C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A145C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1468
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A148C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1498
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A14A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A14B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A14BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A14C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A14D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A14E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A14EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A14F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1510
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A151C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A154C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A157C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A15A0
-	voice_noise_alt 0, 0, 1, 0, 1  @ 86A15AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A10E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A10F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A10FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A112C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A115C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A118C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A11A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A11B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A11BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A11C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A11D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A11E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A11EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A11F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A121C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A124C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A127C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A12A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A12AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A12B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A12C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A12D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A12DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A12E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A12F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A130C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A133C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A136C
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 3, 5  @ 86A1378
+	voice_square_2_alt 60, 0, 3, 0, 2, 6, 5  @ 86A1384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A139C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A13A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A13B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A13C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A13CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A13D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A13E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A13F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A13FC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 9, 1  @ 86A1408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A142C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A145C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A148C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A14A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A14B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A14BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A14C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A14D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A14E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A14EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A14F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A151C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A154C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A157C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A15A0
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 1  @ 86A15AC
 

--- a/sound/voicegroups/voicegroup132.inc
+++ b/sound/voicegroups/voicegroup132.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup132:: @ 86A15B8
 	voice_keysplit_all voicegroup002  @ 86A15B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A15C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A15D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A15DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A15E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A15F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A160C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1618
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1630
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A163C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A15C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A15D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A15DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A15E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A15F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A160C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A163C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1654
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 97, 236  @ 86A1660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A166C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A166C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1678
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 128, 146, 118, 137  @ 86A1684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A169C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A16A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A16B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A16C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A16CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A169C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A16A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A16B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A16C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A16CC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 51, 204, 92, 226  @ 86A16D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A16E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A16F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A16FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A172C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A175C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A178C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A17A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A17B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A17BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A17C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A17D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A17E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A16E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A16F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A16FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A172C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A175C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A178C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A17A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A17B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A17BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A17C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A17D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A17E0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 165, 154, 235  @ 86A17EC
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A17F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A181C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1828
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A184C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A181C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A184C
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A1858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1864
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86A1870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A187C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A187C
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86A1888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A18A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A18AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A18B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A18C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A18D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A18DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A18E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A18F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A190C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A18A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A18AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A18B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A18C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A18D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A18DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A18E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A18F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A190C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1918
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86A1924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A193C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A196C
-	voice_square_1_alt 0, 2, 0, 4, 2, 2  @ 86A1978
-	voice_square_2_alt 3, 0, 1, 7, 5  @ 86A1984
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 4, 6, 0  @ 86A1990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A199C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4920, 0, 4, 6, 0  @ 86A19A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A19B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A19C0
-	voice_square_1_alt 0, 0, 0, 4, 2, 2  @ 86A19CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A19D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A19E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A19F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A19FC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 2, 9, 1  @ 86A1A08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1A14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1A20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1A2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1A38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1A44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1A50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1A5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1A68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1A74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1A80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1A8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1A98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1AA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1AB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1ABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1AC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1AD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1AE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1AEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1AF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1B04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1B10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1B1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1B28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1B34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1B40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1B4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1B58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1B64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1B70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1B7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1B88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1B94
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86A1BA0
-	voice_noise_alt 0, 0, 1, 8, 1  @ 86A1BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A193C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A196C
+	voice_square_1_alt 60, 0, 0, 2, 0, 4, 2, 2  @ 86A1978
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 5  @ 86A1984
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 4, 6, 0  @ 86A1990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A199C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4920, 0, 4, 6, 0  @ 86A19A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A19B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A19C0
+	voice_square_1_alt 60, 0, 0, 0, 0, 4, 2, 2  @ 86A19CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A19D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A19E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A19F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A19FC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 2, 9, 1  @ 86A1A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1A50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1A5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1A74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1B64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1B94
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86A1BA0
+	voice_noise_alt 60, 0, 0, 0, 1, 8, 1  @ 86A1BAC
 

--- a/sound/voicegroups/voicegroup133.inc
+++ b/sound/voicegroups/voicegroup133.inc
@@ -2,130 +2,130 @@
 voicegroup133:: @ 86A1BB8
 	voice_keysplit_all voicegroup002  @ 86A1BB8
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A1BC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1BD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1BDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1BE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1BF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1C00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1C0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1C18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1BDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1BE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1BF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1C00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1C18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1C24
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_anvil_low, 255, 0, 255, 0  @ 86A1C30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1C3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1C48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1C54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1C3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1C48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1C54
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86A1C60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1C6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1C78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1C78
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 128, 146, 108, 137  @ 86A1C84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1C90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1C9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1CA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1CB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1CC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1C90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1CA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1CB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1CCC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 204, 103, 226  @ 86A1CD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1CE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1CF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1CFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1CF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1D08
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127  @ 86A1D14
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 127  @ 86A1D20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1D2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1D38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1D44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1D50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1D5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1D68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1D74
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 86A1D80
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_square_wave, 255, 0, 255, 127  @ 86A1D8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1D98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1DA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1DB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1DBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1DC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1DD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1D98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1DE0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 193, 153  @ 86A1DEC
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A1DF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1E04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1E10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1E1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1E28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1E34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1E40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1E4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1E28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1E34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1E4C
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A1E58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1E64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1E70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1E7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1E7C
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86A1E88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1E94
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 127  @ 86A1EA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1EAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1EB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1EC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1ED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1EDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1EE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1EF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1F00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1F0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1F18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1F24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1F30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1F3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1F48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1EF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1F00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1F18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1F30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1F54
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 255, 0, 255, 127  @ 86A1F60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1F6C
-	voice_square_1_alt 0, 1, 0, 1, 9, 0  @ 86A1F78
-	voice_square_2_alt 3, 0, 2, 9, 1  @ 86A1F84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1F90
-	voice_square_2_alt 2, 1, 0, 9, 1  @ 86A1F9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1FA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1FB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1FC0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A1FCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1FD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1FE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1FF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A1FFC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 0, 15, 0  @ 86A2008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A202C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A205C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A208C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A20A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A20B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A20BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A20C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A20D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A20E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A20EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A20F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A211C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A214C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1F6C
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 9, 0  @ 86A1F78
+	voice_square_2_alt 60, 0, 3, 0, 2, 9, 1  @ 86A1F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1F90
+	voice_square_2_alt 60, 0, 2, 1, 0, 9, 1  @ 86A1F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1FB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1FC0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A1FCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1FF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A1FFC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 0, 15, 0  @ 86A2008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A202C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A205C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A208C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A20A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A20B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A20BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A20C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A20D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A20E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A20EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A20F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A211C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A214C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165  @ 86A2158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A217C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2194
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86A21A0
-	voice_noise_alt 0, 0, 1, 8, 1  @ 86A21AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A217C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2194
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86A21A0
+	voice_noise_alt 60, 0, 0, 0, 1, 8, 1  @ 86A21AC
 

--- a/sound/voicegroups/voicegroup134.inc
+++ b/sound/voicegroups/voicegroup134.inc
@@ -1,93 +1,93 @@
 	.align 2
 voicegroup134:: @ 86A21B8
 	voice_keysplit_all voicegroup001  @ 86A21B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A21C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A21D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A21DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A21E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A21F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A220C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A223C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A226C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A229C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A22A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A22B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A22C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A22CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A22D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A22E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A22F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A22FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A232C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A235C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A238C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A23A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A23B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A23BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A23C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A23D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A23E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A21C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A21D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A21DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A21E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A21F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A220C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A223C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A226C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A229C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A22A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A22B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A22C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A22CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A22D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A22E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A22F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A22FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A232C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A235C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A238C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A23A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A23B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A23BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A23C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A23D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A23E0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 86A23EC
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A23F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A241C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2428
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A244C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A241C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A244C
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A2458
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2470
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A247C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A247C
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86A2488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A24A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A24AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A24B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A24C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A24D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A24DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A24E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A24F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A250C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A253C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A256C
-	voice_square_2_alt 2, 0, 1, 7, 1  @ 86A2578
-	voice_square_1_alt 0, 2, 0, 1, 7, 1  @ 86A2584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A259C
-	voice_square_2_alt 3, 0, 1, 7, 1  @ 86A25A8
-	voice_square_1_alt 0, 3, 0, 1, 7, 1  @ 86A25B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A25C0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 86A25CC
-	voice_square_1_alt 0, 2, 0, 0, 7, 1  @ 86A25D8
-	voice_square_1_alt 0, 3, 0, 0, 7, 1  @ 86A25E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A24A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A24AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A24B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A24C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A24D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A24DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A24E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A24F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A250C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A253C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A256C
+	voice_square_2_alt 60, 0, 2, 0, 1, 7, 1  @ 86A2578
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 7, 1  @ 86A2584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A259C
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 1  @ 86A25A8
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 7, 1  @ 86A25B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A25C0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 86A25CC
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 7, 1  @ 86A25D8
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 7, 1  @ 86A25E4
 

--- a/sound/voicegroups/voicegroup135.inc
+++ b/sound/voicegroups/voicegroup135.inc
@@ -1,86 +1,86 @@
 	.align 2
 voicegroup135:: @ 86A25F0
 	voice_keysplit_all voicegroup002  @ 86A25F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A25FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A262C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A265C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A268C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A26A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A26B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A26BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A26C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A26D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A26E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A25FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A262C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A265C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A268C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A26A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A26B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A26BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A26C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A26D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A26E0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 85, 137, 180, 204  @ 86A26EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A26F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A271C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A274C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A277C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2788
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A27A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A27AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A27B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A27C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A27D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A27DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A27E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A27F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A280C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2830
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A283C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2848
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A286C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A289C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A28A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A28B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A28C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A28CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A28D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A28E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A28F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A28FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A292C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2938
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A295C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A298C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A29A4
-	voice_square_1_alt 0, 2, 0, 0, 9, 0  @ 86A29B0
-	voice_square_2_alt 2, 0, 0, 9, 0  @ 86A29BC
-	voice_square_1_alt 0, 0, 1, 2, 6, 0  @ 86A29C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A26F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A271C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A274C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A277C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A27A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A27AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A27B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A27C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A27D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A27DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A27E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A27F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A280C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A283C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A286C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A289C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A28A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A28B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A28C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A28CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A28D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A28E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A28F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A28FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A292C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A295C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A298C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A29A4
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 9, 0  @ 86A29B0
+	voice_square_2_alt 60, 0, 2, 0, 0, 9, 0  @ 86A29BC
+	voice_square_1_alt 60, 0, 0, 0, 1, 2, 6, 0  @ 86A29C8
 

--- a/sound/voicegroups/voicegroup136.inc
+++ b/sound/voicegroups/voicegroup136.inc
@@ -2,130 +2,130 @@
 voicegroup136:: @ 86A29D4
 	voice_keysplit_all voicegroup002  @ 86A29D4
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A29E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A29EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A29F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2A04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2A10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2A1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2A28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2A34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2A40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2A4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2A58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2A64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2A70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2A7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2A88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2A94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2AA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2AAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2AB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2AC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2AD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2ADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2AE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2AF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2B00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2B0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2B18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A29EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A29F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2A1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2A34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2A40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2A4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2A58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2A64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2A70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2A7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2A88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2A94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2AA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2AAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2AB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2AC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2ADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2AF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2B18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2B24
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127  @ 86A2B30
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 127  @ 86A2B3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2B48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2B54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2B60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2B6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2B78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2B84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2B90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2B60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2B6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2B90
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 86A2B9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2BA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2BB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2BC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2BCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2BD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2BE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2BF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2BFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2C08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2BA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2BB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2BC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2BE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2BFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2C08
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A2C14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2C20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2C2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2C38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2C44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2C50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2C5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2C68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2C74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2C80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2C8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2C98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2CA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2C20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2C2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2C38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2C44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2C50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2C5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2C68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2C74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2C80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2C98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2CB0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 127  @ 86A2CBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2CC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2CD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2CE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2CEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2CF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2D04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2D10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2D1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2D28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2D34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2D40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2D4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2D58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2D64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2D70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2D7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2D88
-	voice_square_2_alt 0, 0, 5, 0, 0  @ 86A2D94
-	voice_square_1_alt 0, 0, 0, 5, 0, 0  @ 86A2DA0
-	voice_square_1_alt 0, 2, 2, 4, 10, 0  @ 86A2DAC
-	voice_square_2_alt 0, 0, 5, 0, 0  @ 86A2DB8
-	voice_square_1_alt 0, 1, 0, 5, 0, 0  @ 86A2DC4
-	voice_square_2_alt 3, 2, 4, 10, 0  @ 86A2DD0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 1, 5, 0, 3  @ 86A2DDC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 1, 5, 0, 3  @ 86A2DE8
-	voice_square_2_alt 1, 0, 1, 10, 2  @ 86A2DF4
-	voice_square_1_alt 0, 1, 0, 1, 10, 0  @ 86A2E00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2E0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2E18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2E24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2E30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2E3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2E48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2E54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2E60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2E6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2E78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2E84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2E90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2E9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2EA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2EB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2EC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2ECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2ED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2EE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2EF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2EFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2F08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2F14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2F20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2F2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2F38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2F44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2F50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2F5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2F68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2F74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2F80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2F8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2F98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2FA4
-	voice_noise_alt 0, 0, 0, 15, 0  @ 86A2FB0
-	voice_noise_alt 0, 0, 2, 4, 0  @ 86A2FBC
-	voice_noise_alt 0, 0, 1, 0, 0  @ 86A2FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2D88
+	voice_square_2_alt 60, 0, 0, 0, 5, 0, 0  @ 86A2D94
+	voice_square_1_alt 60, 0, 0, 0, 0, 5, 0, 0  @ 86A2DA0
+	voice_square_1_alt 60, 0, 0, 2, 2, 4, 10, 0  @ 86A2DAC
+	voice_square_2_alt 60, 0, 0, 0, 5, 0, 0  @ 86A2DB8
+	voice_square_1_alt 60, 0, 0, 1, 0, 5, 0, 0  @ 86A2DC4
+	voice_square_2_alt 60, 0, 3, 2, 4, 10, 0  @ 86A2DD0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 1, 5, 0, 3  @ 86A2DDC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 1, 5, 0, 3  @ 86A2DE8
+	voice_square_2_alt 60, 0, 1, 0, 1, 10, 2  @ 86A2DF4
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 10, 0  @ 86A2E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2E24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2E30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2E3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2E48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2E54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2E60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2F74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2FA4
+	voice_noise_alt 60, 0, 0, 0, 0, 15, 0  @ 86A2FB0
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0  @ 86A2FBC
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 86A2FC8
 

--- a/sound/voicegroups/voicegroup137.inc
+++ b/sound/voicegroups/voicegroup137.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup137:: @ 86A2FD4
 	voice_keysplit_all voicegroup002  @ 86A2FD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2FE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2FEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A2FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A2FF8
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 165, 180, 165  @ 86A3004
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 137, 154, 165  @ 86A3010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A301C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A301C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3034
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 204, 51, 242  @ 86A3040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A304C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3058
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3064
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A304C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3070
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86A307C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A30A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A30AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A30B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A30C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A30D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A30DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A30E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A30F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A310C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A313C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A316C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3190
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A319C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A31A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A31B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A31C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A31CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A31D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A31E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A31F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A30A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A30AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A30B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A30C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A30D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A30DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A30E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A30F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A310C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A313C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A316C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A319C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A31A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A31B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A31C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A31CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A31D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A31E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A31F0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 0, 242  @ 86A31FC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 193, 153  @ 86A3208
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A3214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A322C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A325C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A322C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A325C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3268
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A3274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3280
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86A328C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3298
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86A32A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A32B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A32BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A32C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A32D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A32E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A32EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A32F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A331C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A334C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A337C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3388
-	voice_square_1_alt 0, 1, 1, 2, 3, 1  @ 86A3394
-	voice_square_2_alt 1, 1, 2, 3, 1  @ 86A33A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A33AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A33B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A33C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A33D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A33DC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 2, 4, 1  @ 86A33E8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 2, 4, 1  @ 86A33F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A340C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3430
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A343C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A346C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A349C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A34A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A34B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A34C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A34CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A34D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A34E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A34F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A34FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A352C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A355C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A358C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A35A4
-	voice_noise_alt 0, 0, 0, 15, 0  @ 86A35B0
-	voice_noise_alt 0, 0, 2, 4, 0  @ 86A35BC
-	voice_noise_alt 0, 0, 1, 0, 1  @ 86A35C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A32B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A32BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A32C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A32D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A32E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A32EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A32F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A331C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A334C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A337C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3388
+	voice_square_1_alt 60, 0, 0, 1, 1, 2, 3, 1  @ 86A3394
+	voice_square_2_alt 60, 0, 1, 1, 2, 3, 1  @ 86A33A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A33AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A33B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A33C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A33D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A33DC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 2, 4, 1  @ 86A33E8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 2, 4, 1  @ 86A33F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A340C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A343C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A346C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A349C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A34A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A34B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A34C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A34CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A34D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A34E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A34F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A34FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A352C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A355C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A358C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A35A4
+	voice_noise_alt 60, 0, 0, 0, 0, 15, 0  @ 86A35B0
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0  @ 86A35BC
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 1  @ 86A35C8
 

--- a/sound/voicegroups/voicegroup138.inc
+++ b/sound/voicegroups/voicegroup138.inc
@@ -2,130 +2,130 @@
 voicegroup138:: @ 86A35D4
 	voice_keysplit_all voicegroup002  @ 86A35D4
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A35E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A35EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A35F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A35EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A35F8
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226  @ 86A3604
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 204, 77, 246  @ 86A3610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A361C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A364C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A367C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A361C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A364C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A367C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3694
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 76, 133, 137  @ 86A36A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A36AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A36B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A36C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A36AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A36B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A36C4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 64, 188, 108, 165  @ 86A36D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A36DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A36E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A36DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A36E8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 127  @ 86A36F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A370C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A373C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A376C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3790
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A379C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A37A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A37B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A37C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A37CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A37D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A37E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A37F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A370C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A373C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A376C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A379C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A37A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A37B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A37C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A37CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A37D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A37E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A37F0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 86A37FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3808
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A3814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A382C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3850
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A385C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A382C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A385C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3868
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A3874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A388C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3898
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A38A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A38B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A38BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A38C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A38D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A38E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A38EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A38F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A391C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A388C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A38A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A38B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A38BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A38C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A38D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A38E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A38EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A38F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A391C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3934
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86A3940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A394C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A397C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3988
-	voice_square_1_alt 0, 0, 0, 2, 5, 2  @ 86A3994
-	voice_square_2_alt 3, 0, 1, 6, 3  @ 86A39A0
-	voice_square_2_alt 0, 0, 2, 6, 5  @ 86A39AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A39B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A39C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A39D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A39DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A39E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A39F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3A00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3A0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3A18
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 0, 12, 0  @ 86A3A24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3A30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3A3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3A48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3A54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3A60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3A6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3A78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3A84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3A90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3A9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3AA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3AB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3AC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3ACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3AD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3AE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3AF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3AFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3B08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3B14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3B20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3B2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3B38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3B44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3B50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3B5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3B68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3B74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3B80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3B8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3B98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3BA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3BB0
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86A3BBC
-	voice_noise_alt 0, 0, 1, 6, 0  @ 86A3BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A394C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A397C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3988
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 5, 2  @ 86A3994
+	voice_square_2_alt 60, 0, 3, 0, 1, 6, 3  @ 86A39A0
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5  @ 86A39AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A39B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A39C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A39D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A39DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A39E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A39F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3A18
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 0, 12, 0  @ 86A3A24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3A30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3A3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3A48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3A54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3A6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3A84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3BB0
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86A3BBC
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0  @ 86A3BC8
 

--- a/sound/voicegroups/voicegroup139.inc
+++ b/sound/voicegroups/voicegroup139.inc
@@ -2,130 +2,130 @@
 voicegroup139:: @ 86A3BD4
 	voice_keysplit_all voicegroup002  @ 86A3BD4
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A3BE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3BEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3BF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3C04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3C10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3C1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3C28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3C34
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 165, 51, 242  @ 86A3C40
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_anvil_low, 255, 0, 255, 0  @ 86A3C4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3C58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3C58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3C64
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 86A3C70
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86A3C7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3C88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3C88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3C94
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 128, 127, 103, 201  @ 86A3CA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3CAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3CB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3CC4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 37, 127, 77, 165  @ 86A3CD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3CDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3CE8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 51, 204, 92, 226  @ 86A3CF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3D00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3D0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3D18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3D24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3D30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3D3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3D48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3D54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3D60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3D6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3D78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3D84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3D90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3D9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3DA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3DB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3DC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3DCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3DD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3DE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3DF0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 226  @ 86A3DFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3E08
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A3E14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3E20
-	voice_square_1_alt 0, 2, 0, 2, 3, 1  @ 86A3E2C
-	voice_square_2_alt 3, 0, 2, 7, 2  @ 86A3E38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3E44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3E50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3E5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3E68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3E74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3E80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3E20
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 3, 1  @ 86A3E2C
+	voice_square_2_alt 60, 0, 3, 0, 2, 7, 2  @ 86A3E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3E44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3E50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3E5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3E74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3E80
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86A3E8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3E98
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86A3EA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3EB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3EBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3EC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3ED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3EE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3EEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3EF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3F04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3F10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3F1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3F28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3F34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3EBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3EEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3F34
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 86A3F40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3F4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3F58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3F64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3F64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3F70
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 255, 0, 255, 127  @ 86A3F7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3F88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3F94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3FA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3FAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3FB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3FC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3FD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3FDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3FE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A3FF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A400C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4018
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A4024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4030
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A403C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A406C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A409C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A40A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A40B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A40C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A40CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A40D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A40E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A40F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A40FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A412C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A415C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A418C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A41A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A41B0
-	voice_noise_alt 0, 0, 1, 6, 1  @ 86A41BC
-	voice_noise_alt 0, 0, 1, 6, 1  @ 86A41C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3F88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A3FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A400C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4018
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A4024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A403C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A406C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A409C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A40A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A40B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A40C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A40CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A40D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A40E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A40F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A40FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A412C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A415C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A418C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A41A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A41B0
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1  @ 86A41BC
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1  @ 86A41C8
 

--- a/sound/voicegroups/voicegroup140.inc
+++ b/sound/voicegroups/voicegroup140.inc
@@ -1,7 +1,7 @@
 	.align 2
 voicegroup140:: @ 86A41D4
 	voice_keysplit_all voicegroup001  @ 86A41D4
-	voice_square_1 0, 2, 0, 2, 3, 1  @ 86A41E0
-	voice_square_2_alt 2, 0, 2, 3, 1  @ 86A41EC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A41F8
+	voice_square_1 60, 0, 0, 2, 0, 2, 3, 1  @ 86A41E0
+	voice_square_2_alt 60, 0, 2, 0, 2, 3, 1  @ 86A41EC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A41F8
 

--- a/sound/voicegroups/voicegroup141.inc
+++ b/sound/voicegroups/voicegroup141.inc
@@ -2,130 +2,130 @@
 voicegroup141:: @ 86A4204
 	voice_keysplit_all voicegroup002  @ 86A4204
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A4210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A421C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4234
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A424C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4258
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A427C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A421C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A424C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A427C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4294
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 86A42A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A42AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A42B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A42C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A42AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A42B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A42C4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 76, 133, 137  @ 86A42D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A42DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A42E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A42F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A42DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A42E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A42F4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 64, 188, 108, 165  @ 86A4300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A430C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A430C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4318
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 85, 249, 25, 127  @ 86A4324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A433C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A436C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A439C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A43A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A43B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A43C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A43CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A43D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A43E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A43F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A43FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A442C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A433C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A436C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A439C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A43A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A43B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A43C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A43CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A43D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A43E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A43F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A43FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A442C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4438
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A4444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A445C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4468
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A448C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A445C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A448C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4498
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A44A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A44B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A44BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A44C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A44D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A44E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A44EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A44F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4510
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A451C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A454C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A44B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A44BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A44C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A44D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A44E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A44EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A44F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A451C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A454C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4564
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 86A4570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A457C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A45A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A45AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A45B8
-	voice_square_1_alt 0, 0, 0, 2, 5, 2  @ 86A45C4
-	voice_square_2_alt 3, 0, 2, 7, 3  @ 86A45D0
-	voice_square_2_alt 2, 0, 2, 6, 5  @ 86A45DC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 1, 7, 0, 6  @ 86A45E8
-	voice_square_1_alt 0, 1, 0, 2, 4, 2  @ 86A45F4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 2, 9, 0  @ 86A4600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A460C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4618
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4630
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A463C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A466C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A469C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A46A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A46B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A46C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A46CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A46D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A46E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A46F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A46FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A472C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A475C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A478C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A47A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A47B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A47BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A47C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A47D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A47E0
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86A47EC
-	voice_noise_alt 0, 0, 1, 6, 0  @ 86A47F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A457C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A45A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A45AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A45B8
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 5, 2  @ 86A45C4
+	voice_square_2_alt 60, 0, 3, 0, 2, 7, 3  @ 86A45D0
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 5  @ 86A45DC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 1, 7, 0, 6  @ 86A45E8
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 4, 2  @ 86A45F4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 2, 9, 0  @ 86A4600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A460C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A463C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A466C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A469C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A46A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A46B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A46C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A46CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A46D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A46E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A46F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A46FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A472C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A475C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A478C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A47A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A47B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A47BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A47C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A47D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A47E0
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86A47EC
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0  @ 86A47F8
 

--- a/sound/voicegroups/voicegroup142.inc
+++ b/sound/voicegroups/voicegroup142.inc
@@ -1,87 +1,87 @@
 	.align 2
 voicegroup142:: @ 86A4804
 	voice_keysplit_all voicegroup002  @ 86A4804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A481C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4828
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A484C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A487C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A48A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A48AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A48B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A48C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A481C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A484C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A487C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A48A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A48AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A48B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A48C4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 64, 188, 128, 201  @ 86A48D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A48DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A48E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A48F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A490C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A48DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A48E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A48F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A490C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4918
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 64, 195, 103, 220  @ 86A4924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A493C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A493C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4954
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 128, 195, 72, 127  @ 86A4960
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 85, 188, 103, 160  @ 86A496C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A499C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A49A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A49B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A49C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A499C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A49A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A49B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A49C0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 128, 188, 77, 115  @ 86A49CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A49D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A49E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A49F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A49FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4A08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4A14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4A20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4A2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4A38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4A44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4A50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4A5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4A68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4A74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4A80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4A8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4A98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4AA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4AB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4ABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4AC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4AD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A49D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A49E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A49F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A49FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4A50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4A5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4A74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4AE0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 175, 154, 127  @ 86A4AEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4AF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4B04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4B10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4B1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4B28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4B34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4B40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4B4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4B58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4B64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4B70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4B7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4B88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4B94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4BA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4BAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4BB8
-	voice_square_1_alt 0, 2, 0, 2, 6, 4  @ 86A4BC4
-	voice_square_2_alt 2, 0, 2, 5, 5  @ 86A4BD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4BDC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4900, 0, 7, 15, 0  @ 86A4BE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4B64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4B94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4BB8
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 6, 4  @ 86A4BC4
+	voice_square_2_alt 60, 0, 2, 0, 2, 5, 5  @ 86A4BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4BDC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4900, 0, 7, 15, 0  @ 86A4BE8
 

--- a/sound/voicegroups/voicegroup143.inc
+++ b/sound/voicegroups/voicegroup143.inc
@@ -2,130 +2,130 @@
 voicegroup143:: @ 86A4BF4
 	voice_keysplit_all voicegroup002  @ 86A4BF4
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A4C00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4C0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4C18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4C24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4C30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4C3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4C48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4C54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4C60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4C6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4C78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4C84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4C90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4C9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4CA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4CB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4C18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4C30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4C3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4C48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4C54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4C60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4C78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4C84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4C90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4CA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4CB4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 128, 160, 123, 165  @ 86A4CC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4CCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4CD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4CE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4CF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4CFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4CF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4D08
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 0  @ 86A4D14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4D20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4D2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4D38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4D44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4D50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4D5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4D68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4D74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4D80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4D8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4D98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4DA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4DB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4DBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4DC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4DD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4DE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4DEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4DF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4E04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4E10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4E1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4E28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4D98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4DF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4E28
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A4E34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4E40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4E4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4E58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4E64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4E70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4E7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4E88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4E94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4EA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4EAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4EB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4EC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4ED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4EDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4EE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4EF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4F00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4F0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4F18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4F24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4F30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4F3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4F48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4F54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4F60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4F6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4F78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4F84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4F90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4F9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4FA8
-	voice_square_2_alt 3, 0, 2, 3, 2  @ 86A4FB4
-	voice_square_1_alt 0, 2, 0, 2, 3, 1  @ 86A4FC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4FCC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A4FD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4FE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4FF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A4FFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A502C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A505C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A508C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A50A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A50B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A50BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A50C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A50D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A50E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A50EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A50F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A511C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A514C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A517C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A51A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A51AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A51B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A51C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A51D0
-	voice_noise_alt 0, 0, 1, 9, 0  @ 86A51DC
-	voice_noise_alt 0, 0, 1, 6, 1  @ 86A51E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4E4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4E58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4E7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4E88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4EA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4EF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4F00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4F18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4F30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4F60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4F6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4F78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4F90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4FA8
+	voice_square_2_alt 60, 0, 3, 0, 2, 3, 2  @ 86A4FB4
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 3, 1  @ 86A4FC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4FCC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A4FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4FF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A4FFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A502C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A505C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A508C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A50A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A50B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A50BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A50C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A50D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A50E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A50EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A50F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A511C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A514C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A517C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A51A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A51AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A51B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A51C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A51D0
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 0  @ 86A51DC
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1  @ 86A51E8
 

--- a/sound/voicegroups/voicegroup144.inc
+++ b/sound/voicegroups/voicegroup144.inc
@@ -2,130 +2,130 @@
 voicegroup144:: @ 86A51F4
 	voice_keysplit_all voicegroup002  @ 86A51F4
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A5200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A520C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A523C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A526C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A529C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A52A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A52B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A520C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A523C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A526C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A529C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A52A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A52B4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 85, 188, 92, 165  @ 86A52C0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 85, 127, 180, 165  @ 86A52CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A52D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A52E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A52F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A52FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A52D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A52E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A52F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A52FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5308
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 51, 204, 92, 226  @ 86A5314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A532C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A535C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A538C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A532C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A535C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A538C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 216  @ 86A5398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A53A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A53B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A53A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A53B0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 86A53BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A53C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A53D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A53E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A53EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A53F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A541C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A53C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A53D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A53E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A53EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A53F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A541C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5428
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A5434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A544C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5458
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5470
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A547C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A54A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A54AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A54B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A54C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A54D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A54DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A54E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A54F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A550C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A553C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A556C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A559C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A55A8
-	voice_square_2_alt 3, 0, 2, 4, 2  @ 86A55B4
-	voice_square_2_alt 1, 0, 2, 4, 3  @ 86A55C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A55CC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A55D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A55E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A55F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A55FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A562C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A565C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A568C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A56A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A56B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A56BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A56C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A56D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A56E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A56EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A56F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A571C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A574C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A577C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5788
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A57A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A57AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A57B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A57C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A57D0
-	voice_noise_alt 0, 0, 1, 9, 0  @ 86A57DC
-	voice_noise_alt 0, 0, 1, 6, 0  @ 86A57E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A544C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A547C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A54A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A54AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A54B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A54C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A54D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A54DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A54E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A54F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A550C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A553C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A556C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A559C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A55A8
+	voice_square_2_alt 60, 0, 3, 0, 2, 4, 2  @ 86A55B4
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 3  @ 86A55C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A55CC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A55D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A55E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A55F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A55FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A562C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A565C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A568C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A56A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A56B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A56BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A56C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A56D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A56E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A56EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A56F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A571C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A574C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A577C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A57A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A57AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A57B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A57C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A57D0
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 0  @ 86A57DC
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0  @ 86A57E8
 

--- a/sound/voicegroups/voicegroup145.inc
+++ b/sound/voicegroups/voicegroup145.inc
@@ -2,130 +2,130 @@
 voicegroup145:: @ 86A57F4
 	voice_keysplit_all voicegroup002  @ 86A57F4
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A5800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A580C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A580C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5818
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226  @ 86A5824
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 204, 77, 246  @ 86A5830
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A583C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5848
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A586C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A589C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A58A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A58B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A583C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A586C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A589C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A58A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A58B4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 76, 133, 137  @ 86A58C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A58CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A58D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A58E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A58CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A58D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A58E4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 64, 188, 108, 165  @ 86A58F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A58FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A58FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5908
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 127  @ 86A5914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A592C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5938
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A595C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A598C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A59A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A59B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A59BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A59C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A59D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A59E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A59EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A59F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5A04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A592C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A595C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A598C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A59A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A59B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A59BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A59C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A59D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A59E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A59EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A59F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5A10
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 86A5A1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5A28
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A5A34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5A40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5A4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5A58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5A64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5A70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5A7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5A88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5A40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5A4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5A58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5A64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5A70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5A7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5A88
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A5A94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5AA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5AAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5AB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5AC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5AD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5ADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5AE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5AF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5B00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5B0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5B18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5B24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5B30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5B3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5B48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5AA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5AAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5AB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5AC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5ADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5AF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5B18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5B30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5B3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5B54
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86A5B60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5B6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5B78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5B84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5B90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5B9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5BA8
-	voice_square_1_alt 0, 0, 0, 2, 5, 2  @ 86A5BB4
-	voice_square_2_alt 3, 0, 0, 9, 0  @ 86A5BC0
-	voice_square_2_alt 0, 0, 2, 6, 5  @ 86A5BCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5BD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5BE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5BF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5BFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5C08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5C14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5C20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5C2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5C38
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 0, 12, 0  @ 86A5C44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5C50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5C5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5C68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5C74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5C80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5C8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5C98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5CA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5CB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5CBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5CC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5CD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5CE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5CEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5CF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5D04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5D10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5D1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5D28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5D34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5D40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5D4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5D58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5D64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5D70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5D7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5D88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5D94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5DA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5DAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5DB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5DC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5DD0
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86A5DDC
-	voice_noise_alt 0, 0, 1, 6, 0  @ 86A5DE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5B6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5B90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5B9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5BA8
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 5, 2  @ 86A5BB4
+	voice_square_2_alt 60, 0, 3, 0, 0, 9, 0  @ 86A5BC0
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5  @ 86A5BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5BE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5BFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5C08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5C14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5C20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5C2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5C38
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 0, 12, 0  @ 86A5C44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5C50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5C5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5C68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5C74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5C80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5C98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5CBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5DD0
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86A5DDC
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0  @ 86A5DE8
 

--- a/sound/voicegroups/voicegroup146.inc
+++ b/sound/voicegroups/voicegroup146.inc
@@ -2,130 +2,130 @@
 voicegroup146:: @ 86A5DF4
 	voice_keysplit_all voicegroup002  @ 86A5DF4
 	voice_directsound 60, 0, DirectSoundWaveData_steinway_b_piano, 255, 165, 103, 235  @ 86A5E00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5E0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5E18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5E24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5E30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5E3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5E48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5E54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5E60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5E6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5E78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5E24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5E30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5E3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5E48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5E54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5E60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5E84
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 86A5E90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5E9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5EA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5EB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5EC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5ECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5ED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5EE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5EF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5EFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5F08
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 85, 249, 25, 226  @ 86A5F14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5F20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5F2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5F38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5F44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5F50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5F5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5F68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5F74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5F80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5F8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5F98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5FA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5FB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5FBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5FC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5FD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5FE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5FEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A5FF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A601C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5F74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5FA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5FB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5FBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A5FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A601C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6028
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A6034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A604C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6058
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6064
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6070
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A607C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A60A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A60AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A60B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A60C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A60D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A60DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A60E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A60F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A610C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A613C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A616C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A604C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A607C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A60A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A60AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A60B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A60C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A60D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A60DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A60E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A60F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A610C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A613C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A616C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6190
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 43, 76, 103, 216  @ 86A619C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A61A8
-	voice_square_2_alt 2, 0, 2, 4, 4  @ 86A61B4
-	voice_square_1_alt 0, 2, 0, 0, 15, 0  @ 86A61C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A61CC
-	voice_square_2_alt 2, 0, 0, 15, 0  @ 86A61D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A61E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A61F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A61FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A622C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6238
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86A6244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A625C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6268
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A628C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A62A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A62B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A62BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A62C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A62D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A62E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A62EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A62F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A631C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A634C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A637C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A63A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A63AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A63B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A63C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A63D0
-	voice_noise_alt 0, 0, 1, 9, 0  @ 86A63DC
-	voice_noise_alt 0, 0, 1, 6, 2  @ 86A63E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A61A8
+	voice_square_2_alt 60, 0, 2, 0, 2, 4, 4  @ 86A61B4
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 15, 0  @ 86A61C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A61CC
+	voice_square_2_alt 60, 0, 2, 0, 0, 15, 0  @ 86A61D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A61E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A61F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A61FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A622C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6238
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86A6244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A625C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A628C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A62A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A62B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A62BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A62C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A62D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A62E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A62EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A62F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A631C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A634C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A637C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A63A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A63AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A63B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A63C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A63D0
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 0  @ 86A63DC
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 2  @ 86A63E8
 

--- a/sound/voicegroups/voicegroup147.inc
+++ b/sound/voicegroups/voicegroup147.inc
@@ -2,86 +2,86 @@
 voicegroup147:: @ 86A63F4
 	voice_keysplit_all voicegroup001  @ 86A63F4
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A6400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A640C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6430
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A643C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A646C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A649C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A64A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A64B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A64C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A64CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A64D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A64E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A64F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A64FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A640C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A643C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A646C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A649C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A64A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A64B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A64C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A64CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A64D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A64E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A64F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A64FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6508
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 64, 249, 25, 226  @ 86A6514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A652C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A655C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A658C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A65A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A65B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A65BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A65C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A65D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A65E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A65EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A65F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A661C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A652C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A655C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A658C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A65A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A65B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A65BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A65C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A65D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A65E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A65EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A65F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A661C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6628
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A6634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A664C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A667C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A66A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A66AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A66B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A66C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A66D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A66DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A66E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A66F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A670C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A673C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A676C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6790
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A679C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A67A8
-	voice_square_1_alt 0, 2, 0, 0, 6, 1  @ 86A67B4
-	voice_square_2_alt 2, 0, 0, 6, 1  @ 86A67C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A67CC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 2, 4, 2  @ 86A67D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A664C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A667C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A66A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A66AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A66B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A66C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A66D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A66DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A66E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A66F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A670C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A673C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A676C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A679C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A67A8
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 6, 1  @ 86A67B4
+	voice_square_2_alt 60, 0, 2, 0, 0, 6, 1  @ 86A67C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A67CC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 2, 4, 2  @ 86A67D8
 

--- a/sound/voicegroups/voicegroup148.inc
+++ b/sound/voicegroups/voicegroup148.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup148:: @ 86A67E4
 	voice_keysplit_all voicegroup002  @ 86A67E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A67F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A67FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6808
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A682C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6850
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A685C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6868
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A67F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A67FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A682C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A685C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6874
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_square_wave, 255, 226, 0, 127  @ 86A6880
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86A688C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6898
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A68A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A68B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A68BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A68C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A68D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A68E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A68EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A68F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A691C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A694C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A697C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A69A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A69AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A68A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A68B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A68BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A68C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A68D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A68E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A68EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A68F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A691C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A694C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A697C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A69A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A69AC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_square_wave, 255, 0, 255, 127  @ 86A69B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A69C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A69D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A69DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A69E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A69F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6A00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6A0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A69C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A69D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A69DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A69E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A69F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6A18
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A6A24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6A30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6A3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6A48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6A54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6A60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6A6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6A78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6A84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6A30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6A3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6A48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6A54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6A6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6A84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6A90
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86A6A9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6AA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6AB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6AC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6ACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6AD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6AE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6AF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6AFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6B08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6B14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6B20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6B2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6B38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6B44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6B50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6B5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6B68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6B74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6B80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6B8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6B98
-	voice_square_1_alt 0, 2, 0, 0, 12, 0  @ 86A6BA4
-	voice_square_2_alt 2, 0, 0, 12, 0  @ 86A6BB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6BBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6BC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6BD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6BE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6BEC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A6BF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6C04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6C10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6C1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6C28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6C34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6C40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6C4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6C58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6C64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6C70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6C7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6C88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6C94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6CA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6CAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6CB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6CC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6CD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6CDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6CE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6CF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6D00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6D0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6D18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6D24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6D30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6D3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6D48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6D54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6D60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6D6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6D78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6D84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6D90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6D9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6DA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6DB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6DC0
-	voice_noise_alt 0, 0, 3, 5, 2  @ 86A6DCC
-	voice_noise_alt 0, 0, 1, 6, 5  @ 86A6DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6B98
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 12, 0  @ 86A6BA4
+	voice_square_2_alt 60, 0, 2, 0, 0, 12, 0  @ 86A6BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6BEC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A6BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6C58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6C70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6C7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6C88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6CA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6DC0
+	voice_noise_alt 60, 0, 0, 0, 3, 5, 2  @ 86A6DCC
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 5  @ 86A6DD8
 

--- a/sound/voicegroups/voicegroup149.inc
+++ b/sound/voicegroups/voicegroup149.inc
@@ -2,95 +2,95 @@
 voicegroup149:: @ 86A6DE4
 	voice_keysplit_all voicegroup190  @ 86A6DE4
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A6DF0
-	voice_square_1_alt 0, 2, 0, 0, 12, 0  @ 86A6DFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6E08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6E14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6E20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6E2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6E38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6E44
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 12, 0  @ 86A6DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6E2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6E44
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 165, 51, 242  @ 86A6E50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6E5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6E68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6E74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6E5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6E74
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 86A6E80
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86A6E8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6E98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6EA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6EB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6EBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6EC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6ED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6EE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6EEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6EF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6F04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6F10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6F1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6F28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6F34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6F40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6F4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6F58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6F64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6F70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6F7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6F88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6F94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6FA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6FAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6FB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6FC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6FD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6FDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6FE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A6FF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6EA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6EBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6EEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6F34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6F40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6F64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6F88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A6FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7000
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 86A700C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 165, 154, 153  @ 86A7018
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A7024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7030
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A703C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A706C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A703C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A706C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7078
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A7084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7090
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86A709C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A70A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A70A8
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86A70B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A70C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A70CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A70D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A70E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A70F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A70FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A70C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A70CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A70D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A70E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A70F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A70FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7108
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_oboe, 43, 188, 103, 165  @ 86A7114
 	voice_directsound 60, 0, DirectSoundWaveData_unused_sd90_oboe, 43, 165, 103, 165  @ 86A7120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A712C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A712C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7144
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86A7150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A715C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A718C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7198
-	voice_square_1_alt 0, 1, 1, 2, 3, 1  @ 86A71A4
-	voice_square_2_alt 1, 0, 2, 4, 2  @ 86A71B0
-	voice_square_1_alt 0, 1, 0, 2, 6, 1  @ 86A71BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A71C8
-	voice_square_1_alt 0, 0, 0, 2, 3, 1  @ 86A71D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A71E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A71EC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A71F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A721C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7228
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86A7234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A715C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A718C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7198
+	voice_square_1_alt 60, 0, 0, 1, 1, 2, 3, 1  @ 86A71A4
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 2  @ 86A71B0
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 6, 1  @ 86A71BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A71C8
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 3, 1  @ 86A71D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A71E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A71EC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A71F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A721C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7228
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86A7234
 

--- a/sound/voicegroups/voicegroup150.inc
+++ b/sound/voicegroups/voicegroup150.inc
@@ -2,130 +2,130 @@
 voicegroup150:: @ 86A7240
 	voice_keysplit_all voicegroup002  @ 86A7240
 	voice_directsound 60, 0, DirectSoundWaveData_steinway_b_piano, 255, 165, 103, 235  @ 86A724C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7258
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A727C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A72A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A72AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A72B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A72C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A72D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A72DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A72E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A72F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A730C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A733C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A736C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A739C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A73A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A73B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A73C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A73CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A73D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A73E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A73F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A73FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A742C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A745C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7468
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A748C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7498
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A74A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A74B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A74BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A74C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A74D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A74E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A74EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A74F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7510
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A751C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A754C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A757C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A75A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A75AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A75B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A75C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A75D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A75DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A727C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A72A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A72AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A72B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A72C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A72D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A72DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A72E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A72F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A730C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A733C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A736C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A739C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A73A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A73B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A73C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A73CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A73D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A73E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A73F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A73FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A742C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A745C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A748C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A74A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A74B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A74BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A74C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A74D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A74E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A74EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A74F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A751C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A754C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A757C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A75A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A75AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A75B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A75C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A75D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A75DC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 85, 204, 77, 127  @ 86A75E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A75F4
-	voice_square_2_alt 1, 0, 1, 4, 6  @ 86A7600
-	voice_square_1_alt 0, 1, 0, 2, 4, 5  @ 86A760C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7618
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 86A7624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7630
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A763C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A766C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A769C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A76A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A76B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A76C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A76CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A76D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A76E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A76F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A76FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A772C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A775C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A778C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A77A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A77B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A77BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A77C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A77D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A77E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A77EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A77F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A781C
-	voice_noise_alt 0, 0, 2, 4, 0  @ 86A7828
-	voice_noise_alt 0, 0, 1, 0, 0  @ 86A7834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A75F4
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 6  @ 86A7600
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 4, 5  @ 86A760C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7618
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 86A7624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A763C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A766C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A769C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A76A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A76B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A76C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A76CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A76D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A76E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A76F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A76FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A772C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A775C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A778C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A77A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A77B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A77BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A77C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A77D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A77E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A77EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A77F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A781C
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0  @ 86A7828
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 86A7834
 

--- a/sound/voicegroups/voicegroup151.inc
+++ b/sound/voicegroups/voicegroup151.inc
@@ -1,91 +1,91 @@
 	.align 2
 voicegroup151:: @ 86A7840
 	voice_keysplit_all voicegroup002  @ 86A7840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A784C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A787C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A78A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A78AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A78B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A78C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A78D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A78DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A784C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A787C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A78A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A78AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A78B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A78C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A78D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A78DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86A78E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A78F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A790C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A793C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A796C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A799C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A79A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A79B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A79C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A79CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A79D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A79E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A79F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A79FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7A08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7A14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7A20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7A2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7A38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7A44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7A50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7A5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A78F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A790C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A793C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A796C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A799C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A79A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A79B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A79C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A79CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A79D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A79E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A79F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A79FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7A50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7A5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7A68
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 193, 127  @ 86A7A74
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A7A80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7A8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7A98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7AA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7AB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7ABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7AC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7AD4
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A7AE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7AEC
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86A7AF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7B04
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86A7B10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7B1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7B28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7B34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7B40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7B4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7B58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7B64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7B70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7B7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7B88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7B94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7BA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7BAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7BB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7BC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7BD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7BDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7BE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7BF4
-	voice_square_1_alt 0, 1, 1, 2, 3, 1  @ 86A7C00
-	voice_square_2_alt 1, 0, 2, 4, 2  @ 86A7C0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7C18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7C24
-	voice_square_1_alt 0, 0, 0, 2, 3, 1  @ 86A7C30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7C3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7C48
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A7C54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7B64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7B94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7BB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7BC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7BDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7BE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7BF4
+	voice_square_1_alt 60, 0, 0, 1, 1, 2, 3, 1  @ 86A7C00
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 2  @ 86A7C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7C18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7C24
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 3, 1  @ 86A7C30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7C3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7C48
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A7C54
 

--- a/sound/voicegroups/voicegroup152.inc
+++ b/sound/voicegroups/voicegroup152.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup152:: @ 86A7C60
 	voice_keysplit_all voicegroup002  @ 86A7C60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7C6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7C78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7C84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7C90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7C9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7CA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7CB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7CC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7CCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7CD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7CE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7CF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7C78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7C84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7C90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7CA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7CB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7CF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7CFC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 97, 236  @ 86A7D08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7D14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7D14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7D20
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 128, 160, 175, 165  @ 86A7D2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7D38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7D44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7D50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7D5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7D68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7D74
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 165, 128, 204  @ 86A7D80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7D8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7D98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7DA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7DB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7DBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7DC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7DD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7DE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7DEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7DF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7E04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7E10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7E1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7E28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7E34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7E40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7E4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7E58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7E64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7E70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7E7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7E88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7D98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7DF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7E28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7E34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7E4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7E58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7E7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7E88
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 127, 154, 235  @ 86A7E94
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A7EA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7EAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7EB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7EC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7ED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7EDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7EE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7EF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7EF4
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A7F00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7F0C
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86A7F18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7F24
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86A7F30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7F3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7F48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7F54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7F60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7F6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7F78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7F84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7F90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7F9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7FA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7FB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7FC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7FCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7FD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7FE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7FF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A7FFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8014
-	voice_square_1_alt 0, 2, 0, 4, 2, 1  @ 86A8020
-	voice_square_2_alt 3, 0, 1, 5, 2  @ 86A802C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 4, 6, 0  @ 86A8038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8044
-	voice_programmable_wave_alt ProgrammableWaveData_86B4920, 0, 4, 6, 0  @ 86A8050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A805C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8068
-	voice_square_1_alt 0, 1, 0, 2, 4, 1  @ 86A8074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A808C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A80A4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 2, 9, 1  @ 86A80B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A80BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A80C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A80D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A80E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A80EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A80F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A811C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A814C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A817C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A81A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A81AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A81B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A81C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A81D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A81DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A81E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A81F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A820C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A823C
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86A8248
-	voice_noise_alt 0, 0, 1, 6, 1  @ 86A8254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7F60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7F6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7F78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7F90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7FB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7FC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7FCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7FF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A7FFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8014
+	voice_square_1_alt 60, 0, 0, 2, 0, 4, 2, 1  @ 86A8020
+	voice_square_2_alt 60, 0, 3, 0, 1, 5, 2  @ 86A802C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 4, 6, 0  @ 86A8038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8044
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4920, 0, 4, 6, 0  @ 86A8050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A805C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8068
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 4, 1  @ 86A8074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A808C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A80A4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 2, 9, 1  @ 86A80B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A80BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A80C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A80D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A80E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A80EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A80F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A811C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A814C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A817C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A81A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A81AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A81B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A81C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A81D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A81DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A81E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A81F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A820C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A823C
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86A8248
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1  @ 86A8254
 

--- a/sound/voicegroups/voicegroup153.inc
+++ b/sound/voicegroups/voicegroup153.inc
@@ -2,130 +2,130 @@
 voicegroup153:: @ 86A8260
 	voice_keysplit_all voicegroup002  @ 86A8260
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A826C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A829C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A82A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A82B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A82C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A82CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A82D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A82E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A82F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A82FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A829C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A82A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A82B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A82C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A82CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A82D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A82E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A82F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A82FC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 97, 236  @ 86A8308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A832C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A835C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A838C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A83A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A83B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A83BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A83C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A83D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A83E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A83EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A83F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A841C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8428
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A844C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8458
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8470
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A847C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A832C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A835C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A838C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A83A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A83B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A83BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A83C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A83D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A83E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A83EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A83F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A841C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A844C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A847C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 86A8488
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 127, 154, 235  @ 86A8494
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A84A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A84AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A84B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A84C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A84D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A84DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A84E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A84F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A84AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A84B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A84C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A84D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A84DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A84E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A84F4
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A8500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A850C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A850C
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86A8518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8524
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86A8530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A853C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A856C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A859C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A85A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A85B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A85C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A853C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A856C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A859C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A85A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A85B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A85C0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86A85CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A85D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A85E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A85F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A85FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8614
-	voice_square_1_alt 0, 1, 0, 3, 5, 2  @ 86A8620
-	voice_square_2_alt 3, 0, 3, 4, 2  @ 86A862C
-	voice_square_2_alt 0, 0, 2, 6, 5  @ 86A8638
-	voice_square_1_alt 0, 0, 0, 1, 6, 2  @ 86A8644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A865C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A868C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A86A4
-	voice_programmable_wave_alt ProgrammableWaveData_86B48A0, 0, 1, 12, 0  @ 86A86B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A86BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A86C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A86D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A86E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A86EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A86F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A871C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A874C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A877C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8788
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A87A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A87AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A87B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A87C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A87D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A87DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A87E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A87F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A880C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8830
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A883C
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86A8848
-	voice_noise_alt 0, 0, 1, 6, 2  @ 86A8854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A85D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A85E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A85F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A85FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8614
+	voice_square_1_alt 60, 0, 0, 1, 0, 3, 5, 2  @ 86A8620
+	voice_square_2_alt 60, 0, 3, 0, 3, 4, 2  @ 86A862C
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5  @ 86A8638
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 6, 2  @ 86A8644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A865C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A868C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A86A4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B48A0, 0, 1, 12, 0  @ 86A86B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A86BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A86C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A86D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A86E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A86EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A86F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A871C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A874C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A877C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A87A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A87AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A87B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A87C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A87D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A87DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A87E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A87F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A880C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A883C
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86A8848
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 2  @ 86A8854
 

--- a/sound/voicegroups/voicegroup154.inc
+++ b/sound/voicegroups/voicegroup154.inc
@@ -1,96 +1,96 @@
 	.align 2
 voicegroup154:: @ 86A8860
 	voice_keysplit_all voicegroup002  @ 86A8860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A886C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A886C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8884
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 249, 0, 165  @ 86A8890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A889C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A88A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A88B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A88C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A88CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A88D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A88E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A88F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A88FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A889C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A88A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A88B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A88C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A88CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A88D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A88E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A88F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A88FC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 97, 236  @ 86A8908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A892C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8938
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A895C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A898C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A89A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A89B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A89BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A89C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A89D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A89E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A89EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A89F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8A04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8A10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8A1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8A28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8A34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8A40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8A4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8A58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8A64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8A70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8A7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8A88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A892C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A895C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A898C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A89A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A89B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A89BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A89C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A89D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A89E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A89EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A89F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8A1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8A34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8A40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8A4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8A58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8A64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8A70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8A7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8A88
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 127, 154, 235  @ 86A8A94
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A8AA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8AAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8AB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8AC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8AD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8ADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8AE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8AF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8AAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8AB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8AC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8ADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8AF4
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A8B00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8B0C
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86A8B18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8B24
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86A8B30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8B3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8B48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8B54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8B60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8B6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8B78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8B84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8B90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8B9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8BA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8BB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8BC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8BCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8BD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8BE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8BF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8BFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8C08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8C14
-	voice_square_1_alt 0, 1, 0, 0, 10, 0  @ 86A8C20
-	voice_square_2_alt 1, 0, 0, 10, 0  @ 86A8C2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8C38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8C44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8C50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8C5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8C68
-	voice_programmable_wave_alt ProgrammableWaveData_86B4860, 0, 0, 12, 0  @ 86A8C74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8C80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8C8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8C98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8CA4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 0, 12, 0  @ 86A8CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8B3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8B60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8B6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8B90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8B9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8BA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8BB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8BC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8BE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8BFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8C08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8C14
+	voice_square_1_alt 60, 0, 0, 1, 0, 0, 10, 0  @ 86A8C20
+	voice_square_2_alt 60, 0, 1, 0, 0, 10, 0  @ 86A8C2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8C38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8C44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8C50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8C5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8C68
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4860, 0, 0, 12, 0  @ 86A8C74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8C80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8C98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8CA4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 0, 12, 0  @ 86A8CB0
 

--- a/sound/voicegroups/voicegroup155.inc
+++ b/sound/voicegroups/voicegroup155.inc
@@ -2,130 +2,130 @@
 voicegroup155:: @ 86A8CBC
 	voice_keysplit_all voicegroup002  @ 86A8CBC
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A8CC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8CD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8CE0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 249, 0, 165  @ 86A8CEC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 188, 103, 165  @ 86A8CF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8D04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8D10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8D1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8D28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8D34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8D40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8D4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8D58
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86A8D64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8D70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8D7C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 127  @ 86A8D88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8D94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8DA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8DAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8DB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8DC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8DD0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 127  @ 86A8DDC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 165, 128, 204  @ 86A8DE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8DF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8E00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8E0C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127  @ 86A8E18
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 165, 154, 165  @ 86A8E24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8E30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8E3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8E48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8E54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8E60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8E6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8E78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8E84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8E90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8E9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8EA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8EB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8EC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8ECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8ED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8E30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8E3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8E48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8E54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8E60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8EE4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 86A8EF0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A8EFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8F08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8F14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8F20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8F2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8F38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8F44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8F50
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A8F5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8F68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8F74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8F74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8F80
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86A8F8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8F98
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 165, 180, 165  @ 86A8FA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8FB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8FBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8FC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8FD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8FE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8FEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A8FF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A901C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A904C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9058
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9064
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9070
-	voice_square_1_alt 0, 1, 0, 2, 7, 2  @ 86A907C
-	voice_square_2_alt 3, 0, 3, 6, 2  @ 86A9088
-	voice_square_2_alt 3, 0, 2, 6, 5  @ 86A9094
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 3, 6, 5  @ 86A90A0
-	voice_square_2_alt 0, 0, 2, 6, 5  @ 86A90AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A90B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A90C4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4850, 0, 7, 15, 1  @ 86A90D0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86A90DC
-	voice_programmable_wave_alt ProgrammableWaveData_86B4910, 0, 1, 9, 2  @ 86A90E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A90F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9100
-	voice_square_2_alt 2, 0, 2, 6, 3  @ 86A910C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A913C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A916C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9190
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A919C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A91A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A91B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A91C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A91CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A91D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A91E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A91F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A91FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A922C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8FB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8FBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A8FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A901C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A904C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9070
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 7, 2  @ 86A907C
+	voice_square_2_alt 60, 0, 3, 0, 3, 6, 2  @ 86A9088
+	voice_square_2_alt 60, 0, 3, 0, 2, 6, 5  @ 86A9094
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 3, 6, 5  @ 86A90A0
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5  @ 86A90AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A90B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A90C4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4850, 0, 7, 15, 1  @ 86A90D0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86A90DC
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4910, 0, 1, 9, 2  @ 86A90E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A90F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9100
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 3  @ 86A910C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A913C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A916C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A919C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A91A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A91B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A91C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A91CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A91D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A91E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A91F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A91FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A922C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9250
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165  @ 86A925C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9268
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A928C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9298
-	voice_noise_alt 0, 0, 2, 6, 2  @ 86A92A4
-	voice_noise_alt 0, 0, 1, 6, 0  @ 86A92B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A928C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9298
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 2  @ 86A92A4
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0  @ 86A92B0
 

--- a/sound/voicegroups/voicegroup156.inc
+++ b/sound/voicegroups/voicegroup156.inc
@@ -2,130 +2,130 @@
 voicegroup156:: @ 86A92BC
 	voice_keysplit_all voicegroup002  @ 86A92BC
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A92C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A92D4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A92E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A92EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A92D4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86A92E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A92EC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 249, 0, 165  @ 86A92F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A931C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A934C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A937C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A931C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A934C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A937C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 127  @ 86A9388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A93A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A93AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A93A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A93AC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 255, 0, 255, 165  @ 86A93B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A93C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A93D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A93C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A93D0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 165, 128, 204  @ 86A93DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A93E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A93F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A940C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A93E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A93F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A940C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127  @ 86A9418
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 127  @ 86A9424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9430
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A943C
-	voice_square_2_alt 3, 0, 4, 4, 4  @ 86A9448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A943C
+	voice_square_2_alt 60, 0, 3, 0, 4, 4, 4  @ 86A9448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9460
 	voice_directsound 60, 0, DirectSoundWaveData_unused_sc88_unison_slap, 255, 165, 180, 216  @ 86A946C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9484
-	voice_square_2_alt 1, 0, 1, 7, 5  @ 86A9490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A949C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A94A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A94B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A94C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A94CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A94D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A94E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A94F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9484
+	voice_square_2_alt 60, 0, 1, 0, 1, 7, 5  @ 86A9490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A949C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A94A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A94B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A94C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A94CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A94D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A94E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A94F0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A94FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A952C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A952C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9550
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A955C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9580
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86A958C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9598
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 127  @ 86A95A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A95B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A95BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A95C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A95D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A95E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A95EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A95F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A961C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A964C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9670
-	voice_square_2_alt 2, 0, 2, 3, 1  @ 86A967C
-	voice_square_1_alt 0, 0, 0, 2, 7, 5  @ 86A9688
-	voice_square_1_alt 0, 3, 0, 2, 6, 5  @ 86A9694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A96A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A96AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A96B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A96C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A96D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A96DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A96E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A96F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A970C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A973C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A976C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9790
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A979C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A97A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A97B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A97C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A97CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A97D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A97E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A97F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A97FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9808
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A982C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A95B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A95BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A95C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A95D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A95E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A95EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A95F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A961C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A964C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9670
+	voice_square_2_alt 60, 0, 2, 0, 2, 3, 1  @ 86A967C
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 7, 5  @ 86A9688
+	voice_square_1_alt 60, 0, 0, 3, 0, 2, 6, 5  @ 86A9694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A96A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A96AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A96B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A96C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A96D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A96DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A96E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A96F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A970C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A973C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A976C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A979C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A97A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A97B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A97C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A97CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A97D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A97E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A97F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A97FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A982C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9850
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165  @ 86A985C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9868
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A988C
-	voice_noise_alt 0, 0, 0, 15, 0  @ 86A9898
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86A98A4
-	voice_noise_alt 0, 0, 1, 6, 0  @ 86A98B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A988C
+	voice_noise_alt 60, 0, 0, 0, 0, 15, 0  @ 86A9898
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86A98A4
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0  @ 86A98B0
 

--- a/sound/voicegroups/voicegroup157.inc
+++ b/sound/voicegroups/voicegroup157.inc
@@ -2,130 +2,130 @@
 voicegroup157:: @ 86A98BC
 	voice_keysplit_all voicegroup002  @ 86A98BC
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A98C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A98D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A98E0
-	voice_square_2_alt 3, 0, 2, 6, 5  @ 86A98EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A98F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A991C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A994C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A997C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A98D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A98E0
+	voice_square_2_alt 60, 0, 3, 0, 2, 6, 5  @ 86A98EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A98F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A991C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A994C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A997C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 128, 146, 190, 115  @ 86A9988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A99A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A99AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A99A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A99AC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 255, 0, 255, 165  @ 86A99B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A99C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A99D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A99C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A99D0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 165, 128, 204  @ 86A99DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A99E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A99F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9A00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A99E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A99F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9A0C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127  @ 86A9A18
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 127  @ 86A9A24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9A30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9A3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9A30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9A3C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 253, 0, 149  @ 86A9A48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9A54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9A54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9A60
 	voice_directsound 60, 0, DirectSoundWaveData_unused_sc88_unison_slap, 255, 165, 180, 216  @ 86A9A6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9A78
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 86A9A84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9A90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9A9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9AA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9AB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9AC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9ACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9AD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9AE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9AF0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86A9AFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9B08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9B14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9B20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9B2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9B38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9B44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9B50
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86A9B5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9B68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9B74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9B80
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86A9B8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9B98
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 127  @ 86A9BA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9BB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9BBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9BC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9BD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9BE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9BEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9BF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9C04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9C10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9C1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9C28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9C34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9C40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9C4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9C58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9C64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9C70
-	voice_square_1_alt 0, 1, 0, 2, 7, 2  @ 86A9C7C
-	voice_square_2_alt 3, 0, 3, 3, 0  @ 86A9C88
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 3, 6, 5  @ 86A9C94
-	voice_square_1_alt 0, 0, 0, 2, 7, 2  @ 86A9CA0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86A9CAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9CB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9CC4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 86A9CD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9CDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9CE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9CF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9D00
-	voice_square_2_alt 2, 0, 2, 6, 3  @ 86A9D0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9D18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9D24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9D30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9D3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9D48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9D54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9D60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9D6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9D78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9D84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9D90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9D9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9DA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9DB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9DC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9DCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9DD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9DE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9DF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9DFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9E08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9E14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9E20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9E2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9E38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9E44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9E50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9E5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9E68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9E74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9E80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9E8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9E98
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86A9EA4
-	voice_noise_alt 0, 0, 1, 6, 1  @ 86A9EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9C58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9C70
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 7, 2  @ 86A9C7C
+	voice_square_2_alt 60, 0, 3, 0, 3, 3, 0  @ 86A9C88
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 3, 6, 5  @ 86A9C94
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 7, 2  @ 86A9CA0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86A9CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9CC4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 86A9CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9D00
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 3  @ 86A9D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9E2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9E44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9E50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9E5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9E74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9E80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9E98
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86A9EA4
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1  @ 86A9EB0
 

--- a/sound/voicegroups/voicegroup158.inc
+++ b/sound/voicegroups/voicegroup158.inc
@@ -2,130 +2,130 @@
 voicegroup158:: @ 86A9EBC
 	voice_keysplit_all voicegroup002  @ 86A9EBC
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86A9EC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9ED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9EE0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 249, 0, 165  @ 86A9EEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9EF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9F04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9F10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9F1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9F28
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_anvil_low, 255, 0, 255, 0  @ 86A9F34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9F40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9F4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9F40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9F58
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86A9F64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9F70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9F7C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 128, 146, 108, 137  @ 86A9F88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9F94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9FA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9FAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9FB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9FC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9FD0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 204, 103, 226  @ 86A9FDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9FE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86A9FF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA00C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86A9FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA00C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127  @ 86AA018
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 127  @ 86AA024
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165  @ 86AA030
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA03C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA03C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA054
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 86AA060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA06C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA06C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA078
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 86AA084
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_square_wave, 255, 0, 255, 127  @ 86AA090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA09C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA0A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA0B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA0C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA0CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA0D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA0E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA09C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA0A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA0B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA0C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA0CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA0D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA0E4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 193, 153  @ 86AA0F0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86AA0FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA12C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA12C
 	voice_directsound 60, 0, DirectSoundWaveData_classical_choir_voice_ahhs, 255, 0, 255, 0  @ 86AA138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA150
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86AA15C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA180
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86AA18C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA198
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 236, 188  @ 86AA1A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA1B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA1BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA1C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA1D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA1E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA1EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA1F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA21C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA234
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA24C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA1B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA1BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA1C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA1D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA1E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA1EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA1F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA21C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA24C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA258
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 255, 0, 255, 127  @ 86AA264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA270
-	voice_square_1_alt 0, 1, 0, 1, 9, 0  @ 86AA27C
-	voice_square_2_alt 3, 0, 1, 10, 1  @ 86AA288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA294
-	voice_square_2_alt 2, 1, 0, 9, 1  @ 86AA2A0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 86AA2AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA2B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA2C4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AA2D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA2DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA2E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA2F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA300
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 0, 15, 0  @ 86AA30C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA33C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA36C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA39C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA3A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA3B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA3C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA3CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA3D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA3E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA3F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA3FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA42C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA45C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA468
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA48C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA498
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86AA4A4
-	voice_noise_alt 0, 0, 1, 8, 1  @ 86AA4B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA270
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 9, 0  @ 86AA27C
+	voice_square_2_alt 60, 0, 3, 0, 1, 10, 1  @ 86AA288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA294
+	voice_square_2_alt 60, 0, 2, 1, 0, 9, 1  @ 86AA2A0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 86AA2AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA2B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA2C4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AA2D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA2DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA2E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA2F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA300
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 0, 15, 0  @ 86AA30C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA33C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA36C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA39C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA3A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA3B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA3C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA3CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA3D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA3E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA3F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA3FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA42C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA45C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA48C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA498
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86AA4A4
+	voice_noise_alt 60, 0, 0, 0, 1, 8, 1  @ 86AA4B0
 

--- a/sound/voicegroups/voicegroup159.inc
+++ b/sound/voicegroups/voicegroup159.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup159:: @ 86AA4BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA4BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA4C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA4D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA4E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA4BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA4C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA4D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA4E0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 64, 249, 0, 188  @ 86AA4EC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 51, 249, 0, 165  @ 86AA4F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA510
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA51C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA54C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA57C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA5A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA5AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA5B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA5C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA5D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA51C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA54C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA57C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA5A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA5AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA5B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA5C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA5D0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 85, 249, 25, 127  @ 86AA5DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA5E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA5F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA60C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA618
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA630
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA63C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA66C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA69C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA6A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA6B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA6C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA6CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA6D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA6E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA6F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA5E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA5F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA60C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA63C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA66C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA69C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA6A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA6B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA6C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA6CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA6D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA6E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA6F0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86AA6FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA72C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA75C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA78C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA7A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA7B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA7BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA7C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA7D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA7E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA7EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA7F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA81C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA828
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA84C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA870
-	voice_square_1_alt 0, 2, 0, 7, 0, 6  @ 86AA87C
-	voice_square_2_alt 1, 1, 5, 1, 6  @ 86AA888
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 1, 7, 0, 6  @ 86AA894
-	voice_square_1_alt 0, 0, 1, 4, 3, 6  @ 86AA8A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA8AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA8B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA8C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA8D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA8DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA8E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA8F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA90C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA93C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA96C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA99C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA9A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA9B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA9C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA9CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA9D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA9E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA9F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AA9FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAA08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAA14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAA20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAA2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAA38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAA44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAA50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAA5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAA68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAA74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAA80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAA8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAA98
-	voice_noise_alt 0, 0, 2, 4, 0  @ 86AAAA4
-	voice_noise_alt 0, 0, 1, 0, 0  @ 86AAAB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA72C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA75C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA78C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA7A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA7B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA7BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA7C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA7D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA7E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA7EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA7F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA81C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA84C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA870
+	voice_square_1_alt 60, 0, 0, 2, 0, 7, 0, 6  @ 86AA87C
+	voice_square_2_alt 60, 0, 1, 1, 5, 1, 6  @ 86AA888
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 1, 7, 0, 6  @ 86AA894
+	voice_square_1_alt 60, 0, 0, 0, 1, 4, 3, 6  @ 86AA8A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA8AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA8B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA8C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA8D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA8DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA8E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA8F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA90C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA93C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA96C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA99C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA9A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA9B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA9C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA9CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA9D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA9E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA9F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AA9FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAA08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAA14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAA20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAA2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAA38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAA44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAA50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAA5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAA68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAA74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAA80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAA8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAA98
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0  @ 86AAAA4
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 86AAAB0
 

--- a/sound/voicegroups/voicegroup160.inc
+++ b/sound/voicegroups/voicegroup160.inc
@@ -1,91 +1,91 @@
 	.align 2
 voicegroup160:: @ 86AAABC
 	voice_keysplit_all voicegroup001  @ 86AAABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAAC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAAD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAAE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAAEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAAF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAB04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAB10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAB1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAB28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAB34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAB40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAB4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAB58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAAC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAAD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAAE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAAEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAAF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAB04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAB10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAB1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAB28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAB34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAB40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAB4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAB58
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86AAB64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAB70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAB7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAB88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAB94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AABA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AABAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AABB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AABC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AABD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAB70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAB7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAB88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAB94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AABA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AABAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AABB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AABC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AABD0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 127  @ 86AABDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AABE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AABF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAC00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAC0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAC18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAC24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAC30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAC3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAC48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAC54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AABE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AABF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAC00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAC0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAC18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAC24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAC30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAC3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAC48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAC54
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 86AAC60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAC6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAC78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAC84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAC90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAC9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AACA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AACB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AACC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AACCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AACD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AACE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AACF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAC6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAC78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAC84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAC90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAC9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AACA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AACB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AACC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AACCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AACD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AACE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AACF0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86AACFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAD08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAD14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAD20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAD2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAD38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAD44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAD50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAD5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAD68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAD74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAD80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAD8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAD98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AADA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AADB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AADBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AADC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AADD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AADE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AADEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AADF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAE04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAE10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAE1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAE28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAE34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAE40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAE4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAE58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAE64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAE70
-	voice_square_1_alt 0, 1, 0, 2, 3, 1  @ 86AAE7C
-	voice_square_2_alt 1, 0, 2, 4, 2  @ 86AAE88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAE94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAEA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAEAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAEB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAEC4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AAED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAD08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAD14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAD20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAD2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAD38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAD44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAD50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAD5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAD68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAD74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAD80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAD8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAD98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AADA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AADB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AADBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AADC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AADD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AADE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AADEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AADF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAE04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAE10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAE1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAE28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAE34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAE40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAE4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAE58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAE64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAE70
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 3, 1  @ 86AAE7C
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 2  @ 86AAE88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAE94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAEA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAEAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAEB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAEC4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AAED0
 

--- a/sound/voicegroups/voicegroup161.inc
+++ b/sound/voicegroups/voicegroup161.inc
@@ -2,130 +2,130 @@
 voicegroup161:: @ 86AAEDC
 	voice_keysplit_all voicegroup002  @ 86AAEDC
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86AAEE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAEF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAF00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAF0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAF18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAF24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAF30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAF3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAF48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAF54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAF60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAF6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAF78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAEF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAF00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAF0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAF18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAF24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAF30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAF3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAF48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAF54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAF60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAF6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAF78
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86AAF84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAF90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAF9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAF90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAF9C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 127  @ 86AAFA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAFB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAFC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAFCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAFB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAFC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAFCC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 255, 0, 255, 165  @ 86AAFD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAFE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAFF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AAFFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB02C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB05C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB08C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB0A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB0B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB0BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB0C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB0D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB0E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB0EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB0F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAFE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAFF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AAFFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB02C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB05C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB08C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB0A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB0B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB0BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB0C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB0D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB0E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB0EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB0F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB110
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86AB11C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB14C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB14C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB170
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86AB17C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB188
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86AB194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB1A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB1AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB1B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB1C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB1D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB1DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB1E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB1F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB20C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB23C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB1A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB1AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB1B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB1C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB1D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB1DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB1E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB1F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB20C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB23C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 86AB248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB26C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB290
-	voice_square_1_alt 0, 2, 0, 2, 6, 4  @ 86AB29C
-	voice_square_2_alt 2, 0, 2, 6, 2  @ 86AB2A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB2B4
-	voice_square_2_alt 1, 0, 2, 6, 2  @ 86AB2C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB2CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB2D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB2E4
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AB2F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB2FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB32C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB35C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB38C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB3A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB3B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB3BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB3C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB3D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB3E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB3EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB3F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB41C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB428
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB44C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB458
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB470
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB47C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB4A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB4AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB4B8
-	voice_noise_alt 0, 0, 2, 4, 0  @ 86AB4C4
-	voice_noise_alt 0, 0, 1, 0, 0  @ 86AB4D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB26C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB290
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 6, 4  @ 86AB29C
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 2  @ 86AB2A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB2B4
+	voice_square_2_alt 60, 0, 1, 0, 2, 6, 2  @ 86AB2C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB2CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB2D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB2E4
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AB2F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB2FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB32C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB35C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB38C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB3A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB3B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB3BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB3C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB3D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB3E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB3EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB3F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB41C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB44C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB47C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB4A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB4AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB4B8
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0  @ 86AB4C4
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 86AB4D0
 

--- a/sound/voicegroups/voicegroup162.inc
+++ b/sound/voicegroups/voicegroup162.inc
@@ -1,96 +1,96 @@
 	.align 2
 voicegroup162:: @ 86AB4DC
 	voice_keysplit_all voicegroup002  @ 86AB4DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB4E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB4F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB4E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB4F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB500
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 64, 188, 108, 244  @ 86AB50C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB53C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB56C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB53C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB56C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB578
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86AB584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB59C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB59C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 64, 195, 92, 235  @ 86AB5A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB5B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB5C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB5CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB5D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB5E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB5F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB5B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB5C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB5CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB5D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB5E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB5F0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 127  @ 86AB5FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB62C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB65C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB62C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB65C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 64, 204, 113, 235  @ 86AB668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB68C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB6A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB6B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB6BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB6C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB6D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB6E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB6EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB6F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB68C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB6A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB6B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB6BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB6C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB6D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB6E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB6EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB6F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB710
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86AB71C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB74C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB77C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB788
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB7A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB7AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB7B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB7C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB7D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB7DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB7E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB7F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB80C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB830
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB83C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB848
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB86C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB890
-	voice_square_1_alt 0, 1, 0, 0, 6, 0  @ 86AB89C
-	voice_square_2_alt 1, 0, 0, 6, 0  @ 86AB8A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB8B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB8C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB8CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB8D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB8E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB8F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB8FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB920
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AB92C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB74C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB77C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB7A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB7AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB7B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB7C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB7D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB7DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB7E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB7F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB80C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB83C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB86C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB890
+	voice_square_1_alt 60, 0, 0, 1, 0, 0, 6, 0  @ 86AB89C
+	voice_square_2_alt 60, 0, 1, 0, 0, 6, 0  @ 86AB8A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB8B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB8C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB8CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB8D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB8E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB8F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB8FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB920
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AB92C
 

--- a/sound/voicegroups/voicegroup163.inc
+++ b/sound/voicegroups/voicegroup163.inc
@@ -2,130 +2,130 @@
 voicegroup163:: @ 86AB938
 	voice_keysplit_all voicegroup002  @ 86AB938
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86AB944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB95C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB95C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226  @ 86AB968
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 204, 77, 246  @ 86AB974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB98C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB9A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB9B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB9BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB9C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB9D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB9E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB9EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AB9F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB98C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB9A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB9B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB9BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB9C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB9D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB9E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB9EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AB9F8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 76, 133, 137  @ 86ABA04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABA10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABA1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABA28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABA10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABA1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABA28
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 64, 188, 108, 165  @ 86ABA34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABA40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABA4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABA40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABA4C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 127  @ 86ABA58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABA64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABA70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABA7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABA88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABA94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABAA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABAAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABAB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABAC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABAD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABAE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABAF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABB00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABB0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABB18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABB24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABB30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABB3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABB48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABB54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABA64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABA70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABA7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABA88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABA94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABAA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABAAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABAB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABAC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABAD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABAE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABAF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABB00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABB0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABB18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABB24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABB30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABB3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABB48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABB54
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 86ABB60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABB6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABB6C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86ABB78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABB84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABB90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABB9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABBA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABBB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABBC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABBCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABB84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABB90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABB9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABBA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABBB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABBC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABBCC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86ABBD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABBE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABBE4
 	voice_directsound 60, 0, DirectSoundWaveData_88D6978, 255, 0, 206, 204  @ 86ABBF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABBFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABC08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABC14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABC20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABC2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABC38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABC44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABC50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABC5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABC68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABC74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABC80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABC8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABC98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABBFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABC08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABC14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABC20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABC2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABC38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABC44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABC50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABC5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABC68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABC74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABC80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABC8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABC98
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86ABCA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABCB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABCBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABCC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABCD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABCE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABCEC
-	voice_square_1_alt 0, 0, 0, 1, 5, 2  @ 86ABCF8
-	voice_square_2_alt 3, 0, 3, 4, 2  @ 86ABD04
-	voice_square_2_alt 0, 0, 2, 6, 5  @ 86ABD10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABD1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABD28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABD34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABD40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABD4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABD58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABD64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABD70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABD7C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4900, 0, 0, 12, 0  @ 86ABD88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABD94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABDA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABDAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABDB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABDC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABDD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABDDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABDE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABDF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABE00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABE0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABE18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABE24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABE30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABE3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABE48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABE54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABE60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABE6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABE78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABE84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABE90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABE9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABEA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABEB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABEC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABEE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABEF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABEFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABF08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABF14
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86ABF20
-	voice_noise_alt 0, 0, 1, 6, 0  @ 86ABF2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABCB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABCBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABCC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABCD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABCE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABCEC
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 5, 2  @ 86ABCF8
+	voice_square_2_alt 60, 0, 3, 0, 3, 4, 2  @ 86ABD04
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5  @ 86ABD10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABD1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABD28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABD34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABD40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABD4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABD58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABD64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABD70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABD7C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4900, 0, 0, 12, 0  @ 86ABD88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABD94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABDA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABDAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABDB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABDC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABDD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABDDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABDE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABDF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABE00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABE0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABE18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABE24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABE30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABE3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABE48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABE54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABE60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABE6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABE78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABE84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABE90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABE9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABEA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABEB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABEC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABEE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABEF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABEFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABF08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABF14
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86ABF20
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0  @ 86ABF2C
 

--- a/sound/voicegroups/voicegroup164.inc
+++ b/sound/voicegroups/voicegroup164.inc
@@ -2,130 +2,130 @@
 voicegroup164:: @ 86ABF38
 	voice_keysplit_all voicegroup002  @ 86ABF38
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86ABF44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABF50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABF5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABF50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABF5C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 128, 180, 108, 209  @ 86ABF68
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 85, 204, 77, 246  @ 86ABF74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABF80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABF8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABF98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABFA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABFB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABFBC
-	voice_square_1_alt 0, 2, 0, 0, 10, 6  @ 86ABFC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABFD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABFE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABFEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ABFF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABF80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABF8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABF98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABFA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABFB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABFBC
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 10, 6  @ 86ABFC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABFD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABFE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABFEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ABFF8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 76, 133, 137  @ 86AC004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC01C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC01C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC028
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 64, 188, 108, 165  @ 86AC034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC04C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC04C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 127  @ 86AC058
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC064
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC070
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC07C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC0A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC0AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC0B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC0C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC0D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC0DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC0E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC0F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC10C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC13C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC07C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC0A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC0AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC0B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC0C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC0D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC0DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC0E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC0F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC10C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC13C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC154
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 86AC160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC16C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC16C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86AC178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC190
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC19C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC1A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC1B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC1C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC1CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC1D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC1E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC1F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC1FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC22C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC25C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC268
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC28C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC19C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC1A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC1B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC1C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC1CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC1D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC1E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC1F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC1FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC22C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC25C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC28C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC298
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86AC2A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC2B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC2BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC2C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC2D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC2E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC2EC
-	voice_square_2_alt 2, 0, 2, 6, 2  @ 86AC2F8
-	voice_square_1_alt 0, 2, 0, 1, 7, 4  @ 86AC304
-	voice_programmable_wave_alt ProgrammableWaveData_86B4920, 0, 0, 12, 0  @ 86AC310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC31C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC34C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC37C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 0, 12, 0  @ 86AC388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC3A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC3AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC3B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC3C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC3D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC3DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC3E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC3F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC40C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC430
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC43C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC46C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC49C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC4A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC4B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC4C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC4CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC4D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC4E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC4F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC4FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC514
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86AC520
-	voice_noise_alt 0, 0, 1, 6, 0  @ 86AC52C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC2B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC2BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC2C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC2D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC2E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC2EC
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 2  @ 86AC2F8
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 7, 4  @ 86AC304
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4920, 0, 0, 12, 0  @ 86AC310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC31C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC34C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC37C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 0, 12, 0  @ 86AC388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC3A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC3AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC3B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC3C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC3D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC3DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC3E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC3F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC40C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC43C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC46C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC49C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC4A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC4B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC4C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC4CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC4D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC4E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC4F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC4FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC514
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86AC520
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0  @ 86AC52C
 

--- a/sound/voicegroups/voicegroup165.inc
+++ b/sound/voicegroups/voicegroup165.inc
@@ -2,130 +2,130 @@
 voicegroup165:: @ 86AC538
 	voice_keysplit_all voicegroup002  @ 86AC538
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86AC544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC55C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC58C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC55C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC58C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC598
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_glockenspiel, 255, 165, 51, 242  @ 86AC5A4
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_anvil_low, 255, 0, 255, 0  @ 86AC5B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC5BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC5C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC5BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC5C8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 86AC5D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86AC5E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC5EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC5F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC5EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC5F8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 37, 165, 103, 127  @ 86AC604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC61C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC64C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC61C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC64C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 204, 92, 226  @ 86AC658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC67C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC6A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC6AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC6B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC6C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC6D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC6DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC6E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC6F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC70C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC73C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC67C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC6A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC6AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC6B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC6C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC6D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC6DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC6E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC6F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC70C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC73C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC754
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 226  @ 86AC760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC76C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC76C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86AC778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC784
-	voice_square_1_alt 0, 2, 0, 2, 10, 1  @ 86AC790
-	voice_square_2_alt 2, 0, 2, 6, 6  @ 86AC79C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC7A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC7B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC7C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC7CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC7D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC7E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC784
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 10, 1  @ 86AC790
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 6  @ 86AC79C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC7A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC7B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC7C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC7CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC7D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC7E4
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86AC7F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC7FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC7FC
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86AC808
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC82C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC850
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC85C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC868
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC88C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC82C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC85C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC88C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC898
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 0, 255, 165  @ 86AC8A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC8B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC8B0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_enhanced_delay_shaku, 255, 191, 97, 165  @ 86AC8BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC8C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC8D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC8C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC8D4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 255, 0, 255, 127  @ 86AC8E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC8EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC8F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC91C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC928
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC94C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC97C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AC988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC9A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC9AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC9B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC9C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC9D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC9DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC9E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AC9F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACA00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACA0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACA18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACA24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACA30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACA3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACA48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACA54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACA60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACA6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACA78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACA84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACA90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACA9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACAA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACAB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACAC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACAD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACAE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACAF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACAFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACB08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACB14
-	voice_noise_alt 0, 0, 1, 9, 0  @ 86ACB20
-	voice_noise_alt 0, 0, 1, 6, 1  @ 86ACB2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC8EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC8F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC91C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC94C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC97C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AC988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC9A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC9AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC9B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC9C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC9D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC9DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC9E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AC9F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACA00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACA0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACA18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACA24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACA30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACA3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACA48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACA54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACA60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACA6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACA78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACA84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACA90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACA9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACAA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACAB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACAC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACAD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACAE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACAF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACAFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACB08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACB14
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 0  @ 86ACB20
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1  @ 86ACB2C
 

--- a/sound/voicegroups/voicegroup166.inc
+++ b/sound/voicegroups/voicegroup166.inc
@@ -2,130 +2,130 @@
 voicegroup166:: @ 86ACB38
 	voice_keysplit_all voicegroup002  @ 86ACB38
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86ACB44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACB50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACB5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACB68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACB74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACB80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACB8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACB98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACBA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACB50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACB5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACB68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACB74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACB80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACB8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACB98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACBA4
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_anvil_low, 255, 0, 255, 0  @ 86ACBB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACBBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACBC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACBD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACBBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACBC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACBD4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86ACBE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACBEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACBF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACBEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACBF8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 128, 146, 108, 137  @ 86ACC04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACC10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACC1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACC28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACC34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACC40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACC4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACC10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACC1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACC28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACC34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACC40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACC4C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 204, 103, 226  @ 86ACC58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACC64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACC70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACC7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACC88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACC64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACC70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACC7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACC88
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127  @ 86ACC94
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 127  @ 86ACCA0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165  @ 86ACCAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACCB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACCC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACCD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACCB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACCC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACCD0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 86ACCDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACCE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACCF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACCE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACCF4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 86ACD00
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_square_wave, 255, 0, 255, 127  @ 86ACD0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACD18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACD24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACD30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACD3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACD48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACD54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACD60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACD18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACD24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACD30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACD3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACD48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACD54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACD60
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 193, 153  @ 86ACD6C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86ACD78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACD84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACD90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACD9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACDA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACDB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACDC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACDCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACD84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACD90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACD9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACDA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACDB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACDC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACDCC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86ACDD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACDE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACDF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACDFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACDE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACDF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACDFC
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86ACE08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACE14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACE14
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 236, 188  @ 86ACE20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACE2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACE38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACE44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACE50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACE5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACE68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACE74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACE80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACE8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACE98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACEA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACEB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACEBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACEC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACE2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACE38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACE44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACE50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACE5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACE68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACE74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACE80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACE8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACE98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACEA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACEB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACEBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACEC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACED4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 255, 0, 255, 127  @ 86ACEE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACEEC
-	voice_square_1_alt 0, 3, 0, 1, 9, 0  @ 86ACEF8
-	voice_square_2_alt 3, 0, 2, 9, 1  @ 86ACF04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACF10
-	voice_square_2_alt 2, 1, 0, 9, 1  @ 86ACF1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACF28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACF34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACF40
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86ACF4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACF58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACF64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACF70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACF7C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 0, 15, 0  @ 86ACF88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACF94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACFA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACFAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACFB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACFC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACFD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACFDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACFE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ACFF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD00C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD030
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD03C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD06C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD09C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD0A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD0B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD0C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD0CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD0D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD0E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD0F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD0FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD114
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86AD120
-	voice_noise_alt 0, 0, 1, 8, 1  @ 86AD12C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACEEC
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 9, 0  @ 86ACEF8
+	voice_square_2_alt 60, 0, 3, 0, 2, 9, 1  @ 86ACF04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACF10
+	voice_square_2_alt 60, 0, 2, 1, 0, 9, 1  @ 86ACF1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACF28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACF34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACF40
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86ACF4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACF58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACF64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACF70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACF7C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 0, 15, 0  @ 86ACF88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACF94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACFA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACFAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACFB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACFC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACFD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACFDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACFE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ACFF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD00C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD03C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD06C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD09C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD0A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD0B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD0C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD0CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD0D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD0E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD0F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD0FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD114
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86AD120
+	voice_noise_alt 60, 0, 0, 0, 1, 8, 1  @ 86AD12C
 

--- a/sound/voicegroups/voicegroup167.inc
+++ b/sound/voicegroups/voicegroup167.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup167:: @ 86AD138
 	voice_keysplit_all voicegroup002  @ 86AD138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD15C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD18C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD1A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD1B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD1BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD1C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD1D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD1E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD1EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD1F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD15C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD18C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD1A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD1B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD1BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD1C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD1D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD1E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD1EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD1F8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 76, 133, 137  @ 86AD204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD21C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD21C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD228
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 64, 188, 108, 165  @ 86AD234
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD24C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD24C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 127  @ 86AD258
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD27C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD2A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD2AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD2B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD2C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD2D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD2DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD2E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD2F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD30C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD33C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD36C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD39C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD3A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD3B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD3C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD3CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD27C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD2A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD2AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD2B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD2C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD2D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD2DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD2E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD2F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD30C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD33C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD36C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD39C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD3A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD3B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD3C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD3CC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86AD3D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD3E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD3F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD3FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD42C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD45C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD468
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD48C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD498
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD4A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD4B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD4BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD4C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD4D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD4E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD4EC
-	voice_square_1_alt 0, 0, 0, 1, 10, 4  @ 86AD4F8
-	voice_square_2_alt 3, 0, 2, 8, 3  @ 86AD504
-	voice_square_2_alt 2, 0, 2, 6, 5  @ 86AD510
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD51C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 0, 6, 0  @ 86AD528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD54C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD57C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD5A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD5AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD5B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD5C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD5D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD5DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD5E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD5F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD600
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD60C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD618
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD630
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD63C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD66C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD69C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD6A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD6B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD6C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD6CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD6D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD6E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD6F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD6FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD714
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86AD720
-	voice_noise_alt 0, 0, 1, 6, 0  @ 86AD72C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD3E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD3F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD3FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD42C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD45C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD48C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD4A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD4B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD4BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD4C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD4D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD4E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD4EC
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 10, 4  @ 86AD4F8
+	voice_square_2_alt 60, 0, 3, 0, 2, 8, 3  @ 86AD504
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 5  @ 86AD510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD51C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 0, 6, 0  @ 86AD528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD54C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD57C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD5A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD5AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD5B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD5C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD5D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD5DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD5E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD5F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD60C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD63C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD66C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD69C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD6A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD6B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD6C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD6CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD6D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD6E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD6F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD6FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD714
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86AD720
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0  @ 86AD72C
 

--- a/sound/voicegroups/voicegroup168.inc
+++ b/sound/voicegroups/voicegroup168.inc
@@ -2,130 +2,130 @@
 voicegroup168:: @ 86AD738
 	voice_keysplit_all voicegroup002  @ 86AD738
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86AD744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD75C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD75C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226  @ 86AD768
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 204, 77, 246  @ 86AD774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD78C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD7A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD7B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD7BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD7C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD7D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD7E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD7EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD7F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD78C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD7A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD7B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD7BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD7C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD7D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD7E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD7EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD7F8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 76, 133, 137  @ 86AD804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD81C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD81C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD828
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 64, 188, 108, 165  @ 86AD834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD840
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD84C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD84C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 127  @ 86AD858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD87C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD8A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD8AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD8B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD8C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD8D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD8DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD8E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD8F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD90C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD93C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD87C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD8A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD8AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD8B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD8C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD8D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD8DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD8E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD8F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD90C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD93C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD948
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 216, 0, 165  @ 86AD954
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 86AD960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD96C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD96C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86AD978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD99C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD9A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD9B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD9C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD9CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD9D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD9E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD9F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AD9FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD99C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD9A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD9B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD9C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD9CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD9D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD9E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD9F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AD9FC
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86ADA08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADA14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADA20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADA2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADA38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADA44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADA50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADA5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADA68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADA74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADA80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADA8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADA98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADA14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADA20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADA2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADA38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADA44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADA50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADA5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADA68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADA74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADA80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADA8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADA98
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86ADAA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADAB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADAC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADAD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADAE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADAEC
-	voice_square_1_alt 0, 1, 0, 1, 4, 2  @ 86ADAF8
-	voice_square_2_alt 3, 0, 2, 6, 4  @ 86ADB04
-	voice_square_2_alt 0, 0, 2, 6, 5  @ 86ADB10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADB1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADB28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADB34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADB40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADB4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADB58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADB64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADB70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADB7C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4900, 0, 0, 12, 0  @ 86ADB88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADB94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADBA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADBAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADBB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADBC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADBD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADBDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADBE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADBF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADC00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADC0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADC18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADC24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADC30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADC3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADC48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADC54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADC60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADC6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADC78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADC84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADC90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADC9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADCA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADCB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADCC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADCCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADCD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADCE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADCF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADCFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADD08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADD14
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86ADD20
-	voice_noise_alt 0, 0, 1, 6, 0  @ 86ADD2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADAB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADAC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADAD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADAE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADAEC
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 2  @ 86ADAF8
+	voice_square_2_alt 60, 0, 3, 0, 2, 6, 4  @ 86ADB04
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5  @ 86ADB10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADB1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADB28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADB34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADB40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADB4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADB58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADB64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADB70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADB7C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4900, 0, 0, 12, 0  @ 86ADB88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADB94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADBA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADBAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADBB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADBC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADBD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADBDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADBE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADBF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADC00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADC0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADC18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADC24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADC30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADC3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADC48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADC54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADC60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADC6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADC78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADC84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADC90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADC9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADCA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADCB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADCC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADCCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADCD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADCE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADCF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADCFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADD08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADD14
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86ADD20
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0  @ 86ADD2C
 

--- a/sound/voicegroups/voicegroup169.inc
+++ b/sound/voicegroups/voicegroup169.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup169:: @ 86ADD38
 	voice_keysplit_all voicegroup001  @ 86ADD38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADD44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADD50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADD5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADD68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADD74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADD80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADD8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADD98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADDA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADDB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADDBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADDC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADDD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADDE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADDEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADDF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADD44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADD50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADD5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADD68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADD74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADD80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADD8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADD98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADDA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADDB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADDBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADDC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADDD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADDE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADDEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADDF8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 210  @ 86ADE04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADE10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADE1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADE28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADE34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADE40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADE4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADE58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADE64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADE70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADE7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADE88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADE94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADEA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADEAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADEB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADEC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADE10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADE1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADE28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADE34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADE40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADE4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADE58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADE64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADE70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADE7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADE88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADE94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADEA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADEAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADEB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADEC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADED0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 86ADEDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADEE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADEF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADF00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADF0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADF18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADF24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADF30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADF3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADF48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADF54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADF60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADF6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADF78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADF84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADF90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADF9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADFA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADFB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADFC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADFCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADEE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADEF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADF00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADF0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADF18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADF24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADF30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADF3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADF48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADF54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADF60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADF6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADF78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADF84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADF90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADF9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADFA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADFB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADFC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADFCC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86ADFD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADFE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADFE4
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86ADFF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86ADFFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE02C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE05C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE08C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE0A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE0B0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 86AE0BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE0C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE0D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE0E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE0EC
-	voice_square_1_alt 0, 2, 0, 1, 4, 1  @ 86AE0F8
-	voice_square_2_alt 2, 0, 1, 4, 1  @ 86AE104
-	voice_square_2_alt 0, 0, 1, 4, 1  @ 86AE110
-	voice_square_1_alt 0, 0, 0, 1, 4, 1  @ 86AE11C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE14C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE17C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE1A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE1AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE1B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE1C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE1D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE1DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE1E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE1F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE20C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE23C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE26C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE29C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE2A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE2B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE2C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE2CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE2D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE2E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE2F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE2FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE314
-	voice_noise_alt 0, 0, 2, 4, 0  @ 86AE320
-	voice_noise_alt 0, 0, 1, 0, 0  @ 86AE32C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86ADFFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE02C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE05C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE08C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE0A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE0B0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 86AE0BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE0C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE0D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE0E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE0EC
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1  @ 86AE0F8
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 1  @ 86AE104
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1  @ 86AE110
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1  @ 86AE11C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE14C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE17C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE1A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE1AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE1B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE1C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE1D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE1DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE1E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE1F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE20C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE23C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE26C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE29C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE2A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE2B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE2C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE2CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE2D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE2E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE2F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE2FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE314
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0  @ 86AE320
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 86AE32C
 

--- a/sound/voicegroups/voicegroup170.inc
+++ b/sound/voicegroups/voicegroup170.inc
@@ -1,87 +1,87 @@
 	.align 2
 voicegroup170:: @ 86AE338
 	voice_keysplit_all voicegroup001  @ 86AE338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE35C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE38C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE3A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE3B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE3BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE3C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE3D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE3E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE3EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE3F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE41C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE428
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE434
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE44C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE458
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE470
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE47C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE4A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE4AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE4B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE4C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE4D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE4DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE4E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE4F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE50C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE53C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE35C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE38C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE3A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE3B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE3BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE3C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE3D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE3E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE3EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE3F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE41C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE44C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE47C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE4A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE4AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE4B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE4C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE4D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE4DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE4E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE4F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE50C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE53C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE560
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 86AE56C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE59C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE5A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE5B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE5C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE5CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE59C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE5A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE5B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE5C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE5CC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86AE5D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE5E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE5E4
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86AE5F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE5FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE62C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE65C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE68C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE5FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE62C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE65C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE68C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE698
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86AE6A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE6B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE6BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE6C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE6D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE6E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE6EC
-	voice_square_2_alt 1, 0, 1, 7, 1  @ 86AE6F8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 86AE704
-	voice_square_1_alt 0, 1, 0, 1, 7, 1  @ 86AE710
-	voice_square_2_alt 2, 0, 1, 0, 0  @ 86AE71C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE6B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE6BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE6C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE6D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE6E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE6EC
+	voice_square_2_alt 60, 0, 1, 0, 1, 7, 1  @ 86AE6F8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 1  @ 86AE704
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 7, 1  @ 86AE710
+	voice_square_2_alt 60, 0, 2, 0, 1, 0, 0  @ 86AE71C
 

--- a/sound/voicegroups/voicegroup171.inc
+++ b/sound/voicegroups/voicegroup171.inc
@@ -1,94 +1,94 @@
 	.align 2
 voicegroup171:: @ 86AE728
 	voice_keysplit_all voicegroup001  @ 86AE728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE74C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE77C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE788
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE7A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE7AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE7B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE7C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE7D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE7DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE7E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE7F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE80C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE818
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE830
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE83C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE848
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE86C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE89C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE8A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE8B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE8C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE8CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE8D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE8E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE8F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE8FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE92C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE74C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE77C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE7A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE7AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE7B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE7C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE7D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE7DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE7E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE7F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE80C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE83C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE86C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE89C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE8A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE8B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE8C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE8CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE8D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE8E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE8F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE8FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE92C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE938
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 216, 0, 165  @ 86AE944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE950
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 86AE95C
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86AE968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE98C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE9A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE9B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE9BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE98C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE9A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE9B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE9BC
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86AE9C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE9D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE9E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AE9EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE9D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE9E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AE9EC
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86AE9F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEA04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEA10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEA1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEA28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEA34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEA40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEA4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEA58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEA64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEA70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEA7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEA88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEA04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEA10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEA1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEA28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEA34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEA40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEA4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEA58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEA64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEA70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEA7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEA88
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86AEA94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEAA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEAAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEAB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEAC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEAD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEADC
-	voice_square_2_alt 2, 0, 1, 7, 0  @ 86AEAE8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 86AEAF4
-	voice_square_1_alt 0, 2, 0, 1, 7, 0  @ 86AEB00
-	voice_square_2_alt 2, 0, 2, 0, 0  @ 86AEB0C
-	voice_square_2_alt 3, 0, 1, 7, 0  @ 86AEB18
-	voice_square_1_alt 0, 3, 0, 1, 7, 0  @ 86AEB24
-	voice_square_1_alt 0, 2, 0, 2, 0, 0  @ 86AEB30
-	voice_square_1_alt 0, 3, 0, 0, 7, 0  @ 86AEB3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEB48
-	voice_programmable_wave_alt ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 86AEB54
-	voice_programmable_wave_alt ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 86AEB60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEAA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEAAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEAB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEAC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEAD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEADC
+	voice_square_2_alt 60, 0, 2, 0, 1, 7, 0  @ 86AEAE8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 1  @ 86AEAF4
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 7, 0  @ 86AEB00
+	voice_square_2_alt 60, 0, 2, 0, 2, 0, 0  @ 86AEB0C
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 0  @ 86AEB18
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 7, 0  @ 86AEB24
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 0, 0  @ 86AEB30
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 7, 0  @ 86AEB3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEB48
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4880, 0, 7, 15, 0  @ 86AEB54
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4890, 0, 7, 15, 1  @ 86AEB60
 

--- a/sound/voicegroups/voicegroup172.inc
+++ b/sound/voicegroups/voicegroup172.inc
@@ -2,130 +2,130 @@
 voicegroup172:: @ 86AEB6C
 	voice_keysplit_all voicegroup002  @ 86AEB6C
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86AEB78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEB84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEB90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEB84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEB90
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226  @ 86AEB9C
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 204, 77, 246  @ 86AEBA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEBB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEBC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEBCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEBD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEBE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEBF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEBFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEC08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEC14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEC20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEC2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEBB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEBC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEBCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEBD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEBE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEBF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEBFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEC08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEC14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEC20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEC2C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 76, 133, 137  @ 86AEC38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEC44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEC50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEC5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEC44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEC50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEC5C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 64, 188, 108, 165  @ 86AEC68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEC74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEC80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEC74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEC80
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 127  @ 86AEC8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEC98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AECA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AECB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AECBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AECC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AECD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AECE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AECEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AECF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AED04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AED10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AED1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AED28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AED34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AED40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AED4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AED58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AED64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AED70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AED7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AED88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEC98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AECA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AECB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AECBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AECC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AECD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AECE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AECEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AECF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AED04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AED10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AED1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AED28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AED34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AED40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AED4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AED58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AED64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AED70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AED7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AED88
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 86AED94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEDA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEDA0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86AEDAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEDB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEDC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEDD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEDDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEDE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEDF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEE00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEDB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEDC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEDD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEDDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEDE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEDF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEE00
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86AEE0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEE18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEE24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEE30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEE3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEE48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEE54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEE60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEE6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEE78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEE84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEE90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEE9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEEA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEEB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEEC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEE18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEE24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEE30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEE3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEE48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEE54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEE60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEE6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEE78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEE84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEE90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEE9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEEA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEEB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEEC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEECC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86AEED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEEE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEEF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEEFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEF08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEF14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEF20
-	voice_square_1_alt 0, 1, 0, 2, 5, 2  @ 86AEF2C
-	voice_square_2_alt 3, 0, 2, 6, 3  @ 86AEF38
-	voice_square_2_alt 0, 0, 2, 6, 5  @ 86AEF44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEF50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEF5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEF68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEF74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEF80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEF8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEF98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEFA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEFB0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4900, 0, 0, 12, 0  @ 86AEFBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEFC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEFD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEFE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEFEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AEFF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF004
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF01C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF04C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF058
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF064
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF070
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF07C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF0A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF0AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF0B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF0C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF0D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF0DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF0E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF0F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF10C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF13C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF148
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86AF154
-	voice_noise_alt 0, 0, 1, 6, 0  @ 86AF160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEEE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEEF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEEFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEF08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEF14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEF20
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 5, 2  @ 86AEF2C
+	voice_square_2_alt 60, 0, 3, 0, 2, 6, 3  @ 86AEF38
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5  @ 86AEF44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEF50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEF5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEF68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEF74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEF80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEF8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEF98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEFA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEFB0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4900, 0, 0, 12, 0  @ 86AEFBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEFC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEFD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEFE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEFEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AEFF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF01C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF04C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF07C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF0A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF0AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF0B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF0C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF0D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF0DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF0E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF0F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF10C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF13C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF148
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86AF154
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0  @ 86AF160
 

--- a/sound/voicegroups/voicegroup173.inc
+++ b/sound/voicegroups/voicegroup173.inc
@@ -2,130 +2,130 @@
 voicegroup173:: @ 86AF16C
 	voice_keysplit_all voicegroup002  @ 86AF16C
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86AF178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF190
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226  @ 86AF19C
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 128, 204, 77, 246  @ 86AF1A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF1B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF1C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF1CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF1D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF1E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF1F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF1FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF1B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF1C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF1CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF1D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF1E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF1F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF1FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF208
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86AF214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF220
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF22C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF22C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 51, 0, 203, 127  @ 86AF238
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF25C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF268
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF25C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF280
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 127  @ 86AF28C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 64, 216, 51, 224  @ 86AF298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF2A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF2B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF2BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF2C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF2D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF2E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF2EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF2F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF2A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF2B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF2BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF2C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF2D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF2E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF2EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF2F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF304
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 86AF310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF31C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF34C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF37C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF3A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF31C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF34C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF37C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF3A0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86AF3AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF3B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF3C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF3D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF3DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF3E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF3F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF400
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF40C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF430
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF43C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF46C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF49C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF4A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF4B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF4C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF4CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF3B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF3C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF3D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF3DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF3E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF3F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF40C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF43C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF46C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF49C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF4A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF4B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF4C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF4CC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86AF4D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF4E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF4F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF4FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF520
-	voice_square_1_alt 0, 1, 0, 2, 3, 4  @ 86AF52C
-	voice_square_2_alt 3, 0, 3, 3, 2  @ 86AF538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF55C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF58C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF5A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF5B0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AF5BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF5C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF5D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF5E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF5EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF5F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF604
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF61C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF634
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF640
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF64C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF67C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF6A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF6AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF6B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF6C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF6D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF6DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF6E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF6F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF70C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF73C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF748
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86AF754
-	voice_noise_alt 0, 0, 1, 3, 2  @ 86AF760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF4E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF4F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF4FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF520
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 3, 4  @ 86AF52C
+	voice_square_2_alt 60, 0, 3, 0, 3, 3, 2  @ 86AF538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF55C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF58C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF5A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF5B0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AF5BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF5C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF5D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF5E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF5EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF5F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF61C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF64C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF67C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF6A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF6AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF6B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF6C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF6D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF6DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF6E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF6F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF70C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF73C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF748
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86AF754
+	voice_noise_alt 60, 0, 0, 0, 1, 3, 2  @ 86AF760
 

--- a/sound/voicegroups/voicegroup174.inc
+++ b/sound/voicegroups/voicegroup174.inc
@@ -2,159 +2,159 @@
 voicegroup174:: @ 86AF76C
 	voice_keysplit_all voicegroup002  @ 86AF76C
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86AF778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF790
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF79C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF79C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 249, 0, 165  @ 86AF7A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF7B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF7C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF7CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF7D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF7E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF7F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF7FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF808
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF82C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF7B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF7C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF7CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF7D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF7E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF7F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF7FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF82C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 0, 255, 127  @ 86AF838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF850
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF85C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF85C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 255, 0, 255, 165  @ 86AF868
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF874
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF880
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF88C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF898
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF8A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF8B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF8BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF88C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF8A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF8B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF8BC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 128, 0, 255, 214  @ 86AF8C8
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 128, 0, 255, 206  @ 86AF8D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF8E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF8EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF8F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF910
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF91C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF8E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF8EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF8F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF91C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF928
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 165  @ 86AF934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF94C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF97C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF9A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF94C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF97C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF9A0
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86AF9AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF9B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF9C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF9D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF9DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF9E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AF9F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFA00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF9B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF9C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF9D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF9DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF9E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AF9F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFA00
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86AFA0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFA18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFA24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFA30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFA18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFA24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFA30
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86AFA3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFA48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFA48
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 209  @ 86AFA54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFA60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFA6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFA78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFA84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFA90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFA9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFAA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFAB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFAC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFAD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFAE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFAF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFAFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFB08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFB14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFB20
-	voice_square_1_alt 0, 3, 0, 2, 3, 4  @ 86AFB2C
-	voice_square_2_alt 3, 0, 2, 3, 4  @ 86AFB38
-	voice_square_1_alt 0, 3, 0, 2, 3, 4  @ 86AFB44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFB50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFB5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFB68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFB74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFB80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFB8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFB98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFBA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFBB0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 86AFBBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFBC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFBD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFBE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFBEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFBF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFC04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFC10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFC1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFC28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFC34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFC40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFC4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFC58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFC64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFC70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFC7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFC88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFC94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFCA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFCAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFCB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFCC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFCD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFCDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFCE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFCF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFD00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFA60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFA6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFA78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFA84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFA90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFA9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFAA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFAB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFAC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFAD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFAE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFAF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFAFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFB08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFB14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFB20
+	voice_square_1_alt 60, 0, 0, 3, 0, 2, 3, 4  @ 86AFB2C
+	voice_square_2_alt 60, 0, 3, 0, 2, 3, 4  @ 86AFB38
+	voice_square_1_alt 60, 0, 0, 3, 0, 2, 3, 4  @ 86AFB44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFB50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFB5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFB68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFB74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFB80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFB8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFB98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFBA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFBB0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4840, 0, 7, 15, 0  @ 86AFBBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFBC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFBD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFBE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFBEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFBF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFC04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFC10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFC1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFC28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFC34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFC40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFC4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFC58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFC64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFC70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFC7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFC88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFC94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFCA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFCAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFCB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFCC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFCD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFCDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFCE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFCF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFD00
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165  @ 86AFD0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFD18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFD24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFD30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFD3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFD48
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86AFD54
-	voice_noise_alt 0, 0, 1, 3, 1  @ 86AFD60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFD18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFD24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFD30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFD3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFD48
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86AFD54
+	voice_noise_alt 60, 0, 0, 0, 1, 3, 1  @ 86AFD60
 	voice_keysplit_all voicegroup177  @ 86AFD6C
-	voice_square_1_alt 0, 2, 0, 2, 9, 1  @ 86AFD78
-	voice_square_2_alt 2, 0, 2, 9, 1  @ 86AFD84
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AFD90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFD9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFDA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFDB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFDC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFDCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFDD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFDE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFDF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFDFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFE08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFE14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFE20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFE2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFE38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFE44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFE50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFE5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFE68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFE74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFE80
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 9, 1  @ 86AFD78
+	voice_square_2_alt 60, 0, 2, 0, 2, 9, 1  @ 86AFD84
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AFD90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFD9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFDA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFDB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFDC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFDCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFDD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFDE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFDF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFDFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFE08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFE14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFE20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFE2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFE38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFE44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFE50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFE5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFE68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFE74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFE80
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 165, 154, 127  @ 86AFE8C
 	voice_keysplit_all voicegroup002  @ 86AFE98
-	voice_square_1_alt 0, 2, 0, 2, 3, 1  @ 86AFEA4
-	voice_square_2_alt 2, 0, 2, 3, 1  @ 86AFEB0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AFEBC
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 3, 1  @ 86AFEA4
+	voice_square_2_alt 60, 0, 2, 0, 2, 3, 1  @ 86AFEB0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86AFEBC
 

--- a/sound/voicegroups/voicegroup175.inc
+++ b/sound/voicegroups/voicegroup175.inc
@@ -1,55 +1,55 @@
 	.align 2
 voicegroup175:: @ 86AFEC8
 	voice_keysplit_all voicegroup177  @ 86AFEC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFEE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFEEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFEF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFF04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFF10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFF1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFF28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFF34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFF40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFF4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFF58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFEE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFEEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFEF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFF04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFF10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFF1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFF28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFF34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFF40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFF4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFF58
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 86AFF64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFF70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFF7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFF88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFF94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFFA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFFAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFFB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFFC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFFD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFFDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFF70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFF7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFF88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFF94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFFA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFFAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFFB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFFC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFFD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFFDC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 85, 165, 154, 127  @ 86AFFE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86AFFF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B000C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0030
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B003C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B006C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B009C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B00A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B00B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B00C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B00CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B00D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B00E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B00F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B00FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B012C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86AFFF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B000C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B003C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B006C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B009C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B00A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B00B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B00C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B00CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B00D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B00E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B00F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B00FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B012C
 

--- a/sound/voicegroups/voicegroup176.inc
+++ b/sound/voicegroups/voicegroup176.inc
@@ -1,51 +1,51 @@
 	.align 2
 voicegroup176:: @ 86B0138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B015C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B018C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B01A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B01B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B01BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B01C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B01D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B01E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B01EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B01F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B021C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0234
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0240
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B024C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0258
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B027C
-	voice_square_1_alt 0, 2, 0, 2, 7, 1  @ 86B0288
-	voice_square_2_alt 2, 0, 2, 9, 1  @ 86B0294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B02A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B02AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B02B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B02C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B02D0
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86B02DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B02E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B02F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B030C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B033C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0360
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B036C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B015C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B018C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B01A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B01B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B01BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B01C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B01D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B01E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B01EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B01F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B021C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B024C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B027C
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 7, 1  @ 86B0288
+	voice_square_2_alt 60, 0, 2, 0, 2, 9, 1  @ 86B0294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B02A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B02AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B02B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B02C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B02D0
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86B02DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B02E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B02F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B030C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B033C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B036C
 

--- a/sound/voicegroups/voicegroup177.inc
+++ b/sound/voicegroups/voicegroup177.inc
@@ -1,40 +1,40 @@
 	.align 2
 voicegroup177:: @ 86B0378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B039C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B03A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B03B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B03C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B03CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B03D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B03E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B03F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B03FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B042C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B045C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0468
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0480
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B048C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0498
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B04A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B04B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B04BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B04C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B04D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B04E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B04EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B04F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B039C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B03A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B03B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B03C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B03CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B03D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B03E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B03F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B03FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B042C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B045C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B048C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B04A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B04B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B04BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B04C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B04D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B04E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B04EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B04F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0510
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88_standard_bells, 255, 0, 255, 0  @ 86B051C
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_drum_and_percussion_kick, 255, 0, 255, 0  @ 86B0528
 	voice_directsound_no_resample 67, 71, DirectSoundWaveData_sd90_solo_snare, 255, 180, 175, 228  @ 86B0534
@@ -42,50 +42,50 @@ voicegroup177:: @ 86B0378
 	voice_directsound_no_resample 65, 0, DirectSoundWaveData_sc88_standard_hand_clap, 255, 255, 255, 127  @ 86B054C
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88_orchestra_snare, 255, 0, 255, 242  @ 86B0558
 	voice_directsound 64, 24, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 86B0564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0570
 	voice_directsound 68, 29, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 86B057C
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_standard3_snare, 255, 0, 255, 242  @ 86B0588
 	voice_directsound 72, 64, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 86B0594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B05A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B05A0
 	voice_directsound 76, 39, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 86B05AC
 	voice_directsound 80, 89, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226  @ 86B05B8
 	voice_directsound_no_resample 33, 10, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 86B05C4
 	voice_directsound 84, 104, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 235  @ 86B05D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B05DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B05DC
 	voice_directsound 63, 64, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 86B05E8
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_dance_drums_ride_bell, 255, 165, 103, 231  @ 86B05F4
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_unknown_tambourine, 255, 127, 77, 204  @ 86B0600
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_trinity_cymbal_crash, 255, 231, 0, 188  @ 86B060C
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_unknown_cowbell, 255, 0, 255, 242  @ 86B0618
 	voice_directsound_no_resample 64, 118, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 86B0624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0630
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 86B063C
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 8, 0, 255, 216  @ 86B0648
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_unknown_djembe, 255, 0, 255, 0  @ 86B0654
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88_bongo, 255, 0, 255, 0  @ 86B0660
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 86B066C
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 86B0678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0690
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B069C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B06A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B06B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B06C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B06CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B06D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B06E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B06F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B06FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B072C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B069C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B06A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B06B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B06C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B06CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B06D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B06E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B06F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B06FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B072C
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_unknown_anvil_high, 255, 242, 103, 188  @ 86B0738
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_unknown_anvil_high, 255, 242, 103, 188  @ 86B0744
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_unknown_anvil_high, 255, 165, 103, 188  @ 86B0750
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88_standard_bells, 255, 0, 255, 0  @ 86B075C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0774
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_unknown_anvil_low, 255, 0, 255, 0  @ 86B0780
 	voice_directsound 63, 64, DirectSoundWaveData_unknown_ethnic_drum, 255, 0, 255, 0  @ 86B078C
 	voice_directsound 50, 64, DirectSoundWaveData_unknown_tsuzumi, 255, 0, 255, 0  @ 86B0798

--- a/sound/voicegroups/voicegroup178.inc
+++ b/sound/voicegroups/voicegroup178.inc
@@ -1,91 +1,91 @@
 	.align 2
 voicegroup178:: @ 86B07B0
 	voice_keysplit_all voicegroup177  @ 86B07B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B07BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B07C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B07D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B07E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B07EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B07F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B081C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0828
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0834
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B07BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B07C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B07D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B07E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B07EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B07F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B081C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0840
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 204, 103, 165  @ 86B084C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0870
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B087C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B08A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B08AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B08B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B08C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B087C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B08A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B08AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B08B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B08C4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 165, 154, 165  @ 86B08D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B08DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B08E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B08F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B090C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B093C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0960
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B096C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B099C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B09A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B09B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B09C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B09CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B09D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B09E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B09F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B09FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0A08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0A14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0A20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0A2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0A38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0A44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0A50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0A5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0A68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0A74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0A80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0A8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0A98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0AA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0AB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0ABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0AC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0AD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0AE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0AEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0AF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0B04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0B10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0B1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0B28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0B34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0B40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0B4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0B58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0B64
-	voice_square_1_alt 0, 2, 0, 2, 7, 1  @ 86B0B70
-	voice_square_2_alt 2, 0, 2, 7, 1  @ 86B0B7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0B88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0B94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0BA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0BAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0BB8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 0, 15, 1  @ 86B0BC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B08DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B08E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B08F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B090C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B093C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B096C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B099C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B09A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B09B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B09C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B09CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B09D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B09E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B09F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B09FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0A50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0A5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0A74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0B64
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 7, 1  @ 86B0B70
+	voice_square_2_alt 60, 0, 2, 0, 2, 7, 1  @ 86B0B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0B94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0BB8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 0, 15, 1  @ 86B0BC4
 

--- a/sound/voicegroups/voicegroup179.inc
+++ b/sound/voicegroups/voicegroup179.inc
@@ -3,89 +3,89 @@ voicegroup179:: @ 86B0BD0
 	voice_keysplit_all voicegroup177  @ 86B0BD0
 	voice_keysplit_all voicegroup176  @ 86B0BDC
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86B0BE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0BF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0C00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0C0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0C18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0C24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0C30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0C3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0C48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0C54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0C60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0BF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0C00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0C18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0C30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0C3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0C48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0C54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0C60
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_xylophone, 255, 235, 0, 204  @ 86B0C6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0C78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0C84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0C90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0C9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0CA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0CB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0CC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0CCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0CD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0C78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0C84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0C90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0CA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0CB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0CE4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 85, 165, 154, 127  @ 86B0CF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0CFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0D08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0D14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0D20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0D2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0D38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0D44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0D14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0D50
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 253, 0, 149  @ 86B0D5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0D68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0D74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0D80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0D8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0D98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0DA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0DB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0DBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0DC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0DD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0DE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0DEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0DF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0D98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0DF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0E04
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86B0E10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0E1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0E28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0E34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0E40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0E4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0E58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0E28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0E34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0E4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0E58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0E64
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86B0E70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0E7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0E7C
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86B0E88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0E94
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86B0EA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0EAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0EB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0EC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0ED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0EDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0EE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0EF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0F00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0F0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0F18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0F24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0F30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0F3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0F48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0F54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0F60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0F6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0F78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0F84
-	voice_square_1_alt 0, 3, 0, 0, 10, 0  @ 86B0F90
-	voice_square_2_alt 0, 0, 1, 9, 0  @ 86B0F9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0FA8
-	voice_square_2_alt 3, 0, 1, 9, 0  @ 86B0FB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0FC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0FCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0FD8
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86B0FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0EF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0F00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0F18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0F30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0F60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0F6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0F78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0F84
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 10, 0  @ 86B0F90
+	voice_square_2_alt 60, 0, 0, 0, 1, 9, 0  @ 86B0F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0FA8
+	voice_square_2_alt 60, 0, 3, 0, 1, 9, 0  @ 86B0FB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0FC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0FCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0FD8
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 0  @ 86B0FE4
 

--- a/sound/voicegroups/voicegroup180.inc
+++ b/sound/voicegroups/voicegroup180.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup180:: @ 86B0FF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B0FF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B0FF0
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86B0FFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1014
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 64, 249, 0, 188  @ 86B1020
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 249, 0, 165  @ 86B102C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B105C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1080
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B108C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B10A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B10B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B10BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B10C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B10D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B10E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B10EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B10F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B111C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B114C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B117C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B11A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B11AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B11B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B11C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B11D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B11DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B11E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B11F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1200
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B120C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1218
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B123C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B126C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1290
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B129C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B12A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B12B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B12C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B12CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B12D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B12E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B12F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B12FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B132C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B135C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B138C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B13A4
-	voice_square_1_alt 0, 2, 0, 2, 3, 1  @ 86B13B0
-	voice_square_2_alt 2, 0, 2, 3, 1  @ 86B13BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B13C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B13D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B13E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B13EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B13F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B141C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1428
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1434
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86B1440
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B144C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1458
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1470
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B147C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B14A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B14AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B14B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B14C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B14D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B14DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B14E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B14F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1500
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B150C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1518
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1524
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1530
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B153C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1554
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1560
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B156C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1578
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1584
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1590
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B159C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B15A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B15B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B15C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B15CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B105C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B108C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B10A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B10B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B10BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B10C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B10D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B10E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B10EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B10F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B111C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B114C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B117C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B11A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B11AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B11B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B11C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B11D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B11DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B11E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B11F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B120C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B123C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B126C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B129C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B12A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B12B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B12C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B12CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B12D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B12E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B12F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B12FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B132C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B135C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B138C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B13A4
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 3, 1  @ 86B13B0
+	voice_square_2_alt 60, 0, 2, 0, 2, 3, 1  @ 86B13BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B13C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B13D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B13E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B13EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B13F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B141C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1434
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86B1440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B144C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B147C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B14A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B14AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B14B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B14C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B14D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B14DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B14E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B14F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B150C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B153C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B156C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B159C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B15A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B15B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B15C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B15CC
 	voice_directsound_no_resample 60, 0, DirectSoundWaveData_sc88_standard_hand_clap, 255, 255, 255, 127  @ 86B15D8
-	voice_noise_alt 0, 0, 1, 0, 0  @ 86B15E4
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0  @ 86B15E4
 

--- a/sound/voicegroups/voicegroup181.inc
+++ b/sound/voicegroups/voicegroup181.inc
@@ -1,50 +1,50 @@
 	.align 2
 voicegroup181:: @ 86B15F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B15F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B15F0
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86B15FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B162C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1650
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B165C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1668
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1674
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B168C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1698
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B16A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B16B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B16BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B16C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B16D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B16E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B16EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B16F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1704
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1710
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B171C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1728
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1734
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1740
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B174C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1758
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1764
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1770
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B177C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1788
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1794
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B17A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B17AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B17B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B17C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B17D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B17DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B17E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B17F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1800
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B180C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B162C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B165C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B168C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B16A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B16B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B16BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B16C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B16D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B16E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B16EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B16F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B171C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B174C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B177C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B17A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B17AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B17B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B17C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B17D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B17DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B17E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B17F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B180C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 242, 51, 242  @ 86B1818
 

--- a/sound/voicegroups/voicegroup182.inc
+++ b/sound/voicegroups/voicegroup182.inc
@@ -1,91 +1,91 @@
 	.align 2
 voicegroup182:: @ 86B1824
 	voice_keysplit_all voicegroup002  @ 86B1824
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1830
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B183C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1848
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1854
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1860
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B186C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1878
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1884
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1890
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B189C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B18A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B18B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B18C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B18CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B18D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B18E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B18F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B18FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1908
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1914
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1920
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B192C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1938
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1944
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1950
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B195C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1968
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1974
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1980
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B198C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1998
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B19A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B19B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B19BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B19C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B19D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B19E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B19EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B19F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1A04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1A10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1A1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1A28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1A34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1A40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1A4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B183C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B186C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B189C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B18A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B18B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B18C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B18CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B18D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B18E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B18F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B18FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B192C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B195C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B198C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B19A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B19B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B19BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B19C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B19D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B19E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B19EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B19F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1A1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1A34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1A40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1A4C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 0, 193, 76  @ 86B1A58
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86B1A64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1A70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1A7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1A88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1A94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1AA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1AAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1AB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1A70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1A7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1A88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1A94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1AA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1AAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1AB8
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86B1AC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1AD0
 	voice_keysplit voicegroup008, KeySplitTable4  @ 86B1ADC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1AE8
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86B1AF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1B00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1B0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1B18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1B24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1B30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1B3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1B48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1B54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1B60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1B6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1B78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1B84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1B90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1B9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1BA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1BB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1BC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1BCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1BD8
-	voice_square_1_alt 0, 1, 1, 2, 3, 1  @ 86B1BE4
-	voice_square_2_alt 1, 0, 2, 6, 2  @ 86B1BF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1BFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1C08
-	voice_square_1_alt 0, 0, 0, 2, 3, 1  @ 86B1C14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1C20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1C2C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86B1C38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1B18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1B30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1B3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1B60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1B6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1B90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1B9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1BA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1BB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1BC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1BD8
+	voice_square_1_alt 60, 0, 0, 1, 1, 2, 3, 1  @ 86B1BE4
+	voice_square_2_alt 60, 0, 1, 0, 2, 6, 2  @ 86B1BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1BFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1C08
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 3, 1  @ 86B1C14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1C20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1C2C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86B1C38
 

--- a/sound/voicegroups/voicegroup183.inc
+++ b/sound/voicegroups/voicegroup183.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup183:: @ 86B1C44
 	voice_keysplit_all voicegroup002  @ 86B1C44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1C50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1C5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1C68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1C74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1C80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1C8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1C98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1CA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1CB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1CBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1CC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1CD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1CE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1CEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1CF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1D04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1D10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1D1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1D28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1D34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1D40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1D4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1C50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1C5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1C68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1C74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1C80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1C98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1CBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1D58
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 127  @ 86B1D64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1D70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1D7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1D88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1D94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1DA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1DAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1DB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1DC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1DD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1DDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1DDC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 86B1DE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1DF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1E00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1E0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1E18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1E24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1E30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1E3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1E48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1E54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1E60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1E6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1E78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1E84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1E90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1E9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1EA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1EB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1EC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1ECC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1ED8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1EE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1EF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1EFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1F08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1F14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1F20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1F2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1F38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1F44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1F50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1F5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1F68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1F74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1F80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1F8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1F98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1FA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1FB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1FBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1FC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1FD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1FE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1FEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B1FF8
-	voice_square_1_alt 0, 2, 0, 2, 4, 1  @ 86B2004
-	voice_square_2_alt 2, 0, 2, 4, 1  @ 86B2010
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B201C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86B2028
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2034
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2040
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B204C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2058
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2064
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2070
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B207C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2088
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2094
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B20A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B20AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B20B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B20C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B20D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B20DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B20E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B20F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2100
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B210C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2118
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2124
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2130
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B213C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2148
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2154
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2160
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B216C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2178
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2184
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2190
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B219C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B21A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B21B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B21C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B21CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B21D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B21E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B21F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B21FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2208
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2214
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2220
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86B222C
-	voice_noise_alt 0, 0, 1, 3, 1  @ 86B2238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1E24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1E30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1E3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1E48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1E54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1E60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1F74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1FA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1FB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1FBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B1FF8
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 4, 1  @ 86B2004
+	voice_square_2_alt 60, 0, 2, 0, 2, 4, 1  @ 86B2010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B201C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86B2028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B204C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B207C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B20A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B20AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B20B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B20C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B20D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B20DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B20E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B20F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B210C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B213C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B216C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B219C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B21A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B21B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B21C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B21CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B21D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B21E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B21F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B21FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2220
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86B222C
+	voice_noise_alt 60, 0, 0, 0, 1, 3, 1  @ 86B2238
 

--- a/sound/voicegroups/voicegroup184.inc
+++ b/sound/voicegroups/voicegroup184.inc
@@ -1,89 +1,89 @@
 	.align 2
 voicegroup184:: @ 86B2244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2244
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2250
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B225C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86B2268
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2274
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2280
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B228C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2298
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B22A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B22B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B22BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B22C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B22D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B22E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B225C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86B2268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B228C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B22A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B22B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B22BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B22C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B22D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B22E0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86B22EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B22F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2304
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2310
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B231C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2328
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2334
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2340
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B234C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2358
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2364
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2370
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B237C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2388
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2394
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B23A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B23AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B22F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B231C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B234C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B237C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B23A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B23AC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165  @ 86B23B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B23C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B23D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B23DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B23E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B23F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B23C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B23D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B23DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B23E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B23F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2400
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 86B240C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2418
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2424
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2430
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B243C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2448
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2454
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2460
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B246C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2478
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2484
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2490
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B249C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B24A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B24B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B24C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B24CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B24D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B24E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B24F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B24FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2508
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2514
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2520
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B252C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2538
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2544
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2550
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B255C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2568
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2574
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2580
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B258C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2598
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B25A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B25B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B25BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B25C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B25D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B25E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B25EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B25F8
-	voice_square_2_alt 3, 0, 0, 15, 0  @ 86B2604
-	voice_square_1_alt 0, 2, 0, 0, 15, 0  @ 86B2610
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B261C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2628
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B243C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B246C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B249C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B24A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B24B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B24C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B24CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B24D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B24E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B24F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B24FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B252C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B255C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B258C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B25A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B25B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B25BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B25C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B25D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B25E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B25EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B25F8
+	voice_square_2_alt 60, 0, 3, 0, 0, 15, 0  @ 86B2604
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B261C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2634
 	voice_directsound 60, 0, DirectSoundWaveData_classical_choir_voice_ahhs, 255, 0, 255, 0  @ 86B2640
 

--- a/sound/voicegroups/voicegroup185.inc
+++ b/sound/voicegroups/voicegroup185.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup185:: @ 86B264C
 	voice_keysplit_all voicegroup002  @ 86B264C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2658
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2664
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2670
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B267C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2688
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2694
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B26A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B26AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B26B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B26C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B26D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B26DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B26E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B267C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B26A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B26AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B26B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B26C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B26D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B26DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B26E8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86B26F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2700
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B270C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2718
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2724
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2730
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B273C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2748
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2754
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2760
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B276C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2778
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2784
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2790
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B279C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B270C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B273C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B276C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B279C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 128, 0, 255, 214  @ 86B27A8
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 128, 0, 255, 206  @ 86B27B4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165  @ 86B27C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B27CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B27CC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pick_bass, 255, 253, 0, 149  @ 86B27D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B27E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B27E4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 86B27F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B27FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B27FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2808
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_synth_bass, 255, 252, 0, 115  @ 86B2814
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2820
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B282C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2838
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2844
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2850
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B285C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B282C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B285C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_pizzicato_strings, 255, 216, 0, 165  @ 86B2868
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2874
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_timpani, 255, 246, 0, 226  @ 86B2880
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86B288C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2898
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B28A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B28B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B28BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B28A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B28B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B28BC
 	voice_directsound 60, 0, DirectSoundWaveData_classical_choir_voice_ahhs, 85, 0, 154, 165  @ 86B28C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B28D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B28E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B28D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B28E0
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86B28EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B28F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2904
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B28F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2910
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86B291C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2928
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 209  @ 86B2934
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2940
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B294C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2958
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2964
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2970
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B297C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2988
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2994
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B29A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B29AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B29B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B29C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B29D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B29DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B29E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B294C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B297C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B29A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B29AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B29B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B29C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B29D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B29DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B29E8
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 255, 0, 255, 127  @ 86B29F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2A00
-	voice_square_2_alt 2, 0, 0, 15, 0  @ 86B2A0C
-	voice_square_1_alt 0, 2, 0, 0, 15, 0  @ 86B2A18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2A24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2A30
-	voice_programmable_wave_alt ProgrammableWaveData_86B4920, 0, 7, 15, 0  @ 86B2A3C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4910, 0, 7, 15, 0  @ 86B2A48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2A54
-	voice_programmable_wave_alt ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86B2A60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2A6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2A78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2A84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2A90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2A9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2AA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2AB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2AC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2ACC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2AD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2AE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2AF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2AFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2B08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2B14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2B20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2B2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2B38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2B44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2B50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2B5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2B68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2B74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2B80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2B8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2B98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2BA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2BB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2BBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2BC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2BD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2BE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2BEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2BF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2C04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2C10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2C1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2C28
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86B2C34
-	voice_noise_alt 0, 0, 1, 6, 1  @ 86B2C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2A00
+	voice_square_2_alt 60, 0, 2, 0, 0, 15, 0  @ 86B2A0C
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2A24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2A30
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4920, 0, 7, 15, 0  @ 86B2A3C
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4910, 0, 7, 15, 0  @ 86B2A48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2A54
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4870, 0, 7, 15, 0  @ 86B2A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2A6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2A84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2C28
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86B2C34
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1  @ 86B2C40
 

--- a/sound/voicegroups/voicegroup186.inc
+++ b/sound/voicegroups/voicegroup186.inc
@@ -1,131 +1,131 @@
 	.align 2
 voicegroup186:: @ 86B2C4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2C4C
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86B2C58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2C64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2C70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2C7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2C88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2C94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2CA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2CAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2CB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2CC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2CD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2CDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2CE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2CF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2D00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2D0C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2D18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2D24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2D30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2D3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2D48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2D54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2D60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2D6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2D78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2D84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2D90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2D9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2DA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2DB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2DC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2DCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2DD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2DE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2DF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2DFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2E08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2E14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2E20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2E2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2E38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2E44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2E50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2E5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2E68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2E74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2E80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2E8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2E98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2EA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2EB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2EBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2EC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2ED4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2EE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2EEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2EF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2F04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2F10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2F1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2F28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2F34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2F40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2F4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2F58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2F64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2F70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2F7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2F88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2F94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2FA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2FAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2FB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2FC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2FD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2FDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2FE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B2FF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3000
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B300C
-	voice_square_2_alt 3, 0, 0, 15, 0  @ 86B3018
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3024
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3030
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B303C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3048
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3054
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3060
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B306C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3078
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3084
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3090
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B309C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B30A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B30B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B30C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B30CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B30D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B30E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B30F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B30FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3108
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3114
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3120
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B312C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3138
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3144
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3150
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B315C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3168
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3174
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3180
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B318C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3198
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B31A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B31B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B31BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B31C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B31D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B31E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B31EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B31F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3204
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3210
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B321C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3228
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3234
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86B3240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2C70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2C7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2C88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2CA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2E2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2E44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2E50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2E5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2E74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2E80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2EA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2EBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2EEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2F34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2F40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2F64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2F88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B2FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B300C
+	voice_square_2_alt 60, 0, 3, 0, 0, 15, 0  @ 86B3018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B303C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B306C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B309C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B30A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B30B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B30C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B30CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B30D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B30E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B30F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B30FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B312C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B315C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B318C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B31A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B31B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B31BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B31C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B31D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B31E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B31EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B31F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B321C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3234
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86B3240
 

--- a/sound/voicegroups/voicegroup187.inc
+++ b/sound/voicegroups/voicegroup187.inc
@@ -2,130 +2,130 @@
 voicegroup187:: @ 86B324C
 	voice_keysplit_all voicegroup002  @ 86B324C
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86B3258
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3264
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3270
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B327C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3288
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3294
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B32A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B32AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B32B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B32C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B32D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B32DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B32E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B32F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3300
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B330C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B327C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B32A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B32AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B32B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B32C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B32D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B32DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B32E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B32F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B330C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 255, 76, 133, 137  @ 86B3318
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3324
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3330
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B333C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B333C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_accordion, 64, 188, 108, 165  @ 86B3348
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3354
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3360
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 255, 249, 25, 127  @ 86B336C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3378
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3384
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3390
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B339C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B33A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B33B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B33C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B33CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B33D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B33E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B33F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B33FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3408
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3414
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3420
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B342C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3438
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3444
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3450
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B345C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B339C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B33A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B33B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B33C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B33CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B33D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B33E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B33F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B33FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B342C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B345C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3468
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_harp, 255, 246, 0, 235  @ 86B3474
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3480
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86B348C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3498
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B34A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B34B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B34BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B34C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B34D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B34E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B34A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B34B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B34BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B34C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B34D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B34E0
 	voice_keysplit voicegroup007, KeySplitTable3  @ 86B34EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B34F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3504
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B34F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3510
 	voice_keysplit voicegroup009, KeySplitTable5  @ 86B351C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3528
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3534
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3540
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B354C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3558
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3564
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3570
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B357C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3588
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3594
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B35A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B35AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B354C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B357C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B35A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B35AC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86B35B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B35C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B35D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B35DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B35E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B35F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3600
-	voice_square_1_alt 0, 0, 0, 2, 5, 2  @ 86B360C
-	voice_square_2_alt 1, 0, 1, 7, 1  @ 86B3618
-	voice_square_2_alt 0, 0, 2, 6, 5  @ 86B3624
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3630
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B363C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3648
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3654
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3660
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B366C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3678
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3684
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3690
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 0, 12, 0  @ 86B369C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B36A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B36B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B36C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B36CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B36D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B36E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B36F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B36FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3708
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3714
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3720
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B372C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3738
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3744
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3750
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B375C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3768
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3774
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3780
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B378C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3798
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B37A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B37B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B37BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B37C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B37D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B37E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B37EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B37F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3804
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3810
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B381C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3828
-	voice_noise_alt 0, 0, 2, 6, 0  @ 86B3834
-	voice_noise_alt 0, 0, 1, 6, 1  @ 86B3840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B35C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B35D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B35DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B35E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B35F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3600
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 5, 2  @ 86B360C
+	voice_square_2_alt 60, 0, 1, 0, 1, 7, 1  @ 86B3618
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5  @ 86B3624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B363C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B366C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3690
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 0, 12, 0  @ 86B369C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B36A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B36B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B36C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B36CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B36D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B36E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B36F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B36FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B372C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B375C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B378C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B37A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B37B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B37BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B37C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B37D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B37E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B37EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B37F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B381C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3828
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0  @ 86B3834
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1  @ 86B3840
 

--- a/sound/voicegroups/voicegroup188.inc
+++ b/sound/voicegroups/voicegroup188.inc
@@ -2,130 +2,130 @@
 voicegroup188:: @ 86B384C
 	voice_keysplit_all voicegroup002  @ 86B384C
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86B3858
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3864
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3870
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226  @ 86B387C
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 128, 204, 77, 246  @ 86B3888
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3894
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B38A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B38AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B38B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B38C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B38D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B38DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B38E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B38A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B38AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B38B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B38C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B38D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B38DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B38E8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86B38F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3900
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B390C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B390C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 51, 0, 203, 127  @ 86B3918
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3924
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3930
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B393C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3948
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3954
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B393C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3960
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 127  @ 86B396C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 64, 216, 51, 224  @ 86B3978
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3984
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3990
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B399C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B39A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B39B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B39C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B39CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B39D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B39E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B399C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B39A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B39B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B39C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B39CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B39D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B39E4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 86B39F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B39FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3A08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3A14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3A20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3A2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3A38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3A44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3A50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3A5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3A68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3A74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B39FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3A50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3A5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3A74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3A80
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86B3A8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3A98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3AA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3AB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3ABC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3AC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3AD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3AE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3AEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3AF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3B04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3B10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3B1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3B28
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3B34
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3B40
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3B4C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3B58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3B64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3B70
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3B7C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3B88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3B94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3BA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3B64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3B94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3BAC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86B3BB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3BC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3BD0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3BDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3BE8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3BF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3C00
-	voice_square_1_alt 0, 1, 0, 2, 6, 1  @ 86B3C0C
-	voice_square_2_alt 3, 0, 3, 3, 2  @ 86B3C18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3C24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3C30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3C3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3C48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3C54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3C60
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3C6C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3C78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3C84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3C90
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 2  @ 86B3C9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3CA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3CB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3CC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3CCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3CD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3CE4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3CF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3CFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3D08
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3D14
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3D20
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3D2C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3D38
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3D44
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3D50
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3D5C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3D68
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3D74
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3D80
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3D8C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3D98
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3DA4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3DB0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3DBC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3DC8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3DD4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3DE0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3DEC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3DF8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3E04
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3E10
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3E1C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3E28
-	voice_noise_alt 0, 0, 2, 7, 0  @ 86B3E34
-	voice_noise_alt 0, 0, 1, 9, 1  @ 86B3E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3BC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3BDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3BE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3BF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3C00
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 6, 1  @ 86B3C0C
+	voice_square_2_alt 60, 0, 3, 0, 3, 3, 2  @ 86B3C18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3C30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3C3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3C48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3C54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3C60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3C78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3C84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3C90
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 2  @ 86B3C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3CA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3CB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3CF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3D14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3D98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3DF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3E28
+	voice_noise_alt 60, 0, 0, 0, 2, 7, 0  @ 86B3E34
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 1  @ 86B3E40
 

--- a/sound/voicegroups/voicegroup189.inc
+++ b/sound/voicegroups/voicegroup189.inc
@@ -2,94 +2,94 @@
 voicegroup189:: @ 86B3E4C
 	voice_keysplit_all voicegroup002  @ 86B3E4C
 	voice_keysplit voicegroup005, KeySplitTable1  @ 86B3E58
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3E64
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3E70
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226  @ 86B3E7C
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 128, 204, 77, 246  @ 86B3E88
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3E94
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3EA0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3EAC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3EB8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3EC4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3ED0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3EDC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3EA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3EE8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_tubular_bell, 255, 165, 90, 216  @ 86B3EF4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3F00
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3F00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3F0C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_organ2, 51, 0, 203, 127  @ 86B3F18
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3F24
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3F30
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3F3C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3F48
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3F54
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3F60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3F30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3F60
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 128, 249, 25, 127  @ 86B3F6C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_nylon_str_guitar, 64, 216, 51, 224  @ 86B3F78
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3F84
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3F90
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3F9C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3FA8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3FB4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3FC0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3FCC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3FD8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3F90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3FB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3FC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3FCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3FE4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_fretless_bass, 255, 253, 0, 188  @ 86B3FF0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B3FFC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4008
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4014
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4020
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B402C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4038
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4044
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4050
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B405C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4068
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4074
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B3FFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B402C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B405C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4080
 	voice_keysplit voicegroup006, KeySplitTable2  @ 86B408C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4098
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B40A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B40B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B40BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B40C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B40D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B40E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B40EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B40F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4104
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4110
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B411C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4128
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4134
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4140
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B414C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4158
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4164
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4170
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B417C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4188
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4194
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B41A0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B41AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B40A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B40B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B40BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B40C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B40D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B40E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B40EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B40F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B411C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B414C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B417C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B41A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B41AC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88_flute, 255, 127, 231, 127  @ 86B41B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B41C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B41D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B41DC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B41E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B41F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4200
-	voice_square_1_alt 0, 2, 0, 2, 6, 3  @ 86B420C
-	voice_square_2_alt 3, 0, 2, 7, 2  @ 86B4218
-	voice_square_1_alt 0, 1, 0, 2, 6, 2  @ 86B4224
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4230
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B423C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4248
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4254
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4260
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B426C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4278
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4284
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B41C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B41D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B41DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B41E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B41F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4200
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 6, 3  @ 86B420C
+	voice_square_2_alt 60, 0, 3, 0, 2, 7, 2  @ 86B4218
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 6, 2  @ 86B4224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B423C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B426C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4290
 

--- a/sound/voicegroups/voicegroup190.inc
+++ b/sound/voicegroups/voicegroup190.inc
@@ -1,90 +1,90 @@
 	.align 2
 voicegroup190:: @ 86B429C
-	voice_programmable_wave_alt ProgrammableWaveData_86B4830, 0, 7, 15, 2  @ 86B429C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B42A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B42B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B42C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B42CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B42D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B42E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B42F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B42FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4308
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4314
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4320
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B432C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4338
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4344
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4350
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B435C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4368
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4374
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4380
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B438C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4398
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B43A4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B43B0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B43BC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B43C8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B43D4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B43E0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B43EC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B43F8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4404
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4410
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B441C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4428
-	voice_noise_alt 0, 0, 2, 7, 0  @ 86B4434
-	voice_noise_alt 0, 0, 1, 9, 1  @ 86B4440
+	voice_programmable_wave_alt 60, 0, ProgrammableWaveData_86B4830, 0, 7, 15, 2  @ 86B429C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B42A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B42B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B42C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B42CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B42D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B42E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B42F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B42FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B432C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B435C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B438C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B43A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B43B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B43BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B43C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B43D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B43E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B43EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B43F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B441C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4428
+	voice_noise_alt 60, 0, 0, 0, 2, 7, 0  @ 86B4434
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 1  @ 86B4440
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_drum_and_percussion_kick, 255, 0, 255, 0  @ 86B444C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4458
 	voice_directsound_no_resample 64, 52, DirectSoundWaveData_sc88_orchestra_snare, 255, 0, 255, 242  @ 86B4464
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4470
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B447C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4488
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4494
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B44A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B447C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B44A0
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88_standard3_snare, 255, 0, 255, 242  @ 86B44AC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B44B8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B44C4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B44D0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B44DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B44B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B44C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B44D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B44DC
 	voice_directsound_no_resample 33, 104, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 86B44E8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B44F4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B44F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4500
 	voice_directsound 63, 64, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 86B450C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4518
 	voice_directsound_no_resample 64, 34, DirectSoundWaveData_unknown_tambourine, 255, 127, 77, 204  @ 86B4524
 	voice_directsound_no_resample 64, 14, DirectSoundWaveData_trinity_cymbal_crash, 255, 231, 0, 188  @ 86B4530
 	voice_directsound_no_resample 64, 89, DirectSoundWaveData_unknown_cowbell, 255, 0, 255, 242  @ 86B453C
 	voice_directsound_no_resample 64, 24, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 86B4548
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4554
 	voice_directsound_no_resample 64, 54, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 255, 235, 0, 231  @ 86B4560
 	voice_directsound_no_resample 64, 54, DirectSoundWaveData_sc88_orchestra_cymbal_crash, 8, 0, 255, 216  @ 86B456C
 	voice_directsound_no_resample 64, 94, DirectSoundWaveData_unknown_djembe, 255, 0, 255, 0  @ 86B4578
 	voice_directsound_no_resample 64, 34, DirectSoundWaveData_sc88_bongo, 255, 0, 255, 0  @ 86B4584
 	voice_directsound_no_resample 64, 34, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 86B4590
 	voice_directsound_no_resample 64, 90, DirectSoundWaveData_sc88_bongo_low, 255, 0, 255, 0  @ 86B459C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B45A8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B45B4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B45C0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B45CC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B45D8
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B45E4
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B45F0
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B45FC
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4608
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4614
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4620
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B462C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4638
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4644
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B45A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B45B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B45C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B45CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B45D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B45E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B45F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B45FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B462C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4650
 	voice_directsound_no_resample 64, 39, DirectSoundWaveData_unknown_anvil_high, 255, 242, 103, 188  @ 86B465C
 	voice_directsound_no_resample 64, 79, DirectSoundWaveData_unknown_anvil_high, 255, 242, 103, 188  @ 86B4668
 	voice_directsound_no_resample 64, 39, DirectSoundWaveData_unknown_anvil_high, 255, 165, 103, 188  @ 86B4674
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88_standard_bells, 255, 0, 255, 0  @ 86B4680
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B468C
-	voice_square_1 0, 2, 0, 0, 15, 0  @ 86B4698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B468C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0  @ 86B4698
 	voice_directsound_no_resample 64, 104, DirectSoundWaveData_unknown_anvil_low, 255, 0, 255, 0  @ 86B46A4
 	voice_directsound 63, 64, DirectSoundWaveData_unknown_ethnic_drum, 255, 0, 255, 0  @ 86B46B0


### PR DESCRIPTION
Information: Our current audio macros preclude the definition of root key and pan (applicable when used in drumsets, aka "keysplit_all") for GB channels. However, this functionality does exist in m4a--Pokemon Emerald just happens not to use it. However, for the sake of people working with custom music, I believe these values should be modifiable by users.

Additionally, given the recent events that have occurred with this repo, I would like to make something fully clear: I have indeed looked at the GBA SDK before, which contains notes on how these sounds are defined; therefore, I cannot blame you if you reject this PR on the grounds that the information is "tainted." However, this information is readily available and matches the same macros used for directsound--it's hardly information that one would need the source to know.