### PR TITLE
[LEAK INFORMED] The Bug that Never Was; remove BUG: comment, as the t…

### DIFF
--- a/src/roulette.c
+++ b/src/roulette.c
@@ -454,7 +454,7 @@ static const struct BgTemplate sBgTemplates[] =
 };
 static const struct WindowTemplate sWindowTemplate =
 {
-      .bg = 0;
+      .bg = 0,
       .tilemapLeft = 3,
       .tilemapTop = 15,
       .width = 24,

--- a/src/roulette.c
+++ b/src/roulette.c
@@ -452,19 +452,15 @@ static const struct BgTemplate sBgTemplates[] =
         .baseTile = 0
     }
 };
-static const struct WindowTemplate sWindowTemplates[] =
+static const struct WindowTemplate sWindowTemplate =
 {
-    {
-        .bg = 0,
-        .tilemapLeft = 3,
-        .tilemapTop = 15,
-        .width = 24,
-        .height = 4,
-        .paletteNum = 15,
-        .baseBlock = 0xC5
-    },
-    // BUG: Array not terminated properly
-    //DUMMY_WIN_TEMPLATE
+      .bg = 0;
+      .tilemapLeft = 3,
+      .tilemapTop = 15,
+      .width = 24,
+      .height = 4,
+      .paletteNum = 15,
+      .baseBlock = 0xC5
 };
 
 static const struct GridSelection sGridSelections[NUM_GRID_SELECTIONS + 1] =
@@ -1093,7 +1089,7 @@ static void InitRouletteBgAndWindows(void)
     SetBgTilemapBuffer(0, sRoulette->tilemapBuffers[0]);
     SetBgTilemapBuffer(1, sRoulette->tilemapBuffers[2]);
     SetBgTilemapBuffer(2, sRoulette->tilemapBuffers[6]);
-    InitWindows(sWindowTemplates);
+    InitWindows(&sWindowTemplate);
     InitTextBoxGfxAndPrinters();
     sTextWindowId = 0;
     sRoulette->gridTilemap = malloc_and_decompress(sGrid_Tilemap, &size);


### PR DESCRIPTION
…emplate is of no array

It turns out the template is standalone. Whether or not this was a good design choice or poor is different entirely, or whether the correct method or not was called is another issue entirely. Nevertheless, template is not an array.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed sWindowTemplates from an array to a singular variable
Now we are sending the address of the struct instead of the array containing it

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->MEATLOAF#4302
<!--- Contributors must join https://discord.gg/d5dubZ3 -->