### PR TITLE
Replace POKEMON_SLOTS_NUMBER

### DIFF
--- a/include/data.h
+++ b/include/data.h
@@ -2,7 +2,6 @@
 #define GUARD_DATA_H
 
 #include "constants/moves.h"
-#include "constants/species.h"
 
 #define SPECIES_SHINY_TAG 500
 

--- a/include/global.h
+++ b/include/global.h
@@ -8,6 +8,7 @@
 #include "constants/global.h"
 #include "constants/flags.h"
 #include "constants/vars.h"
+#include "constants/species.h"
 
 // Prevent cross-jump optimization.
 #define BLOCK_CROSS_JUMP asm("");
@@ -65,8 +66,6 @@
 // Converts a Q24.8 fixed-point format number to a regular integer
 #define Q_24_8_TO_INT(n) ((int)((n) >> 8))
 
-#define POKEMON_SLOTS_NUMBER 412
-
 #define min(a, b) ((a) < (b) ? (a) : (b))
 #define max(a, b) ((a) >= (b) ? (a) : (b))
 
@@ -115,7 +114,7 @@
 
 #define ROUND_BITS_TO_BYTES(numBits)(((numBits) / 8) + (((numBits) % 8) ? 1 : 0))
 
-#define DEX_FLAGS_NO (ROUND_BITS_TO_BYTES(POKEMON_SLOTS_NUMBER))
+#define DEX_FLAGS_NO (ROUND_BITS_TO_BYTES(NUM_SPECIES))
 #define NUM_FLAG_BYTES (ROUND_BITS_TO_BYTES(FLAGS_COUNT))
 
 struct Coords8

--- a/src/apprentice.c
+++ b/src/apprentice.c
@@ -27,7 +27,6 @@
 #include "constants/items.h"
 #include "constants/pokemon.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/trainers.h"
 #include "constants/moves.h"
 

--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -14,7 +14,6 @@
 #include "constants/battle_ai.h"
 #include "constants/battle_move_effects.h"
 #include "constants/moves.h"
-#include "constants/species.h"
 
 #define AI_ACTION_DONE          0x0001
 #define AI_ACTION_FLEE          0x0002

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -9,7 +9,6 @@
 #include "constants/item_effects.h"
 #include "constants/items.h"
 #include "constants/moves.h"
-#include "constants/species.h"
 
 // this file's functions
 static bool8 HasSuperEffectiveMoveAgainstOpponents(bool8 noRng);

--- a/src/battle_anim_effects_3.c
+++ b/src/battle_anim_effects_3.c
@@ -21,7 +21,6 @@
 #include "constants/battle_anim.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/weather.h"
 
 extern const struct SpriteTemplate gThoughtBubbleSpriteTemplate;

--- a/src/battle_anim_mons.c
+++ b/src/battle_anim_mons.c
@@ -15,7 +15,6 @@
 #include "trig.h"
 #include "util.h"
 #include "constants/battle_anim.h"
-#include "constants/species.h"
 
 #define GET_UNOWN_LETTER(personality) ((        \
       (((personality & 0x03000000) >> 24) << 6) \

--- a/src/battle_anim_sound_tasks.c
+++ b/src/battle_anim_sound_tasks.c
@@ -5,7 +5,6 @@
 #include "sound.h"
 #include "task.h"
 #include "constants/battle_anim.h"
-#include "constants/species.h"
 
 // this file's functions
 static void sub_8158B98(u8 taskId);

--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -13,7 +13,6 @@
 #include "task.h"
 #include "util.h"
 #include "constants/abilities.h"
-#include "constants/species.h"
 
 static EWRAM_DATA u8 sLinkSendTaskId = 0;
 static EWRAM_DATA u8 sLinkReceiveTaskId = 0;

--- a/src/battle_dome.c
+++ b/src/battle_dome.c
@@ -33,7 +33,6 @@
 #include "graphics.h"
 #include "constants/battle_dome.h"
 #include "constants/frontier_util.h"
-#include "constants/species.h"
 #include "constants/moves.h"
 #include "constants/pokemon.h"
 #include "constants/trainers.h"

--- a/src/battle_factory.c
+++ b/src/battle_factory.c
@@ -8,7 +8,6 @@
 #include "frontier_util.h"
 #include "battle_tower.h"
 #include "random.h"
-#include "constants/species.h"
 #include "constants/battle_ai.h"
 #include "constants/battle_factory.h"
 #include "constants/battle_frontier.h"

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -17,7 +17,6 @@
 #include "sound.h"
 #include "party_menu.h"
 #include "m4a.h"
-#include "constants/species.h"
 #include "decompress.h"
 #include "data.h"
 #include "palette.h"

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -15,7 +15,6 @@
 #include "util.h"
 #include "gpu_regs.h"
 #include "battle_message.h"
-#include "constants/species.h"
 #include "pokedex.h"
 #include "palette.h"
 #include "international_string_util.h"

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -58,7 +58,6 @@
 #include "constants/party_menu.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/trainers.h"
 #include "cable_club.h"
 

--- a/src/battle_pike.c
+++ b/src/battle_pike.c
@@ -21,7 +21,6 @@
 #include "constants/layouts.h"
 #include "constants/rgb.h"
 #include "constants/trainers.h"
-#include "constants/species.h"
 #include "constants/moves.h"
 #include "constants/party_menu.h"
 #include "constants/battle_pike.h"

--- a/src/battle_pyramid.c
+++ b/src/battle_pyramid.c
@@ -35,7 +35,6 @@
 #include "constants/layouts.h"
 #include "constants/maps.h"
 #include "constants/moves.h"
-#include "constants/species.h"
 #include "constants/trainers.h"
 
 extern const struct MapLayout *const gMapLayouts[];

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -16,7 +16,6 @@
 #include "random.h"
 #include "battle_controllers.h"
 #include "battle_interface.h"
-#include "constants/species.h"
 #include "constants/songs.h"
 #include "constants/trainers.h"
 #include "constants/battle_anim.h"

--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -44,7 +44,6 @@
 #include "constants/songs.h"
 #include "constants/map_types.h"
 #include "constants/maps.h"
-#include "constants/species.h"
 #include "constants/trainers.h"
 #include "constants/trainer_hill.h"
 

--- a/src/battle_tent.c
+++ b/src/battle_tent.c
@@ -17,7 +17,6 @@
 #include "constants/items.h"
 #include "constants/layouts.h"
 #include "constants/region_map_sections.h"
-#include "constants/species.h"
 #include "constants/trainers.h"
 
 // This file's functions.

--- a/src/battle_tower.c
+++ b/src/battle_tower.c
@@ -35,7 +35,6 @@
 #include "constants/trainers.h"
 #include "constants/event_objects.h"
 #include "constants/moves.h"
-#include "constants/species.h"
 #include "constants/easy_chat.h"
 #include "constants/tv.h"
 

--- a/src/battle_tv.c
+++ b/src/battle_tv.c
@@ -6,7 +6,6 @@
 #include "constants/battle_string_ids.h"
 #include "constants/battle_anim.h"
 #include "constants/moves.h"
-#include "constants/species.h"
 #include "battle_message.h"
 #include "tv.h"
 

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -21,7 +21,6 @@
 #include "constants/hold_effects.h"
 #include "constants/items.h"
 #include "constants/moves.h"
-#include "constants/species.h"
 #include "constants/weather.h"
 #include "battle_arena.h"
 #include "battle_pyramid.h"

--- a/src/birch_pc.c
+++ b/src/birch_pc.c
@@ -2,7 +2,6 @@
 #include "event_data.h"
 #include "field_message_box.h"
 #include "pokedex.h"
-#include "constants/species.h"
 #include "strings.h"
 
 bool16 ScriptGetPokedexInfo(void)

--- a/src/braille_puzzles.c
+++ b/src/braille_puzzles.c
@@ -8,7 +8,6 @@
 #include "constants/field_effects.h"
 #include "constants/maps.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/metatile_labels.h"
 #include "fieldmap.h"
 #include "party_menu.h"

--- a/src/contest.c
+++ b/src/contest.c
@@ -42,7 +42,6 @@
 #include "constants/moves.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/tv.h"
 
 // This file's functions.

--- a/src/credits.c
+++ b/src/credits.c
@@ -22,7 +22,6 @@
 #include "pokedex.h"
 #include "event_data.h"
 #include "random.h"
-#include "constants/species.h"
 
 enum
 {

--- a/src/data.c
+++ b/src/data.c
@@ -5,7 +5,6 @@
 #include "graphics.h"
 #include "constants/items.h"
 #include "constants/moves.h"
-#include "constants/species.h"
 #include "constants/trainers.h"
 #include "constants/battle_ai.h"
 

--- a/src/data/bard_music/pokemon.h
+++ b/src/data/bard_music/pokemon.h
@@ -1,6 +1,5 @@
 #ifndef GUARD_DATA_BARD_MUSIC_POKEMON_H
 #define GUARD_DATA_BARD_MUSIC_POKEMON_H
-#include "constants/species.h"
 
 const u16 gNumSpeciesNames = NUM_SPECIES;
 

--- a/src/data/contest_opponents.h
+++ b/src/data/contest_opponents.h
@@ -1,7 +1,6 @@
 
 #include "global.h"
 #include "contest.h"
-#include "constants/species.h"
 
 #define CONTEST_OPPONENT_JIMMY 0
 #define CONTEST_OPPONENT_EDITH 1

--- a/src/data/easy_chat/easy_chat_group_pokemon.h
+++ b/src/data/easy_chat/easy_chat_group_pokemon.h
@@ -1,5 +1,3 @@
-#include "constants/species.h"
-
 const u16 gEasyChatGroup_Pokemon[] = {
     SPECIES_ABRA,
     SPECIES_ABSOL,

--- a/src/data/easy_chat/easy_chat_group_pokemon2.h
+++ b/src/data/easy_chat/easy_chat_group_pokemon2.h
@@ -1,5 +1,3 @@
-#include "constants/species.h"
-
 const u16 gEasyChatGroup_Pokemon2[] = {
 	SPECIES_ABRA,
 	SPECIES_AERODACTYL,

--- a/src/data/lilycove_lady.h
+++ b/src/data/lilycove_lady.h
@@ -1,7 +1,6 @@
 #include "constants/easy_chat.h"
 #include "constants/event_objects.h"
 #include "constants/items.h"
-#include "constants/species.h"
 #include "constants/moves.h"
 
 static const u16 sContestLadyMonGfxId[] =

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -22,7 +22,6 @@
 #include "constants/items.h"
 #include "constants/moves.h"
 #include "constants/region_map_sections.h"
-#include "constants/species.h"
 
 // this file's functions
 static void ClearDaycareMonMail(struct DayCareMail *mail);

--- a/src/decompress.c
+++ b/src/decompress.c
@@ -4,7 +4,6 @@
 #include "decompress.h"
 #include "pokemon.h"
 #include "text.h"
-#include "constants/species.h"
 
 EWRAM_DATA ALIGNED(4) u8 gDecompressionBuffer[0x4000] = {0};
 

--- a/src/dodrio_berry_picking.c
+++ b/src/dodrio_berry_picking.c
@@ -24,7 +24,6 @@
 #include "window.h"
 #include "constants/items.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 
 struct DodrioSubstruct_0160
 {

--- a/src/easy_chat.c
+++ b/src/easy_chat.c
@@ -32,7 +32,6 @@
 #include "constants/lilycove_lady.h"
 #include "constants/mauville_old_man.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/rgb.h"
 
 #define EZCHAT_TASK_STATE        0

--- a/src/ereader_helpers.c
+++ b/src/ereader_helpers.c
@@ -12,7 +12,6 @@
 #include "trainer_hill.h"
 #include "constants/easy_chat.h"
 #include "constants/trainers.h"
-#include "constants/species.h"
 #include "constants/moves.h"
 #include "constants/items.h"
 

--- a/src/evolution_scene.c
+++ b/src/evolution_scene.c
@@ -30,7 +30,6 @@
 #include "trade.h"
 #include "util.h"
 #include "constants/battle_string_ids.h"
-#include "constants/species.h"
 #include "constants/songs.h"
 #include "constants/rgb.h"
 

--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -29,7 +29,6 @@
 #include "constants/maps.h"
 #include "constants/moves.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/trainer_types.h"
 
 static EWRAM_DATA u8 gUnknown_0203734C = 0;

--- a/src/field_poison.c
+++ b/src/field_poison.c
@@ -16,7 +16,6 @@
 #include "trainer_hill.h"
 #include "constants/field_poison.h"
 #include "constants/party_menu.h"
-#include "constants/species.h"
 
 static bool32 IsMonValidSpecies(struct Pokemon *pokemon)
 {

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -60,7 +60,6 @@
 #include "constants/script_menu.h"
 #include "constants/slot_machine.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/moves.h"
 #include "constants/party_menu.h"
 #include "constants/battle_frontier.h"

--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -31,7 +31,6 @@
 #include "constants/battle_frontier.h"
 #include "constants/frontier_util.h"
 #include "constants/trainers.h"
-#include "constants/species.h"
 #include "constants/game_stat.h"
 #include "constants/moves.h"
 #include "constants/items.h"

--- a/src/hall_of_fame.c
+++ b/src/hall_of_fame.c
@@ -18,7 +18,6 @@
 #include "window.h"
 #include "credits.h"
 #include "bg.h"
-#include "constants/species.h"
 #include "constants/game_stat.h"
 #include "util.h"
 #include "string_util.h"

--- a/src/intro.c
+++ b/src/intro.c
@@ -21,7 +21,6 @@
 #include "intro.h"
 #include "graphics.h"
 #include "sound.h"
-#include "constants/species.h"
 #include "util.h"
 #include "title_screen.h"
 #include "constants/rgb.h"

--- a/src/link_rfu_2.c
+++ b/src/link_rfu_2.c
@@ -15,7 +15,6 @@
 #include "string_util.h"
 #include "task.h"
 #include "text.h"
-#include "constants/species.h"
 #include "save.h"
 #include "mystery_gift.h"
 

--- a/src/lottery_corner.c
+++ b/src/lottery_corner.c
@@ -4,7 +4,6 @@
 #include "pokemon.h"
 #include "constants/items.h"
 #include "random.h"
-#include "constants/species.h"
 #include "string_util.h"
 #include "text.h"
 #include "pokemon_storage_system.h"

--- a/src/mail.c
+++ b/src/mail.c
@@ -16,7 +16,6 @@
 #include "gpu_regs.h"
 #include "bg.h"
 #include "pokemon_icon.h"
-#include "constants/species.h"
 #include "malloc.h"
 #include "easy_chat.h"
 #include "constants/rgb.h"

--- a/src/mail_data.c
+++ b/src/mail_data.c
@@ -3,7 +3,6 @@
 #include "constants/items.h"
 #include "pokemon.h"
 #include "pokemon_icon.h"
-#include "constants/species.h"
 #include "text.h"
 #include "international_string_util.h"
 

--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -3,7 +3,6 @@
 #include "bg.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/trainers.h"
 #include "decompress.h"
 #include "event_data.h"

--- a/src/match_call.c
+++ b/src/match_call.c
@@ -32,7 +32,6 @@
 #include "constants/maps.h"
 #include "constants/region_map_sections.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/trainers.h"
 
 struct MatchCallState

--- a/src/menu_specialized.c
+++ b/src/menu_specialized.c
@@ -25,7 +25,6 @@
 #include "window.h"
 #include "constants/berry.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "gba/io_reg.h"
 
 extern const struct CompressedSpriteSheet gMonFrontPicTable[];

--- a/src/mevent2.c
+++ b/src/mevent2.c
@@ -10,7 +10,6 @@
 #include "new_game.h"
 #include "mevent.h"
 #include "constants/mevent.h"
-#include "constants/species.h"
 
 static EWRAM_DATA bool32 gUnknown_02022C70 = FALSE;
 

--- a/src/mevent_801BAAC.c
+++ b/src/mevent_801BAAC.c
@@ -1,5 +1,4 @@
 #include "global.h"
-#include "constants/species.h"
 #include "bg.h"
 #include "gpu_regs.h"
 #include "palette.h"

--- a/src/mystery_event_script.c
+++ b/src/mystery_event_script.c
@@ -9,7 +9,6 @@
 #include "pokemon.h"
 #include "pokemon_size_record.h"
 #include "script.h"
-#include "constants/species.h"
 #include "strings.h"
 #include "string_util.h"
 #include "text.h"

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -65,7 +65,6 @@
 #include "constants/maps.h"
 #include "constants/region_map_sections.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/trainer_hill.h"
 #include "constants/weather.h"
 

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -74,7 +74,6 @@
 #include "constants/party_menu.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 
 #define PARTY_PAL_SELECTED     (1 << 0)
 #define PARTY_PAL_FAINTED      (1 << 1)

--- a/src/pokeball.c
+++ b/src/pokeball.c
@@ -13,7 +13,6 @@
 #include "trig.h"
 #include "util.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 
 extern struct MusicPlayerInfo gMPlayInfo_BGM;
 

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -28,7 +28,6 @@
 #include "window.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 
 enum
 {

--- a/src/pokedex_area_screen.c
+++ b/src/pokedex_area_screen.c
@@ -20,7 +20,6 @@
 #include "constants/region_map_sections.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 
 #define AREA_SCREEN_WIDTH 32
 #define AREA_SCREEN_HEIGHT 20

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -44,7 +44,6 @@
 #include "constants/layouts.h"
 #include "constants/moves.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/trainers.h"
 
 struct SpeciesItem

--- a/src/pokemon_animation.c
+++ b/src/pokemon_animation.c
@@ -8,7 +8,6 @@
 #include "util.h"
 #include "constants/battle_anim.h"
 #include "constants/rgb.h"
-#include "constants/species.h"
 
 struct UnkAnimStruct
 {

--- a/src/pokemon_icon.c
+++ b/src/pokemon_icon.c
@@ -4,7 +4,6 @@
 #include "palette.h"
 #include "pokemon_icon.h"
 #include "sprite.h"
-#include "constants/species.h"
 
 #define POKE_ICON_BASE_PAL_TAG 56000
 

--- a/src/pokemon_jump.c
+++ b/src/pokemon_jump.c
@@ -29,7 +29,6 @@
 #include "pokemon_jump.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 
 struct PokemonJump1_MonInfo
 {

--- a/src/pokemon_size_record.c
+++ b/src/pokemon_size_record.c
@@ -6,7 +6,6 @@
 #include "pokemon_size_record.h"
 #include "string_util.h"
 #include "text.h"
-#include "constants/species.h"
 
 #define DEFAULT_MAX_SIZE 0x8000 // was 0x8100 in Ruby/Sapphire
 

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -41,7 +41,6 @@
 #include "constants/moves.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 
 struct WallpaperTable
 {

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -46,7 +46,6 @@
 #include "constants/region_map_sections.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 
 // Screen titles (upper left)
 #define PSS_LABEL_WINDOW_POKEMON_INFO_TITLE 0

--- a/src/pokenav_conditions_1.c
+++ b/src/pokenav_conditions_1.c
@@ -12,7 +12,6 @@
 #include "strings.h"
 #include "text.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 
 struct PokenavSub11
 {

--- a/src/pokenav_match_call_2.c
+++ b/src/pokenav_match_call_2.c
@@ -23,7 +23,6 @@
 #include "constants/game_stat.h"
 #include "constants/region_map_sections.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 
 struct Pokenav4Struct
 {

--- a/src/rayquaza_scene.c
+++ b/src/rayquaza_scene.c
@@ -14,7 +14,6 @@
 #include "decompress.h"
 #include "sound.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/rgb.h"
 #include "random.h"
 

--- a/src/record_mixing.c
+++ b/src/record_mixing.c
@@ -5,7 +5,6 @@
 #include "text.h"
 #include "item.h"
 #include "task.h"
-#include "constants/species.h"
 #include "save.h"
 #include "load_save.h"
 #include "pokemon.h"

--- a/src/reshow_battle_screen.c
+++ b/src/reshow_battle_screen.c
@@ -11,7 +11,6 @@
 #include "battle_controllers.h"
 #include "link.h"
 #include "sprite.h"
-#include "constants/species.h"
 #include "constants/trainers.h"
 #include "battle_interface.h"
 #include "battle_anim.h"

--- a/src/roamer.c
+++ b/src/roamer.c
@@ -4,7 +4,6 @@
 #include "random.h"
 #include "roamer.h"
 #include "constants/maps.h"
-#include "constants/species.h"
 
 enum
 {

--- a/src/roulette.c
+++ b/src/roulette.c
@@ -30,7 +30,6 @@
 #include "constants/coins.h"
 #include "constants/rgb.h"
 #include "constants/roulette.h"
-#include "constants/species.h"
 #include "constants/songs.h"
 
 #define BALLS_PER_ROUND 6

--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -22,7 +22,6 @@
 #include "string_util.h"
 #include "tv.h"
 #include "constants/items.h"
-#include "constants/species.h"
 #include "constants/tv.h"
 #include "constants/battle_frontier.h"
 

--- a/src/secret_base.c
+++ b/src/secret_base.c
@@ -46,7 +46,6 @@
 #include "constants/moves.h"
 #include "constants/secret_bases.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/trainers.h"
 #include "constants/tv.h"
 

--- a/src/starter_choose.c
+++ b/src/starter_choose.c
@@ -22,7 +22,6 @@
 #include "trig.h"
 #include "window.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 #include "constants/rgb.h"
 
 #define STARTER_MON_COUNT   3

--- a/src/trade.c
+++ b/src/trade.c
@@ -49,7 +49,6 @@
 #include "constants/moves.h"
 #include "constants/region_map_sections.h"
 #include "constants/rgb.h"
-#include "constants/species.h"
 #include "constants/songs.h"
 #include "constants/union_room.h"
 

--- a/src/trainer_hill.c
+++ b/src/trainer_hill.c
@@ -29,7 +29,6 @@
 #include "constants/layouts.h"
 #include "constants/moves.h"
 #include "constants/maps.h"
-#include "constants/species.h"
 #include "constants/trainers.h"
 #include "constants/easy_chat.h"
 #include "constants/trainer_hill.h"

--- a/src/trainer_pokemon_sprites.c
+++ b/src/trainer_pokemon_sprites.c
@@ -2,7 +2,6 @@
 #include "sprite.h"
 #include "window.h"
 #include "malloc.h"
-#include "constants/species.h"
 #include "palette.h"
 #include "decompress.h"
 #include "trainer_pokemon_sprites.h"

--- a/src/tv.c
+++ b/src/tv.c
@@ -42,7 +42,6 @@
 #include "constants/moves.h"
 #include "constants/region_map_sections.h"
 #include "constants/script_menu.h"
-#include "constants/species.h"
 #include "constants/tv.h"
 
 // Static type declarations

--- a/src/union_room.c
+++ b/src/union_room.c
@@ -52,7 +52,6 @@
 #include "constants/party_menu.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
-#include "constants/species.h"
 
 // States for Task_RunUnionRoom
 enum {

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -21,7 +21,6 @@
 #include "constants/items.h"
 #include "constants/layouts.h"
 #include "constants/maps.h"
-#include "constants/species.h"
 #include "constants/weather.h"
 
 extern const u8 EventScript_RepelWoreOff[];


### PR DESCRIPTION
`POKEMON_SLOTS_NUMBER` is an easy to miss constant that just duplicates `NUM_SPECIES`. If people want to differentiate the two they still can in `DEX_FLAGS_NO`, which was its only usage