### PR TITLE
Get rid of the fake match in item_icon.c

### DIFF
--- a/include/item_icon.h
+++ b/include/item_icon.h
@@ -1,8 +1,8 @@
 #ifndef GUARD_ITEM_ICON_H
 #define GUARD_ITEM_ICON_H
 
-extern void *gItemIconDecompressionBuffer;
-extern void *gItemIcon4x4Buffer;
+extern u8 *gItemIconDecompressionBuffer;
+extern u8 *gItemIcon4x4Buffer;
 
 extern const struct SpriteTemplate gItemIconSpriteTemplate;
 

--- a/src/item_icon.c
+++ b/src/item_icon.c
@@ -7,8 +7,8 @@
 #include "constants/items.h"
 
 // EWRAM vars
-EWRAM_DATA void *gItemIconDecompressionBuffer = NULL;
-EWRAM_DATA void *gItemIcon4x4Buffer = NULL;
+EWRAM_DATA u8 *gItemIconDecompressionBuffer = NULL;
+EWRAM_DATA u8 *gItemIcon4x4Buffer = NULL;
 
 // const rom data
 #include "data/item_icon_table.h"

--- a/src/item_icon.c
+++ b/src/item_icon.c
@@ -55,12 +55,10 @@ const struct SpriteTemplate gItemIconSpriteTemplate =
 // code
 bool8 AllocItemIconTemporaryBuffers(void)
 {
-    gItemIconDecompressionBuffer = gItemIconDecompressionBuffer; // needed to match
     gItemIconDecompressionBuffer = Alloc(0x120);
     if (gItemIconDecompressionBuffer == NULL)
         return FALSE;
 
-    gItemIcon4x4Buffer = gItemIcon4x4Buffer; // needed to match
     gItemIcon4x4Buffer = AllocZeroed(0x200);
     if (gItemIcon4x4Buffer == NULL)
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

In possibly the strangest matching ever, only by changing the buffers to u8 pointers instead of void pointers was I able to match AllocItemIconTemporaryBuffers.

I have no idea why the compiler does this, but it does.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->