### PR TITLE
use constant for max directsound channels

### DIFF
--- a/constants/m4a_constants.inc
+++ b/constants/m4a_constants.inc
@@ -1,6 +1,7 @@
 	.equiv ID_NUMBER, 0x68736d53
 
 	.equiv PCM_DMA_BUF_SIZE, 1584
+	.equiv MAX_DIRECTSOUND_CHANNELS, 12
 
 	.equiv C_V, 0x40
 
@@ -93,7 +94,7 @@
 	struct_field o_SoundInfo_plynote, 4
 	struct_field o_SoundInfo_ExtVolPit, 4
 	struct_field o_SoundInfo_gap2, 16
-	struct_field o_SoundInfo_chans, 768
+	struct_field o_SoundInfo_chans, MAX_DIRECTSOUND_CHANNELS * 64
 	struct_field o_SoundInfo_pcmBuffer, PCM_DMA_BUF_SIZE * 2
 	struct_field SoundInfo_size, 0
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use a constant for the size of o_SoundInfo_chans to make it easier to resize when using more/less channels; corresponds to the constant with the same name in m4a_internal.h

## **Discord contact info**
Kurausukun#9923