### PR TITLE
Make broader use of RGB macros

### DIFF
--- a/include/constants/rgb.h
+++ b/include/constants/rgb.h
@@ -10,7 +10,7 @@
 #define _RGB(r, g, b) ((((b) & 0x1F) << 10) + (((g) & 0x1F) << 5) + ((r) & 0x1F))
 
 #define RGB_ALPHA       (1 << 15)
-#define IS_ALPHA(color) (color & RGB_ALPHA)
+#define IS_ALPHA(color) ((color) & RGB_ALPHA)
 
 #define RGB_BLACK      RGB(0, 0, 0)
 #define RGB_WHITE      RGB(31, 31, 31)

--- a/include/constants/rgb.h
+++ b/include/constants/rgb.h
@@ -5,18 +5,21 @@
 #define GET_G(color) (((color) >> 5) & 0x1F)
 #define GET_B(color) (((color) >> 10) & 0x1F)
 
-#define RGB(r, g, b) ((r) | ((g) << 5) | ((b) << 10))
+#define RGB(r, g, b)  ((r) | ((g) << 5) | ((b) << 10))
 #define RGB2(r, g, b) (((b) << 10) | ((g) << 5) | (r))
 #define _RGB(r, g, b) ((((b) & 0x1F) << 10) + (((g) & 0x1F) << 5) + ((r) & 0x1F))
 
-#define RGB_BLACK RGB(0, 0, 0)
-#define RGB_WHITE RGB(31, 31, 31)
-#define RGB_RED RGB(31, 0, 0)
-#define RGB_GREEN RGB(0, 31, 0)
-#define RGB_BLUE RGB(0, 0, 31)
-#define RGB_YELLOW RGB(31, 31, 0)
-#define RGB_MAGENTA RGB(31, 0, 31)
-#define RGB_CYAN RGB(0, 31, 31)
-#define RGB_WHITEALPHA (RGB_WHITE | 0x8000)
+#define RGB_ALPHA       (1 << 15)
+#define IS_ALPHA(color) (color & RGB_ALPHA)
+
+#define RGB_BLACK      RGB(0, 0, 0)
+#define RGB_WHITE      RGB(31, 31, 31)
+#define RGB_RED        RGB(31, 0, 0)
+#define RGB_GREEN      RGB(0, 31, 0)
+#define RGB_BLUE       RGB(0, 0, 31)
+#define RGB_YELLOW     RGB(31, 31, 0)
+#define RGB_MAGENTA    RGB(31, 0, 31)
+#define RGB_CYAN       RGB(0, 31, 31)
+#define RGB_WHITEALPHA (RGB_WHITE | RGB_ALPHA)
 
 #endif // GUARD_RGB_H

--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -934,43 +934,43 @@ void FreeResourcesAndDestroySprite(struct Sprite *sprite, u8 spriteId)
 // r, g, b are between 0 and 16
 void MultiplyInvertedPaletteRGBComponents(u16 i, u8 r, u8 g, u8 b)
 {
-    int curRed;
-    int curGreen;
-    int curBlue;
-    u16 outPal;
-
-    outPal = gPlttBufferUnfaded[i];
-    curRed = outPal & 0x1f;
-    curGreen = (outPal & (0x1f << 5)) >> 5;
-    curBlue = (outPal & (0x1f << 10)) >> 10;
-    curRed += (((0x1f - curRed) * r) >> 4);
-    curGreen += (((0x1f - curGreen) * g) >> 4);
-    curBlue += (((0x1f - curBlue) * b) >> 4);
-    outPal = curRed;
-    outPal |= curGreen << 5;
-    outPal |= curBlue << 10;
-    gPlttBufferFaded[i] = outPal;
+    int curRed, curGreen, curBlue;
+    u16 palette = gPlttBufferUnfaded[i];
+    
+    curRed   = (palette & RGB_RED);
+    curGreen = (palette & RGB_GREEN) >>  5;
+    curBlue  = (palette & RGB_BLUE)  >> 10;
+    
+    curRed   += (((0x1F - curRed)   * r) >> 4);
+    curGreen += (((0x1F - curGreen) * g) >> 4);
+    curBlue  += (((0x1F - curBlue)  * b) >> 4);
+    
+    palette  = curRed;
+    palette |= (curGreen <<  5);
+    palette |= (curBlue  << 10);
+    
+    gPlttBufferFaded[i] = palette;
 }
 
 // r, g, b are between 0 and 16
 void MultiplyPaletteRGBComponents(u16 i, u8 r, u8 g, u8 b)
 {
-    int curRed;
-    int curGreen;
-    int curBlue;
-    u16 outPal;
-
-    outPal = gPlttBufferUnfaded[i];
-    curRed = outPal & 0x1f;
-    curGreen = (outPal & (0x1f << 5)) >> 5;
-    curBlue = (outPal & (0x1f << 10)) >> 10;
-    curRed -= ((curRed * r) >> 4);
+    int curRed, curGreen, curBlue;
+    u16 palette = gPlttBufferUnfaded[i];
+    
+    curRed   = (palette & RGB_RED);
+    curGreen = (palette & RGB_GREEN) >>  5;
+    curBlue  = (palette & RGB_BLUE)  >> 10;
+    
+    curRed   -= ((curRed   * r) >> 4);
     curGreen -= ((curGreen * g) >> 4);
-    curBlue -= ((curBlue * b) >> 4);
-    outPal = curRed;
-    outPal |= curGreen << 5;
-    outPal |= curBlue << 10;
-    gPlttBufferFaded[i] = outPal;
+    curBlue  -= ((curBlue  * b) >> 4);
+    
+    palette  = curRed;
+    palette |= curGreen <<  5;
+    palette |= curBlue  << 10;
+    
+    gPlttBufferFaded[i] = palette;
 }
 
 // Task data for Task_PokecenterHeal and Task_HallOfFameRecord

--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -935,42 +935,42 @@ void FreeResourcesAndDestroySprite(struct Sprite *sprite, u8 spriteId)
 void MultiplyInvertedPaletteRGBComponents(u16 i, u8 r, u8 g, u8 b)
 {
     int curRed, curGreen, curBlue;
-    u16 palette = gPlttBufferUnfaded[i];
+    u16 color = gPlttBufferUnfaded[i];
     
-    curRed   = (palette & RGB_RED);
-    curGreen = (palette & RGB_GREEN) >>  5;
-    curBlue  = (palette & RGB_BLUE)  >> 10;
+    curRed   = (color & RGB_RED);
+    curGreen = (color & RGB_GREEN) >>  5;
+    curBlue  = (color & RGB_BLUE)  >> 10;
     
     curRed   += (((0x1F - curRed)   * r) >> 4);
     curGreen += (((0x1F - curGreen) * g) >> 4);
     curBlue  += (((0x1F - curBlue)  * b) >> 4);
     
-    palette  = curRed;
-    palette |= (curGreen <<  5);
-    palette |= (curBlue  << 10);
+    color  = curRed;
+    color |= (curGreen <<  5);
+    color |= (curBlue  << 10);
     
-    gPlttBufferFaded[i] = palette;
+    gPlttBufferFaded[i] = color;
 }
 
 // r, g, b are between 0 and 16
 void MultiplyPaletteRGBComponents(u16 i, u8 r, u8 g, u8 b)
 {
     int curRed, curGreen, curBlue;
-    u16 palette = gPlttBufferUnfaded[i];
+    u16 color = gPlttBufferUnfaded[i];
     
-    curRed   = (palette & RGB_RED);
-    curGreen = (palette & RGB_GREEN) >>  5;
-    curBlue  = (palette & RGB_BLUE)  >> 10;
+    curRed   = (color & RGB_RED);
+    curGreen = (color & RGB_GREEN) >>  5;
+    curBlue  = (color & RGB_BLUE)  >> 10;
     
     curRed   -= ((curRed   * r) >> 4);
     curGreen -= ((curGreen * g) >> 4);
     curBlue  -= ((curBlue  * b) >> 4);
     
-    palette  = curRed;
-    palette |= curGreen <<  5;
-    palette |= curBlue  << 10;
+    color  = curRed;
+    color |= curGreen <<  5;
+    color |= curBlue  << 10;
     
-    gPlttBufferFaded[i] = palette;
+    gPlttBufferFaded[i] = color;
 }
 
 // Task data for Task_PokecenterHeal and Task_HallOfFameRecord

--- a/src/image_processing_effects.c
+++ b/src/image_processing_effects.c
@@ -129,11 +129,11 @@ static void ApplyImageEffect_RedChannelGrayscale(u8 delta)
         u16 *pixel = &pixelRow[gCanvasColumnStart];
         for (i = 0; i < gCanvasColumnEnd; i++, pixel++)
         {
-            if (!(0x8000 & *pixel))
+            if (!IS_ALPHA(*pixel))
             {
                 // Gets the grayscale value, based on the pixel's red channel.
                 // Also adds a delta to skew lighter or darker.
-                u8 grayValue = (31 & *pixel);
+                u8 grayValue = (*pixel & RGB_RED);
                 grayValue += delta;
                 if (grayValue > 31)
                     grayValue = 31;
@@ -154,9 +154,9 @@ static void ApplyImageEffect_RedChannelGrayscaleHighlight(u8 highlight)
         u16 *pixel = &pixelRow[gCanvasColumnStart];
         for (i = 0; i < gCanvasColumnEnd; i++, pixel++)
         {
-            if (!(0x8000 & *pixel))
+            if (!IS_ALPHA(*pixel))
             {
-                u8 grayValue = (31 & *pixel);
+                u8 grayValue = (*pixel & RGB_RED);
                 if (grayValue > 31 - highlight)
                     grayValue = 31 - (highlight >> 1);
 
@@ -183,7 +183,7 @@ static void ApplyImageEffect_Grayscale(void)
         u16 *pixel = &pixelRow[gCanvasColumnStart];
         for (i = 0; i < gCanvasColumnEnd; i++, pixel++)
         {
-            if (!(0x8000 & *pixel))
+            if (!IS_ALPHA(*pixel))
                 *pixel = ConvertColorToGrayscale(pixel);
         }
     }
@@ -203,7 +203,7 @@ static void ApplyImageEffect_Blur(void)
         pixel += gCanvasWidth;
         while (j < gCanvasRowEnd - 1)
         {
-            if (!(0x8000 & *pixel))
+            if (!IS_ALPHA(*pixel))
             {
                 *pixel = QuantizePixel_Blur(&prevPixel, pixel, pixel + gCanvasWidth);
                 prevPixel = *pixel;
@@ -225,7 +225,7 @@ static void ApplyImageEffect_PersonalityColor(u8 personality)
         u16 *pixel = &pixelRow[gCanvasColumnStart];
         for (i = 0; i < gCanvasColumnEnd; i++, pixel++)
         {
-            if (!(0x8000 & *pixel))
+            if (!IS_ALPHA(*pixel))
                 *pixel = QuantizePixel_PersonalityColor(pixel, personality);
         }
     }
@@ -241,7 +241,7 @@ static void ApplyImageEffect_BlackAndWhite(void)
         u16 *pixel = &pixelRow[gCanvasColumnStart];
         for (i = 0; i < gCanvasColumnEnd; i++, pixel++)
         {
-            if (!(0x8000 & *pixel))
+            if (!IS_ALPHA(*pixel))
                 *pixel = QuantizePixel_BlackAndWhite(pixel);
         }
     }
@@ -293,7 +293,7 @@ static void ApplyImageEffect_Invert(void)
         u16 *pixel = &pixelRow[gCanvasColumnStart];
         for (i = 0; i < gCanvasColumnEnd; i++, pixel++)
         {
-            if (!(0x8000 & *pixel))
+            if (!IS_ALPHA(*pixel))
                 *pixel = QuantizePixel_Invert(pixel);
         }
     }
@@ -311,7 +311,7 @@ static void ApplyImageEffect_Shimmer(void)
     {
         for (j = 0; j < 64; j++, pixel++)
         {
-            if (!(0x8000 & *pixel))
+            if (!IS_ALPHA(*pixel))
                 *pixel = QuantizePixel_Invert(pixel);
         }
     }
@@ -321,30 +321,30 @@ static void ApplyImageEffect_Shimmer(void)
     {
         pixel = &gCanvasPixels[j];
         prevPixel = *pixel;
-        *pixel = 0x8000;
+        *pixel = RGB_ALPHA;
         for (i = 1, pixel += 64; i < 63; i++, pixel += 64)
         {
-            if (!(0x8000 & *pixel))
+            if (!IS_ALPHA(*pixel))
             {
                 *pixel = QuantizePixel_BlurHard(&prevPixel, pixel, pixel + 64);
                 prevPixel = *pixel;
             }
         }
 
-        *pixel = 0x8000;
+        *pixel = RGB_ALPHA;
         pixel = &gCanvasPixels[j];
         prevPixel = *pixel;
-        *pixel = 0x8000;
+        *pixel = RGB_ALPHA;
         for (i = 1, pixel += 64; i < 63; i++, pixel += 64)
         {
-            if (!(0x8000 & *pixel))
+            if (!IS_ALPHA(*pixel))
             {
                 *pixel = QuantizePixel_BlurHard(&prevPixel, pixel, pixel + 64);
                 prevPixel = *pixel;
             }
         }
 
-        *pixel = 0x8000;
+        *pixel = RGB_ALPHA;
     }
 
     // Finally, invert colors back to the original color space.
@@ -355,7 +355,7 @@ static void ApplyImageEffect_Shimmer(void)
     {
         for (j = 0; j < 64; j++, pixel++)
         {
-            if (!(0x8000 & *pixel))
+            if (!IS_ALPHA(*pixel))
                 *pixel = QuantizePixel_Invert(pixel);
         }
     }
@@ -372,7 +372,7 @@ static void ApplyImageEffect_BlurRight(void)
         u16 prevPixel = *pixel;
         for (i = 1, pixel++; i < gCanvasColumnEnd - 1; i++, pixel++)
         {
-            if (!(0x8000 & *pixel))
+            if (!IS_ALPHA(*pixel))
             {
                 *pixel = QuantizePixel_MotionBlur(&prevPixel, pixel);
                 prevPixel = *pixel;
@@ -392,7 +392,7 @@ static void ApplyImageEffect_BlurDown(void)
         u16 prevPixel = *pixel;
         for (j = 1, pixel += gCanvasWidth; j < gCanvasRowEnd - 1; j++, pixel += gCanvasWidth)
         {
-            if (!(0x8000 & *pixel))
+            if (!IS_ALPHA(*pixel))
             {
                 *pixel = QuantizePixel_MotionBlur(&prevPixel, pixel);
                 prevPixel = *pixel;
@@ -447,11 +447,11 @@ static void AddPointillismPoints(u16 arg0)
     {
         u16 *pixel = &gCanvasPixels[points[i].row * 64] + points[i].column;
 
-        if (!(0x8000 & *pixel))
+        if (!IS_ALPHA(*pixel))
         {
-            u16 red = (*pixel) & 0x1F;
-            u16 green = (*pixel >> 5) & 0x1F;
-            u16 blue = (*pixel >> 10) & 0x1F;
+            u16 red =   GET_R(*pixel);
+            u16 green = GET_G(*pixel);
+            u16 blue =  GET_B(*pixel);
 
             switch (colorType)
             {
@@ -501,9 +501,9 @@ static void AddPointillismPoints(u16 arg0)
 static u16 ConvertColorToGrayscale(u16 *color)
 {
     s32 clr = *color;
-    s32 r = clr & 0x1F;
-    s32 g = (clr >> 5) & 0x1F;
-    s32 b = (clr >> 10) & 0x1F;
+    s32 r = GET_R(clr);
+    s32 g = GET_G(clr);
+    s32 b = GET_B(clr);
     s32 gray = (r * Q_8_8(0.3) + g * Q_8_8(0.59) + b * Q_8_8(0.1133)) >> 8;
     return RGB2(gray, gray, gray);
 }
@@ -512,9 +512,9 @@ static u16 ConvertColorToGrayscale(u16 *color)
 // Everything else is white.
 static u16 QuantizePixel_PersonalityColor(u16 *color, u8 personality)
 {
-    u16 red = *color & 0x1F;
-    u16 green = (*color >> 5) & 0x1F;
-    u16 blue = (*color >> 10) & 0x1F;
+    u16 red =   GET_R(*color);
+    u16 green = GET_G(*color);
+    u16 blue =  GET_B(*color);
 
     if (red < 17 && green < 17 && blue < 17)
         return GetColorFromPersonality(personality);
@@ -526,9 +526,9 @@ static u16 QuantizePixel_PersonalityColor(u16 *color, u8 personality)
 // the mon's personality value, return a color.
 static u16 GetColorFromPersonality(u8 personality)
 {
-    u16 red = 0;
+    u16 red =   0;
     u16 green = 0;
-    u16 blue = 0;
+    u16 blue =  0;
     u8 strength = (personality / 6) % 3;
     u8 colorType = personality % 6;
 
@@ -577,9 +577,9 @@ static u16 GetColorFromPersonality(u8 personality)
 
 static u16 QuantizePixel_BlackAndWhite(u16 *color)
 {
-    u16 red = *color & 0x1F;
-    u16 green = (*color >> 5) & 0x1F;
-    u16 blue = (*color >> 10) & 0x1F;
+    u16 red =   GET_R(*color);
+    u16 green = GET_G(*color);
+    u16 blue =  GET_B(*color);
 
     if (red < 17 && green < 17 && blue < 17)
         return RGB_BLACK;
@@ -591,9 +591,9 @@ static u16 QuantizePixel_BlackOutline(u16 *pixelA, u16 *pixelB)
 {
     if (*pixelA != RGB_BLACK)
     {
-        if (*pixelA & 0x8000)
-            return 0x8000;
-        if (*pixelB & 0x8000)
+        if (IS_ALPHA(*pixelA))
+            return RGB_ALPHA;
+        if (IS_ALPHA(*pixelB))
             return RGB_BLACK;
 
         return *pixelA;
@@ -604,13 +604,13 @@ static u16 QuantizePixel_BlackOutline(u16 *pixelA, u16 *pixelB)
 
 static u16 QuantizePixel_Invert(u16 *color)
 {
-    u16 red = *color & 0x1F;
-    u16 green = (*color >> 5) & 0x1F;
-    u16 blue = (*color >> 10) & 0x1F;
+    u16 red =   GET_R(*color);
+    u16 green = GET_G(*color);
+    u16 blue =  GET_B(*color);
 
-    red = 31 - red;
+    red   = 31 - red;
     green = 31 - green;
-    blue = 31 - blue;
+    blue  = 31 - blue;
 
     return RGB2(red, green, blue);
 }
@@ -626,12 +626,12 @@ static u16 QuantizePixel_MotionBlur(u16 *prevPixel, u16 *curPixel)
     if (*prevPixel == *curPixel)
         return *curPixel;
 
-    pixelChannels[0][0] = (*prevPixel >> 0)  & 0x1F;
-    pixelChannels[0][1] = (*prevPixel >> 5)  & 0x1F;
-    pixelChannels[0][2] = (*prevPixel >> 10) & 0x1F;
-    pixelChannels[1][0] = (*curPixel  >> 0)  & 0x1F;
-    pixelChannels[1][1] = (*curPixel  >> 5)  & 0x1F;
-    pixelChannels[1][2] = (*curPixel  >> 10) & 0x1F;
+    pixelChannels[0][0] = GET_R(*prevPixel);
+    pixelChannels[0][1] = GET_G(*prevPixel);
+    pixelChannels[0][2] = GET_B(*prevPixel);
+    pixelChannels[1][0] = GET_R(*curPixel);
+    pixelChannels[1][1] = GET_G(*curPixel);
+    pixelChannels[1][2] = GET_B(*curPixel);
 
     // Don't blur light colors.
     if (pixelChannels[0][0] > 25 && pixelChannels[0][1] > 25 && pixelChannels[0][2] > 25)
@@ -667,9 +667,9 @@ static u16 QuantizePixel_MotionBlur(u16 *prevPixel, u16 *curPixel)
             largestDiff = diffs[0];
     }
 
-    red =   (pixelChannels[1][0] * (31 - largestDiff / 2)) / 31;
+    red   = (pixelChannels[1][0] * (31 - largestDiff / 2)) / 31;
     green = (pixelChannels[1][1] * (31 - largestDiff / 2)) / 31;
-    blue =  (pixelChannels[1][2] * (31 - largestDiff / 2)) / 31;
+    blue  = (pixelChannels[1][2] * (31 - largestDiff / 2)) / 31;
     return RGB2(red, green, blue);
 }
 
@@ -684,13 +684,13 @@ static u16 QuantizePixel_Blur(u16 *prevPixel, u16 *curPixel, u16 *nextPixel)
     if (*prevPixel == *curPixel && *nextPixel == *curPixel)
         return *curPixel;
 
-    red   = (*curPixel >> 0)  & 0x1F;
-    green = (*curPixel >> 5)  & 0x1F;
-    blue  = (*curPixel >> 10) & 0x1F;
+    red   = GET_R(*curPixel);
+    green = GET_G(*curPixel);
+    blue  = GET_B(*curPixel);
 
-    prevAvg = (((*prevPixel >> 0) & 0x1F) + ((*prevPixel >> 5) & 0x1F) + ((*prevPixel >> 10) & 0x1F)) / 3;
-    curAvg  = (((*curPixel  >> 0) & 0x1F) + ((*curPixel  >> 5) & 0x1F) + ((*curPixel  >> 10) & 0x1F)) / 3;
-    nextAvg = (((*nextPixel >> 0) & 0x1F) + ((*nextPixel >> 5) & 0x1F) + ((*nextPixel >> 10) & 0x1F)) / 3;
+    prevAvg = (GET_R(*prevPixel) + GET_G(*prevPixel) + GET_B(*prevPixel)) / 3;
+    curAvg  = (GET_R(*curPixel)  + GET_G(*curPixel)  + GET_B(*curPixel))  / 3;
+    nextAvg = (GET_R(*nextPixel) + GET_G(*nextPixel) + GET_B(*nextPixel)) / 3;
 
     if (prevAvg == curAvg && nextAvg == curAvg)
         return *curPixel;
@@ -728,14 +728,14 @@ static u16 QuantizePixel_BlurHard(u16 *prevPixel, u16 *curPixel, u16 *nextPixel)
     if (*prevPixel == *curPixel && *nextPixel == *curPixel)
         return *curPixel;
 
-    red   = (*curPixel >> 0)  & 0x1F;
-    green = (*curPixel >> 5)  & 0x1F;
-    blue  = (*curPixel >> 10) & 0x1F;
-
-    prevAvg = (((*prevPixel >> 0) & 0x1F) + ((*prevPixel >> 5) & 0x1F) + ((*prevPixel >> 10) & 0x1F)) / 3;
-    curAvg  = (((*curPixel  >> 0) & 0x1F) + ((*curPixel  >> 5) & 0x1F) + ((*curPixel  >> 10) & 0x1F)) / 3;
-    nextAvg = (((*nextPixel >> 0) & 0x1F) + ((*nextPixel >> 5) & 0x1F) + ((*nextPixel >> 10) & 0x1F)) / 3;
-
+    red   = GET_R(*curPixel);
+    green = GET_G(*curPixel);
+    blue  = GET_B(*curPixel);
+    
+    prevAvg = (GET_R(*prevPixel) + GET_G(*prevPixel) + GET_B(*prevPixel)) / 3;
+    curAvg  = (GET_R(*curPixel)  + GET_G(*curPixel)  + GET_B(*curPixel))  / 3;
+    nextAvg = (GET_R(*nextPixel) + GET_G(*nextPixel) + GET_B(*nextPixel)) / 3;
+    
     if (prevAvg == curAvg && nextAvg == curAvg)
         return *curPixel;
 
@@ -851,37 +851,37 @@ void ApplyImageProcessingQuantization(struct ImageProcessingContext *context)
 
 static void SetPresetPalette_PrimaryColors(void)
 {
-    gCanvasPalette[0]  = RGB2(0, 0, 0);
-    gCanvasPalette[1]  = RGB2(6, 6, 6);
-    gCanvasPalette[2]  = RGB2(29, 29, 29);
-    gCanvasPalette[3]  = RGB2(11, 11, 11);
-    gCanvasPalette[4]  = RGB2(29, 6, 6);
-    gCanvasPalette[5]  = RGB2(6, 29, 6);
-    gCanvasPalette[6]  = RGB2(6, 6, 29);
-    gCanvasPalette[7]  = RGB2(29, 29, 6);
-    gCanvasPalette[8]  = RGB2(29, 6, 29);
-    gCanvasPalette[9]  = RGB2(6, 29, 29);
-    gCanvasPalette[10] = RGB2(29, 11, 6);
-    gCanvasPalette[11] = RGB2(11, 29, 6);
-    gCanvasPalette[12] = RGB2(6, 11, 29);
-    gCanvasPalette[13] = RGB2(29, 6, 11);
-    gCanvasPalette[14] = RGB2(6, 29, 11);
-    gCanvasPalette[15] = RGB2(11, 6, 29);
+    gCanvasPalette[0]  = RGB_BLACK;
+    gCanvasPalette[1]  = RGB(6, 6, 6);
+    gCanvasPalette[2]  = RGB(29, 29, 29);
+    gCanvasPalette[3]  = RGB(11, 11, 11);
+    gCanvasPalette[4]  = RGB(29, 6, 6);
+    gCanvasPalette[5]  = RGB(6, 29, 6);
+    gCanvasPalette[6]  = RGB(6, 6, 29);
+    gCanvasPalette[7]  = RGB(29, 29, 6);
+    gCanvasPalette[8]  = RGB(29, 6, 29);
+    gCanvasPalette[9]  = RGB(6, 29, 29);
+    gCanvasPalette[10] = RGB(29, 11, 6);
+    gCanvasPalette[11] = RGB(11, 29, 6);
+    gCanvasPalette[12] = RGB(6, 11, 29);
+    gCanvasPalette[13] = RGB(29, 6, 11);
+    gCanvasPalette[14] = RGB(6, 29, 11);
+    gCanvasPalette[15] = RGB(11, 6, 29);
 }
 
 static void SetPresetPalette_BlackAndWhite(void)
 {
-    gCanvasPalette[0] = RGB2(0, 0, 0);
-    gCanvasPalette[1] = RGB2(0, 0, 0);
-    gCanvasPalette[2] = RGB2(31, 31, 31);
+    gCanvasPalette[0] = RGB_BLACK;
+    gCanvasPalette[1] = RGB_BLACK;
+    gCanvasPalette[2] = RGB_WHITE;
 }
 
 static void SetPresetPalette_GrayscaleSmall(void)
 {
     u8 i;
 
-    gCanvasPalette[0] = RGB2(0, 0, 0);
-    gCanvasPalette[1] = RGB2(0, 0, 0);
+    gCanvasPalette[0] = RGB_BLACK;
+    gCanvasPalette[1] = RGB_BLACK;
     for (i = 0; i < 14; i++)
         gCanvasPalette[i + 2] = RGB2(2 * (i + 2), 2 * (i + 2), 2 * (i + 2));
 }
@@ -890,7 +890,7 @@ static void SetPresetPalette_Grayscale(void)
 {
     u8 i;
 
-    gCanvasPalette[0] = RGB2(0, 0, 0);
+    gCanvasPalette[0] = RGB_BLACK;
     for (i = 0; i < 32; i++)
         gCanvasPalette[i + 1] = RGB2(i, i, i);
 }
@@ -914,7 +914,7 @@ static void QuantizePalette_Standard(bool8 useLimitedPalette)
         u16 *pixel = &pixelRow[gCanvasColumnStart];
         for (i = 0; i < gCanvasColumnEnd; i++, pixel++)
         {
-            if (*pixel & 0x8000)
+            if (IS_ALPHA(*pixel))
             {
                 *pixel = gCanvasPaletteStart;
             }
@@ -982,7 +982,7 @@ static void QuantizePalette_BlackAndWhite(void)
         u16 *pixel = &pixelRow[gCanvasColumnStart];
         for (i = 0; i < gCanvasColumnEnd; i++, pixel++)
         {
-            if (*pixel & 0x8000)
+            if (IS_ALPHA(*pixel))
             {
                 *pixel = gCanvasPaletteStart;
             }
@@ -1013,7 +1013,7 @@ static void QuantizePalette_GrayscaleSmall(void)
         u16 *pixel = &pixelRow[gCanvasColumnStart];
         for (i = 0; i < gCanvasColumnEnd; i++, pixel++)
         {
-            if (*pixel & 0x8000)
+            if (IS_ALPHA(*pixel))
                 *pixel = gCanvasPaletteStart;
             else
                 *pixel = QuantizePixel_GrayscaleSmall(pixel) + gCanvasPaletteStart;
@@ -1031,7 +1031,7 @@ static void QuantizePalette_Grayscale(void)
         u16 *pixel = &pixelRow[gCanvasColumnStart];
         for (i = 0; i < gCanvasColumnEnd; i++, pixel++)
         {
-            if (*pixel & 0x8000)
+            if (IS_ALPHA(*pixel))
                 *pixel = gCanvasPaletteStart;
             else
                 *pixel = QuantizePixel_Grayscale(pixel) + gCanvasPaletteStart;
@@ -1049,7 +1049,7 @@ static void QuantizePalette_PrimaryColors(void)
         u16 *pixel = &pixelRow[gCanvasColumnStart];
         for (i = 0; i < gCanvasColumnEnd; i++, pixel++)
         {
-            if (*pixel & 0x8000)
+            if (IS_ALPHA(*pixel))
                 *pixel = gCanvasPaletteStart;
             else
                 *pixel = QuantizePixel_PrimaryColors(pixel) + gCanvasPaletteStart;
@@ -1060,9 +1060,9 @@ static void QuantizePalette_PrimaryColors(void)
 // Quantizes the pixel's color channels to nearest multiple of 4, and clamps to [6, 30].
 static u16 QuantizePixel_Standard(u16 *pixel)
 {
-    u16 red = *pixel & 0x1F;
-    u16 green = (*pixel >> 5) & 0x1F;
-    u16 blue = (*pixel >> 10) & 0x1F;
+    u16 red =   GET_R(*pixel);
+    u16 green = GET_G(*pixel);
+    u16 blue =  GET_B(*pixel);
 
     // Quantize color channels to muliples of 4, rounding up.
     if (red & 3)
@@ -1091,10 +1091,10 @@ static u16 QuantizePixel_Standard(u16 *pixel)
 
 static u16 QuantizePixel_PrimaryColors(u16* color)
 {
-    u16 red = *color & 0x1F;
-    u16 green = (*color >> 5) & 0x1F;
-    u16 blue = (*color >> 10) & 0x1F;
-
+    u16 red =   GET_R(*color);
+    u16 green = GET_G(*color);
+    u16 blue =  GET_B(*color);
+    
     if (red < 12 && green < 11 && blue < 11)
         return 1;
 
@@ -1206,9 +1206,9 @@ static u16 QuantizePixel_PrimaryColors(u16* color)
 
 static u16 QuantizePixel_GrayscaleSmall(u16 *color)
 {
-    u16 red = *color & 0x1F;
-    u16 green = (*color >> 5) & 0x1F;
-    u16 blue = (*color >> 10) & 0x1F;
+    u16 red =   GET_R(*color);
+    u16 green = GET_G(*color);
+    u16 blue =  GET_B(*color);
     u16 average = ((red + green + blue) / 3) & 0x1E;
     if (average == 0)
         return 1;
@@ -1218,9 +1218,9 @@ static u16 QuantizePixel_GrayscaleSmall(u16 *color)
 
 static u16 QuantizePixel_Grayscale(u16 *color)
 {
-    u16 red = *color & 0x1F;
-    u16 green = (*color >> 5) & 0x1F;
-    u16 blue = (*color >> 10) & 0x1F;
+    u16 red =   GET_R(*color);
+    u16 green = GET_G(*color);
+    u16 blue =  GET_B(*color);
     u16 average = (red + green + blue) / 3;
     return average + 1;
 }

--- a/src/palette.c
+++ b/src/palette.c
@@ -624,7 +624,7 @@ static u8 UpdateFastPaletteFade(void)
             if (b < b0)
                 b = b0;
 
-            gPlttBufferFaded[i] = r | (g << 5) | (b << 10);
+            gPlttBufferFaded[i] = RGB(r, g, b);
         }
         break;
     case FAST_FADE_OUT_TO_WHITE:
@@ -642,7 +642,7 @@ static u8 UpdateFastPaletteFade(void)
             if (b > 31)
                 b = 31;
 
-            gPlttBufferFaded[i] = r | (g << 5) | (b << 10);
+            gPlttBufferFaded[i] = RGB(r, g, b);
         }
         break;
     case FAST_FADE_IN_FROM_BLACK:
@@ -668,7 +668,7 @@ static u8 UpdateFastPaletteFade(void)
             if (b > b0)
                 b = b0;
 
-            gPlttBufferFaded[i] = r | (g << 5) | (b << 10);
+            gPlttBufferFaded[i] = RGB(r, g, b);
         }
         break;
     case FAST_FADE_OUT_TO_BLACK:
@@ -686,7 +686,7 @@ static u8 UpdateFastPaletteFade(void)
             if (b < 0)
                 b = 0;
 
-            gPlttBufferFaded[i] = r | (g << 5) | (b << 10);
+            gPlttBufferFaded[i] = RGB(r, g, b);
         }
     }
 
@@ -856,13 +856,13 @@ void TintPalette_GrayScale(u16 *palette, u16 count)
 
     for (i = 0; i < count; i++)
     {
-        r = (*palette >>  0) & 0x1F;
-        g = (*palette >>  5) & 0x1F;
-        b = (*palette >> 10) & 0x1F;
+        r = GET_R(*palette);
+        g = GET_G(*palette);
+        b = GET_B(*palette);
 
         gray = (r * Q_8_8(0.3) + g * Q_8_8(0.59) + b * Q_8_8(0.1133)) >> 8;
 
-        *palette++ = (gray << 10) | (gray << 5) | (gray << 0);
+        *palette++ = RGB2(gray, gray, gray);
     }
 }
 
@@ -873,18 +873,18 @@ void TintPalette_GrayScale2(u16 *palette, u16 count)
 
     for (i = 0; i < count; i++)
     {
-        r = (*palette >>  0) & 0x1F;
-        g = (*palette >>  5) & 0x1F;
-        b = (*palette >> 10) & 0x1F;
+        r = GET_R(*palette);
+        g = GET_G(*palette);
+        b = GET_B(*palette);
 
         gray = (r * Q_8_8(0.3) + g * Q_8_8(0.59) + b * Q_8_8(0.1133)) >> 8;
 
-        if (gray > 0x1F)
-            gray = 0x1F;
+        if (gray > 31)
+            gray = 31;
 
         gray = sRoundedDownGrayscaleMap[gray];
 
-        *palette++ = (gray << 10) | (gray << 5) | (gray << 0);
+        *palette++ = RGB2(gray, gray, gray);
     }
 }
 
@@ -895,9 +895,9 @@ void TintPalette_SepiaTone(u16 *palette, u16 count)
 
     for (i = 0; i < count; i++)
     {
-        r = (*palette >>  0) & 0x1F;
-        g = (*palette >>  5) & 0x1F;
-        b = (*palette >> 10) & 0x1F;
+        r = GET_R(*palette);
+        g = GET_G(*palette);
+        b = GET_B(*palette);
 
         gray = (r * Q_8_8(0.3) + g * Q_8_8(0.59) + b * Q_8_8(0.1133)) >> 8;
 
@@ -908,7 +908,7 @@ void TintPalette_SepiaTone(u16 *palette, u16 count)
         if (r > 31)
             r = 31;
 
-        *palette++ = (b << 10) | (g << 5) | (r << 0);
+        *palette++ = RGB2(r, g, b);
     }
 }
 
@@ -919,9 +919,9 @@ void TintPalette_CustomTone(u16 *palette, u16 count, u16 rTone, u16 gTone, u16 b
 
     for (i = 0; i < count; i++)
     {
-        r = (*palette >>  0) & 0x1F;
-        g = (*palette >>  5) & 0x1F;
-        b = (*palette >> 10) & 0x1F;
+        r = GET_R(*palette);
+        g = GET_G(*palette);
+        b = GET_B(*palette);
 
         gray = (r * Q_8_8(0.3) + g * Q_8_8(0.59) + b * Q_8_8(0.1133)) >> 8;
 
@@ -936,7 +936,7 @@ void TintPalette_CustomTone(u16 *palette, u16 count, u16 rTone, u16 gTone, u16 b
         if (b > 31)
             b = 31;
 
-        *palette++ = (b << 10) | (g << 5) | (r << 0);
+        *palette++ = RGB2(r, g, b);
     }
 }
 

--- a/src/pokenav_main_menu.c
+++ b/src/pokenav_main_menu.c
@@ -496,7 +496,7 @@ void PokenavCopyPalette(const u16 *src, const u16 *dest, int size, int a3, int a
             g1 = ((((GET_G(*dest) << 8) - (g << 8)) / a3) * a4) >> 8;
             b1 = ((((GET_B(*dest) << 8) - (b << 8)) / a3) * a4) >> 8;
 
-            r = (r + r1) & 0x1F; //_RGB(r + r1, g + g1, b + b1); doesn't match; I have to assign the value of ((r + r1) & 0x1F) to r1
+            r = (r + r1) & 0x1F; //_RGB(r + r1, g + g1, b + b1); doesn't match; I have to assign the value of ((r + r1) & 0x1F) to r
             g = (g + g1) & 0x1F; //See above
             b = (b + b1) & 0x1F; //See above
 


### PR DESCRIPTION
## Description
Use the `RGB`, `RGB2`, `GET_R`, `GET_G` and `GET_B` macros where needed; introduce a constant for `RBG_ALPHA`; introduce a macro for checking for alpha transparency, `IS_ALPHA`, which is used a lot in `image_processing_effects.c`.

## **Discord contact info**
Spherical Ice#4683