### PR TITLE
Fix prefixes of variable names

### DIFF
--- a/gflib/dma3_manager.c
+++ b/gflib/dma3_manager.c
@@ -10,8 +10,8 @@
 
 struct Dma3Request
 {
-    const void *src;
-    void *dest;
+    const u8 *src;
+    u8 *dest;
     u16 size;
     u16 mode;
     u32 value;

--- a/gflib/dma3_manager.c
+++ b/gflib/dma3_manager.c
@@ -8,88 +8,90 @@
 #define DMA_REQUEST_COPY16 3
 #define DMA_REQUEST_FILL16 4
 
-BSS_DATA struct
+struct Dma3Request
 {
-    const u8 *src;
-    u8 *dest;
+    const void *src;
+    void *dest;
     u16 size;
     u16 mode;
     u32 value;
-} gDma3Requests[MAX_DMA_REQUESTS];
+};
 
-static volatile bool8 gDma3ManagerLocked;
-static u8 gDma3RequestCursor;
+static struct Dma3Request sDma3Requests[MAX_DMA_REQUESTS];
+
+static vbool8 sDma3ManagerLocked;
+static u8 sDma3RequestCursor;
 
 void ClearDma3Requests(void)
 {
     int i;
 
-    gDma3ManagerLocked = TRUE;
-    gDma3RequestCursor = 0;
+    sDma3ManagerLocked = TRUE;
+    sDma3RequestCursor = 0;
 
     for (i = 0; i < MAX_DMA_REQUESTS; i++)
     {
-        gDma3Requests[i].size = 0;
-        gDma3Requests[i].src = NULL;
-        gDma3Requests[i].dest = NULL;
+        sDma3Requests[i].size = 0;
+        sDma3Requests[i].src = NULL;
+        sDma3Requests[i].dest = NULL;
     }
 
-    gDma3ManagerLocked = FALSE;
+    sDma3ManagerLocked = FALSE;
 }
 
 void ProcessDma3Requests(void)
 {
     u16 bytesTransferred;
 
-    if (gDma3ManagerLocked)
+    if (sDma3ManagerLocked)
         return;
 
     bytesTransferred = 0;
 
     // as long as there are DMA requests to process (unless size or vblank is an issue), do not exit
-    while (gDma3Requests[gDma3RequestCursor].size != 0)
+    while (sDma3Requests[sDma3RequestCursor].size != 0)
     {
-        bytesTransferred += gDma3Requests[gDma3RequestCursor].size;
+        bytesTransferred += sDma3Requests[sDma3RequestCursor].size;
 
         if (bytesTransferred > 40 * 1024)
             return; // don't transfer more than 40 KiB
         if (*(u8 *)REG_ADDR_VCOUNT > 224)
             return; // we're about to leave vblank, stop
 
-        switch (gDma3Requests[gDma3RequestCursor].mode)
+        switch (sDma3Requests[sDma3RequestCursor].mode)
         {
         case DMA_REQUEST_COPY32: // regular 32-bit copy
-            Dma3CopyLarge32_(gDma3Requests[gDma3RequestCursor].src,
-                             gDma3Requests[gDma3RequestCursor].dest,
-                             gDma3Requests[gDma3RequestCursor].size);
+            Dma3CopyLarge32_(sDma3Requests[sDma3RequestCursor].src,
+                             sDma3Requests[sDma3RequestCursor].dest,
+                             sDma3Requests[sDma3RequestCursor].size);
             break;
         case DMA_REQUEST_FILL32: // repeat a single 32-bit value across RAM
-            Dma3FillLarge32_(gDma3Requests[gDma3RequestCursor].value,
-                             gDma3Requests[gDma3RequestCursor].dest,
-                             gDma3Requests[gDma3RequestCursor].size);
+            Dma3FillLarge32_(sDma3Requests[sDma3RequestCursor].value,
+                             sDma3Requests[sDma3RequestCursor].dest,
+                             sDma3Requests[sDma3RequestCursor].size);
             break;
         case DMA_REQUEST_COPY16:    // regular 16-bit copy
-            Dma3CopyLarge16_(gDma3Requests[gDma3RequestCursor].src,
-                             gDma3Requests[gDma3RequestCursor].dest,
-                             gDma3Requests[gDma3RequestCursor].size);
+            Dma3CopyLarge16_(sDma3Requests[sDma3RequestCursor].src,
+                             sDma3Requests[sDma3RequestCursor].dest,
+                             sDma3Requests[sDma3RequestCursor].size);
             break;
         case DMA_REQUEST_FILL16: // repeat a single 16-bit value across RAM
-            Dma3FillLarge16_(gDma3Requests[gDma3RequestCursor].value,
-                             gDma3Requests[gDma3RequestCursor].dest,
-                             gDma3Requests[gDma3RequestCursor].size);
+            Dma3FillLarge16_(sDma3Requests[sDma3RequestCursor].value,
+                             sDma3Requests[sDma3RequestCursor].dest,
+                             sDma3Requests[sDma3RequestCursor].size);
             break;
         }
 
         // Free the request
-        gDma3Requests[gDma3RequestCursor].src = NULL;
-        gDma3Requests[gDma3RequestCursor].dest = NULL;
-        gDma3Requests[gDma3RequestCursor].size = 0;
-        gDma3Requests[gDma3RequestCursor].mode = 0;
-        gDma3Requests[gDma3RequestCursor].value = 0;
-        gDma3RequestCursor++;
+        sDma3Requests[sDma3RequestCursor].src = NULL;
+        sDma3Requests[sDma3RequestCursor].dest = NULL;
+        sDma3Requests[sDma3RequestCursor].size = 0;
+        sDma3Requests[sDma3RequestCursor].mode = 0;
+        sDma3Requests[sDma3RequestCursor].value = 0;
+        sDma3RequestCursor++;
 
-        if (gDma3RequestCursor >= MAX_DMA_REQUESTS) // loop back to the first DMA request
-            gDma3RequestCursor = 0;
+        if (sDma3RequestCursor >= MAX_DMA_REQUESTS) // loop back to the first DMA request
+            sDma3RequestCursor = 0;
     }
 }
 
@@ -98,30 +100,30 @@ s16 RequestDma3Copy(const void *src, void *dest, u16 size, u8 mode)
     int cursor;
     int i = 0;
 
-    gDma3ManagerLocked = TRUE;
-    cursor = gDma3RequestCursor;
+    sDma3ManagerLocked = TRUE;
+    cursor = sDma3RequestCursor;
 
     while (i < MAX_DMA_REQUESTS)
     {
-        if (gDma3Requests[cursor].size == 0) // an empty request was found.
+        if (sDma3Requests[cursor].size == 0) // an empty request was found.
         {
-            gDma3Requests[cursor].src = src;
-            gDma3Requests[cursor].dest = dest;
-            gDma3Requests[cursor].size = size;
+            sDma3Requests[cursor].src = src;
+            sDma3Requests[cursor].dest = dest;
+            sDma3Requests[cursor].size = size;
 
             if (mode == 1)
-                gDma3Requests[cursor].mode = DMA_REQUEST_COPY32;
+                sDma3Requests[cursor].mode = DMA_REQUEST_COPY32;
             else
-                gDma3Requests[cursor].mode = DMA_REQUEST_COPY16;
+                sDma3Requests[cursor].mode = DMA_REQUEST_COPY16;
 
-            gDma3ManagerLocked = FALSE;
+            sDma3ManagerLocked = FALSE;
             return cursor;
         }
         if (++cursor >= MAX_DMA_REQUESTS) // loop back to start.
             cursor = 0;
         i++;
     }
-    gDma3ManagerLocked = FALSE;
+    sDma3ManagerLocked = FALSE;
     return -1;  // no free DMA request was found
 }
 
@@ -130,31 +132,31 @@ s16 RequestDma3Fill(s32 value, void *dest, u16 size, u8 mode)
     int cursor;
     int i = 0;
 
-    cursor = gDma3RequestCursor;
-    gDma3ManagerLocked = TRUE;
+    cursor = sDma3RequestCursor;
+    sDma3ManagerLocked = TRUE;
 
     while (i < MAX_DMA_REQUESTS)
     {
-        if (gDma3Requests[cursor].size == 0) // an empty request was found.
+        if (sDma3Requests[cursor].size == 0) // an empty request was found.
         {
-            gDma3Requests[cursor].dest = dest;
-            gDma3Requests[cursor].size = size;
-            gDma3Requests[cursor].mode = mode;
-            gDma3Requests[cursor].value = value;
+            sDma3Requests[cursor].dest = dest;
+            sDma3Requests[cursor].size = size;
+            sDma3Requests[cursor].mode = mode;
+            sDma3Requests[cursor].value = value;
 
             if(mode == 1)
-                gDma3Requests[cursor].mode = DMA_REQUEST_FILL32;
+                sDma3Requests[cursor].mode = DMA_REQUEST_FILL32;
             else
-                gDma3Requests[cursor].mode = DMA_REQUEST_FILL16;
+                sDma3Requests[cursor].mode = DMA_REQUEST_FILL16;
 
-            gDma3ManagerLocked = FALSE;
+            sDma3ManagerLocked = FALSE;
             return cursor;
         }
         if (++cursor >= MAX_DMA_REQUESTS) // loop back to start.
             cursor = 0;
         i++;
     }
-    gDma3ManagerLocked = FALSE;
+    sDma3ManagerLocked = FALSE;
     return -1;  // no free DMA request was found
 }
 
@@ -166,7 +168,7 @@ s16 CheckForSpaceForDma3Request(s16 index)
     {
         while (i < MAX_DMA_REQUESTS)
         {
-            if (gDma3Requests[i].size != 0)
+            if (sDma3Requests[i].size != 0)
                 return -1;
             i++;
         }
@@ -174,7 +176,7 @@ s16 CheckForSpaceForDma3Request(s16 index)
     }
     else  // check the specified request
     {
-        if (gDma3Requests[index].size != 0)
+        if (sDma3Requests[index].size != 0)
             return -1;
         return 0;
     }


### PR DESCRIPTION
Many static variables in this function are falsely labeled with a g prefix, as if it were global, when they are in fact static variables.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
Shoomer#2702