### PR TITLE
docs: fix simple typo, redunant -> redundant

### DIFF
--- a/include/constants/battle_frontier.h
+++ b/include/constants/battle_frontier.h
@@ -51,7 +51,7 @@
 #define MAX_BATTLE_FRONTIER_POINTS 9999
 #define MAX_STREAK 9999
 
-// These sets of facility ids would be redunant if the order was consistent
+// These sets of facility ids would be redundant if the order was consistent
 // The order is important for this set so that all the non-link records can be continuous
 #define RANKING_HALL_BATTLE_TOWER_SINGLES   0
 #define RANKING_HALL_BATTLE_TOWER_DOUBLES   1


### PR DESCRIPTION
There is a small typo in include/constants/battle_frontier.h.

Should read `redundant` rather than `redunant`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md