### PR TITLE
Use the field effects palette tag constant for the heart icon

### DIFF
--- a/src/trainer_see.c
+++ b/src/trainer_see.c
@@ -179,7 +179,7 @@ static const struct SpriteTemplate sSpriteTemplate_ExclamationQuestionMark =
 static const struct SpriteTemplate sSpriteTemplate_HeartIcon =
 {
     .tileTag = 0xffff,
-    .paletteTag = 0x1004,
+    .paletteTag = FLDEFF_PAL_TAG_GENERAL_0,
     .oam = &sOamData_Icons,
     .anims = sSpriteAnimTable_Icons,
     .images = sSpriteImageTable_HeartIcon,


### PR DESCRIPTION
## Description
Use the constant `FLDEFF_PAL_TAG_GENERAL_0` for the heart icon's palette tag.

## **Discord contact info**
Spherical Ice#4683