### PR TITLE
Use constants for item data, misc other constants/fixes

### DIFF
--- a/data/battle_ai_scripts.s
+++ b/data/battle_ai_scripts.s
@@ -2057,12 +2057,22 @@ AI_CV_Protect_ScoreDown2:
 AI_CV_Protect_End:
 	end
 
+@ BUG: Foresight is only encouraged if the user is Ghost type or
+@      has high evasion, but should check target instead
 AI_CV_Foresight:
+.ifdef BUGFIX
+	get_target_type1
+	if_equal TYPE_GHOST, AI_CV_Foresight2
+	get_target_type2
+	if_equal TYPE_GHOST, AI_CV_Foresight2
+	if_stat_level_more_than AI_TARGET, STAT_EVASION, 8, AI_CV_Foresight3
+.else
 	get_user_type1
 	if_equal TYPE_GHOST, AI_CV_Foresight2
 	get_user_type2
 	if_equal TYPE_GHOST, AI_CV_Foresight2
 	if_stat_level_more_than AI_USER, STAT_EVASION, 8, AI_CV_Foresight3
+.endif
 	score -2
 	goto AI_CV_Foresight_End
 
@@ -2329,13 +2339,13 @@ AI_CV_SemiInvulnerable2:
 	if_status2 AI_TARGET, STATUS2_CURSED, AI_CV_SemiInvulnerable_TryEncourage
 	if_status3 AI_TARGET, STATUS3_LEECHSEED, AI_CV_SemiInvulnerable_TryEncourage
 	get_weather
-	.ifdef BUGFIX
+.ifdef BUGFIX
 	if_equal AI_WEATHER_HAIL, AI_CV_SemiInvulnerable_CheckIceType
 	if_equal AI_WEATHER_SANDSTORM, AI_CV_SemiInvulnerable_CheckSandstormTypes
-	.else
+.else
 	if_equal AI_WEATHER_HAIL, AI_CV_SemiInvulnerable_CheckSandstormTypes
 	if_equal AI_WEATHER_SANDSTORM, AI_CV_SemiInvulnerable_CheckIceType
-	.endif
+.endif
 	goto AI_CV_SemiInvulnerable5
 
 AI_CV_SemiInvulnerable_CheckSandstormTypes:
@@ -2404,11 +2414,11 @@ AI_CV_Hail_End:
 
 @ BUG: Facade score is increased if the target is statused, but should be if the user is
 AI_CV_Facade:
-	.ifdef BUGFIX
+.ifdef BUGFIX
 	if_not_status AI_USER, STATUS1_POISON | STATUS1_BURN | STATUS1_PARALYSIS | STATUS1_TOXIC_POISON, AI_CV_Facade_End
-	.else
+.else
 	if_not_status AI_TARGET, STATUS1_POISON | STATUS1_BURN | STATUS1_PARALYSIS | STATUS1_TOXIC_POISON, AI_CV_Facade_End
-	.endif
+.endif
 	score +1
 AI_CV_Facade_End:
 	end

--- a/data/battle_ai_scripts.s
+++ b/data/battle_ai_scripts.s
@@ -462,18 +462,18 @@ AI_CBM_Attract: @ 82DC5F5
 	get_ability AI_TARGET
 	if_equal ABILITY_OBLIVIOUS, Score_Minus10
 	get_gender AI_USER
-	if_equal 0, AI_CBM_Attract_CheckIfTargetIsFemale
-	if_equal 254, AI_CBM_Attract_CheckIfTargetIsMale
+	if_equal MON_MALE, AI_CBM_Attract_CheckIfTargetIsFemale
+	if_equal MON_FEMALE, AI_CBM_Attract_CheckIfTargetIsMale
 	goto Score_Minus10
 
 AI_CBM_Attract_CheckIfTargetIsFemale: @ 82DC61A
 	get_gender AI_TARGET
-	if_equal 254, AI_CBM_Attract_End
+	if_equal MON_FEMALE, AI_CBM_Attract_End
 	goto Score_Minus10
 
 AI_CBM_Attract_CheckIfTargetIsMale: @ 82DC627
 	get_gender AI_TARGET
-	if_equal 0, AI_CBM_Attract_End
+	if_equal MON_MALE, AI_CBM_Attract_End
 	goto Score_Minus10
 
 AI_CBM_Attract_End: @ 82DC634

--- a/data/maps/CaveOfOrigin_1F/scripts.inc
+++ b/data/maps/CaveOfOrigin_1F/scripts.inc
@@ -3,5 +3,5 @@ CaveOfOrigin_1F_MapScripts:: @ 8235768
 	.byte 0
 
 CaveOfOrigin_1F_OnTransition: @ 823576E
-	call_if_set FLAG_UNUSED_RS_LEGENDARY_BATTLE_DONE, CaveOfOrigin_EventScript_SetTempVars
+	call_if_set FLAG_UNUSED_RS_LEGENDARY_BATTLE_DONE, CaveOfOrigin_EventScript_DisableTriggers
 	end

--- a/data/maps/CaveOfOrigin_UnusedRubySapphireMap1/scripts.inc
+++ b/data/maps/CaveOfOrigin_UnusedRubySapphireMap1/scripts.inc
@@ -3,5 +3,5 @@ CaveOfOrigin_UnusedRubySapphireMap1_MapScripts:: @ 8235778
 	.byte 0
 
 CaveOfOrigin_UnusedRubySapphireMap1_OnTransition: @ 823577E
-	call_if_set FLAG_UNUSED_RS_LEGENDARY_BATTLE_DONE, CaveOfOrigin_EventScript_SetTempVars
+	call_if_set FLAG_UNUSED_RS_LEGENDARY_BATTLE_DONE, CaveOfOrigin_EventScript_DisableTriggers
 	end

--- a/data/maps/CaveOfOrigin_UnusedRubySapphireMap2/scripts.inc
+++ b/data/maps/CaveOfOrigin_UnusedRubySapphireMap2/scripts.inc
@@ -3,6 +3,6 @@ CaveOfOrigin_UnusedRubySapphireMap2_MapScripts:: @ 8235788
 	.byte 0
 
 CaveOfOrigin_UnusedRubySapphireMap2_OnTransition: @ 823578E
-	call_if_set FLAG_UNUSED_RS_LEGENDARY_BATTLE_DONE, CaveOfOrigin_EventScript_SetTempVars
+	call_if_set FLAG_UNUSED_RS_LEGENDARY_BATTLE_DONE, CaveOfOrigin_EventScript_DisableTriggers
 	end
 

--- a/data/maps/CaveOfOrigin_UnusedRubySapphireMap3/scripts.inc
+++ b/data/maps/CaveOfOrigin_UnusedRubySapphireMap3/scripts.inc
@@ -3,6 +3,6 @@ CaveOfOrigin_UnusedRubySapphireMap3_MapScripts:: @ 8235798
 	.byte 0
 
 CaveOfOrigin_UnusedRubySapphireMap3_OnTransition: @ 823579E
-	call_if_set FLAG_UNUSED_RS_LEGENDARY_BATTLE_DONE, CaveOfOrigin_EventScript_SetTempVars
+	call_if_set FLAG_UNUSED_RS_LEGENDARY_BATTLE_DONE, CaveOfOrigin_EventScript_DisableTriggers
 	end
 

--- a/data/scripts/cave_of_origin.inc
+++ b/data/scripts/cave_of_origin.inc
@@ -36,7 +36,7 @@ CaveOfOrigin_EventScript_Shake:: @ 82722A7
 	releaseall
 	end
 
-CaveOfOrigin_EventScript_SetTempVars:: @ 82722C1
+CaveOfOrigin_EventScript_DisableTriggers:: @ 82722C1
 	setvar VAR_TEMP_1, 1
 	setvar VAR_TEMP_2, 1
 	setvar VAR_TEMP_3, 1

--- a/data/scripts/pkmn_center_nurse.inc
+++ b/data/scripts/pkmn_center_nurse.inc
@@ -65,7 +65,7 @@ EventScript_PkmnCenterNurse_ReturnPkmn:: @ 82719E2
     goto_if_eq EventScript_PkmnCenterNurse_ReturnPkmn2
     message gText_RestoredPkmnToFullHealth
     waitmessage
-    applymovement VAR_0x800B, EventScript_PkmnCenterNurse_Bow
+    applymovement VAR_0x800B, Movement_PkmnCenterNurse_Bow
     waitmovement 0
     message gText_WeHopeToSeeYouAgain
     return
@@ -73,7 +73,7 @@ EventScript_PkmnCenterNurse_ReturnPkmn:: @ 82719E2
 EventScript_PkmnCenterNurse_ReturnPkmn2:: @ 8271A03
     message gText_ThankYouForWaiting
     waitmessage
-    applymovement VAR_0x800B, EventScript_PkmnCenterNurse_Bow
+    applymovement VAR_0x800B, Movement_PkmnCenterNurse_Bow
     waitmovement 0
     message gText_WeHopeToSeeYouAgain2
     return
@@ -84,7 +84,7 @@ EventScript_PkmnCenterNurse_PlayerWaitingInUnionRoom:: @ 8271A19
     setflag FLAG_NURSE_UNION_ROOM_REMINDER
     message CableClub_Text_PlayerIsWaiting
     waitmessage
-    applymovement VAR_0x800B, EventScript_PkmnCenterNurse_Bow
+    applymovement VAR_0x800B, Movement_PkmnCenterNurse_Bow
     waitmovement 0
     message gText_WeHopeToSeeYouAgain
     return
@@ -129,7 +129,7 @@ EventScript_PkmnCenterNurse_GoldCardHealPkmn:: @ 8271AC5
     goto EventScript_PkmnCenterNurse_HealPkmn
     end
 
-EventScript_PkmnCenterNurse_Bow: @ 8271AD0
+Movement_PkmnCenterNurse_Bow: @ 8271AD0
     nurse_joy_bow
     delay_4
     step_end

--- a/data/scripts/record_mix.inc
+++ b/data/scripts/record_mix.inc
@@ -6,16 +6,15 @@ EventScript_MixRecordsPrompt:: @ 8271D5E
 	compare VAR_RESULT, YES
 	goto_if_eq EventScript_MixRecords
 	compare VAR_RESULT, NO
-	goto_if_eq EventScript_DeclineMixRecords
-	goto EventScript_DeclineMixRecords
+	goto_if_eq EventScript_EndMixRecords
+	goto EventScript_EndMixRecords
 
 EventScript_MixRecords:: @ 8271D83
 	special RecordMixingPlayerSpotTriggered
 	waitstate
 	lock
 	faceplayer
-
-EventScript_DeclineMixRecords:: @ 8271D89
+EventScript_EndMixRecords:: @ 8271D89
 	message Text_WeHopeToSeeYouAgain
 	waitmessage
 	waitbuttonpress

--- a/include/constants/items.h
+++ b/include/constants/items.h
@@ -17,7 +17,11 @@
 #define ITEM_LUXURY_BALL 11
 #define ITEM_PREMIER_BALL 12
 
-#define LAST_BALL ITEM_PREMIER_BALL
+// Note: If moving ball IDs around, updating FIRST_BALL/LAST_BALL is not sufficient
+//       Several places expect the ball IDs to be first and contiguous (e.g. gBattlescriptsForBallThrow and MON_DATA_POKEBALL)
+//       If adding new balls, it's easiest to insert them after the last ball and increment the below IDs (and removing ITEM_034 for example)
+#define FIRST_BALL ITEM_MASTER_BALL
+#define LAST_BALL  ITEM_PREMIER_BALL
 
 // Pokemon Items
 #define ITEM_POTION 13
@@ -145,6 +149,8 @@
 #define ITEM_FAB_MAIL 131
 #define ITEM_RETRO_MAIL 132
 
+#define FIRST_MAIL_INDEX ITEM_ORANGE_MAIL
+
 // Berries
 #define ITEM_CHERI_BERRY 133
 #define ITEM_CHESTO_BERRY 134
@@ -189,6 +195,10 @@
 #define ITEM_LANSAT_BERRY 173
 #define ITEM_STARF_BERRY 174
 #define ITEM_ENIGMA_BERRY 175
+
+#define FIRST_BERRY_INDEX ITEM_CHERI_BERRY
+#define LAST_BERRY_INDEX  ITEM_ENIGMA_BERRY
+
 #define ITEM_0B0 176
 #define ITEM_0B1 177
 #define ITEM_0B2 178
@@ -467,9 +477,6 @@
 #define ITEMS_COUNT 377
 #define ITEM_FIELD_ARROW ITEMS_COUNT
 
-#define FIRST_BERRY_INDEX             ITEM_CHERI_BERRY
-#define LAST_BERRY_INDEX              ITEM_ENIGMA_BERRY
-
 // Range of berries given out by various NPCS
 #define FIRST_BERRY_MASTER_BERRY      ITEM_POMEG_BERRY
 #define LAST_BERRY_MASTER_BERRY       ITEM_NOMEL_BERRY
@@ -489,8 +496,6 @@
 #define NUM_ROUTE_114_MAN_BERRIES_SKIPPED (FIRST_ROUTE_114_MAN_BERRY - FIRST_BERRY_INDEX)
 
 #define ITEM_TO_BERRY(itemId)(((itemId - FIRST_BERRY_INDEX) + 1))
-
-#define FIRST_MAIL_INDEX ITEM_ORANGE_MAIL
 
 #define NUM_TECHNICAL_MACHINES 50
 #define NUM_HIDDEN_MACHINES     8

--- a/include/constants/items.h
+++ b/include/constants/items.h
@@ -490,6 +490,8 @@
 
 #define ITEM_TO_BERRY(itemId)(((itemId - FIRST_BERRY_INDEX) + 1))
 
+#define FIRST_MAIL_INDEX ITEM_ORANGE_MAIL
+
 #define NUM_TECHNICAL_MACHINES 50
 #define NUM_HIDDEN_MACHINES     8
 
@@ -505,6 +507,21 @@
 #define OLD_ROD   0
 #define GOOD_ROD  1
 #define SUPER_ROD 2
+
+// Secondary IDs for bikes
+#define MACH_BIKE 0
+#define ACRO_BIKE 1
+
+// Item type IDs (used to determine the exit callback)
+#define ITEM_USE_MAIL        0
+#define ITEM_USE_PARTY_MENU  1
+#define ITEM_USE_FIELD       2
+#define ITEM_USE_PBLOCK_CASE 3
+#define ITEM_USE_BAG_MENU    4 // No exit callback, stays in bag menu
+
+// Item battle usage IDs (only checked to see if nonzero)
+#define ITEM_B_USE_MEDICINE 1
+#define ITEM_B_USE_OTHER    2
 
 // Check if the item is one that can be used on a Pokemon.
 #define ITEM_HAS_EFFECT(item) ((item) >= ITEM_POTION && (item) <= ITEM_0B2)

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -240,11 +240,11 @@ struct Evolution
 
 #define NUM_UNOWN_FORMS 28
 
-#define GET_UNOWN_LETTER(personality) (( \
-      ((personality & 0x03000000) >> 18) \
-    | ((personality & 0x00030000) >> 12) \
-    | ((personality & 0x00000300) >> 6)  \
-    | ((personality & 0x00000003) >> 0)  \
+#define GET_UNOWN_LETTER(personality) ((   \
+      (((personality) & 0x03000000) >> 18) \
+    | (((personality) & 0x00030000) >> 12) \
+    | (((personality) & 0x00000300) >> 6)  \
+    | (((personality) & 0x00000003) >> 0)  \
 ) % NUM_UNOWN_FORMS)
 
 extern u8 gPlayerPartyCount;

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -238,6 +238,15 @@ struct Evolution
     u16 targetSpecies;
 };
 
+#define NUM_UNOWN_FORMS 28
+
+#define GET_UNOWN_LETTER(personality) (( \
+      ((personality & 0x03000000) >> 18) \
+    | ((personality & 0x00030000) >> 12) \
+    | ((personality & 0x00000300) >> 6)  \
+    | ((personality & 0x00000003) >> 0)  \
+) % NUM_UNOWN_FORMS)
+
 extern u8 gPlayerPartyCount;
 extern struct Pokemon gPlayerParty[PARTY_SIZE];
 extern u8 gEnemyPartyCount;

--- a/src/battle_anim_mons.c
+++ b/src/battle_anim_mons.c
@@ -16,13 +16,6 @@
 #include "util.h"
 #include "constants/battle_anim.h"
 
-#define GET_UNOWN_LETTER(personality) ((        \
-      (((personality & 0x03000000) >> 24) << 6) \
-    | (((personality & 0x00030000) >> 16) << 4) \
-    | (((personality & 0x00000300) >> 8) << 2)  \
-    | (((personality & 0x00000003) >> 0) << 0)  \
-) % 28)
-
 #define IS_DOUBLE_BATTLE() ((gBattleTypeFlags & BATTLE_TYPE_DOUBLE))
 
 extern const struct OamData gOamData_AffineNormal_ObjNormal_64x64;

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -2722,7 +2722,7 @@ void SpriteCB_FaintOpponentMon(struct Sprite *sprite)
     if (species == SPECIES_UNOWN)
     {
         u32 personalityValue = GetMonData(&gEnemyParty[gBattlerPartyIndexes[battler]], MON_DATA_PERSONALITY);
-        u16 unownForm = ((((personalityValue & 0x3000000) >> 18) | ((personalityValue & 0x30000) >> 12) | ((personalityValue & 0x300) >> 6) | (personalityValue & 3)) % 0x1C);
+        u16 unownForm = GET_UNOWN_LETTER(personalityValue);
         u16 unownSpecies;
 
         if (unownForm == 0)

--- a/src/berry_crush.c
+++ b/src/berry_crush.c
@@ -877,7 +877,7 @@ void StartBerryCrush(MainCallback callback)
 static void GetBerryFromBag(void)
 {
     if (gSpecialVar_ItemId < FIRST_BERRY_INDEX || gSpecialVar_ItemId > LAST_BERRY_INDEX + 1)
-        gSpecialVar_ItemId = ITEM_CHERI_BERRY;
+        gSpecialVar_ItemId = FIRST_BERRY_INDEX;
     else
         RemoveBagItem(gSpecialVar_ItemId, 1);
 

--- a/src/credits.c
+++ b/src/credits.c
@@ -1158,7 +1158,7 @@ static void CB2_RunCreditsSequence(void)
 static void sub_8175548(void)
 {
     ResetBgsAndClearDma3BusyFlags(0);
-    InitBgsFromTemplates(0, sBackgroundTemplates, 1);
+    InitBgsFromTemplates(0, sBackgroundTemplates, ARRAY_COUNT(sBackgroundTemplates));
     SetBgTilemapBuffer(0, AllocZeroed(BG_SCREEN_SIZE));
     LoadPalette(gUnknown_085E56F0, 0x80, 0x40);
     InitWindows(sWindowTemplates);

--- a/src/data/items.h
+++ b/src/data/items.h
@@ -7,9 +7,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
 // Pokeballs
@@ -21,10 +20,10 @@ const struct Item gItems[] =
         .price = 0,
         .description = sMasterBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = 0,
-        .battleUsage = 2,
+        .type = ITEM_MASTER_BALL - 1,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = 0,
+        .secondaryId = ITEM_MASTER_BALL - 1,
     },
 
     [ITEM_ULTRA_BALL] =
@@ -34,10 +33,10 @@ const struct Item gItems[] =
         .price = 1200,
         .description = sUltraBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = 1,
-        .battleUsage = 2,
+        .type = ITEM_ULTRA_BALL - 1,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = 1,
+        .secondaryId = ITEM_ULTRA_BALL - 1,
     },
 
     [ITEM_GREAT_BALL] =
@@ -47,10 +46,10 @@ const struct Item gItems[] =
         .price = 600,
         .description = sGreatBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = 2,
-        .battleUsage = 2,
+        .type = ITEM_GREAT_BALL - 1,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = 2,
+        .secondaryId = ITEM_GREAT_BALL - 1,
     },
 
     [ITEM_POKE_BALL] =
@@ -60,10 +59,10 @@ const struct Item gItems[] =
         .price = 200,
         .description = sPokeBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = 3,
-        .battleUsage = 2,
+        .type = ITEM_POKE_BALL - 1,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = 3,
+        .secondaryId = ITEM_POKE_BALL - 1,
     },
 
     [ITEM_SAFARI_BALL] =
@@ -73,10 +72,10 @@ const struct Item gItems[] =
         .price = 0,
         .description = sSafariBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = 4,
-        .battleUsage = 2,
+        .type = ITEM_SAFARI_BALL - 1,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = 4,
+        .secondaryId = ITEM_SAFARI_BALL - 1,
     },
 
     [ITEM_NET_BALL] =
@@ -86,10 +85,10 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sNetBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = 5,
-        .battleUsage = 2,
+        .type = ITEM_NET_BALL - 1,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = 5,
+        .secondaryId = ITEM_NET_BALL - 1,
     },
 
     [ITEM_DIVE_BALL] =
@@ -99,10 +98,10 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sDiveBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = 6,
-        .battleUsage = 2,
+        .type = ITEM_DIVE_BALL - 1,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = 6,
+        .secondaryId = ITEM_DIVE_BALL - 1,
     },
 
     [ITEM_NEST_BALL] =
@@ -112,10 +111,10 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sNestBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = 7,
-        .battleUsage = 2,
+        .type = ITEM_NEST_BALL - 1,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = 7,
+        .secondaryId = ITEM_NEST_BALL - 1,
     },
 
     [ITEM_REPEAT_BALL] =
@@ -125,10 +124,10 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sRepeatBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = 8,
-        .battleUsage = 2,
+        .type = ITEM_REPEAT_BALL - 1,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = 8,
+        .secondaryId = ITEM_REPEAT_BALL - 1,
     },
 
     [ITEM_TIMER_BALL] =
@@ -138,10 +137,10 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sTimerBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = 9,
-        .battleUsage = 2,
+        .type = ITEM_TIMER_BALL - 1,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = 9,
+        .secondaryId = ITEM_TIMER_BALL - 1,
     },
 
     [ITEM_LUXURY_BALL] =
@@ -151,10 +150,10 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sLuxuryBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = 10,
-        .battleUsage = 2,
+        .type = ITEM_LUXURY_BALL - 1,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = 10,
+        .secondaryId = ITEM_LUXURY_BALL - 1,
     },
 
     [ITEM_PREMIER_BALL] =
@@ -164,10 +163,10 @@ const struct Item gItems[] =
         .price = 200,
         .description = sPremierBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = 11,
-        .battleUsage = 2,
+        .type = ITEM_PREMIER_BALL - 1,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = 11,
+        .secondaryId = ITEM_PREMIER_BALL - 1,
     },
 
 // Medicine
@@ -180,11 +179,10 @@ const struct Item gItems[] =
         .holdEffectParam = 20,
         .description = sPotionDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_ANTIDOTE] =
@@ -194,11 +192,10 @@ const struct Item gItems[] =
         .price = 100,
         .description = sAntidoteDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_BURN_HEAL] =
@@ -208,11 +205,10 @@ const struct Item gItems[] =
         .price = 250,
         .description = sBurnHealDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_ICE_HEAL] =
@@ -222,11 +218,10 @@ const struct Item gItems[] =
         .price = 250,
         .description = sIceHealDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_AWAKENING] =
@@ -236,11 +231,10 @@ const struct Item gItems[] =
         .price = 250,
         .description = sAwakeningDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_PARALYZE_HEAL] =
@@ -250,11 +244,10 @@ const struct Item gItems[] =
         .price = 200,
         .description = sParalyzeHealDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_FULL_RESTORE] =
@@ -265,11 +258,10 @@ const struct Item gItems[] =
         .holdEffectParam = 255,
         .description = sFullRestoreDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_MAX_POTION] =
@@ -280,11 +272,10 @@ const struct Item gItems[] =
         .holdEffectParam = 255,
         .description = sMaxPotionDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_HYPER_POTION] =
@@ -295,11 +286,10 @@ const struct Item gItems[] =
         .holdEffectParam = 200,
         .description = sHyperPotionDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_SUPER_POTION] =
@@ -310,11 +300,10 @@ const struct Item gItems[] =
         .holdEffectParam = 50,
         .description = sSuperPotionDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_FULL_HEAL] =
@@ -324,11 +313,10 @@ const struct Item gItems[] =
         .price = 600,
         .description = sFullHealDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_REVIVE] =
@@ -338,11 +326,10 @@ const struct Item gItems[] =
         .price = 1500,
         .description = sReviveDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_MAX_REVIVE] =
@@ -352,11 +339,10 @@ const struct Item gItems[] =
         .price = 4000,
         .description = sMaxReviveDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_FRESH_WATER] =
@@ -367,11 +353,10 @@ const struct Item gItems[] =
         .holdEffectParam = 50,
         .description = sFreshWaterDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_SODA_POP] =
@@ -382,11 +367,10 @@ const struct Item gItems[] =
         .holdEffectParam = 60,
         .description = sSodaPopDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_LEMONADE] =
@@ -397,11 +381,10 @@ const struct Item gItems[] =
         .holdEffectParam = 80,
         .description = sLemonadeDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_MOOMOO_MILK] =
@@ -412,11 +395,10 @@ const struct Item gItems[] =
         .holdEffectParam = 100,
         .description = sMoomooMilkDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_ENERGY_POWDER] =
@@ -426,11 +408,10 @@ const struct Item gItems[] =
         .price = 500,
         .description = sEnergyPowderDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_ENERGY_ROOT] =
@@ -440,11 +421,10 @@ const struct Item gItems[] =
         .price = 800,
         .description = sEnergyRootDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_HEAL_POWDER] =
@@ -454,11 +434,10 @@ const struct Item gItems[] =
         .price = 450,
         .description = sHealPowderDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_REVIVAL_HERB] =
@@ -468,11 +447,10 @@ const struct Item gItems[] =
         .price = 2800,
         .description = sRevivalHerbDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_ETHER] =
@@ -483,11 +461,10 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sEtherDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_PPRecovery,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_PPRecovery,
-        .secondaryId = 0,
     },
 
     [ITEM_MAX_ETHER] =
@@ -498,11 +475,10 @@ const struct Item gItems[] =
         .holdEffectParam = 255,
         .description = sMaxEtherDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_PPRecovery,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_PPRecovery,
-        .secondaryId = 0,
     },
 
     [ITEM_ELIXIR] =
@@ -513,11 +489,10 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sElixirDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_PPRecovery,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_PPRecovery,
-        .secondaryId = 0,
     },
 
     [ITEM_MAX_ELIXIR] =
@@ -528,11 +503,10 @@ const struct Item gItems[] =
         .holdEffectParam = 255,
         .description = sMaxElixirDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_PPRecovery,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_PPRecovery,
-        .secondaryId = 0,
     },
 
     [ITEM_LAVA_COOKIE] =
@@ -542,11 +516,10 @@ const struct Item gItems[] =
         .price = 200,
         .description = sLavaCookieDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_BLUE_FLUTE] =
@@ -556,11 +529,10 @@ const struct Item gItems[] =
         .price = 100,
         .description = sBlueFluteDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_YELLOW_FLUTE] =
@@ -570,11 +542,10 @@ const struct Item gItems[] =
         .price = 200,
         .description = sYellowFluteDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_RED_FLUTE] =
@@ -584,11 +555,10 @@ const struct Item gItems[] =
         .price = 300,
         .description = sRedFluteDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_BLACK_FLUTE] =
@@ -599,9 +569,8 @@ const struct Item gItems[] =
         .holdEffectParam = 50,
         .description = sBlackFluteDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_BlackWhiteFlute,
-        .secondaryId = 0,
     },
 
     [ITEM_WHITE_FLUTE] =
@@ -612,9 +581,8 @@ const struct Item gItems[] =
         .holdEffectParam = 150,
         .description = sWhiteFluteDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_BlackWhiteFlute,
-        .secondaryId = 0,
     },
 
     [ITEM_BERRY_JUICE] =
@@ -626,11 +594,10 @@ const struct Item gItems[] =
         .holdEffectParam = 20,
         .description = sBerryJuiceDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_SACRED_ASH] =
@@ -640,9 +607,8 @@ const struct Item gItems[] =
         .price = 200,
         .description = sSacredAshDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_SacredAsh,
-        .secondaryId = 0,
     },
 
 // Collectibles
@@ -654,9 +620,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sShoalSaltDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SHOAL_SHELL] =
@@ -666,9 +631,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sShoalShellDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_RED_SHARD] =
@@ -678,9 +642,8 @@ const struct Item gItems[] =
         .price = 200,
         .description = sRedShardDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_BLUE_SHARD] =
@@ -690,9 +653,8 @@ const struct Item gItems[] =
         .price = 200,
         .description = sBlueShardDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_YELLOW_SHARD] =
@@ -702,9 +664,8 @@ const struct Item gItems[] =
         .price = 200,
         .description = sYellowShardDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_GREEN_SHARD] =
@@ -714,9 +675,8 @@ const struct Item gItems[] =
         .price = 200,
         .description = sGreenShardDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_034] =
@@ -726,9 +686,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_035] =
@@ -738,9 +697,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_036] =
@@ -750,9 +708,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_037] =
@@ -762,9 +719,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_038] =
@@ -774,9 +730,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_039] =
@@ -786,9 +741,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_03A] =
@@ -798,9 +752,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_03B] =
@@ -810,9 +763,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_03C] =
@@ -822,9 +774,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_03D] =
@@ -834,9 +785,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_03E] =
@@ -846,9 +796,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
 // Vitamins
@@ -860,9 +809,8 @@ const struct Item gItems[] =
         .price = 9800,
         .description = sHPUpDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_PROTEIN] =
@@ -872,9 +820,8 @@ const struct Item gItems[] =
         .price = 9800,
         .description = sProteinDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_IRON] =
@@ -884,9 +831,8 @@ const struct Item gItems[] =
         .price = 9800,
         .description = sIronDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_CARBOS] =
@@ -896,9 +842,8 @@ const struct Item gItems[] =
         .price = 9800,
         .description = sCarbosDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_CALCIUM] =
@@ -908,9 +853,8 @@ const struct Item gItems[] =
         .price = 9800,
         .description = sCalciumDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_RARE_CANDY] =
@@ -920,9 +864,8 @@ const struct Item gItems[] =
         .price = 4800,
         .description = sRareCandyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_RareCandy,
-        .secondaryId = 0,
     },
 
     [ITEM_PP_UP] =
@@ -932,9 +875,8 @@ const struct Item gItems[] =
         .price = 9800,
         .description = sPPUpDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_PPUp,
-        .secondaryId = 0,
     },
 
     [ITEM_ZINC] =
@@ -944,9 +886,8 @@ const struct Item gItems[] =
         .price = 9800,
         .description = sZincDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_PP_MAX] =
@@ -956,9 +897,8 @@ const struct Item gItems[] =
         .price = 9800,
         .description = sPPMaxDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_PPUp,
-        .secondaryId = 0,
     },
 
     [ITEM_048] =
@@ -968,9 +908,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
 // Battle items
@@ -982,11 +921,10 @@ const struct Item gItems[] =
         .price = 700,
         .description = sGuardSpecDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .battleUsage = 2,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_StatIncrease,
-        .secondaryId = 0,
     },
 
     [ITEM_DIRE_HIT] =
@@ -996,11 +934,10 @@ const struct Item gItems[] =
         .price = 650,
         .description = sDireHitDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .battleUsage = 2,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_StatIncrease,
-        .secondaryId = 0,
     },
 
     [ITEM_X_ATTACK] =
@@ -1010,11 +947,10 @@ const struct Item gItems[] =
         .price = 500,
         .description = sXAttackDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .battleUsage = 2,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_StatIncrease,
-        .secondaryId = 0,
     },
 
     [ITEM_X_DEFEND] =
@@ -1024,11 +960,10 @@ const struct Item gItems[] =
         .price = 550,
         .description = sXDefendDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .battleUsage = 2,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_StatIncrease,
-        .secondaryId = 0,
     },
 
     [ITEM_X_SPEED] =
@@ -1038,11 +973,10 @@ const struct Item gItems[] =
         .price = 350,
         .description = sXSpeedDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .battleUsage = 2,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_StatIncrease,
-        .secondaryId = 0,
     },
 
     [ITEM_X_ACCURACY] =
@@ -1052,11 +986,10 @@ const struct Item gItems[] =
         .price = 950,
         .description = sXAccuracyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .battleUsage = 2,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_StatIncrease,
-        .secondaryId = 0,
     },
 
     [ITEM_X_SPECIAL] =
@@ -1066,11 +999,10 @@ const struct Item gItems[] =
         .price = 350,
         .description = sXSpecialDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .battleUsage = 2,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_StatIncrease,
-        .secondaryId = 0,
     },
 
     [ITEM_POKE_DOLL] =
@@ -1080,11 +1012,10 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sPokeDollDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .battleUsage = 2,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_Escape,
-        .secondaryId = 0,
     },
 
     [ITEM_FLUFFY_TAIL] =
@@ -1094,11 +1025,10 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sFluffyTailDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .battleUsage = 2,
+        .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_Escape,
-        .secondaryId = 0,
     },
 
     [ITEM_052] =
@@ -1108,9 +1038,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
 // Field items
@@ -1123,9 +1052,8 @@ const struct Item gItems[] =
         .holdEffectParam = 200,
         .description = sSuperRepelDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Repel,
-        .secondaryId = 0,
     },
 
     [ITEM_MAX_REPEL] =
@@ -1136,9 +1064,8 @@ const struct Item gItems[] =
         .holdEffectParam = 250,
         .description = sMaxRepelDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Repel,
-        .secondaryId = 0,
     },
 
     [ITEM_ESCAPE_ROPE] =
@@ -1148,9 +1075,8 @@ const struct Item gItems[] =
         .price = 550,
         .description = sEscapeRopeDesc,
         .pocket = POCKET_ITEMS,
-        .type = 2,
+        .type = ITEM_USE_FIELD,
         .fieldUseFunc = ItemUseOutOfBattle_EscapeRope,
-        .secondaryId = 0,
     },
 
     [ITEM_REPEL] =
@@ -1161,9 +1087,8 @@ const struct Item gItems[] =
         .holdEffectParam = 100,
         .description = sRepelDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Repel,
-        .secondaryId = 0,
     },
 
     [ITEM_057] =
@@ -1173,9 +1098,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_058] =
@@ -1185,9 +1109,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_059] =
@@ -1197,9 +1120,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_05A] =
@@ -1209,9 +1131,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_05B] =
@@ -1221,9 +1142,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_05C] =
@@ -1233,9 +1153,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
 // Evolution stones
@@ -1247,9 +1166,8 @@ const struct Item gItems[] =
         .price = 2100,
         .description = sSunStoneDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_EvolutionStone,
-        .secondaryId = 0,
     },
 
     [ITEM_MOON_STONE] =
@@ -1259,9 +1177,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sMoonStoneDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_EvolutionStone,
-        .secondaryId = 0,
     },
 
     [ITEM_FIRE_STONE] =
@@ -1271,9 +1188,8 @@ const struct Item gItems[] =
         .price = 2100,
         .description = sFireStoneDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_EvolutionStone,
-        .secondaryId = 0,
     },
 
     [ITEM_THUNDER_STONE] =
@@ -1283,9 +1199,8 @@ const struct Item gItems[] =
         .price = 2100,
         .description = sThunderStoneDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_EvolutionStone,
-        .secondaryId = 0,
     },
 
     [ITEM_WATER_STONE] =
@@ -1295,9 +1210,8 @@ const struct Item gItems[] =
         .price = 2100,
         .description = sWaterStoneDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_EvolutionStone,
-        .secondaryId = 0,
     },
 
     [ITEM_LEAF_STONE] =
@@ -1307,9 +1221,8 @@ const struct Item gItems[] =
         .price = 2100,
         .description = sLeafStoneDesc,
         .pocket = POCKET_ITEMS,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_EvolutionStone,
-        .secondaryId = 0,
     },
 
     [ITEM_063] =
@@ -1319,9 +1232,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_064] =
@@ -1331,9 +1243,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_065] =
@@ -1343,9 +1254,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_066] =
@@ -1355,9 +1265,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
 // Valuable items
@@ -1369,9 +1278,8 @@ const struct Item gItems[] =
         .price = 500,
         .description = sTinyMushroomDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_BIG_MUSHROOM] =
@@ -1381,9 +1289,8 @@ const struct Item gItems[] =
         .price = 5000,
         .description = sBigMushroomDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_069] =
@@ -1393,9 +1300,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_PEARL] =
@@ -1405,9 +1311,8 @@ const struct Item gItems[] =
         .price = 1400,
         .description = sPearlDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_BIG_PEARL] =
@@ -1417,9 +1322,8 @@ const struct Item gItems[] =
         .price = 7500,
         .description = sBigPearlDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_STARDUST] =
@@ -1429,9 +1333,8 @@ const struct Item gItems[] =
         .price = 2000,
         .description = sStardustDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_STAR_PIECE] =
@@ -1441,9 +1344,8 @@ const struct Item gItems[] =
         .price = 9800,
         .description = sStarPieceDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_NUGGET] =
@@ -1453,9 +1355,8 @@ const struct Item gItems[] =
         .price = 10000,
         .description = sNuggetDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_HEART_SCALE] =
@@ -1465,9 +1366,8 @@ const struct Item gItems[] =
         .price = 100,
         .description = sHeartScaleDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_070] =
@@ -1477,9 +1377,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_071] =
@@ -1489,9 +1388,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_072] =
@@ -1501,9 +1399,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_073] =
@@ -1513,9 +1410,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_074] =
@@ -1525,9 +1421,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_075] =
@@ -1537,9 +1432,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_076] =
@@ -1549,9 +1443,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_077] =
@@ -1561,9 +1454,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_078] =
@@ -1573,9 +1465,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
 // Mail
@@ -1586,9 +1477,9 @@ const struct Item gItems[] =
         .price = 50,
         .description = sOrangeMailDesc,
         .pocket = POCKET_ITEMS,
-        .type = 0,
+        .type = ITEM_USE_MAIL,
         .fieldUseFunc = ItemUseOutOfBattle_Mail,
-        .secondaryId = 0,
+        .secondaryId = ITEM_ORANGE_MAIL - FIRST_MAIL_INDEX,
     },
 
     [ITEM_HARBOR_MAIL] =
@@ -1598,9 +1489,9 @@ const struct Item gItems[] =
         .price = 50,
         .description = sHarborMailDesc,
         .pocket = POCKET_ITEMS,
-        .type = 0,
+        .type = ITEM_USE_MAIL,
         .fieldUseFunc = ItemUseOutOfBattle_Mail,
-        .secondaryId = 1,
+        .secondaryId = ITEM_HARBOR_MAIL - FIRST_MAIL_INDEX,
     },
 
     [ITEM_GLITTER_MAIL] =
@@ -1610,9 +1501,9 @@ const struct Item gItems[] =
         .price = 50,
         .description = sGlitterMailDesc,
         .pocket = POCKET_ITEMS,
-        .type = 0,
+        .type = ITEM_USE_MAIL,
         .fieldUseFunc = ItemUseOutOfBattle_Mail,
-        .secondaryId = 2,
+        .secondaryId = ITEM_GLITTER_MAIL - FIRST_MAIL_INDEX,
     },
 
     [ITEM_MECH_MAIL] =
@@ -1622,9 +1513,9 @@ const struct Item gItems[] =
         .price = 50,
         .description = sMechMailDesc,
         .pocket = POCKET_ITEMS,
-        .type = 0,
+        .type = ITEM_USE_MAIL,
         .fieldUseFunc = ItemUseOutOfBattle_Mail,
-        .secondaryId = 3,
+        .secondaryId = ITEM_MECH_MAIL - FIRST_MAIL_INDEX,
     },
 
     [ITEM_WOOD_MAIL] =
@@ -1634,9 +1525,9 @@ const struct Item gItems[] =
         .price = 50,
         .description = sWoodMailDesc,
         .pocket = POCKET_ITEMS,
-        .type = 0,
+        .type = ITEM_USE_MAIL,
         .fieldUseFunc = ItemUseOutOfBattle_Mail,
-        .secondaryId = 4,
+        .secondaryId = ITEM_WOOD_MAIL - FIRST_MAIL_INDEX,
     },
 
     [ITEM_WAVE_MAIL] =
@@ -1646,9 +1537,9 @@ const struct Item gItems[] =
         .price = 50,
         .description = sWaveMailDesc,
         .pocket = POCKET_ITEMS,
-        .type = 0,
+        .type = ITEM_USE_MAIL,
         .fieldUseFunc = ItemUseOutOfBattle_Mail,
-        .secondaryId = 5,
+        .secondaryId = ITEM_WAVE_MAIL - FIRST_MAIL_INDEX,
     },
 
     [ITEM_BEAD_MAIL] =
@@ -1658,9 +1549,9 @@ const struct Item gItems[] =
         .price = 50,
         .description = sBeadMailDesc,
         .pocket = POCKET_ITEMS,
-        .type = 0,
+        .type = ITEM_USE_MAIL,
         .fieldUseFunc = ItemUseOutOfBattle_Mail,
-        .secondaryId = 6,
+        .secondaryId = ITEM_BEAD_MAIL - FIRST_MAIL_INDEX,
     },
 
     [ITEM_SHADOW_MAIL] =
@@ -1670,9 +1561,9 @@ const struct Item gItems[] =
         .price = 50,
         .description = sShadowMailDesc,
         .pocket = POCKET_ITEMS,
-        .type = 0,
+        .type = ITEM_USE_MAIL,
         .fieldUseFunc = ItemUseOutOfBattle_Mail,
-        .secondaryId = 7,
+        .secondaryId = ITEM_SHADOW_MAIL - FIRST_MAIL_INDEX,
     },
 
     [ITEM_TROPIC_MAIL] =
@@ -1682,9 +1573,9 @@ const struct Item gItems[] =
         .price = 50,
         .description = sTropicMailDesc,
         .pocket = POCKET_ITEMS,
-        .type = 0,
+        .type = ITEM_USE_MAIL,
         .fieldUseFunc = ItemUseOutOfBattle_Mail,
-        .secondaryId = 8,
+        .secondaryId = ITEM_TROPIC_MAIL - FIRST_MAIL_INDEX,
     },
 
     [ITEM_DREAM_MAIL] =
@@ -1694,9 +1585,9 @@ const struct Item gItems[] =
         .price = 50,
         .description = sDreamMailDesc,
         .pocket = POCKET_ITEMS,
-        .type = 0,
+        .type = ITEM_USE_MAIL,
         .fieldUseFunc = ItemUseOutOfBattle_Mail,
-        .secondaryId = 9,
+        .secondaryId = ITEM_DREAM_MAIL - FIRST_MAIL_INDEX,
     },
 
     [ITEM_FAB_MAIL] =
@@ -1706,9 +1597,9 @@ const struct Item gItems[] =
         .price = 50,
         .description = sFabMailDesc,
         .pocket = POCKET_ITEMS,
-        .type = 0,
+        .type = ITEM_USE_MAIL,
         .fieldUseFunc = ItemUseOutOfBattle_Mail,
-        .secondaryId = 10,
+        .secondaryId = ITEM_FAB_MAIL - FIRST_MAIL_INDEX,
     },
 
     [ITEM_RETRO_MAIL] =
@@ -1718,9 +1609,9 @@ const struct Item gItems[] =
         .price = 0,
         .description = sRetroMailDesc,
         .pocket = POCKET_ITEMS,
-        .type = 0,
+        .type = ITEM_USE_MAIL,
         .fieldUseFunc = ItemUseOutOfBattle_Mail,
-        .secondaryId = 11,
+        .secondaryId = ITEM_RETRO_MAIL - FIRST_MAIL_INDEX,
     },
 
 // Berries
@@ -1733,11 +1624,10 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_CURE_PAR,
         .description = sCheriBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_CHESTO_BERRY] =
@@ -1748,11 +1638,10 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_CURE_SLP,
         .description = sChestoBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_PECHA_BERRY] =
@@ -1763,11 +1652,10 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_CURE_PSN,
         .description = sPechaBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_RAWST_BERRY] =
@@ -1778,11 +1666,10 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_CURE_BRN,
         .description = sRawstBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_ASPEAR_BERRY] =
@@ -1793,11 +1680,10 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_CURE_FRZ,
         .description = sAspearBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_LEPPA_BERRY] =
@@ -1809,11 +1695,10 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sLeppaBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_PPRecovery,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_PPRecovery,
-        .secondaryId = 0,
     },
 
     [ITEM_ORAN_BERRY] =
@@ -1825,11 +1710,10 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sOranBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_PERSIM_BERRY] =
@@ -1840,11 +1724,10 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_CURE_CONFUSION,
         .description = sPersimBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_LUM_BERRY] =
@@ -1855,11 +1738,10 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_CURE_STATUS,
         .description = sLumBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_SITRUS_BERRY] =
@@ -1871,11 +1753,10 @@ const struct Item gItems[] =
         .holdEffectParam = 30,
         .description = sSitrusBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_Medicine,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_Medicine,
-        .secondaryId = 0,
     },
 
     [ITEM_FIGY_BERRY] =
@@ -1887,9 +1768,8 @@ const struct Item gItems[] =
         .holdEffectParam = 8,
         .description = sFigyBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_WIKI_BERRY] =
@@ -1901,9 +1781,8 @@ const struct Item gItems[] =
         .holdEffectParam = 8,
         .description = sWikiBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_MAGO_BERRY] =
@@ -1915,9 +1794,8 @@ const struct Item gItems[] =
         .holdEffectParam = 8,
         .description = sMagoBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_AGUAV_BERRY] =
@@ -1929,9 +1807,8 @@ const struct Item gItems[] =
         .holdEffectParam = 8,
         .description = sAguavBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_IAPAPA_BERRY] =
@@ -1943,9 +1820,8 @@ const struct Item gItems[] =
         .holdEffectParam = 8,
         .description = sIapapaBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_RAZZ_BERRY] =
@@ -1955,9 +1831,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sRazzBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_BLUK_BERRY] =
@@ -1967,9 +1842,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sBlukBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_NANAB_BERRY] =
@@ -1979,9 +1853,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sNanabBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_WEPEAR_BERRY] =
@@ -1991,9 +1864,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sWepearBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_PINAP_BERRY] =
@@ -2003,9 +1875,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sPinapBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_POMEG_BERRY] =
@@ -2015,9 +1886,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sPomegBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_ReduceEV,
-        .secondaryId = 0,
     },
 
     [ITEM_KELPSY_BERRY] =
@@ -2027,9 +1897,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sKelpsyBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_ReduceEV,
-        .secondaryId = 0,
     },
 
     [ITEM_QUALOT_BERRY] =
@@ -2039,9 +1908,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sQualotBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_ReduceEV,
-        .secondaryId = 0,
     },
 
     [ITEM_HONDEW_BERRY] =
@@ -2051,9 +1919,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sHondewBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_ReduceEV,
-        .secondaryId = 0,
     },
 
     [ITEM_GREPA_BERRY] =
@@ -2063,9 +1930,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sGrepaBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_ReduceEV,
-        .secondaryId = 0,
     },
 
     [ITEM_TAMATO_BERRY] =
@@ -2075,9 +1941,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sTamatoBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_ReduceEV,
-        .secondaryId = 0,
     },
 
     [ITEM_CORNN_BERRY] =
@@ -2087,9 +1952,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sCornnBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_MAGOST_BERRY] =
@@ -2099,9 +1963,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sMagostBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_RABUTA_BERRY] =
@@ -2111,9 +1974,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sRabutaBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_NOMEL_BERRY] =
@@ -2123,9 +1985,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sNomelBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SPELON_BERRY] =
@@ -2135,9 +1996,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sSpelonBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_PAMTRE_BERRY] =
@@ -2147,9 +2007,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sPamtreBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_WATMEL_BERRY] =
@@ -2159,9 +2018,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sWatmelBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_DURIN_BERRY] =
@@ -2171,9 +2029,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sDurinBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_BELUE_BERRY] =
@@ -2183,9 +2040,8 @@ const struct Item gItems[] =
         .price = 20,
         .description = sBelueBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_LIECHI_BERRY] =
@@ -2197,9 +2053,8 @@ const struct Item gItems[] =
         .holdEffectParam = 4,
         .description = sLiechiBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_GANLON_BERRY] =
@@ -2211,9 +2066,8 @@ const struct Item gItems[] =
         .holdEffectParam = 4,
         .description = sGanlonBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SALAC_BERRY] =
@@ -2225,9 +2079,8 @@ const struct Item gItems[] =
         .holdEffectParam = 4,
         .description = sSalacBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_PETAYA_BERRY] =
@@ -2239,9 +2092,8 @@ const struct Item gItems[] =
         .holdEffectParam = 4,
         .description = sPetayaBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_APICOT_BERRY] =
@@ -2253,9 +2105,8 @@ const struct Item gItems[] =
         .holdEffectParam = 4,
         .description = sApicotBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_LANSAT_BERRY] =
@@ -2267,9 +2118,8 @@ const struct Item gItems[] =
         .holdEffectParam = 4,
         .description = sLansatBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_STARF_BERRY] =
@@ -2281,9 +2131,8 @@ const struct Item gItems[] =
         .holdEffectParam = 4,
         .description = sStarfBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_ENIGMA_BERRY] =
@@ -2293,11 +2142,10 @@ const struct Item gItems[] =
         .price = 20,
         .description = sEnigmaBerryDesc,
         .pocket = POCKET_BERRIES,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU, // Type handled by ItemUseOutOfBattle_EnigmaBerry
         .fieldUseFunc = ItemUseOutOfBattle_EnigmaBerry,
-        .battleUsage = 1,
+        .battleUsage = ITEM_B_USE_MEDICINE,
         .battleUseFunc = ItemUseInBattle_EnigmaBerry,
-        .secondaryId = 0,
     },
 
     [ITEM_0B0] =
@@ -2307,9 +2155,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0B1] =
@@ -2319,9 +2166,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0B2] =
@@ -2331,9 +2177,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
 // Hold items
@@ -2347,9 +2192,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sBrightPowderDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_WHITE_HERB] =
@@ -2360,9 +2204,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_RESTORE_STATS,
         .description = sWhiteHerbDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_MACHO_BRACE] =
@@ -2373,9 +2216,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_MACHO_BRACE,
         .description = sMachoBraceDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_EXP_SHARE] =
@@ -2386,9 +2228,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_EXP_SHARE,
         .description = sExpShareDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_QUICK_CLAW] =
@@ -2400,9 +2241,8 @@ const struct Item gItems[] =
         .holdEffectParam = 20,
         .description = sQuickClawDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SOOTHE_BELL] =
@@ -2413,9 +2253,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_HAPPINESS_UP,
         .description = sSootheBellDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_MENTAL_HERB] =
@@ -2426,9 +2265,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_CURE_ATTRACT,
         .description = sMentalHerbDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_CHOICE_BAND] =
@@ -2439,9 +2277,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_CHOICE_BAND,
         .description = sChoiceBandDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_KINGS_ROCK] =
@@ -2453,9 +2290,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sKingsRockDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SILVER_POWDER] =
@@ -2467,9 +2303,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sSilverPowderDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_AMULET_COIN] =
@@ -2481,9 +2316,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sAmuletCoinDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_CLEANSE_TAG] =
@@ -2494,9 +2328,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_REPEL,
         .description = sCleanseTagDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SOUL_DEW] =
@@ -2507,9 +2340,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_SOUL_DEW,
         .description = sSoulDewDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_DEEP_SEA_TOOTH] =
@@ -2520,9 +2352,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_DEEP_SEA_TOOTH,
         .description = sDeepSeaToothDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_DEEP_SEA_SCALE] =
@@ -2533,9 +2364,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_DEEP_SEA_SCALE,
         .description = sDeepSeaScaleDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SMOKE_BALL] =
@@ -2546,9 +2376,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_CAN_ALWAYS_RUN,
         .description = sSmokeBallDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_EVERSTONE] =
@@ -2559,9 +2388,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_PREVENT_EVOLVE,
         .description = sEverstoneDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_FOCUS_BAND] =
@@ -2573,9 +2401,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sFocusBandDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_LUCKY_EGG] =
@@ -2586,9 +2413,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_LUCKY_EGG,
         .description = sLuckyEggDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SCOPE_LENS] =
@@ -2599,9 +2425,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_SCOPE_LENS,
         .description = sScopeLensDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_METAL_COAT] =
@@ -2613,9 +2438,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sMetalCoatDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_LEFTOVERS] =
@@ -2627,9 +2451,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sLeftoversDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_DRAGON_SCALE] =
@@ -2641,9 +2464,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sDragonScaleDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_LIGHT_BALL] =
@@ -2654,9 +2476,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_LIGHT_BALL,
         .description = sLightBallDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SOFT_SAND] =
@@ -2668,9 +2489,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sSoftSandDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_HARD_STONE] =
@@ -2682,9 +2502,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sHardStoneDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_MIRACLE_SEED] =
@@ -2696,9 +2515,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sMiracleSeedDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_BLACK_GLASSES] =
@@ -2710,9 +2528,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sBlackGlassesDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_BLACK_BELT] =
@@ -2724,9 +2541,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sBlackBeltDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_MAGNET] =
@@ -2738,9 +2554,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sMagnetDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_MYSTIC_WATER] =
@@ -2752,9 +2567,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sMysticWaterDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SHARP_BEAK] =
@@ -2766,9 +2580,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sSharpBeakDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_POISON_BARB] =
@@ -2780,9 +2593,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sPoisonBarbDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_NEVER_MELT_ICE] =
@@ -2794,9 +2606,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sNeverMeltIceDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SPELL_TAG] =
@@ -2808,9 +2619,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sSpellTagDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_TWISTED_SPOON] =
@@ -2822,9 +2632,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sTwistedSpoonDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_CHARCOAL] =
@@ -2836,9 +2645,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sCharcoalDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_DRAGON_FANG] =
@@ -2850,9 +2658,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sDragonFangDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SILK_SCARF] =
@@ -2864,9 +2671,8 @@ const struct Item gItems[] =
         .holdEffectParam = 10,
         .description = sSilkScarfDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_UP_GRADE] =
@@ -2877,9 +2683,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_UP_GRADE,
         .description = sUpGradeDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SHELL_BELL] =
@@ -2891,9 +2696,8 @@ const struct Item gItems[] =
         .holdEffectParam = 8,
         .description = sShellBellDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SEA_INCENSE] =
@@ -2905,9 +2709,8 @@ const struct Item gItems[] =
         .holdEffectParam = 5,
         .description = sSeaIncenseDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_LAX_INCENSE] =
@@ -2919,9 +2722,8 @@ const struct Item gItems[] =
         .holdEffectParam = 5,
         .description = sLaxIncenseDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_LUCKY_PUNCH] =
@@ -2932,9 +2734,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_LUCKY_PUNCH,
         .description = sLuckyPunchDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_METAL_POWDER] =
@@ -2945,9 +2746,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_METAL_POWDER,
         .description = sMetalPowderDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_THICK_CLUB] =
@@ -2958,9 +2758,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_THICK_CLUB,
         .description = sThickClubDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_STICK] =
@@ -2971,9 +2770,8 @@ const struct Item gItems[] =
         .holdEffect = HOLD_EFFECT_STICK,
         .description = sStickDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0E2] =
@@ -2983,9 +2781,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0E3] =
@@ -2995,9 +2792,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0E4] =
@@ -3007,9 +2803,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0E5] =
@@ -3019,9 +2814,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0E6] =
@@ -3031,9 +2825,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0E7] =
@@ -3043,9 +2836,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0E8] =
@@ -3055,9 +2847,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0E9] =
@@ -3067,9 +2858,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0EA] =
@@ -3079,9 +2869,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0EB] =
@@ -3091,9 +2880,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0EC] =
@@ -3103,9 +2891,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0ED] =
@@ -3115,9 +2902,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0EE] =
@@ -3127,9 +2913,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0EF] =
@@ -3139,9 +2924,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0F0] =
@@ -3151,9 +2935,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0F1] =
@@ -3163,9 +2946,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0F2] =
@@ -3175,9 +2957,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0F3] =
@@ -3187,9 +2968,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0F4] =
@@ -3199,9 +2979,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0F5] =
@@ -3211,9 +2990,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0F6] =
@@ -3223,9 +3001,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0F7] =
@@ -3235,9 +3012,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0F8] =
@@ -3247,9 +3023,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0F9] =
@@ -3259,9 +3034,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0FA] =
@@ -3271,9 +3045,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0FB] =
@@ -3283,9 +3056,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0FC] =
@@ -3295,9 +3067,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_0FD] =
@@ -3307,9 +3078,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_RED_SCARF] =
@@ -3319,9 +3089,8 @@ const struct Item gItems[] =
         .price = 100,
         .description = sRedScarfDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_BLUE_SCARF] =
@@ -3331,9 +3100,8 @@ const struct Item gItems[] =
         .price = 100,
         .description = sBlueScarfDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_PINK_SCARF] =
@@ -3343,9 +3111,8 @@ const struct Item gItems[] =
         .price = 100,
         .description = sPinkScarfDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_GREEN_SCARF] =
@@ -3355,9 +3122,8 @@ const struct Item gItems[] =
         .price = 100,
         .description = sGreenScarfDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_YELLOW_SCARF] =
@@ -3367,9 +3133,8 @@ const struct Item gItems[] =
         .price = 100,
         .description = sYellowScarfDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
 // Key items
@@ -3383,9 +3148,9 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 2,
+        .type = ITEM_USE_FIELD,
         .fieldUseFunc = ItemUseOutOfBattle_Bike,
-        .secondaryId = 0,
+        .secondaryId = MACH_BIKE,
     },
 
     [ITEM_COIN_CASE] =
@@ -3396,9 +3161,8 @@ const struct Item gItems[] =
         .description = sCoinCaseDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CoinCase,
-        .secondaryId = 0,
     },
 
     [ITEM_ITEMFINDER] =
@@ -3410,9 +3174,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 2,
+        .type = ITEM_USE_FIELD,
         .fieldUseFunc = ItemUseOutOfBattle_Itemfinder,
-        .secondaryId = 0,
     },
 
     [ITEM_OLD_ROD] =
@@ -3424,7 +3187,7 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 2,
+        .type = ITEM_USE_FIELD,
         .fieldUseFunc = ItemUseOutOfBattle_Rod,
         .secondaryId = OLD_ROD,
     },
@@ -3438,7 +3201,7 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 2,
+        .type = ITEM_USE_FIELD,
         .fieldUseFunc = ItemUseOutOfBattle_Rod,
         .secondaryId = GOOD_ROD,
     },
@@ -3452,7 +3215,7 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 2,
+        .type = ITEM_USE_FIELD,
         .fieldUseFunc = ItemUseOutOfBattle_Rod,
         .secondaryId = SUPER_ROD,
     },
@@ -3465,9 +3228,8 @@ const struct Item gItems[] =
         .description = sSSTicketDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_CONTEST_PASS] =
@@ -3478,9 +3240,8 @@ const struct Item gItems[] =
         .description = sContestPassDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_10B] =
@@ -3490,9 +3251,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_WAILMER_PAIL] =
@@ -3503,9 +3263,8 @@ const struct Item gItems[] =
         .description = sWailmerPailDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 2,
+        .type = ITEM_USE_FIELD,
         .fieldUseFunc = ItemUseOutOfBattle_WailmerPail,
-        .secondaryId = 0,
     },
 
     [ITEM_DEVON_GOODS] =
@@ -3516,9 +3275,8 @@ const struct Item gItems[] =
         .description = sDevonGoodsDesc,
         .importance = 2,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SOOT_SACK] =
@@ -3529,9 +3287,8 @@ const struct Item gItems[] =
         .description = sSootSackDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_BASEMENT_KEY] =
@@ -3542,9 +3299,8 @@ const struct Item gItems[] =
         .description = sBasementKeyDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_ACRO_BIKE] =
@@ -3556,9 +3312,9 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 2,
+        .type = ITEM_USE_FIELD,
         .fieldUseFunc = ItemUseOutOfBattle_Bike,
-        .secondaryId = 1,
+        .secondaryId = ACRO_BIKE,
     },
 
     [ITEM_POKEBLOCK_CASE] =
@@ -3570,9 +3326,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 3,
+        .type = ITEM_USE_PBLOCK_CASE,
         .fieldUseFunc = ItemUseOutOfBattle_PokeblockCase,
-        .secondaryId = 0,
     },
 
     [ITEM_LETTER] =
@@ -3583,9 +3338,8 @@ const struct Item gItems[] =
         .description = sLetterDesc,
         .importance = 2,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_EON_TICKET] =
@@ -3596,7 +3350,7 @@ const struct Item gItems[] =
         .description = sEonTicketDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
         .secondaryId = 1,
     },
@@ -3609,9 +3363,8 @@ const struct Item gItems[] =
         .description = sRedOrbDesc,
         .importance = 2,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_BLUE_ORB] =
@@ -3622,9 +3375,8 @@ const struct Item gItems[] =
         .description = sBlueOrbDesc,
         .importance = 2,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SCANNER] =
@@ -3635,9 +3387,8 @@ const struct Item gItems[] =
         .description = sScannerDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_GO_GOGGLES] =
@@ -3648,9 +3399,8 @@ const struct Item gItems[] =
         .description = sGoGogglesDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_METEORITE] =
@@ -3661,9 +3411,8 @@ const struct Item gItems[] =
         .description = sMeteoriteDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_ROOM_1_KEY] =
@@ -3674,9 +3423,8 @@ const struct Item gItems[] =
         .description = sRoom1KeyDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_ROOM_2_KEY] =
@@ -3687,9 +3435,8 @@ const struct Item gItems[] =
         .description = sRoom2KeyDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_ROOM_4_KEY] =
@@ -3700,9 +3447,8 @@ const struct Item gItems[] =
         .description = sRoom4KeyDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_ROOM_6_KEY] =
@@ -3713,9 +3459,8 @@ const struct Item gItems[] =
         .description = sRoom6KeyDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_STORAGE_KEY] =
@@ -3726,9 +3471,8 @@ const struct Item gItems[] =
         .description = sStorageKeyDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_ROOT_FOSSIL] =
@@ -3739,9 +3483,8 @@ const struct Item gItems[] =
         .description = sRootFossilDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_CLAW_FOSSIL] =
@@ -3752,9 +3495,8 @@ const struct Item gItems[] =
         .description = sClawFossilDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_DEVON_SCOPE] =
@@ -3765,9 +3507,8 @@ const struct Item gItems[] =
         .description = sDevonScopeDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
 // TMs/HMs
@@ -3779,9 +3520,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM01Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM02_DRAGON_CLAW] =
@@ -3791,9 +3531,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM02Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM03_WATER_PULSE] =
@@ -3803,9 +3542,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM03Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM04_CALM_MIND] =
@@ -3815,9 +3553,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM04Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM05_ROAR] =
@@ -3827,9 +3564,8 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sTM05Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM06_TOXIC] =
@@ -3839,9 +3575,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM06Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM07_HAIL] =
@@ -3851,9 +3586,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM07Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM08_BULK_UP] =
@@ -3863,9 +3597,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM08Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM09_BULLET_SEED] =
@@ -3875,9 +3608,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM09Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM10_HIDDEN_POWER] =
@@ -3887,9 +3619,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM10Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM11_SUNNY_DAY] =
@@ -3899,9 +3630,8 @@ const struct Item gItems[] =
         .price = 2000,
         .description = sTM11Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM12_TAUNT] =
@@ -3911,9 +3641,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM12Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM13_ICE_BEAM] =
@@ -3923,9 +3652,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM13Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM14_BLIZZARD] =
@@ -3935,9 +3663,8 @@ const struct Item gItems[] =
         .price = 5500,
         .description = sTM14Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM15_HYPER_BEAM] =
@@ -3947,9 +3674,8 @@ const struct Item gItems[] =
         .price = 7500,
         .description = sTM15Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM16_LIGHT_SCREEN] =
@@ -3959,9 +3685,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM16Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM17_PROTECT] =
@@ -3971,9 +3696,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM17Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM18_RAIN_DANCE] =
@@ -3983,9 +3707,8 @@ const struct Item gItems[] =
         .price = 2000,
         .description = sTM18Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM19_GIGA_DRAIN] =
@@ -3995,9 +3718,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM19Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM20_SAFEGUARD] =
@@ -4007,9 +3729,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM20Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM21_FRUSTRATION] =
@@ -4019,9 +3740,8 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sTM21Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM22_SOLARBEAM] =
@@ -4031,9 +3751,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM22Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM23_IRON_TAIL] =
@@ -4043,9 +3762,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM23Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM24_THUNDERBOLT] =
@@ -4055,9 +3773,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM24Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM25_THUNDER] =
@@ -4067,9 +3784,8 @@ const struct Item gItems[] =
         .price = 5500,
         .description = sTM25Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM26_EARTHQUAKE] =
@@ -4079,9 +3795,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM26Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM27_RETURN] =
@@ -4091,9 +3806,8 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sTM27Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM28_DIG] =
@@ -4103,9 +3817,8 @@ const struct Item gItems[] =
         .price = 2000,
         .description = sTM28Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM29_PSYCHIC] =
@@ -4115,9 +3828,8 @@ const struct Item gItems[] =
         .price = 2000,
         .description = sTM29Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM30_SHADOW_BALL] =
@@ -4127,9 +3839,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM30Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM31_BRICK_BREAK] =
@@ -4139,9 +3850,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM31Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM32_DOUBLE_TEAM] =
@@ -4151,9 +3861,8 @@ const struct Item gItems[] =
         .price = 2000,
         .description = sTM32Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM33_REFLECT] =
@@ -4163,9 +3872,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM33Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM34_SHOCK_WAVE] =
@@ -4175,9 +3883,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM34Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM35_FLAMETHROWER] =
@@ -4187,9 +3894,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM35Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM36_SLUDGE_BOMB] =
@@ -4199,9 +3905,8 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sTM36Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM37_SANDSTORM] =
@@ -4211,9 +3916,8 @@ const struct Item gItems[] =
         .price = 2000,
         .description = sTM37Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM38_FIRE_BLAST] =
@@ -4223,9 +3927,8 @@ const struct Item gItems[] =
         .price = 5500,
         .description = sTM38Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM39_ROCK_TOMB] =
@@ -4235,9 +3938,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM39Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM40_AERIAL_ACE] =
@@ -4247,9 +3949,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM40Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM41_TORMENT] =
@@ -4259,9 +3960,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM41Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM42_FACADE] =
@@ -4271,9 +3971,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM42Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM43_SECRET_POWER] =
@@ -4283,9 +3982,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM43Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM44_REST] =
@@ -4295,9 +3993,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM44Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM45_ATTRACT] =
@@ -4307,9 +4004,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM45Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM46_THIEF] =
@@ -4319,9 +4015,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM46Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM47_STEEL_WING] =
@@ -4331,9 +4026,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM47Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM48_SKILL_SWAP] =
@@ -4343,9 +4037,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM48Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM49_SNATCH] =
@@ -4355,9 +4048,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM49Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_TM50_OVERHEAT] =
@@ -4367,9 +4059,8 @@ const struct Item gItems[] =
         .price = 3000,
         .description = sTM50Desc,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_HM01_CUT] =
@@ -4380,9 +4071,8 @@ const struct Item gItems[] =
         .description = sHM01Desc,
         .importance = 1,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_HM02_FLY] =
@@ -4393,9 +4083,8 @@ const struct Item gItems[] =
         .description = sHM02Desc,
         .importance = 1,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_HM03_SURF] =
@@ -4406,9 +4095,8 @@ const struct Item gItems[] =
         .description = sHM03Desc,
         .importance = 1,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_HM04_STRENGTH] =
@@ -4419,9 +4107,8 @@ const struct Item gItems[] =
         .description = sHM04Desc,
         .importance = 1,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_HM05_FLASH] =
@@ -4432,9 +4119,8 @@ const struct Item gItems[] =
         .description = sHM05Desc,
         .importance = 1,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_HM06_ROCK_SMASH] =
@@ -4445,9 +4131,8 @@ const struct Item gItems[] =
         .description = sHM06Desc,
         .importance = 1,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_HM07_WATERFALL] =
@@ -4458,9 +4143,8 @@ const struct Item gItems[] =
         .description = sHM07Desc,
         .importance = 1,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_HM08_DIVE] =
@@ -4471,9 +4155,8 @@ const struct Item gItems[] =
         .description = sHM08Desc,
         .importance = 1,
         .pocket = POCKET_TM_HM,
-        .type = 1,
+        .type = ITEM_USE_PARTY_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_TMHM,
-        .secondaryId = 0,
     },
 
     [ITEM_15B] =
@@ -4483,9 +4166,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_15C] =
@@ -4495,9 +4177,8 @@ const struct Item gItems[] =
         .price = 0,
         .description = sDummyDesc,
         .pocket = POCKET_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
 // FireRed/LeafGreen key items
@@ -4510,9 +4191,8 @@ const struct Item gItems[] =
         .description = sOaksParcelDesc,
         .importance = 2,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_POKE_FLUTE] =
@@ -4523,9 +4203,8 @@ const struct Item gItems[] =
         .description = sPokeFluteDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SECRET_KEY] =
@@ -4536,9 +4215,8 @@ const struct Item gItems[] =
         .description = sSecretKeyDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_BIKE_VOUCHER] =
@@ -4549,9 +4227,8 @@ const struct Item gItems[] =
         .description = sBikeVoucherDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_GOLD_TEETH] =
@@ -4562,9 +4239,8 @@ const struct Item gItems[] =
         .description = sGoldTeethDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_OLD_AMBER] =
@@ -4575,9 +4251,8 @@ const struct Item gItems[] =
         .description = sOldAmberDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_CARD_KEY] =
@@ -4588,9 +4263,8 @@ const struct Item gItems[] =
         .description = sCardKeyDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_LIFT_KEY] =
@@ -4601,9 +4275,8 @@ const struct Item gItems[] =
         .description = sLiftKeyDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_HELIX_FOSSIL] =
@@ -4614,9 +4287,8 @@ const struct Item gItems[] =
         .description = sHelixFossilDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_DOME_FOSSIL] =
@@ -4627,9 +4299,8 @@ const struct Item gItems[] =
         .description = sDomeFossilDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SILPH_SCOPE] =
@@ -4640,9 +4311,8 @@ const struct Item gItems[] =
         .description = sSilphScopeDesc,
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_BICYCLE] =
@@ -4654,9 +4324,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 2,
+        .type = ITEM_USE_FIELD,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_TOWN_MAP] =
@@ -4668,9 +4337,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_VS_SEEKER] =
@@ -4682,9 +4350,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 2,
+        .type = ITEM_USE_FIELD,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_FAME_CHECKER] =
@@ -4696,9 +4363,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_TM_CASE] =
@@ -4710,9 +4376,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_BERRY_POUCH] =
@@ -4724,9 +4389,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_TEACHY_TV] =
@@ -4738,9 +4402,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 2,
+        .type = ITEM_USE_FIELD,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_TRI_PASS] =
@@ -4752,9 +4415,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_RAINBOW_PASS] =
@@ -4766,9 +4428,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_TEA] =
@@ -4780,9 +4441,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_MYSTIC_TICKET] =
@@ -4794,9 +4454,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_AURORA_TICKET] =
@@ -4808,9 +4467,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_POWDER_JAR] =
@@ -4822,9 +4480,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_PowderJar,
-        .secondaryId = 0,
     },
 
     [ITEM_RUBY] =
@@ -4836,9 +4493,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_SAPPHIRE] =
@@ -4850,9 +4506,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
 // Emerald-specific key items
@@ -4866,9 +4521,8 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 
     [ITEM_OLD_SEA_MAP] =
@@ -4880,8 +4534,7 @@ const struct Item gItems[] =
         .importance = 1,
         .unk19 = 1,
         .pocket = POCKET_KEY_ITEMS,
-        .type = 4,
+        .type = ITEM_USE_BAG_MENU,
         .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
-        .secondaryId = 0,
     },
 };

--- a/src/data/items.h
+++ b/src/data/items.h
@@ -20,10 +20,10 @@ const struct Item gItems[] =
         .price = 0,
         .description = sMasterBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = ITEM_MASTER_BALL - 1,
+        .type = ITEM_MASTER_BALL - FIRST_BALL,
         .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = ITEM_MASTER_BALL - 1,
+        .secondaryId = ITEM_MASTER_BALL - FIRST_BALL,
     },
 
     [ITEM_ULTRA_BALL] =
@@ -33,10 +33,10 @@ const struct Item gItems[] =
         .price = 1200,
         .description = sUltraBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = ITEM_ULTRA_BALL - 1,
+        .type = ITEM_ULTRA_BALL - FIRST_BALL,
         .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = ITEM_ULTRA_BALL - 1,
+        .secondaryId = ITEM_ULTRA_BALL - FIRST_BALL,
     },
 
     [ITEM_GREAT_BALL] =
@@ -46,10 +46,10 @@ const struct Item gItems[] =
         .price = 600,
         .description = sGreatBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = ITEM_GREAT_BALL - 1,
+        .type = ITEM_GREAT_BALL - FIRST_BALL,
         .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = ITEM_GREAT_BALL - 1,
+        .secondaryId = ITEM_GREAT_BALL - FIRST_BALL,
     },
 
     [ITEM_POKE_BALL] =
@@ -59,10 +59,10 @@ const struct Item gItems[] =
         .price = 200,
         .description = sPokeBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = ITEM_POKE_BALL - 1,
+        .type = ITEM_POKE_BALL - FIRST_BALL,
         .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = ITEM_POKE_BALL - 1,
+        .secondaryId = ITEM_POKE_BALL - FIRST_BALL,
     },
 
     [ITEM_SAFARI_BALL] =
@@ -72,10 +72,10 @@ const struct Item gItems[] =
         .price = 0,
         .description = sSafariBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = ITEM_SAFARI_BALL - 1,
+        .type = ITEM_SAFARI_BALL - FIRST_BALL,
         .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = ITEM_SAFARI_BALL - 1,
+        .secondaryId = ITEM_SAFARI_BALL - FIRST_BALL,
     },
 
     [ITEM_NET_BALL] =
@@ -85,10 +85,10 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sNetBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = ITEM_NET_BALL - 1,
+        .type = ITEM_NET_BALL - FIRST_BALL,
         .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = ITEM_NET_BALL - 1,
+        .secondaryId = ITEM_NET_BALL - FIRST_BALL,
     },
 
     [ITEM_DIVE_BALL] =
@@ -98,10 +98,10 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sDiveBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = ITEM_DIVE_BALL - 1,
+        .type = ITEM_DIVE_BALL - FIRST_BALL,
         .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = ITEM_DIVE_BALL - 1,
+        .secondaryId = ITEM_DIVE_BALL - FIRST_BALL,
     },
 
     [ITEM_NEST_BALL] =
@@ -111,10 +111,10 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sNestBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = ITEM_NEST_BALL - 1,
+        .type = ITEM_NEST_BALL - FIRST_BALL,
         .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = ITEM_NEST_BALL - 1,
+        .secondaryId = ITEM_NEST_BALL - FIRST_BALL,
     },
 
     [ITEM_REPEAT_BALL] =
@@ -124,10 +124,10 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sRepeatBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = ITEM_REPEAT_BALL - 1,
+        .type = ITEM_REPEAT_BALL - FIRST_BALL,
         .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = ITEM_REPEAT_BALL - 1,
+        .secondaryId = ITEM_REPEAT_BALL - FIRST_BALL,
     },
 
     [ITEM_TIMER_BALL] =
@@ -137,10 +137,10 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sTimerBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = ITEM_TIMER_BALL - 1,
+        .type = ITEM_TIMER_BALL - FIRST_BALL,
         .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = ITEM_TIMER_BALL - 1,
+        .secondaryId = ITEM_TIMER_BALL - FIRST_BALL,
     },
 
     [ITEM_LUXURY_BALL] =
@@ -150,10 +150,10 @@ const struct Item gItems[] =
         .price = 1000,
         .description = sLuxuryBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = ITEM_LUXURY_BALL - 1,
+        .type = ITEM_LUXURY_BALL - FIRST_BALL,
         .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = ITEM_LUXURY_BALL - 1,
+        .secondaryId = ITEM_LUXURY_BALL - FIRST_BALL,
     },
 
     [ITEM_PREMIER_BALL] =
@@ -163,10 +163,10 @@ const struct Item gItems[] =
         .price = 200,
         .description = sPremierBallDesc,
         .pocket = POCKET_POKE_BALLS,
-        .type = ITEM_PREMIER_BALL - 1,
+        .type = ITEM_PREMIER_BALL - FIRST_BALL,
         .battleUsage = ITEM_B_USE_OTHER,
         .battleUseFunc = ItemUseInBattle_PokeBall,
-        .secondaryId = ITEM_PREMIER_BALL - 1,
+        .secondaryId = ITEM_PREMIER_BALL - FIRST_BALL,
     },
 
 // Medicine

--- a/src/decompress.c
+++ b/src/decompress.c
@@ -86,7 +86,7 @@ void LoadSpecialPokePic(const struct CompressedSpriteSheet *src, void *dest, s32
 {
     if (species == SPECIES_UNOWN)
     {
-        u16 i = (((personality & 0x3000000) >> 18) | ((personality & 0x30000) >> 12) | ((personality & 0x300) >> 6) | (personality & 3)) % 0x1C;
+        u16 i = GET_UNOWN_LETTER(personality);
 
         // The other Unowns are separate from Unown A.
         if (i == 0)
@@ -308,7 +308,7 @@ void LoadSpecialPokePic_2(const struct CompressedSpriteSheet *src, void *dest, s
 {
     if (species == SPECIES_UNOWN)
     {
-        u16 i = (((personality & 0x3000000) >> 18) | ((personality & 0x30000) >> 12) | ((personality & 0x300) >> 6) | (personality & 3)) % 0x1C;
+        u16 i = GET_UNOWN_LETTER(personality);
 
         // The other Unowns are separate from Unown A.
         if (i == 0)
@@ -366,7 +366,7 @@ void LoadSpecialPokePic_DontHandleDeoxys(const struct CompressedSpriteSheet *src
 {
     if (species == SPECIES_UNOWN)
     {
-        u16 i = (((personality & 0x3000000) >> 18) | ((personality & 0x30000) >> 12) | ((personality & 0x300) >> 6) | (personality & 3)) % 0x1C;
+        u16 i = GET_UNOWN_LETTER(personality);
 
         // The other Unowns are separate from Unown A.
         if (i == 0)

--- a/src/diploma.c
+++ b/src/diploma.c
@@ -168,7 +168,7 @@ static const struct BgTemplate sDiplomaBgTemplates[2] =
 static void InitDiplomaBg(void)
 {
     ResetBgsAndClearDma3BusyFlags(0);
-    InitBgsFromTemplates(0, sDiplomaBgTemplates, 2);
+    InitBgsFromTemplates(0, sDiplomaBgTemplates, ARRAY_COUNT(sDiplomaBgTemplates));
     SetBgTilemapBuffer(1, sDiplomaTilemapPtr);
     SetGpuReg(REG_OFFSET_DISPCNT, DISPCNT_OBJ_ON | DISPCNT_OBJ_1D_MAP);
     ShowBg(0);

--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -1513,9 +1513,9 @@ static void ShowLinkContestResultsWindow(void)
     AddTextPrinterParameterized(gRecordsWindowId, 1, gText_Smart, x, 89, TEXT_SPEED_FF, NULL);
     AddTextPrinterParameterized(gRecordsWindowId, 1, gText_Tough, x, 105, TEXT_SPEED_FF, NULL);
 
-    for (i = 0; i < 5; i++)
+    for (i = 0; i < CONTEST_CATEGORIES_COUNT; i++)
     {
-        for (j = 0; j < 4; j++)
+        for (j = 0; j < CONTESTANT_COUNT; j++)
         {
             ConvertIntToDecimalStringN(gStringVar4, gSaveBlock2Ptr->contestLinkResults[i][j], STR_CONV_MODE_RIGHT_ALIGN, 4);
             AddTextPrinterParameterized(gRecordsWindowId, 1, gStringVar4, (j * 38) + 64, (i * 16) + 41, TEXT_SPEED_FF, NULL);

--- a/src/item.c
+++ b/src/item.c
@@ -102,8 +102,8 @@ void CopyItemNameHandlePlural(u16 itemId, u8 *dst, u32 quantity)
     }
     else
     {
-        if (itemId >= ITEM_CHERI_BERRY && itemId <= ITEM_ENIGMA_BERRY)
-            GetBerryCountString(dst, gBerries[itemId - ITEM_CHERI_BERRY].name, quantity);
+        if (itemId >= FIRST_BERRY_INDEX && itemId <= LAST_BERRY_INDEX)
+            GetBerryCountString(dst, gBerries[itemId - FIRST_BERRY_INDEX].name, quantity);
         else
             StringCopy(dst, ItemId_GetName(itemId));
     }

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -1721,7 +1721,7 @@ void ItemMenu_UseOutOfBattle(u8 taskId)
     if (ItemId_GetFieldFunc(gSpecialVar_ItemId))
     {
         BagMenu_RemoveSomeWindow();
-        if (CalculatePlayerPartyCount() == 0 && ItemId_GetType(gSpecialVar_ItemId) == 1)
+        if (CalculatePlayerPartyCount() == 0 && ItemId_GetType(gSpecialVar_ItemId) == ITEM_USE_PARTY_MENU)
             BagMenu_PrintThereIsNoPokemon(taskId);
         else
         {

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -742,7 +742,7 @@ void BagMenu_InitBGs(void)
     ResetVramOamAndBgCntRegs();
     memset(gBagMenu->tilemapBuffer, 0, 0x800);
     ResetBgsAndClearDma3BusyFlags(0);
-    InitBgsFromTemplates(0, sBgTemplates_ItemMenu, 3);
+    InitBgsFromTemplates(0, sBgTemplates_ItemMenu, ARRAY_COUNT(sBgTemplates_ItemMenu));
     SetBgTilemapBuffer(2, gBagMenu->tilemapBuffer);
     ResetAllBgsCoordinates();
     ScheduleBgCopyTilemapToVram(2);

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -865,7 +865,7 @@ void GetItemName(s8 *dest, u16 itemId)
             }
             break;
         case BERRIES_POCKET:
-            ConvertIntToDecimalStringN(gStringVar1, itemId - ITEM_CHERI_BERRY + 1, STR_CONV_MODE_LEADING_ZEROS, 2);
+            ConvertIntToDecimalStringN(gStringVar1, itemId - FIRST_BERRY_INDEX + 1, STR_CONV_MODE_LEADING_ZEROS, 2);
             CopyItemName(itemId, gStringVar2);
             StringExpandPlaceholders(dest, gText_NumberVar1Clear7Var2);
             break;

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -77,13 +77,13 @@ EWRAM_DATA static void(*sItemUseOnFieldCB)(u8 taskId) = NULL;
 // Below is set TRUE by UseRegisteredKeyItemOnField
 #define tUsingRegisteredKeyItem  data[3]
 
-// .rodata
-
+// UB here if an item with type ITEM_USE_MAIL or ITEM_USE_BAG_MENU uses SetUpItemUseCallback
+// Never occurs in vanilla, but can occur with improperly created items
 static const MainCallback sItemUseCallbacks[] =
 {
-    CB2_ShowPartyMenuForItemUse,
-    CB2_ReturnToField,
-    NULL,
+    [ITEM_USE_PARTY_MENU - 1]  = CB2_ShowPartyMenuForItemUse,
+    [ITEM_USE_FIELD - 1]       = CB2_ReturnToField,
+    [ITEM_USE_PBLOCK_CASE - 1] = NULL,
 };
 
 static const u8 sClockwiseDirections[] = {DIR_NORTH, DIR_EAST, DIR_SOUTH, DIR_WEST};
@@ -94,13 +94,12 @@ static const struct YesNoFuncTable sUseTMHMYesNoFuncTable =
     .noFunc = BagMenu_InitListsMenu,
 };
 
-// .text
-
+#define tEnigmaBerryType data[4]
 static void SetUpItemUseCallback(u8 taskId)
 {
     u8 type;
     if (gSpecialVar_ItemId == ITEM_ENIGMA_BERRY)
-        type = gTasks[taskId].data[4] - 1;
+        type = gTasks[taskId].tEnigmaBerryType - 1;
     else
         type = ItemId_GetType(gSpecialVar_ItemId) - 1;
     if (!InBattlePyramid())
@@ -218,9 +217,9 @@ void ItemUseOutOfBattle_Bike(u8 taskId)
 
 static void ItemUseOnFieldCB_Bike(u8 taskId)
 {
-    if (!ItemId_GetSecondaryId(gSpecialVar_ItemId))
+    if (ItemId_GetSecondaryId(gSpecialVar_ItemId) == MACH_BIKE)
         GetOnOffBike(PLAYER_AVATAR_FLAG_MACH_BIKE);
-    else
+    else // ACRO_BIKE
         GetOnOffBike(PLAYER_AVATAR_FLAG_ACRO_BIKE);
     ScriptUnfreezeObjectEvents();
     ScriptContext2_Disable();
@@ -1065,28 +1064,28 @@ void ItemUseOutOfBattle_EnigmaBerry(u8 taskId)
     case ITEM_EFFECT_SPDEF_EV:
     case ITEM_EFFECT_SPEED_EV:
     case ITEM_EFFECT_DEF_EV:
-        gTasks[taskId].data[4] = 1;
+        gTasks[taskId].tEnigmaBerryType = ITEM_USE_PARTY_MENU;
         ItemUseOutOfBattle_Medicine(taskId);
         break;
     case ITEM_EFFECT_SACRED_ASH:
-        gTasks[taskId].data[4] = 1;
+        gTasks[taskId].tEnigmaBerryType = ITEM_USE_PARTY_MENU;
         ItemUseOutOfBattle_SacredAsh(taskId);
         break;
     case ITEM_EFFECT_RAISE_LEVEL:
-        gTasks[taskId].data[4] = 1;
+        gTasks[taskId].tEnigmaBerryType = ITEM_USE_PARTY_MENU;
         ItemUseOutOfBattle_RareCandy(taskId);
         break;
     case ITEM_EFFECT_PP_UP:
     case ITEM_EFFECT_PP_MAX:
-        gTasks[taskId].data[4] = 1;
+        gTasks[taskId].tEnigmaBerryType = ITEM_USE_PARTY_MENU;
         ItemUseOutOfBattle_PPUp(taskId);
         break;
     case ITEM_EFFECT_HEAL_PP:
-        gTasks[taskId].data[4] = 1;
+        gTasks[taskId].tEnigmaBerryType = ITEM_USE_PARTY_MENU;
         ItemUseOutOfBattle_PPRecovery(taskId);
         break;
     default:
-        gTasks[taskId].data[4] = 4;
+        gTasks[taskId].tEnigmaBerryType = ITEM_USE_BAG_MENU;
         ItemUseOutOfBattle_CannotUse(taskId);
         break;
     }

--- a/src/mail.c
+++ b/src/mail.c
@@ -125,7 +125,7 @@ static void CB2_ExitMailReadFreeVars(void);
 
 // .rodata
 
-static const struct BgTemplate sUnknown_0859F290[] = {
+static const struct BgTemplate sBgTemplates[] = {
     {
         .bg = 0,
         .charBaseIndex = 2,
@@ -336,7 +336,7 @@ static bool8 MailReadBuildGraphics(void)
             break;
         case 6:
             ResetBgsAndClearDma3BusyFlags(0);
-            InitBgsFromTemplates(0, sUnknown_0859F290, 3);
+            InitBgsFromTemplates(0, sBgTemplates, ARRAY_COUNT(sBgTemplates));
             SetBgTilemapBuffer(1, sMailRead->bg1TilemapBuffer);
             SetBgTilemapBuffer(2, sMailRead->bg2TilemapBuffer);
             break;

--- a/src/mail.c
+++ b/src/mail.c
@@ -254,7 +254,7 @@ void ReadMail(struct MailStruct *mail, void (*callback)(void), bool8 flag)
     sMailRead->parserMultiple = ConvertEasyChatWordsToString;
     if (IS_ITEM_MAIL(mail->itemId))
     {
-        sMailRead->mailType = mail->itemId - ITEM_ORANGE_MAIL;
+        sMailRead->mailType = mail->itemId - FIRST_MAIL_INDEX;
     }
     else
     {
@@ -279,10 +279,10 @@ void ReadMail(struct MailStruct *mail, void (*callback)(void), bool8 flag)
             default:
                 sMailRead->animsActive = 0;
                 break;
-            case ITEM_BEAD_MAIL - ITEM_ORANGE_MAIL:
+            case ITEM_BEAD_MAIL - FIRST_MAIL_INDEX:
                 sMailRead->animsActive = 1;
                 break;
-            case ITEM_DREAM_MAIL - ITEM_ORANGE_MAIL:
+            case ITEM_DREAM_MAIL - FIRST_MAIL_INDEX:
                 sMailRead->animsActive = 2;
                 break;
         }

--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -2097,7 +2097,7 @@ static void NewGameBirchSpeech_ShowGenderMenu(void)
 {
     DrawMainMenuWindowBorder(&gNewGameBirchSpeechTextWindows[1], 0xF3);
     FillWindowPixelBuffer(1, PIXEL_FILL(1));
-    PrintMenuTable(1, 2, sMenuActions_Gender);
+    PrintMenuTable(1, ARRAY_COUNT(sMenuActions_Gender), sMenuActions_Gender);
     InitMenuInUpperLeftCornerPlaySoundWhenAPressed(1, 2, 0);
     PutWindowTilemap(1);
     CopyWindowToVram(1, 3);

--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -1799,7 +1799,7 @@ static void CB2_NewGameBirchSpeech_ReturnFromNamingScreen(void)
     ResetBgsAndClearDma3BusyFlags(0);
     SetGpuReg(REG_OFFSET_DISPCNT, 0);
     SetGpuReg(REG_OFFSET_DISPCNT, DISPCNT_OBJ_ON | DISPCNT_OBJ_1D_MAP);
-    InitBgsFromTemplates(0, sMainMenuBgTemplates, 2);
+    InitBgsFromTemplates(0, sMainMenuBgTemplates, ARRAY_COUNT(sMainMenuBgTemplates));
     InitBgFromTemplate(&sBirchBgTemplate);
     SetVBlankCallback(NULL);
     SetGpuReg(REG_OFFSET_BG2CNT, 0);

--- a/src/mevent_server.c
+++ b/src/mevent_server.c
@@ -288,8 +288,8 @@ static u32 (*const func_tbl[])(struct mevent_srv_common *) = {
 static u32 mevent_srv_exec_common(struct mevent_srv_common * svr)
 {
     u32 response;
-    AGB_ASSERT(svr->mainseqno < NELEMS(func_tbl));
+    AGB_ASSERT(svr->mainseqno < ARRAY_COUNT(func_tbl));
     response = func_tbl[svr->mainseqno](svr);
-    AGB_ASSERT(svr->mainseqno < NELEMS(func_tbl));
+    AGB_ASSERT(svr->mainseqno < ARRAY_COUNT(func_tbl));
     return response;
 }

--- a/src/player_pc.c
+++ b/src/player_pc.c
@@ -443,7 +443,7 @@ static void InitItemStorageMenu(u8 taskId, u8 var)
     windowTemplate.width = GetMaxWidthInMenuTable(gPCText_ItemPCOptionsText, 4);
     data[4] = AddWindow(&windowTemplate);
     SetStandardWindowBorderStyle(data[4], 0);
-    PrintMenuTable(data[4], 4, gPCText_ItemPCOptionsText);
+    PrintMenuTable(data[4], ARRAY_COUNT(gPCText_ItemPCOptionsText), gPCText_ItemPCOptionsText);
     InitMenuInUpperLeftCornerPlaySoundWhenAPressed(data[4], 4, var);
     ScheduleBgCopyTilemapToVram(0);
     ItemStorageMenuPrint(gPCText_OptionDescList[var]);
@@ -686,7 +686,7 @@ static void Mailbox_ReturnToPlayerPC(u8 taskId)
 static void Mailbox_PrintMailOptions(u8 taskId)
 {
     u8 r4 = sub_81D1C84(2);
-    PrintMenuTable(r4, 4, gMailboxMailOptions);
+    PrintMenuTable(r4, ARRAY_COUNT(gMailboxMailOptions), gMailboxMailOptions);
     InitMenuInUpperLeftCornerPlaySoundWhenAPressed(r4, 4, 0);
     ScheduleBgCopyTilemapToVram(0);
     gTasks[taskId].func = Mailbox_MailOptionsProcessInput;

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -1373,7 +1373,7 @@ static const struct SearchOptionText sDexSearchColorOptions[] =
     {},
 };
 
-static const struct SearchOptionText sDexSearchTypeOptions[] =
+static const struct SearchOptionText sDexSearchTypeOptions[NUMBER_OF_MON_TYPES + 1] = // + 2 for "None" and terminator, - 1 for Mystery
 {
     {gText_DexEmptyString, gText_DexSearchTypeNone},
     {gText_DexEmptyString, gTypeNames[TYPE_NORMAL]},
@@ -1407,7 +1407,7 @@ static const u8 sOrderOptions[] =
     ORDER_SMALLEST,
 };
 
-static const u8 sDexSearchTypeIds[] =
+static const u8 sDexSearchTypeIds[NUMBER_OF_MON_TYPES] =
 {
     TYPE_NONE,
     TYPE_NORMAL,

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2304,14 +2304,14 @@ void CreateMonWithGenderNatureLetter(struct Pokemon *mon, u16 species, u8 level,
 {
     u32 personality;
 
-    if ((u8)(unownLetter - 1) < 28)
+    if ((u8)(unownLetter - 1) < NUM_UNOWN_FORMS)
     {
         u16 actualLetter;
 
         do
         {
             personality = Random32();
-            actualLetter = ((((personality & 0x3000000) >> 18) | ((personality & 0x30000) >> 12) | ((personality & 0x300) >> 6) | (personality & 0x3)) % 28);
+            actualLetter = GET_UNOWN_LETTER(personality);
         }
         while (nature != GetNatureFromPersonality(personality)
             || gender != GetGenderFromSpeciesAndPersonality(species, personality)

--- a/src/pokemon_icon.c
+++ b/src/pokemon_icon.c
@@ -1099,7 +1099,7 @@ u16 GetUnownLetterByPersonality(u32 personality)
     if (!personality)
         return 0;
     else
-        return (((personality & 0x3000000) >> 18) | ((personality & 0x30000) >> 12) | ((personality & 0x300) >> 6) | (personality & 0x3)) % 0x1C;
+        return GET_UNOWN_LETTER(personality);
 }
 
 u16 sub_80D2E84(u16 species)

--- a/src/pokenav_conditions_3.c
+++ b/src/pokenav_conditions_3.c
@@ -419,7 +419,7 @@ static u32 LoopedTask_OpenConditionSearchResults(s32 state)
     switch (state)
     {
     case 0:
-        InitBgTemplates(sConditionSearchResultBgTemplates, NELEMS(sConditionSearchResultBgTemplates));
+        InitBgTemplates(sConditionSearchResultBgTemplates, ARRAY_COUNT(sConditionSearchResultBgTemplates));
         DecompressAndCopyTileDataToVram(1, sConditionSearchResultTiles, 0, 0, 0);
         SetBgTilemapBuffer(1, searchList->buff);
         CopyToBgTilemapBuffer(1, sConditionSearchResultTilemap, 0, 0);

--- a/src/pokenav_menu_handler_2.c
+++ b/src/pokenav_menu_handler_2.c
@@ -750,7 +750,7 @@ static void LoadPokenavOptionPalettes(void)
 {
     s32 i;
 
-    for (i = 0; i < NELEMS(sPokenavOptionsSpriteSheets); i++)
+    for (i = 0; i < ARRAY_COUNT(sPokenavOptionsSpriteSheets); i++)
         LoadCompressedSpriteSheet(&sPokenavOptionsSpriteSheets[i]);
     Pokenav_AllocAndLoadPalettes(sPokenavOptionsSpritePalettes);
 }

--- a/src/pokenav_ribbons_1.c
+++ b/src/pokenav_ribbons_1.c
@@ -427,7 +427,7 @@ static u32 LoopedTask_OpenRibbonsMonList(s32 state)
     switch (state)
     {
     case 0:
-        InitBgTemplates(sMonRibbonListBgTemplates, NELEMS(sMonRibbonListBgTemplates));
+        InitBgTemplates(sMonRibbonListBgTemplates, ARRAY_COUNT(sMonRibbonListBgTemplates));
         DecompressAndCopyTileDataToVram(1, sMonRibbonListFrameTiles, 0, 0, 0);
         SetBgTilemapBuffer(1, monMenu->buff);
         CopyToBgTilemapBuffer(1, sMonRibbonListFrameTilemap, 0, 0);

--- a/src/region_map.c
+++ b/src/region_map.c
@@ -1677,7 +1677,7 @@ void CB2_OpenFlyMap(void)
         break;
     case 1:
         ResetBgsAndClearDma3BusyFlags(0);
-        InitBgsFromTemplates(1, sFlyMapBgTemplates, 3);
+        InitBgsFromTemplates(1, sFlyMapBgTemplates, ARRAY_COUNT(sFlyMapBgTemplates));
         gMain.state++;
         break;
     case 2:

--- a/src/save_failed_screen.c
+++ b/src/save_failed_screen.c
@@ -62,7 +62,7 @@ static const struct OamData sClockOamData =
     .affineParam = 0
 };
 
-static const struct BgTemplate gUnknown_085EFD88[3] =
+static const struct BgTemplate sBgTemplates[3] =
 {
     {
         .bg = 0,
@@ -212,7 +212,7 @@ static void CB2_SaveFailedScreen(void)
         LZ77UnCompVram(gBirchGrassTilemap, (void *)(BG_SCREEN_ADDR(15)));
         LZ77UnCompVram(sSaveFailedClockGfx, (void *)(VRAM + 0x10020));
         ResetBgsAndClearDma3BusyFlags(0);
-        InitBgsFromTemplates(0, gUnknown_085EFD88, 3);
+        InitBgsFromTemplates(0, sBgTemplates, ARRAY_COUNT(sBgTemplates));
         SetBgTilemapBuffer(0, (void *)&gDecompressionBuffer[0x2000]);
         CpuFill32(0, &gDecompressionBuffer[0x2000], 0x800);
         LoadBgTiles(0, gTextWindowFrame1_Gfx, 0x120, 0x214);

--- a/src/secret_base.c
+++ b/src/secret_base.c
@@ -996,7 +996,7 @@ static void ShowRegistryMenuActions(u8 taskId)
     template.width = GetMaxWidthInMenuTable(sRegistryMenuActions, 2);
     data[7] = AddWindow(&template);
     SetStandardWindowBorderStyle(data[7], 0);
-    PrintMenuTable(data[7], 2, sRegistryMenuActions);
+    PrintMenuTable(data[7], ARRAY_COUNT(sRegistryMenuActions), sRegistryMenuActions);
     InitMenuInUpperLeftCornerPlaySoundWhenAPressed(data[7], 2, 0);
     ScheduleBgCopyTilemapToVram(0);
     gTasks[taskId].func = HandleRegistryMenuActionsInput;


### PR DESCRIPTION
Miscellaneous fixes that had been "on the list" for a while.

- Use constants for item secondary IDs, "type", and battle usage
- Add some missing `ARRAY_COUNT` usage
- Use `GET_UNOWN_LETTER` generally instead of just in `battle_anim_mons.c`
- Add some other minor missing constant usage
- Fix a few bad script labels
- Note/fix a bug in AI script for Foresight