### PR TITLE
Add local label support within preproc.

### DIFF
--- a/tools/preproc/asm_file.cpp
+++ b/tools/preproc/asm_file.cpp
@@ -27,6 +27,8 @@
 #include "utf8.h"
 #include "string_parser.h"
 
+static int asmFileIdentifier;
+
 AsmFile::AsmFile(std::string filename) : m_filename(filename)
 {
     FILE *fp = std::fopen(filename.c_str(), "rb");
@@ -55,7 +57,9 @@ AsmFile::AsmFile(std::string filename) : m_filename(filename)
     m_pos = 0;
     m_lineNum = 1;
     m_lineStart = 0;
-
+    m_curNonLocalLabel = std::string{"_.L"}.append(std::to_string(asmFileIdentifier));
+    asmFileIdentifier++;
+    m_nonLocalLabelFound = false;
     RemoveComments();
 }
 
@@ -66,6 +70,10 @@ AsmFile::AsmFile(AsmFile&& other) : m_filename(std::move(other.m_filename))
     m_size = other.m_size;
     m_lineNum = other.m_lineNum;
     m_lineStart = other.m_lineStart;
+    m_curNonLocalLabel = other.m_curNonLocalLabel;
+    m_nonLocalLabelFound = other.m_nonLocalLabelFound;
+    m_localLabels = other.m_localLabels;
+    m_identified = false;
 
     other.m_buffer = nullptr;
 }
@@ -73,6 +81,40 @@ AsmFile::AsmFile(AsmFile&& other) : m_filename(std::move(other.m_filename))
 AsmFile::~AsmFile()
 {
     delete[] m_buffer;
+}
+
+void AsmFile::TryPrintErrorHeaderMessage ()
+{
+    if (this->m_identified) {
+        return;
+    }
+
+    fprintf(stderr, "\n%s: Preproc messages\n", this->m_filename.c_str());
+    this->m_identified = true;
+}
+
+void AsmFile::RaiseErrorWhereButContinue (long lineNum, const char * format, ...)
+{
+    this->TryPrintErrorHeaderMessage();
+
+    std::va_list args;
+    va_start(args, format);
+    this->ReportDiagnosticWhere("error", lineNum, format, args);
+    va_end(args);
+
+    Preproc::numErrors++;
+}
+
+void AsmFile::RaiseErrorButContinue (const char * format, ...)
+{
+    this->TryPrintErrorHeaderMessage();
+
+    std::va_list args;
+    va_start(args, format);
+    this->ReportDiagnostic("error", format, args);
+    va_end(args);
+
+    Preproc::numErrors++;
 }
 
 // Removes comments to simplify further processing.
@@ -102,7 +144,9 @@ void AsmFile::RemoveComments()
                 pos++;
             }
         }
-        else if (m_buffer[pos] == '@' && (pos == 0 || m_buffer[pos - 1] != '\\'))
+        else if (
+            (m_buffer[pos] == '@' && (pos == 0 || m_buffer[pos - 1] != '\\'))
+            || (m_buffer[pos] == '/' && m_buffer[pos + 1] == '/'))
         {
             while (m_buffer[pos] != '\n' && m_buffer[pos] != 0)
                 m_buffer[pos++] = ' ';
@@ -175,29 +219,234 @@ Directive AsmFile::GetDirective()
         return Directive::Unknown;
 }
 
-// Checks if we're at label that ends with '::'.
-// Returns the name if so and an empty string if not.
-std::string AsmFile::GetGlobalLabel()
+LocalLabelInfo::LocalLabelInfo ()
 {
+    this->defined = true;
+}
+
+LocalLabelInfo::LocalLabelInfo (long lineNum)
+{
+    this->defined = false;
+    this->lineNums.emplace(lineNum);
+}
+
+// scan each line
+// if nonlocal label define:
+//  go through each local label found
+//  if not defined, print error
+//  then set the current nonlocal label
+// if local label define:
+//  replace local label with nonlocal label equivalent
+//  set local label as defined
+// if local label in statement:
+//  replace local label with nonlocal label equivalent
+//  add line number of reference
+
+// Check if we're parsing a label
+// the label is a global label if it ends with ::
+// the label is a local label if it starts with the local label prefix (currently '$', but check char_util.h) and ends with :
+// the label is a nonlocal label if it ends with :
+// otherwise, it is not a label
+// returns the type of label, and sets the argument pointer to the resulting label string
+LabelType AsmFile::TryParseLabel(std::string& returnLabel)
+{
+    //SkipWhitespace();
+
     long start = m_pos;
     long pos = m_pos;
 
-    if (IsIdentifierStartingChar(m_buffer[pos]))
+    if (IsCharGnuAssemblerNameBeginner(m_buffer[pos]))
     {
+        bool isLocalLabel = false;
+
+        if (m_buffer[pos] == LOCAL_LABEL_PREFIX) {
+            isLocalLabel = true;
+        }
+
         pos++;
 
-        while (IsIdentifierChar(m_buffer[pos]))
+        while (IsPartOfGnuAssemblerName(m_buffer[pos]))
             pos++;
+
+        //
+        if (m_buffer[pos] == ':')
+        {
+            std::size_t newSize = pos - start;
+            returnLabel.resize(newSize);
+            returnLabel.replace(0, newSize, &m_buffer[start], newSize);
+
+            if (!isLocalLabel) {
+                this->FindUndefinedLocalLabelsThenClear();
+                this->m_curNonLocalLabel = returnLabel;
+                this->m_nonLocalLabelFound = true;
+            } else {
+                auto localLabelInfo = this->m_localLabels.find(returnLabel);
+                if (localLabelInfo == this->m_localLabels.end()) {
+                    this->m_localLabels.emplace(returnLabel, LocalLabelInfo());
+                } else {
+                    if (!localLabelInfo->second.defined) {
+                        localLabelInfo->second.defined = true;
+                    } else {
+                        this->RaiseErrorButContinue("local label %s is already defined", returnLabel.c_str());
+                    }
+                }
+            }
+
+            LabelType labelType;
+
+            if (m_buffer[pos + 1] == ':') {
+                if (!isLocalLabel) {
+                    labelType = LabelType::Global;
+                } else {
+                    this->RaiseErrorButContinue("local label %s cannot be made global (change :: to :)", returnLabel.c_str());
+                    labelType = LabelType::Local;
+                }
+                m_pos = pos + 2;
+            } else {
+                if (isLocalLabel) {
+                    labelType = LabelType::Local;
+                } else {
+                    labelType = LabelType::Nonlocal;
+                }
+                m_pos = pos + 1;
+            }
+
+            if (isLocalLabel) {
+                if (!this->m_nonLocalLabelFound) {
+                    this->RaiseErrorButContinue("local label %s defined before non-local label", returnLabel.c_str());
+                }
+                returnLabel.insert(0, this->m_curNonLocalLabel);
+            }
+
+            ExpectEmptyRestOfLine();
+            return labelType;
+        }
     }
 
-    if (m_buffer[pos] == ':' && m_buffer[pos + 1] == ':')
-    {
-        m_pos = pos + 2;
-        ExpectEmptyRestOfLine();
-        return std::string(&m_buffer[start], pos - start);
+    return LabelType::NotALabel;
+}
+
+void AsmFile::FindUndefinedLocalLabelsThenClear ()
+{
+    for (auto const& localLabel : this->m_localLabels) {
+        if (!localLabel.second.defined) {
+            for (long lineNum : localLabel.second.lineNums) {
+                this->RaiseErrorWhereButContinue(lineNum, "local label %s was not defined within its scope", localLabel.first.c_str());
+            }
+        }
     }
 
-    return std::string();
+    this->m_localLabels.clear();
+}
+
+// return true if a local label was replaced
+void AsmFile::FindAndReplaceLocalLabels (std::string& outputLine)
+{
+    // first check if the prefix is in the line at all
+    // to avoid allocating a string
+
+    long pos = m_pos;
+    unsigned char c;
+    bool foundLocalLabelPrefix = false;
+
+    while (true) {
+        c = m_buffer[pos];
+        if (c == '\n' || c == '\0') {
+            break;
+        } else if (c == LOCAL_LABEL_PREFIX) {
+            foundLocalLabelPrefix = true;
+            break;
+        }
+        pos++;
+    }
+
+    if (!foundLocalLabelPrefix) {
+        if (c == '\0') {
+            if (pos >= m_size) {
+                this->RaiseWarning("file doesn't end with newline");
+                puts(&m_buffer[m_lineStart]);
+            } else {
+                this->RaiseError("unexpected null character");
+            }
+            m_pos = pos;
+        } else {
+            m_buffer[pos] = '\0';
+            puts(&m_buffer[m_lineStart]);
+            m_buffer[pos] = '\n';
+            m_pos = pos;
+            m_pos++;
+            m_lineStart = m_pos;
+            m_lineNum++;
+        }
+        return;
+    }
+
+    outputLine.resize(0);
+
+    // a local label can start after any non-name character
+    bool canStartLocalLabel = true;
+
+    while (true) {
+        c = m_buffer[m_pos];
+        //isParsingNonNameChars = IsPartOfGnuAssemblerName(c);
+
+        if (c == LOCAL_LABEL_PREFIX && canStartLocalLabel) {
+            outputLine += this->m_curNonLocalLabel;
+            //outputLine += LOCAL_LABEL_PREFIX;
+            m_pos++;
+            bool justFoundLocalLabelPrefix = true;
+
+            long start = m_pos;
+            while (true) {
+                c = m_buffer[m_pos];
+                if (!IsPartOfGnuAssemblerName(c)) {
+                    if (justFoundLocalLabelPrefix) {
+                        this->RaiseErrorButContinue("local label prefix \"%c\" must be followed by a label name", LOCAL_LABEL_PREFIX);
+                    }
+                    break;
+                }
+                justFoundLocalLabelPrefix = false;
+                m_pos++;
+            }
+
+            std::string localLabelName = std::string(&m_buffer[start - 1], m_pos - start + 1); 
+            auto localLabelInfo = this->m_localLabels.find(localLabelName);
+            if (localLabelInfo == this->m_localLabels.end()) {
+                this->m_localLabels.emplace(localLabelName, LocalLabelInfo(this->m_lineNum));
+            // only add line numbers if the label isn't defined
+            // as they're only used for reporting errors
+            } else if (!localLabelInfo->second.defined) {
+                std::set<long> * lineNums = &localLabelInfo->second.lineNums;
+                lineNums->emplace_hint(lineNums->end(), this->m_lineNum);
+            }
+
+            outputLine += localLabelName;
+
+            if (c == '\n' || c == '\0') {
+                break;
+            }
+        } else if (c == '\n' || c == '\0') {
+            break;
+        } else {
+            canStartLocalLabel = !IsPartOfGnuAssemblerName(c);
+            outputLine += c;
+        }
+        m_pos++;        
+    }
+
+    if (c == '\0') {
+        if (m_pos >= m_size) {
+            this->RaiseWarning("file doesn't end with newline");
+            puts(&m_buffer[m_lineStart]);
+        } else {
+            this->RaiseError("unexpected null character");
+        }
+    } else {
+        puts(outputLine.c_str());
+        m_pos++;
+        m_lineStart = m_pos;
+        m_lineNum++;
+    }
 }
 
 // Skips tabs and spaces.
@@ -503,10 +752,16 @@ void AsmFile::OutputLocation()
 // Reports a diagnostic message.
 void AsmFile::ReportDiagnostic(const char* type, const char* format, std::va_list args)
 {
+    this->ReportDiagnosticWhere(type, this->m_lineNum, format, args);
+}
+
+// Reports a diagnostic message, but with a custom line number
+void AsmFile::ReportDiagnosticWhere(const char* type, long lineNum, const char* format, std::va_list args)
+{
     const int bufferSize = 1024;
     char buffer[bufferSize];
     std::vsnprintf(buffer, bufferSize, format, args);
-    std::fprintf(stderr, "%s:%ld: %s: %s\n", m_filename.c_str(), m_lineNum, type, buffer);
+    std::fprintf(stderr, "%s:%ld: %s: %s\n", m_filename.c_str(), lineNum, type, buffer);
 }
 
 #define DO_REPORT(type)                   \
@@ -528,5 +783,6 @@ void AsmFile::RaiseError(const char* format, ...)
 // Reports a warning diagnostic.
 void AsmFile::RaiseWarning(const char* format, ...)
 {
+    this->TryPrintErrorHeaderMessage();
     DO_REPORT("warning");
 }

--- a/tools/preproc/asm_file.h
+++ b/tools/preproc/asm_file.h
@@ -24,6 +24,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <string>
+#include <set>
 #include "preproc.h"
 
 enum class Directive
@@ -34,6 +35,16 @@ enum class Directive
     Unknown
 };
 
+enum class LabelType
+{
+    Nonlocal,
+    Local,
+    Global,
+    NotALabel
+};
+
+class LocalLabelInfo;
+
 class AsmFile
 {
 public:
@@ -42,13 +53,15 @@ public:
     AsmFile(const AsmFile&) = delete;
     ~AsmFile();
     Directive GetDirective();
-    std::string GetGlobalLabel();
+    LabelType TryParseLabel(std::string& returnLabel);
+    void FindAndReplaceLocalLabels(std::string& outputLine);
     std::string ReadPath();
     int ReadString(unsigned char* s);
     int ReadBraille(unsigned char* s);
     bool IsAtEnd();
     void OutputLine();
     void OutputLocation();
+    void FindUndefinedLocalLabelsThenClear();
 
 private:
     char* m_buffer;
@@ -57,6 +70,12 @@ private:
     long m_lineNum;
     long m_lineStart;
     std::string m_filename;
+    std::string m_curNonLocalLabel;
+    bool m_nonLocalLabelFound;
+    std::map<std::string, LocalLabelInfo> m_localLabels;
+    bool m_identified = false;
+    //struct 
+    //std::vector<
 
     bool ConsumeComma();
     int ReadPadLength();
@@ -65,8 +84,23 @@ private:
     void SkipWhitespace();
     void ExpectEmptyRestOfLine();
     void ReportDiagnostic(const char* type, const char* format, std::va_list args);
-    void RaiseError(const char* format, ...);
+    void ReportDiagnosticWhere(const char* type, long lineNum, const char* format, std::va_list args);
+    void RaiseError(const char * format, ...);
+    void RaiseErrorWhereButContinue(long lineNum, const char * format, ...);
+    void RaiseErrorButContinue(const char * format, ...);
     void RaiseWarning(const char* format, ...);
+    void TryPrintErrorHeaderMessage();
+};
+
+class LocalLabelInfo
+{
+    public:
+        LocalLabelInfo();
+        LocalLabelInfo(long lineNum);
+        //~LocalLabelInfo();
+
+        bool defined;
+        std::set<long> lineNums;
 };
 
 #endif // ASM_FILE_H

--- a/tools/preproc/char_util.h
+++ b/tools/preproc/char_util.h
@@ -68,4 +68,21 @@ inline bool IsIdentifierChar(unsigned char c)
     return IsAsciiAlphanum(c) || c == '_';
 }
 
+inline bool IsCharGnuAssemblerNameBeginner(unsigned char c)
+{
+    return IsAsciiAlpha(c) || c == '$' || c == '_' || c == '.';
+}
+
+inline bool IsPartOfGnuAssemblerName(unsigned char c)
+{
+    return IsAsciiAlphanum(c) || c == '$' || c == '_' || c == '.';
+}
+
+inline bool IsGnuAssemblerWhitespace(unsigned char c)
+{
+    return c == ' ' || c == '\t'; // || c == '\f';
+}
+
+#define LOCAL_LABEL_PREFIX '$'
+
 #endif // CHAR_UTIL_H

--- a/tools/preproc/preproc.cpp
+++ b/tools/preproc/preproc.cpp
@@ -27,6 +27,11 @@
 
 Charmap* g_charmap;
 
+namespace Preproc
+{
+    int numErrors = 0;
+}
+
 void PrintAsmBytes(unsigned char *s, int length)
 {
     if (length > 0)
@@ -49,10 +54,13 @@ void PreprocAsmFile(std::string filename)
 
     stack.push(AsmFile(filename));
 
+    std::string lineBuffer;
+
     for (;;)
     {
         while (stack.top().IsAtEnd())
         {
+            stack.top().FindUndefinedLocalLabelsThenClear();
             stack.pop();
 
             if (stack.empty())
@@ -66,6 +74,7 @@ void PreprocAsmFile(std::string filename)
         switch (directive)
         {
         case Directive::Include:
+            // stack.top().FindUndefinedLocalLabelsThenClear();
             stack.push(AsmFile(stack.top().ReadPath()));
             stack.top().OutputLocation();
             break;
@@ -85,18 +94,25 @@ void PreprocAsmFile(std::string filename)
         }
         case Directive::Unknown:
         {
-            std::string globalLabel = stack.top().GetGlobalLabel();
+            LabelType labelType = stack.top().TryParseLabel(lineBuffer);
 
-            if (globalLabel.length() != 0)
+            switch (labelType)
             {
-                const char *s = globalLabel.c_str();
-                std::printf("%s: ; .global %s\n", s, s);
-            }
-            else
-            {
-                stack.top().OutputLine();
-            }
+                const char * labelCStr;
 
+                case LabelType::NotALabel:
+                    stack.top().FindAndReplaceLocalLabels(lineBuffer);
+                    break;
+                case LabelType::Global:
+                    labelCStr = lineBuffer.c_str();
+                    std::printf("%s: ; .global %s\n", labelCStr, labelCStr);
+                    break;
+                case LabelType::Nonlocal:
+                case LabelType::Local:
+                    labelCStr = lineBuffer.c_str();
+                    std::printf("%s:\n", labelCStr);
+                    break;
+            }
             break;
         }
         }
@@ -151,6 +167,10 @@ int main(int argc, char **argv)
         PreprocCFile(argv[1]);
     else
         FATAL_ERROR("\"%s\" has an unknown file extension of \"%s\".\n", argv[1], extension);
+
+    if (Preproc::numErrors > 0) {
+        std::exit(1);
+    }
 
     return 0;
 }

--- a/tools/preproc/preproc.h
+++ b/tools/preproc/preproc.h
@@ -51,4 +51,9 @@ const unsigned long kMaxCharmapSequenceLength = 16;
 
 extern Charmap* g_charmap;
 
+namespace Preproc
+{
+    extern int numErrors;
+}
+
 #endif // PREPROC_H


### PR DESCRIPTION
## Description
The prefix chosen was `$` since it's a valid gnu assembler name character and isn't used by other directives. `.` would have been preferable but it would require extra coding.

Semantics:
- Local labels are scoped by a non-local (or global) label. That is, local labels will become undefined when a non-local label is used, which means that the names of local labels can be reused as long as a non-local label is defined.
- Local labels can be referenced before they are declared, like normal labels. If a local label is referenced but not defined within its scope, then preproc will report an error.
- Since this is a preproc extension, local labels **will not work in macros**. If you need this advanced support, I would suggest looking at [my fork of PikalaxALT/easyaspi's agbcc + binutils](https://github.com/luckytyphlosion/agbcc/tree/new_layout_with_libs), which implements true local label support within gnu assembler.
- Internally, preproc will transform a local label into the concatenation of the last non-local label and the local label. E.g. for this input:
    ```arm
    NonlocalLabel1:
        .byte 10
        .word $localLabel @ forward reference
    $localLabel:
        .byte 20
        .word $localLabel @ backwards reference

    NonlocalLabel2:
        .hword 30
        .word $localLabel @ forward reference
    $localLabel:
        .hword 40
        .word $localLabel @ backwards reference
    ```
    preproc will transform it to:
    ```arm
    NonlocalLabel:
        .byte 10
        .word NonlocalLabel$localLabel @ forward reference
    NonlocalLabel$localLabel:
        .byte 20
        .word NonlocalLabel$localLabel @ backwards reference

    NonlocalLabel2:
        .hword 30
        .word NonlocalLabel2$localLabel @ forward reference
    NonlocalLabel2$localLabel:
        .hword 40
        .word NonlocalLabel2$localLabel @ backwards reference
    ```
    This means that you can also reference a local label outside of its scope, but this hasn't been tested. What is guaranteed is that the local label substitution (e.g. `.word $localLabel` -> `.word NonlocalLabel2$localLabel`) will only happen if the `$` is directly after a non-word character (anything that isn't alphanumeric, `_`, `.`, or `$`).
- Per file, local labels cannot be defined before a non-local label is defined. Part of this behaviour is a bit weird and not really designed for since it represents an edge case. For example:
    ```arm
    NonlocalLabel1:
        .byte 10
    $localLabel1:
        .byte 20

        .include "some_data.inc"

    @ in file "some_data.inc"
        .word $localLabel2
    ```
    would not be valid, however:
    ```arm
    @ in file 
    NonlocalLabel1:
        .byte 10
        .word $localLabel1
    $localLabel2:
        .include "more_data.inc"
    @ in file "more_data.inc"
    NonlocalLabel2:
        .byte 20

    @ back to the base file
    $localLabel1:
        .byte 30
    ```
    is (probably) valid. However, most users will probably never feel the need for cross-file local labels.
- Tests were done in another, private repository, but if needed I could refactor some scripts to use local labels to show their correctness. The following tests were done:
    - defining a label before it's referenced, then defining the label
    - defining a label before it's referenced, and not defining it (should error)
    - defining multiple of the same label before it's referenced, and not defining it (should error)
    - defining multiple different labels before they're referenced, and not defining them (should error)
    - defining multiple different labels multiple times before they're referenced, and not defining them (should error)
    - defining local label as global (should error)
    - defining local label before a non-local label is defined (should error)
    - defining just the local label prefix (should error)
    - referencing a local label at the end of a file without a newline
    - validating local labels at the end of the file


## **Discord contact info**
luckytyphlosion#1166