### PR TITLE
Remove unnecessary string.h includes

### DIFF
--- a/src/field_message_box.c
+++ b/src/field_message_box.c
@@ -1,6 +1,5 @@
 #include "global.h"
 #include "menu.h"
-#include "string.h"
 #include "string_util.h"
 #include "task.h"
 #include "text.h"

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -41,7 +41,6 @@
 #include "shop.h"
 #include "sound.h"
 #include "sprite.h"
-#include "string.h"
 #include "strings.h"
 #include "string_util.h"
 #include "task.h"

--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -28,7 +28,6 @@
 #include "scanline_effect.h"
 #include "sound.h"
 #include "sprite.h"
-#include "string.h"
 #include "strings.h"
 #include "string_util.h"
 #include "task.h"


### PR DESCRIPTION
Standard library headers from agbcc should always be included with `<>` rather than `""`. Unclear if these were meant to refer to `tools/agbcc/include/string.h` or `include/strings.h`, but they're not necessary.