### PR TITLE
Remove unneeded bitwise operations

### DIFF
--- a/gflib/bg.c
+++ b/gflib/bg.c
@@ -9,19 +9,19 @@
 struct BgControl
 {
     struct BgConfig {
-        u16 visible:1;
-        u16 unknown_1:1;
-        u16 screenSize:2;
-        u16 priority:2;
-        u16 mosaic:1;
-        u16 wraparound:1;
+        u8 visible:1;
+        u8 unknown_1:1;
+        u8 screenSize:2;
+        u8 priority:2;
+        u8 mosaic:1;
+        u8 wraparound:1;
 
-        u16 charBaseIndex:2;
-        u16 mapBaseIndex:5;
-        u16 paletteMode:1;
+        u8 charBaseIndex:2;
+        u8 mapBaseIndex:5;
+        u8 paletteMode:1;
 
-        u8 unknown_2;
-        u8 unknown_3;
+        u8 unknown_2; // Assigned to but never read
+        u8 unknown_3; // Assigned to but never read
     } configs[NUM_BACKGROUNDS];
 
     u16 bgVisibilityAndMode;
@@ -102,17 +102,17 @@ static void SetBgControlAttributes(u8 bg, u8 charBaseIndex, u8 mapBaseIndex, u8 
     {
         if (charBaseIndex != 0xFF)
         {
-            sGpuBgConfigs.configs[bg].charBaseIndex = charBaseIndex & 0x3;
+            sGpuBgConfigs.configs[bg].charBaseIndex = charBaseIndex;
         }
 
         if (mapBaseIndex != 0xFF)
         {
-            sGpuBgConfigs.configs[bg].mapBaseIndex = mapBaseIndex & 0x1F;
+            sGpuBgConfigs.configs[bg].mapBaseIndex = mapBaseIndex;
         }
 
         if (screenSize != 0xFF)
         {
-            sGpuBgConfigs.configs[bg].screenSize = screenSize & 0x3;
+            sGpuBgConfigs.configs[bg].screenSize = screenSize;
         }
 
         if (paletteMode != 0xFF)
@@ -122,12 +122,12 @@ static void SetBgControlAttributes(u8 bg, u8 charBaseIndex, u8 mapBaseIndex, u8 
 
         if (priority != 0xFF)
         {
-            sGpuBgConfigs.configs[bg].priority = priority & 0x3;
+            sGpuBgConfigs.configs[bg].priority = priority;
         }
 
         if (mosaic != 0xFF)
         {
-            sGpuBgConfigs.configs[bg].mosaic = mosaic & 0x1;
+            sGpuBgConfigs.configs[bg].mosaic = mosaic;
         }
 
         if (wraparound != 0xFF)


### PR DESCRIPTION
By making the struct items u8 instead of u16, I could remove the bitwise operations entirely