### PR TITLE
Add labels for cracked floor metatiles

### DIFF
--- a/include/constants/metatile_labels.h
+++ b/include/constants/metatile_labels.h
@@ -165,6 +165,8 @@
 
 // gTileset_Cave
 #define METATILE_Cave_EntranceCover                     0x229
+#define METATILE_Cave_CrackedFloor_Hole                 0x206
+#define METATILE_Cave_CrackedFloor                      0x22F
 #define METATILE_Cave_SealedChamberEntrance_TopLeft     0x22A
 #define METATILE_Cave_SealedChamberEntrance_TopMid      0x22B
 #define METATILE_Cave_SealedChamberEntrance_TopRight    0x22C
@@ -191,6 +193,7 @@
 #define METATILE_Pacifidlog_HalfSubmergedLogs_Vertical1   0x261
 #define METATILE_Pacifidlog_SubmergedLogs_Vertical0       0x25A
 #define METATILE_Pacifidlog_SubmergedLogs_Vertical1       0x262
+#define METATILE_Pacifidlog_SkyPillar_CrackedFloor_Hole   0x237
 #define METATILE_Pacifidlog_SkyPillar_DoorOpen_Top        0x2AA
 #define METATILE_Pacifidlog_SkyPillar_DoorOpen_Bottom     0x2B2
 

--- a/src/field_tasks.c
+++ b/src/field_tasks.c
@@ -635,9 +635,12 @@ static void AshGrassPerStepCallback(u8 taskId)
     }
 }
 
+// This function uses the constants for gTileset_Cave's metatile labels, but other tilesets with
+// the CrackedFloorPerStepCallback callback use the same metatile numbers for the cracked floor
+// and hole metatiles, such as gTileset_MirageTower.
 static void SetCrackedFloorHoleMetatile(s16 x, s16 y)
 {
-    MapGridSetMetatileIdAt(x, y, MapGridGetMetatileIdAt(x, y) == 0x22f ? 0x206 : 0x237);// unsure what these are referring to
+    MapGridSetMetatileIdAt(x, y, MapGridGetMetatileIdAt(x, y) == METATILE_Cave_CrackedFloor ? METATILE_Cave_CrackedFloor_Hole : METATILE_Pacifidlog_SkyPillar_CrackedFloor_Hole);
     CurrentMapDrawMetatileAt(x, y);
 }
 


### PR DESCRIPTION
## Description
`SetCrackedFloorHoleMetatile` currently is missing constants for the metatile values. This adds metatile labels, as well as a comment explaining that while gTileset_Cave's labels are used, other tilesets use the same metatile numbers.

## **Discord contact info**
Spherical Ice#4683