### PR TITLE
Make filler in PokemonSubstruct0 explicit

### DIFF
--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -11,6 +11,7 @@ struct PokemonSubstruct0
     u32 experience;
     u8 ppBonuses;
     u8 friendship;
+    u16 filler;
 };
 
 struct PokemonSubstruct1


### PR DESCRIPTION
People often want to edit these structs without changing their size, so marking filler to indicate more clearly that it's available for use