### PR TITLE
Fix  of alignment of MultiBootWaitCycles

### DIFF
--- a/src/multiboot.c
+++ b/src/multiboot.c
@@ -449,7 +449,7 @@ static void MultiBootWaitCycles(u32 cycles)
     cmp  r2, 8\n\
     beq  MultiBootWaitCyclesLoop\n\
     movs r1, 4\n\
-MultiBootWaitCyclesLoop:\n\
+    MultiBootWaitCyclesLoop:\n\
     subs r0, r1\n\
     bgt  MultiBootWaitCyclesLoop\n\
     bx   lr\n");


### PR DESCRIPTION
Literally just a tab insertion