### PR TITLE
Fix incorrect bug description

### DIFF
--- a/src/daycare.c
+++ b/src/daycare.c
@@ -547,13 +547,17 @@ static void InheritIVs(struct Pokemon *egg, struct DayCare *daycare)
     for (i = 0; i < INHERITED_IV_COUNT; i++)
     {
         // Randomly pick an IV from the available list and stop from being chosen again.
-        selectedIvs[i] = availableIVs[Random() % (NUM_STATS - i)];
-        // BUG: Instead of removing the IV that was just picked (like in RS and FRLG), this
+        // BUG: Instead of removing the IV that was just picked, this
         // removes position 0 (HP) then position 1 (DEF), then position 2. This is why HP and DEF
         // have a lower chance to be inherited in Emerald and why the IV picked for inheritance can
-        // be repeated. Uncomment the inline comment and remove the existing expression to get the
-        // intended behavior and  to match the other Gen 3 games. 
-        RemoveIVIndexFromList(availableIVs, i /*selectedIvs[i]*/);
+        // be repeated. Amusingly, FRLG and RS also got this wrong. They remove selectedIvs[i], which
+        // is not an index! This means that it can sometimes remove the wrong stat. To fix, delete 
+        // the following two lines and uncomment the rest of the block.
+        selectedIvs[i] = availableIVs[Random() % (NUM_STATS - i)];
+        RemoveIVIndexFromList(availableIVs, i);
+        // u8 index = Random() % (NUM_STATS - i);
+        // selectedIvs[i] = availableIVs[index];
+        // RemoveIVIndexFromList(availableIVs, index);
     }
 
     // Determine which parent each of the selected IVs should inherit from.


### PR DESCRIPTION
Apologies, I got this wrong in my last PR. Turns out, FireRed and LeafGreen also have incorrect behavior! :masuda:

They remove the stat value always, which is incorrect because the stat value is not an index, leading to the wrong element being removed from the array in certain situations.