### PR TITLE
rewrite MultiBootWaitCycles as naked function

### DIFF
--- a/src/multiboot.c
+++ b/src/multiboot.c
@@ -1,3 +1,4 @@
+#include "global.h"
 #include "gba/gba.h"
 #include "multiboot.h"
 
@@ -435,23 +436,23 @@ static int MultiBootHandShake(struct MultiBootParam *mp)
 #undef must_data
 }
 
-static NOINLINE void MultiBootWaitCycles(u32 cycles)
+NAKED
+static void MultiBootWaitCycles(u32 cycles)
 {
-    asm("mov r2, pc");
-    asm("lsr r2, #24");
-    asm("mov r1, #12");
-    asm("cmp r2, #0x02");
-    asm("beq MultiBootWaitCyclesLoop");
-
-    asm("mov r1, #13");
-    asm("cmp r2, #0x08");
-    asm("beq MultiBootWaitCyclesLoop");
-
-    asm("mov r1, #4");
-
-    asm("MultiBootWaitCyclesLoop:");
-    asm("sub r0, r1");
-    asm("bgt MultiBootWaitCyclesLoop");
+    asm_unified("\
+    mov  r2, pc\n\
+    lsrs r2, 24\n\
+    movs r1, 12\n\
+    cmp  r2, 2\n\
+    beq  MultiBootWaitCyclesLoop\n\
+    movs r1, 13\n\
+    cmp  r2, 8\n\
+    beq  MultiBootWaitCyclesLoop\n\
+    movs r1, 4\n\
+MultiBootWaitCyclesLoop:\n\
+    subs r0, r1\n\
+    bgt  MultiBootWaitCyclesLoop\n\
+    bx   lr\n");
 }
 
 static void MultiBootWaitSendDone(void)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Before, when compiling MultiBootWaitCycles with O3 and MODERN=1, you
might have run into problems during optimizations when the compiler tried
to optimize the function, even if declared NOINLINE.

When rewriting this function as NAKED function, this no longer happens
as the optimizer will treat it as black box and compilation will resume.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Decompilation (matching, fixing nonmatching, fakematching, etc.)
- [ ] Documentation (naming symbols, commenting, etc.)
- [ ] Style (code style refactors, typo, etc.)
- [x] Other: Improve compatibility with modern compilers.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I am a member of the [pret Discord server](https://discord.gg/d5dubZ3).
- [x] `make compare` and `make compare modern` on my local machine outputs ![OK](https://cdn.discordapp.com/emojis/504128071524286475.png?v=1).
- [x] My code follows the code style of this project.
- [ ] If I am fixing a bug or undefined behavior in the modern build, I have documented the bug and tested the fix locally.
- [ ] All my usage, if any, of the leaked source code has been disclosed in pret's server.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
iTrash#7602