### PR TITLE
Fix formatting in linker script

### DIFF
--- a/ld_script.txt
+++ b/ld_script.txt
@@ -22,7 +22,7 @@ SECTIONS {
         INCLUDE "sym_ewram.ld"
 
         . = 0x40000;
-}
+    }
 
     . = 0x3000000;
 

--- a/ld_script_modern.txt
+++ b/ld_script_modern.txt
@@ -17,7 +17,7 @@ SECTIONS {
         gflib/*.o(ewram_data);
 
         . = 0x40000;
-}
+    }
 
     . = 0x3000000;
 


### PR DESCRIPTION
The closing brace should be aligned with the opening brace