### PR TITLE
[LEAK INFORMED] Replace bitfield with s16 variable

### DIFF
--- a/gflib/sprite.h
+++ b/gflib/sprite.h
@@ -44,7 +44,7 @@ struct AnimFrameCmd
 {
     // If the sprite has an array of images, this is the array index.
     // If the sprite has a sheet, this is the tile offset.
-    u32 imageValue:16;
+    s16 imageValue;
 
     u32 duration:6;
     u32 hFlip:1;


### PR DESCRIPTION
Throughout the code, image value is an s16, except in this struct.

To simplify things, I used an s16 in instead of a u32:16 bitmap.

This follows the rest of the code more closely.

<!--- Provide a general summary of your changes in the Title above -->
Replaced u32:16 with s16
## Description
<!--- Describe your changes in detail -->
Replaced u32:16 with s16 in sprite.h, line 47, in struct AnimFrameCmd
## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
MEATLOAF#4302
<!--- Contributors must join https://discord.gg/d5dubZ3 -->