### PR TITLE
Simplify RAM reset adaptation for modern

### DIFF
--- a/src/crt0.s
+++ b/src/crt0.s
@@ -93,7 +93,7 @@ Init: @ 8000204
 	str r0, [r1]
 	.if MODERN
 	mov r0, #255 @ RESET_ALL
-	swi #1 << 16
+	svc #1 << 16
 	.endif @ MODERN
 	ldr r1, =AgbMain + 1
 	mov lr, pc

--- a/src/crt0.s
+++ b/src/crt0.s
@@ -91,6 +91,10 @@ Init: @ 8000204
 	ldr r1, =INTR_VECTOR
 	adr r0, IntrMain
 	str r0, [r1]
+	.if MODERN
+	mov r0, #255 @ RESET_ALL
+	swi #1 << 16
+	.endif @ MODERN
 	ldr r1, =AgbMain + 1
 	mov lr, pc
 	bx r1

--- a/src/main.c
+++ b/src/main.c
@@ -85,25 +85,9 @@ void EnableVCountIntrAtLine150(void);
 
 void AgbMain()
 {
-#if MODERN
     // Modern compilers are liberal with the stack on entry to this function,
     // so RegisterRamReset may crash if it resets IWRAM.
-    RegisterRamReset(RESET_ALL & ~RESET_IWRAM);
-    asm("mov\tr1, #0xC0\n"
-        "\tlsl\tr1, r1, #0x12\n"
-        "\tmov r2, #0xFC\n"
-        "\tlsl r2, r2, #0x7\n"
-        "\tadd\tr2, r1, r2\n"
-        "\tmov\tr0, #0\n"
-        "\tmov\tr3, r0\n"
-        "\tmov\tr4, r0\n"
-        "\tmov\tr5, r0\n"
-        ".LCU0:\n"
-        "\tstmia r1!, {r0, r3, r4, r5}\n"
-        "\tcmp\tr1, r2\n"
-        "\tbcc\t.LCU0\n"
-    );
-#else
+#if !MODERN
     RegisterRamReset(RESET_ALL);
 #endif //MODERN
     *(vu16 *)BG_PLTT = 0x7FFF;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When compiling with newer versions of gcc, AgbMain preserves more registers than when compiled with agbcc. This results in the vanilla RegisterRamReset call crashing, due to the return address on the stack being overwritten with 0. The current fix injects a manual loop into AgbMain to clear IWRAM. The proposed solution instead moves the RegisterRamReset to crt0 when compiling with modern gcc. It's more efficient and less of an eyesore this way.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
PikalaxALT#5823
<!--- Contributors must join https://discord.gg/d5dubZ3 -->