### PR TITLE
Add comments noting dead code

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -60,7 +60,7 @@ void StopScript(struct ScriptContext *ctx)
 
 bool8 RunScriptCommand(struct ScriptContext *ctx)
 {
-    if (ctx->mode == 0) 
+    if (ctx->mode == 0)
         return FALSE;
 
     switch (ctx->mode)

--- a/src/script.c
+++ b/src/script.c
@@ -60,12 +60,12 @@ void StopScript(struct ScriptContext *ctx)
 
 bool8 RunScriptCommand(struct ScriptContext *ctx)
 {
-    if (ctx->mode == 0)
+    if (ctx->mode == 0) 
         return FALSE;
 
     switch (ctx->mode)
     {
-    case 0:
+    case 0: //Already handled in above if statement
         return FALSE;
     case 2:
         if (ctx->nativePtr)
@@ -81,13 +81,13 @@ bool8 RunScriptCommand(struct ScriptContext *ctx)
             u8 cmdCode;
             ScrCmdFunc *func;
 
-            if (!ctx->scriptPtr)
+            if (ctx->scriptPtr == NULL)
             {
                 ctx->mode = 0;
                 return FALSE;
             }
 
-            if (ctx->scriptPtr == gNullScriptPtr)
+            if (ctx->scriptPtr == gNullScriptPtr) //Dead code; above if statement already handles ctx->scriptPtr being NULL; this will never execute
             {
                 while (1)
                     asm("svc 2"); // HALT


### PR DESCRIPTION
Hey all, Meatloaf here!

asm("svc 2") will never execute due to the above statement already handling this case, so that has been noted. Additionally, the case 0: statement is redundant due to the if statement already handling that case.

<!--- Provide a general summary of your changes in the Title above -->
Changed !ctx->scriptPtr to ctx->scriptPtr == NULL in script.c, line 84
## Description
<!--- Describe your changes in detail -->
I only added comments and changed a single statement to reflect this
## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
MEATLOAF#4302
<!--- Contributors must join https://discord.gg/d5dubZ3 -->