### PR TITLE
[BUG-FIX COMMENT] Comment in bug fix for match_call records

### DIFF
--- a/src/match_call.c
+++ b/src/match_call.c
@@ -1847,7 +1847,7 @@ static u16 GetFrontierStreakInfo(u16 facilityId, u32 *topicTextId)
         }
         *topicTextId = 2;
         break;
-        case FRONTIER_FACILITY_PIKE: //BUG: Should be "case FRONTIER_FACILITY_FACTORY"
+    case FRONTIER_FACILITY_PIKE: //BUG: Should be "case FRONTIER_FACILITY_FACTORY"
         for (i = 0; i < 2; i++)
         {
             for (j = 0; j < 2; j++)

--- a/src/match_call.c
+++ b/src/match_call.c
@@ -1817,10 +1817,9 @@ static u16 GetFrontierStreakInfo(u16 facilityId, u32 *topicTextId)
         }
         *topicTextId = 3;
         break;
-    case FRONTIER_FACILITY_FACTORY:
+    case FRONTIER_FACILITY_FACTORY:  //BUG: Should be "case FRONTIER_FACILITY_PIKE"
         for (i = 0; i < 2; i++)
         {
-            // BUG: should be looking at battle factory records.
             if (streak < gSaveBlock2Ptr->frontier.pikeRecordStreaks[i])
                 streak = gSaveBlock2Ptr->frontier.pikeRecordStreaks[i];
         }
@@ -1848,12 +1847,11 @@ static u16 GetFrontierStreakInfo(u16 facilityId, u32 *topicTextId)
         }
         *topicTextId = 2;
         break;
-    case FRONTIER_FACILITY_PIKE:
+        case FRONTIER_FACILITY_PIKE: //BUG: Should be "case FRONTIER_FACILITY_FACTORY"
         for (i = 0; i < 2; i++)
         {
             for (j = 0; j < 2; j++)
             {
-                // BUG: should be looking at battle pike records.
                 if (streak < gSaveBlock2Ptr->frontier.factoryRecordWinStreaks[i][j])
                     streak = gSaveBlock2Ptr->frontier.factoryRecordWinStreaks[i][j];
             }

--- a/src/match_call.c
+++ b/src/match_call.c
@@ -1817,7 +1817,7 @@ static u16 GetFrontierStreakInfo(u16 facilityId, u32 *topicTextId)
         }
         *topicTextId = 3;
         break;
-    case FRONTIER_FACILITY_FACTORY:  //BUG: Should be "case FRONTIER_FACILITY_PIKE"
+    case FRONTIER_FACILITY_FACTORY: //BUG: Should be "case FRONTIER_FACILITY_PIKE"
         for (i = 0; i < 2; i++)
         {
             if (streak < gSaveBlock2Ptr->frontier.pikeRecordStreaks[i])


### PR DESCRIPTION
The issue isn't that the cases are looking at the wrong data, but the wrong case labels were used. This is because in the original code, the enum values for pike and factory were accidentally swapped. This doesn't show up in pret, but is the reason why the bug happens. Switching the case values is the fix to this issue.

<!--- Provide a general summary of your changes in the Title above -->
In commented out lines, fixed the cases in match_call.c
## Description
<!--- Describe your changes in detail -->
## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->MEATLOAF#4302
<!--- Contributors must join https://discord.gg/d5dubZ3 -->