### PR TITLE
improve asmdiff.sh

### DIFF
--- a/asmdiff.sh
+++ b/asmdiff.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 OBJDUMP="$DEVKITARM/bin/arm-none-eabi-objdump -D -bbinary -marmv4t -Mforce-thumb"
-OPTIONS="--start-address=$(($1)) --stop-address=$(($1 + $2))"
+if [ $(($1)) -ge $((0x8000000)) ]; then
+    OPTIONS="--adjust-vma=0x8000000 --start-address=$(($1)) --stop-address=$(($1 + $2))"
+else
+    OPTIONS="--start-address=$(($1)) --stop-address=$(($1 + $2))"
+fi
 $OBJDUMP $OPTIONS baserom.gba > baserom.dump
 $OBJDUMP $OPTIONS pokeemerald.gba > pokeemerald.dump
 diff -u baserom.dump pokeemerald.dump


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
asmdiff.sh now accepts both actual memory addresses and GBA memory addresses, achieved by checking whether the given address is at least 0x8000000.

## **Discord contact info**
Kurausukun#9923