### PR TITLE
Designated initializers for gTrainerBackPicTable

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -295,11 +295,6 @@ const union AnimCmd *const gUnknown_082FF70C[] =
 #define SPECIES_PAL(species, pal) [SPECIES_##species] = {pal, SPECIES_##species}
 #define SPECIES_SHINY_PAL(species, pal) [SPECIES_##species] = {pal, SPECIES_##species + SPECIES_SHINY_TAG}
 
-#define TRAINER_SPRITE(trainerPic, sprite, size) [TRAINER_PIC_##trainerPic] = {sprite, size, TRAINER_PIC_##trainerPic}
-#define TRAINER_PAL(trainerPic, pal) [TRAINER_PIC_##trainerPic] = {pal, TRAINER_PIC_##trainerPic}
-
-#define TRAINER_BACK_PAL(trainerPic, pal) [TRAINER_BACK_PIC_##trainerPic] = {pal, TRAINER_BACK_PIC_##trainerPic}
-
 #include "data/pokemon_graphics/unknown_anims.h"
 #include "data/pokemon_graphics/front_pic_coordinates.h"
 #include "data/pokemon_graphics/still_front_pic_table.h"

--- a/src/data/trainer_graphics/back_pic_tables.h
+++ b/src/data/trainer_graphics/back_pic_tables.h
@@ -13,17 +13,21 @@ const struct MonCoords gTrainerBackPicCoords[] =
 // this table goes functionally unused, since none of these pics are compressed
 // and the place they would get extracted to gets overwritten later anyway
 // the casts are so they'll play nice with the strict struct definition
+#define TRAINER_BACK_SPRITE(trainerPic, sprite, size) [TRAINER_BACK_PIC_##trainerPic] = {(const u32 *)sprite, size, TRAINER_BACK_PIC_##trainerPic}
+
 const struct CompressedSpriteSheet gTrainerBackPicTable[] =
 {
-    (const u32 *)gTrainerBackPic_Brendan, 0x2000, TRAINER_BACK_PIC_BRENDAN,
-    (const u32 *)gTrainerBackPic_May, 0x2000, TRAINER_BACK_PIC_MAY,
-    (const u32 *)gTrainerBackPic_Red, 0x2800, TRAINER_BACK_PIC_RED,
-    (const u32 *)gTrainerBackPic_Leaf, 0x2800, TRAINER_BACK_PIC_LEAF,
-    (const u32 *)gTrainerBackPic_RubySapphireBrendan, 0x2000, TRAINER_BACK_PIC_RUBY_SAPPHIRE_BRENDAN,
-    (const u32 *)gTrainerBackPic_RubySapphireMay, 0x2000, TRAINER_BACK_PIC_RUBY_SAPPHIRE_MAY,
-    (const u32 *)gTrainerBackPic_Wally, 0x2000, TRAINER_BACK_PIC_WALLY,
-    (const u32 *)gTrainerBackPic_Steven, 0x2000, TRAINER_BACK_PIC_STEVEN,
+    TRAINER_BACK_SPRITE(BRENDAN, gTrainerBackPic_Brendan, 0x2000),
+    TRAINER_BACK_SPRITE(MAY, gTrainerBackPic_May, 0x2000),
+    TRAINER_BACK_SPRITE(RED, gTrainerBackPic_Red, 0x2800),
+    TRAINER_BACK_SPRITE(LEAF, gTrainerBackPic_Leaf, 0x2800),
+    TRAINER_BACK_SPRITE(RUBY_SAPPHIRE_BRENDAN, gTrainerBackPic_RubySapphireBrendan, 0x2000),
+    TRAINER_BACK_SPRITE(RUBY_SAPPHIRE_MAY, gTrainerBackPic_RubySapphireMay, 0x2000),
+    TRAINER_BACK_SPRITE(WALLY, gTrainerBackPic_Wally, 0x2000),
+    TRAINER_BACK_SPRITE(STEVEN, gTrainerBackPic_Steven, 0x2000),
 };
+
+#define TRAINER_BACK_PAL(trainerPic, pal) [TRAINER_BACK_PIC_##trainerPic] = {pal, TRAINER_BACK_PIC_##trainerPic}
 
 const struct CompressedSpritePalette gTrainerBackPicPaletteTable[] =
 {

--- a/src/data/trainer_graphics/front_pic_tables.h
+++ b/src/data/trainer_graphics/front_pic_tables.h
@@ -95,6 +95,8 @@ const struct MonCoords gTrainerFrontPicCoords[] =
     [TRAINER_PIC_RS_MAY] = {.size = 8, .y_offset = 1},
 };
 
+#define TRAINER_SPRITE(trainerPic, sprite, size) [TRAINER_PIC_##trainerPic] = {sprite, size, TRAINER_PIC_##trainerPic}
+
 const struct CompressedSpriteSheet gTrainerFrontPicTable[] =
 {
     TRAINER_SPRITE(HIKER, gTrainerFrontPic_Hiker, 0x800),
@@ -191,6 +193,8 @@ const struct CompressedSpriteSheet gTrainerFrontPicTable[] =
     TRAINER_SPRITE(RS_BRENDAN, gTrainerFrontPic_RubySapphireBrendan, 0x800),
     TRAINER_SPRITE(RS_MAY, gTrainerFrontPic_RubySapphireMay, 0x800),
 };
+
+#define TRAINER_PAL(trainerPic, pal) [TRAINER_PIC_##trainerPic] = {pal, TRAINER_PIC_##trainerPic}
 
 const struct CompressedSpritePalette gTrainerFrontPicPaletteTable[] =
 {


### PR DESCRIPTION
Not a huge fan of macros that hide constant use but `gTrainerBackPicTable` was missing indexes to be consistent with other trainer tables. Also moved the macro definitions to above each respective table, should be clearer what they do and it's the only place they're used.