### PR TITLE
[Leak-informed] Resolve fakematch CopyGlyphToWindow.

### DIFF
--- a/gflib/text.c
+++ b/gflib/text.c
@@ -462,40 +462,37 @@ u8 GetLastTextColor(u8 colorType)
     }
 }
 
-#define GLYPH_COPY(fromY_, toY_, fromX_, toX_, unk)                                                               \
-    {                                                                                                             \
-        u32 i, j, *ptr, toY, fromX, toX, r5, bits;                                                                \
-        u8 *dst;                                                                                                  \
-        j = fromX_;                                                                                               \
-        i = fromY_;                                                                                               \
-        ptr = unk;                                                                                                \
-        toX = toX_;                                                                                               \
-        toY = toY_;                                                                                               \
-        fromX = fromX_;                                                                                           \
-                                                                                                                  \
-        for (; i < toY; i++)                                                                                      \
-        {                                                                                                         \
-            asm("":::"sl"); /* NONMATCHING */                                                                     \
-            r5 = *(ptr++);                                                                                        \
-            for (j = fromX; j < toX; j++)                                                                         \
-            {                                                                                                     \
-                const u32 toOrr = r5 & 0xF;                                                                       \
-                if (toOrr)                                                                                        \
-                {                                                                                                 \
-                    dst = windowTiles + ((j / 8) * 32) + ((j % 8) / 2) + ((i / 8) * widthOffset) + ((i % 8) * 4); \
-                    bits = ((j & 1) * 4);                                                                         \
-                    *dst = (toOrr << bits) | (*dst & (0xF0 >> bits));                                             \
-                }                                                                                                 \
-                r5 >>= 4;                                                                                         \
-            }                                                                                                     \
-        }                                                                                                         \
+inline static void GLYPH_COPY(u8 *windowTiles, u32 widthOffset, u32 j, u32 i, u32 *ptr, s32 width, s32 height)                                           //
+{
+    // WHYYYYYYYYY is dummyX needed aaaaaaaaaaaaaaaaaaaaa
+    u32 xAdd, yAdd, r5, bits, toOrr, dummyX;
+    u8 *dst;
+
+    xAdd = j + width;
+    yAdd = i + height;
+    dummyX = j; // :masuda:
+    for (; i < yAdd; i++)
+    {
+        r5 = *ptr++;
+        for (j = dummyX; j < xAdd; j++)
+        {
+            // This inline assignent turns out to be needed as well.
+            if ((toOrr = r5 & 0xF))
+            {
+                dst = windowTiles + ((j / 8) * 32) + ((j % 8) / 2) + ((i / 8) * widthOffset) + ((i % 8) * 4);
+                bits = ((j & 1) * 4);
+                *dst = (toOrr << bits) | (*dst & (0xF0 >> bits));
+            }
+            r5 >>= 4;
+        }
     }
+}
 
 void CopyGlyphToWindow(struct TextPrinter *textPrinter)
 {
     struct Window *win;
     struct WindowTemplate *winTempl;
-    struct Struct_03002F90 *unkStruct;
+    u32 *unkStruct;
     u32 currX, currY, widthOffset;
     s32 r4, r0;
     u8 *windowTiles;
@@ -503,17 +500,18 @@ void CopyGlyphToWindow(struct TextPrinter *textPrinter)
     win = &gWindows[textPrinter->printerTemplate.windowId];
     winTempl = &win->window;
 
-    r4 = (winTempl->width * 8) - textPrinter->printerTemplate.currentX;
-    if (r4 > gUnknown_03002F90.width)
+    // these inline assignments are required as well to match. Compiler is super fucking sensitive and needs like SEVERAL changes.
+    if ((r4 = (winTempl->width * 8) - textPrinter->printerTemplate.currentX) > gUnknown_03002F90.width)
         r4 = gUnknown_03002F90.width;
 
-    r0 = (winTempl->height * 8) - textPrinter->printerTemplate.currentY;
-    if (r0 > gUnknown_03002F90.height)
+    if ((r0 = (winTempl->height * 8) - textPrinter->printerTemplate.currentY) > gUnknown_03002F90.height)
         r0 = gUnknown_03002F90.height;
 
     currX = textPrinter->printerTemplate.currentX;
     currY = textPrinter->printerTemplate.currentY;
-    unkStruct = &gUnknown_03002F90;
+    // i could only get this to work as a u32 due to lvalue bullshit and the macro
+    // really needs to be an inline to avoid temp bullshit below. It might work as a macro too, but...
+    unkStruct = (u32 *)&gUnknown_03002F90.unk0;
     windowTiles = win->tileData;
     widthOffset = winTempl->width * 32;
 
@@ -521,45 +519,31 @@ void CopyGlyphToWindow(struct TextPrinter *textPrinter)
     {
         if (r0 < 9)
         {
-            GLYPH_COPY(currY, currY + r0, currX, currX + r4, unkStruct->unk0);
+            GLYPH_COPY(windowTiles, widthOffset, currX, currY, unkStruct, r4, r0);
         }
         else
         {
-            u32 temp;
-            GLYPH_COPY(currY, currY + 8, currX, currX + r4, unkStruct->unk0);
-
-            temp = currY + 8;
-            GLYPH_COPY(temp, (temp - 8) + r0, currX, currX + r4, unkStruct->unk40);
+            GLYPH_COPY(windowTiles, widthOffset, currX, currY, unkStruct, r4, 8);
+            GLYPH_COPY(windowTiles, widthOffset, currX, currY + 8, unkStruct + 16, r4, r0 - 8);
         }
     }
     else
     {
-        u32 temp;
         if (r0 < 9)
         {
-            GLYPH_COPY(currY, currY + r0, currX, currX + 8, unkStruct->unk0);
-
-            temp = currX + 8;
-            GLYPH_COPY(currY, currY + r0, temp, (temp - 8) + r4, unkStruct->unk20);
+            GLYPH_COPY(windowTiles, widthOffset, currX, currY, unkStruct, 8, r0);
+            GLYPH_COPY(windowTiles, widthOffset, currX + 8, currY, unkStruct + 8, r4 - 8, r0);
         }
         else
         {
-            GLYPH_COPY(currY, currY + 8, currX, currX + 8, unkStruct->unk0);
-
-            temp = currX + 8;
-            GLYPH_COPY(currY, currY + 8, temp, temp - 8 + r4, unkStruct->unk20);
-
-            temp = currY + 8;
-            GLYPH_COPY(temp, temp - 8 + r0, currX, currX + 8, unkStruct->unk40);
-            {
-                u32 tempX, tempY;
-                tempX = currX + 8;
-                tempY = currY + 8;
-                GLYPH_COPY(tempY, tempY - 8 + r0, tempX, tempX - 8 + r4, unkStruct->unk60);
-            }
+            GLYPH_COPY(windowTiles, widthOffset, currX, currY, unkStruct, 8, 8);
+            GLYPH_COPY(windowTiles, widthOffset, currX + 8, currY, unkStruct + 8, r4 - 8, 8);
+            GLYPH_COPY(windowTiles, widthOffset, currX, currY + 8, unkStruct + 16, 8, r0 - 8);
+            GLYPH_COPY(windowTiles, widthOffset, currX + 8, currY + 8, unkStruct + 24, r4 - 8, r0 - 8);
         }
     }
 }
+
 void ClearTextSpan(struct TextPrinter *textPrinter, u32 width)
 {
     struct Window *window;


### PR DESCRIPTION
The function in the OG source was used to discover the required fixes for this function. I did my best to remove any unnecessary changes, although I do have a few disclaimers:

1] While not specifically mentioning if Game Freak did or didn't use an inline, it looks better as one due to usage of temporaries. I tried to test a macro but I can't deal with lvalue errors, so here we are.
2] In addition to an inline possibly being required, there are at least 2 in-condition assignment of variables being required to match. Reverting any of these causes an error because it doesn't match.
3] Doing the u32* array instead of the struct members works while the struct doesn't. The reason is using the struct requires a local array assignment in order to iterate over the loop, and regalloc does not match if you do this. Suck it, Rose.

Discord:
Revo#7090