### PR TITLE
Add bugfix for Pokémon with affine transforms as part of their entry animation glitching when being sent out/put back in ball

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -98,7 +98,7 @@ Then edit `BagMenu_MoveCursorCallback` in [src/item_menu.c](https://github.com/p
 
 ## Pokémon that have an affine transform as part of their entry animation glitch when going in and out of Poké Balls without a screen transition in between
 
-**Fix:** Edit sub_817F77C in [src/pokemon_animation.c](https://github.com/pret/pokeemerald/blob/master/src/pokemon_animation.c#L1028) and remove the ifdef/endif lines:
+**Fix:** Edit `sub_817F77C` in [src/pokemon_animation.c](https://github.com/pret/pokeemerald/blob/master/src/pokemon_animation.c#L1028) and remove the ifdef/endif lines:
 
 ```diff
     ...

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -98,7 +98,7 @@ Then edit `BagMenu_MoveCursorCallback` in [src/item_menu.c](https://github.com/p
 
 ## Pokémon that have an affine transform as part of their entry animation glitch when going in and out of Poké Balls without a screen transition in between
 
-**Fix:** Edit `sub_817F77C` in [src/pokemon_animation.c](https://github.com/pret/pokeemerald/blob/master/src/pokemon_animation.c#L1028) and remove the ifdef/endif lines:
+**Fix:** Edit `sub_817F77C` in [src/pokemon_animation.c](https://github.com/pret/pokeemerald/blob/master/src/pokemon_animation.c#L1028):
 
 ```diff
     ...

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -1,7 +1,7 @@
 
 # Bugs and Glitches
 
-These are known bugs and glitches in the original Pokémon Emerald game: code that clearly does not work as intended, or that only works in limited circumstances but has the possibility to fail or crash.
+These are known bugs and glitches in the original Pokémon Emerald game: code that clearly does not work as intended, or that only works in limited circumstances but has the possibility to fail or crash. Defining the `BUGFIX` preprocessor variable will fix some of these automatically.
 
 Fixes are written in the `diff` format. If you've used Git before, this should look familiar:
 
@@ -60,7 +60,7 @@ void CB2_InitTitleScreen(void)
 		SetGpuReg(REG_OFFSET_BLDY, 0);
 		...
 ```
-This matches with the code of FR/LG and does what GF originally wanted to do.
+This matches what FRLG does and obtains the seed differently than RS, independently of the RTC.
 
 ## Scrolling through items in the bag causes the image to flicker
 
@@ -94,4 +94,22 @@ Then edit `BagMenu_MoveCursorCallback` in [src/item_menu.c](https://github.com/p
 +	RemoveBagItemIconSprite(gBagMenu->unk81B_1);
 	if (a != -2)
 	...
+```
+
+## Pokémon that have an affine transform as part of their entry animation glitch when going in and out of Poké Balls without a screen transition in between
+
+**Fix:** Edit sub_817F77C in [src/pokemon_animation.c](https://github.com/pret/pokeemerald/blob/master/src/pokemon_animation.c#L1028) and remove the ifdef/endif lines:
+
+```diff
+    ...
+-#ifdef BUGFIX
+    else
+    {
+        // FIX: Reset these back to normal after they were changed so Poké Ball catch/release
+        // animations without a screen transition in between don't break
+        sprite->affineAnimPaused = FALSE;
+        sprite->affineAnims = gUnknown_082FF694;
+    }
+-#endif // BUGFIX
+}
 ```

--- a/src/pokemon_animation.c
+++ b/src/pokemon_animation.c
@@ -1041,6 +1041,15 @@ static void sub_817F77C(struct Sprite *sprite)
         sprite->oam.matrixNum |= (sprite->hFlip << 3);
         sprite->oam.affineMode = ST_OAM_AFFINE_OFF;
     }
+#ifdef BUGFIX
+    else
+    {
+        // FIX: Reset these back to normal after they were changed so Poké Ball catch/release
+        // animations without a screen transition in between don't break
+        sprite->affineAnimPaused = FALSE;
+        sprite->affineAnims = gUnknown_082FF694;
+    }
+#endif // BUGFIX
 }
 
 static void pokemonanimfunc_01(struct Sprite *sprite)

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -2578,7 +2578,7 @@ static void DrawPokerusCuredSymbol(struct Pokemon *mon) // This checks if the mo
     ScheduleBgCopyTilemapToVram(3);
 }
 
-static void SetDexNumberColor(bool8 isMonShiny)
+static void SetMonPicBackgroundPalette(bool8 isMonShiny)
 {
     if (!isMonShiny)
         SetBgTilemapPalette(3, 1, 4, 8, 8, 0);
@@ -2715,12 +2715,12 @@ static void PrintNotEggInfo(void)
         if (!IsMonShiny(mon))
         {
             PrintTextOnWindow(PSS_LABEL_WINDOW_PORTRAIT_DEX_NUMBER, gStringVar1, 0, 1, 0, 1);
-            SetDexNumberColor(FALSE);
+            SetMonPicBackgroundPalette(FALSE);
         }
         else
         {
             PrintTextOnWindow(PSS_LABEL_WINDOW_PORTRAIT_DEX_NUMBER, gStringVar1, 0, 1, 0, 7);
-            SetDexNumberColor(TRUE);
+            SetMonPicBackgroundPalette(TRUE);
         }
         PutWindowTilemap(PSS_LABEL_WINDOW_PORTRAIT_DEX_NUMBER);
     }
@@ -2728,9 +2728,9 @@ static void PrintNotEggInfo(void)
     {
         ClearWindowTilemap(PSS_LABEL_WINDOW_PORTRAIT_DEX_NUMBER);
         if (!IsMonShiny(mon))
-            SetDexNumberColor(FALSE);
+            SetMonPicBackgroundPalette(FALSE);
         else
-            SetDexNumberColor(TRUE);
+            SetMonPicBackgroundPalette(TRUE);
     }
     StringCopy(gStringVar1, gText_LevelSymbol);
     ConvertIntToDecimalStringN(gStringVar2, summary->level, STR_CONV_MODE_LEFT_ALIGN, 3);


### PR DESCRIPTION
## Description
If a Pokémon uses an affine transform as part of their entry animation, and there is an attempt to catch them _without_ a screen transition in between (like in the Safari Zone), and the catch fails, then their sprite will not start small and grow to normal size when it comes out of the ball; rather, it will start at full size and just look weird. Similarly, if you have the Birch intro Pokémon be recalled into its ball and it had an affine animation when it entered, it will turn into a colored square blob. This fixes both of these issues.

Oh and also fixes the name of `SetDexNumberColor` as that was noticed while this PR was being compiled.

## **Discord contact info**
Sierraffinity#4131