### PR TITLE
[STYLE] Change "inline static void" to "static inline void"

### DIFF
--- a/gflib/text.c
+++ b/gflib/text.c
@@ -462,7 +462,7 @@ u8 GetLastTextColor(u8 colorType)
     }
 }
 
-inline static void GLYPH_COPY(u8 *windowTiles, u32 widthOffset, u32 j, u32 i, u32 *ptr, s32 width, s32 height)                                           //
+static inline void GLYPH_COPY(u8 *windowTiles, u32 widthOffset, u32 j, u32 i, u32 *ptr, s32 width, s32 height)                                           //
 {
     u32 xAdd, yAdd, r5, bits, toOrr, dummyX;
     u8 *dst;


### PR DESCRIPTION
I propose "static inline void" because EVERY OTHER inline function in pret's codebase has "static inline void", not "inline static void". When I did a search for "static inline" every other function with static inline came up, except the GLYPH_COPY one. GLYPH_COPY is the only function to use "inline static", which is stylistically inconsistent.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Swap the words "Static" and "inline"
## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->MEATLOAF#4302
<!--- Contributors must join https://discord.gg/d5dubZ3 -->