### PR TITLE
Commented bug in event object viewer

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1972,7 +1972,7 @@ static void LoadObjectEventPalette(u16 paletteTag)
 {
     u16 i = FindObjectEventPaletteIndexByTag(paletteTag);
 
-    if (i != OBJ_EVENT_PAL_TAG_NONE) // BUG: FindObjectEventPatelleIndex should be returning a u16 with the result of OBJ_EVENT_PAL_TAG_NONE. Because of this bug, this condition is always true
+    if (i != OBJ_EVENT_PAL_TAG_NONE) // BUG: FindObjectEventPaletteIndexByTag should be returning a u16 with the result of OBJ_EVENT_PAL_TAG_NONE. Because of this bug, this condition is always true
     {
         sub_808E8F4(&sObjectEventSpritePalettes[i]);
     }

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1972,7 +1972,7 @@ static void LoadObjectEventPalette(u16 paletteTag)
 {
     u16 i = FindObjectEventPaletteIndexByTag(paletteTag);
 
-    if (i != OBJ_EVENT_PAL_TAG_NONE) // always true
+    if (i != OBJ_EVENT_PAL_TAG_NONE) // BUG: FindObjectEventPatelleIndex should be returning a u16 with the result of OBJ_EVENT_PAL_TAG_NONE. Because of this bug, this condition is always true
     {
         sub_808E8F4(&sObjectEventSpritePalettes[i]);
     }


### PR DESCRIPTION
The compiler changed the return value to 0xff of FindObjectEventPaletteIndexByTag because it returns a u8, which is why pret's codebase says return 0xff. However, GAME FREAK actually wrote "return OBJ_EVENT_PAL_TAG_NONE". This is impossible because of u8's range. Whether this has a bug in vanilla gameplay is unknown.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->