### PR TITLE
Change toOrrX and toOrrY to u8 in void FillBitmapRect4Bit, glib/blit.c

### DIFF
--- a/gflib/blit.c
+++ b/gflib/blit.c
@@ -76,7 +76,7 @@ void FillBitmapRect4Bit(struct Bitmap *surface, u16 x, u16 y, u16 width, u16 hei
     s32 yEnd;
     s32 multiplierY;
     s32 loopX, loopY;
-    s32 toOrr1, toOrr2;
+    u8 toOrr1, toOrr2;
 
     xEnd = x + width;
     if (xEnd > surface->width)
@@ -87,8 +87,8 @@ void FillBitmapRect4Bit(struct Bitmap *surface, u16 x, u16 y, u16 width, u16 hei
         yEnd = surface->height;
 
     multiplierY = (surface->width + (surface->width & 7)) >> 3;
-    toOrr1 = (u32)(fillValue << 0x1C) >> 0x18;
-    toOrr2 = (fillValue & 0xF);
+    toOrr1 = fillValue << 4;
+    toOrr2 = fillValue & 0xF;
 
     for (loopY = y; loopY < yEnd; loopY++)
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed toOrrX and toOrrY to u8 void FillBitmapRect4Bit, glib/blit.c
## Description
Changed toOrrX and toOrrY to u8 void FillBitmapRect4Bit, glib/blit.c
<!--- Describe your changes in detail -->
## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Decompilation (matching, fixing nonmatching, fakematching, etc.)
- [ ] Documentation (naming symbols, commenting, etc.)
- [X] Style (code style refactors, typo, etc.)
- [ ] Other: <!--- replace this comment with your type of change -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I am a member of the [pret Discord server](https://discord.gg/d5dubZ3).
- [X] `make compare` and `make compare modern` on my local machine outputs ![OK](https://cdn.discordapp.com/emojis/504128071524286475.png?v=1).
- [X] My code follows the code style of this project.
- [ ] If I am fixing a bug or undefined behavior in the modern build, I have documented the bug and tested the fix locally.
- [x] All my usage, if any, of the leaked source code has been disclosed in pret's server.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
MEATLOAF#4302