### PR TITLE
Minor BUGFIX changes, remove redundant bug fix descriptions

### DIFF
--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -13,54 +13,8 @@ Fixes are written in the `diff` format. If you've used Git before, this should l
 
 ## Contents
 
-- [RNG does not get seeded](#rng-does-not-get-seeded)
 - [Scrolling through items in the bag causes the image to flicker](#scrolling-through-items-in-the-bag-causes-the-image-to-flicker)
 
-
-## RNG does not get seeded
-
-**Fix:** Add the following function to [src/main.c](https://github.com/pret/pokeemerald/blob/master/src/main.c):
-```diff
-+static void SeedRngWithRtc(void)
-+{
-+	u32 seed = RtcGetMinuteCount();
-+	seed = (seed >> 16) ^ (seed & 0xFFFF);
-+	SeedRng(seed);
-+}
-```
-
-And edit `AgbMain`:
-
-```diff
-	...
-	RtcInit();
-	CheckForFlashMemory();
-	InitMainCallbacks();
-	InitMapMusic();
-+	SeedRngWithRtc();
-	ClearDma3Requests();
-	...
-```
-
-This restores the code of Ruby/Sapphire.
-
-**Alternate Fix:** Edit the following function in [src/title_screen.c](https://github.com/pret/pokeemerald/blob/master/src/title_screen.c):
-
-```diff
-void CB2_InitTitleScreen(void)
-{
-	switch (gMain.state)
-	{
-	default:
-	case 0:
-		SetVBlankCallback(NULL);
-+		StartTimer1();
-		SetGpuReg(REG_OFFSET_BLDCNT, 0);
-		SetGpuReg(REG_OFFSET_BLDALPHA, 0);
-		SetGpuReg(REG_OFFSET_BLDY, 0);
-		...
-```
-This matches what FRLG does and obtains the seed differently than RS, independently of the RTC.
 
 ## Scrolling through items in the bag causes the image to flicker
 

--- a/docs/bugs_and_glitches.md
+++ b/docs/bugs_and_glitches.md
@@ -1,7 +1,7 @@
 
 # Bugs and Glitches
 
-These are known bugs and glitches in the original Pokémon Emerald game: code that clearly does not work as intended, or that only works in limited circumstances but has the possibility to fail or crash. Defining the `BUGFIX` preprocessor variable will fix some of these automatically.
+These are known bugs and glitches in the original Pokémon Emerald game: code that clearly does not work as intended, or that only works in limited circumstances but has the possibility to fail or crash. Defining the `BUGFIX` and `UBFIX` preprocessor variables will fix some of these automatically. `UBFIX` will already be defined for MODERN builds.
 
 Fixes are written in the `diff` format. If you've used Git before, this should look familiar:
 
@@ -48,22 +48,4 @@ Then edit `BagMenu_MoveCursorCallback` in [src/item_menu.c](https://github.com/p
 +	RemoveBagItemIconSprite(gBagMenu->itemIconSlot);
 	if (itemIndex != LIST_CANCEL)
 	...
-```
-
-## Pokémon that have an affine transform as part of their entry animation glitch when going in and out of Poké Balls without a screen transition in between
-
-**Fix:** Edit `sub_817F77C` in [src/pokemon_animation.c](https://github.com/pret/pokeemerald/blob/master/src/pokemon_animation.c#L1028):
-
-```diff
-    ...
--#ifdef BUGFIX
-    else
-    {
-        // FIX: Reset these back to normal after they were changed so Poké Ball catch/release
-        // animations without a screen transition in between don't break
-        sprite->affineAnimPaused = FALSE;
-        sprite->affineAnims = gUnknown_082FF694;
-    }
--#endif // BUGFIX
-}
 ```

--- a/src/main.c
+++ b/src/main.c
@@ -75,7 +75,7 @@ static EWRAM_DATA u16 gTrainerId = 0;
 static void UpdateLinkAndCallCallbacks(void);
 static void InitMainCallbacks(void);
 static void CallCallbacks(void);
-//static void SeedRngWithRtc(void);
+static void SeedRngWithRtc(void);
 static void ReadKeys(void);
 void InitIntrHandlers(void);
 static void WaitForVBlank(void);
@@ -102,7 +102,9 @@ void AgbMain()
     CheckForFlashMemory();
     InitMainCallbacks();
     InitMapMusic();
-    //SeedRngWithRtc(); see comment at SeedRngWithRtc declaration below
+#ifdef BUGFIX
+    SeedRngWithRtc(); // see comment at SeedRngWithRtc definition below
+#endif
     ClearDma3Requests();
     ResetBgs();
     SetDefaultFontsPointer();
@@ -213,13 +215,15 @@ void EnableVCountIntrAtLine150(void)
     EnableInterrupts(INTR_FLAG_VCOUNT);
 }
 
-// oops! FRLG commented this out to remove RTC, however Emerald didnt undo this!
-//static void SeedRngWithRtc(void)
-//{
-//    u32 seed = RtcGetMinuteCount();
-//    seed = (seed >> 16) ^ (seed & 0xFFFF);
-//    SeedRng(seed);
-//}
+// FRLG commented this out to remove RTC, however Emerald didn't undo this!
+#ifdef BUGFIX
+static void SeedRngWithRtc(void)
+{
+    u32 seed = RtcGetMinuteCount();
+    seed = (seed >> 16) ^ (seed & 0xFFFF);
+    SeedRng(seed);
+}
+#endif
 
 void InitKeys(void)
 {

--- a/src/pokemon_animation.c
+++ b/src/pokemon_animation.c
@@ -6,6 +6,7 @@
 #include "task.h"
 #include "trig.h"
 #include "util.h"
+#include "data.h"
 #include "constants/battle_anim.h"
 #include "constants/rgb.h"
 


### PR DESCRIPTION
- Put `SeedRngWithRtc` fix in BUGFIX conditional instead of comments
- Remove the now redundant `SeedRngWithRtc` description from the bug fix doc, as well as the incorrect alternate fix.
- The bug fix for `sub_817F77C` needs to include `data.h`, which it currently doesn't
- Remove the redundant description of how to fix `sub_817F77C`, which just repeats the comment from the function and removes the directives.

I think descriptions of changes in `docs/bug_and_glitches.md` should be limited to fixes that are either too involved to implement with a `BUGFIX` conditional, or which introduce some novel change that doesn't seem to be the "obvious" or "intended" solution (such as adding an entirely new function). 

If we want to include the bugs fixed by `BUGFIX`/`UBFIX` in the document, they should be listed separately with an explanation at the top that all that needs to be done is to add the corresponding define. The changes don't need to be re-described.