### PR TITLE
Remove unneeded volatile qualifiers

### DIFF
--- a/gflib/gpu_regs.c
+++ b/gflib/gpu_regs.c
@@ -10,9 +10,9 @@
 
 static u8 sGpuRegBuffer[GPU_REG_BUF_SIZE];
 static u8 sGpuRegWaitingList[GPU_REG_BUF_SIZE];
-static volatile bool8 sGpuRegBufferLocked;
-static volatile bool8 sShouldSyncRegIE;
-static vu16 sRegIE;
+static bool8 sGpuRegBufferLocked;
+static bool8 sShouldSyncRegIE;
+static u16 sRegIE;
 
 static void CopyBufferedValueToGpuReg(u8 regOffset);
 static void SyncRegIE(void);

--- a/include/scanline_effect.h
+++ b/include/scanline_effect.h
@@ -16,7 +16,7 @@
 
 struct ScanlineEffectParams
 {
-    volatile void *dmaDest;
+    void *dmaDest;
     u32 dmaControl;
     u8 initState;
     u8 unused9;
@@ -24,8 +24,8 @@ struct ScanlineEffectParams
 
 struct ScanlineEffect
 {
-    void *dmaSrcBuffers[2];
-    volatile void *dmaDest;
+    const void *dmaSrcBuffers[2];
+    void *dmaDest;
     u32 dmaControl;
     void (*setFirstScanlineReg)(void);
     u8 srcBuffer;

--- a/src/battle_anim_dark.c
+++ b/src/battle_anim_dark.c
@@ -427,7 +427,7 @@ void AnimTask_MoveAttackerMementoShadow(u8 taskId)
         task->data[10] = gBattle_BG1_Y;
         SetGpuReg(REG_OFFSET_BLDCNT, BLDCNT_TGT2_ALL | BLDCNT_EFFECT_BLEND | BLDCNT_TGT1_BG1);
         FillPalette(0, animBg.paletteId * 16, 32);
-        scanlineParams.dmaDest = &REG_BG1VOFS;
+        scanlineParams.dmaDest = (void *)REG_ADDR_BG1VOFS;
         var0 = WINOUT_WIN01_BG1;
         if (!IsContest())
             gBattle_BG2_X += 240;
@@ -437,7 +437,7 @@ void AnimTask_MoveAttackerMementoShadow(u8 taskId)
         task->data[10] = gBattle_BG2_Y;
         SetGpuReg(REG_OFFSET_BLDCNT, BLDCNT_TGT2_ALL | BLDCNT_EFFECT_BLEND | BLDCNT_TGT1_BG2);
         FillPalette(0, 144, 32);
-        scanlineParams.dmaDest = &REG_BG2VOFS;
+        scanlineParams.dmaDest = (void *)&REG_BG2VOFS;
         var0 = WINOUT_WIN01_BG2;
         if (!IsContest())
             gBattle_BG1_X += 240;
@@ -598,9 +598,9 @@ void AnimTask_MoveTargetMementoShadow(u8 taskId)
         break;
     case 3:
         if (task->data[3] == 1)
-            scanlineParams.dmaDest = &REG_BG1VOFS;
+            scanlineParams.dmaDest = (void *)&REG_BG1VOFS;
         else
-            scanlineParams.dmaDest = &REG_BG2VOFS;
+            scanlineParams.dmaDest = (void *)&REG_BG2VOFS;
 
         for (i = 0; i < 112; i++)
         {

--- a/src/battle_anim_dark.c
+++ b/src/battle_anim_dark.c
@@ -437,7 +437,7 @@ void AnimTask_MoveAttackerMementoShadow(u8 taskId)
         task->data[10] = gBattle_BG2_Y;
         SetGpuReg(REG_OFFSET_BLDCNT, BLDCNT_TGT2_ALL | BLDCNT_EFFECT_BLEND | BLDCNT_TGT1_BG2);
         FillPalette(0, 144, 32);
-        scanlineParams.dmaDest = (void *)&REG_BG2VOFS;
+        scanlineParams.dmaDest = (void *)REG_ADDR_BG2VOFS;
         var0 = WINOUT_WIN01_BG2;
         if (!IsContest())
             gBattle_BG1_X += 240;
@@ -598,9 +598,9 @@ void AnimTask_MoveTargetMementoShadow(u8 taskId)
         break;
     case 3:
         if (task->data[3] == 1)
-            scanlineParams.dmaDest = (void *)&REG_BG1VOFS;
+            scanlineParams.dmaDest = (void *)REG_ADDR_BG1VOFS;
         else
-            scanlineParams.dmaDest = (void *)&REG_BG2VOFS;
+            scanlineParams.dmaDest = (void *)REG_ADDR_BG2VOFS;
 
         for (i = 0; i < 112; i++)
         {

--- a/src/battle_anim_dragon.c
+++ b/src/battle_anim_dragon.c
@@ -334,12 +334,12 @@ void AnimTask_DragonDanceWaver(u8 taskId)
     u8 y;
     if (GetBattlerSpriteBGPriorityRank(gBattleAnimAttacker) == 1)
     {
-        scanlineParams.dmaDest = &REG_BG1HOFS;
+        scanlineParams.dmaDest = (void *)REG_ADDR_BG1HOFS;
         task->data[2] = gBattle_BG1_X;
     }
     else
     {
-        scanlineParams.dmaDest = &REG_BG2HOFS;
+        scanlineParams.dmaDest = (void *)REG_ADDR_BG2HOFS;
         task->data[2] = gBattle_BG2_X;
     }
 

--- a/src/battle_anim_effects_3.c
+++ b/src/battle_anim_effects_3.c
@@ -3328,14 +3328,14 @@ void AnimTask_AcidArmor(u8 taskId)
     task->data[15] = GetAnimBattlerSpriteId(gBattleAnimArgs[0]);
     if (GetBattlerSpriteBGPriorityRank(battler) == 1)
     {
-        scanlineParams.dmaDest = (void *)&REG_BG1HOFS;
+        scanlineParams.dmaDest = (void *)REG_ADDR_BG1HOFS;
         SetGpuReg(REG_OFFSET_BLDCNT, BLDCNT_TGT2_ALL | BLDCNT_EFFECT_BLEND | BLDCNT_TGT1_BG1);
         bgX = gBattle_BG1_X;
         bgY = gBattle_BG1_Y;
     }
     else
     {
-        scanlineParams.dmaDest = (void *)&REG_BG2HOFS;
+        scanlineParams.dmaDest = (void *)REG_ADDR_BG2HOFS;
         SetGpuReg(REG_OFFSET_BLDCNT, BLDCNT_TGT2_ALL | BLDCNT_EFFECT_BLEND | BLDCNT_TGT1_BG2);
         bgX = gBattle_BG2_X;
         bgY = gBattle_BG2_Y;

--- a/src/battle_anim_effects_3.c
+++ b/src/battle_anim_effects_3.c
@@ -1819,9 +1819,9 @@ void AnimTask_RapinSpinMonElevation(u8 taskId)
     }
 
     if (toBG2 == 1)
-        scanlineParams.dmaDest = &REG_BG1HOFS;
+        scanlineParams.dmaDest = (void *)REG_ADDR_BG1HOFS;
     else
-        scanlineParams.dmaDest = &REG_BG2HOFS;
+        scanlineParams.dmaDest = (void *)REG_ADDR_BG2HOFS;
 
     scanlineParams.dmaControl = SCANLINE_EFFECT_DMACNT_16BIT;
     scanlineParams.initState = 1;
@@ -3328,14 +3328,14 @@ void AnimTask_AcidArmor(u8 taskId)
     task->data[15] = GetAnimBattlerSpriteId(gBattleAnimArgs[0]);
     if (GetBattlerSpriteBGPriorityRank(battler) == 1)
     {
-        scanlineParams.dmaDest = &REG_BG1HOFS;
+        scanlineParams.dmaDest = (void *)&REG_BG1HOFS;
         SetGpuReg(REG_OFFSET_BLDCNT, BLDCNT_TGT2_ALL | BLDCNT_EFFECT_BLEND | BLDCNT_TGT1_BG1);
         bgX = gBattle_BG1_X;
         bgY = gBattle_BG1_Y;
     }
     else
     {
-        scanlineParams.dmaDest = &REG_BG2HOFS;
+        scanlineParams.dmaDest = (void *)&REG_BG2HOFS;
         SetGpuReg(REG_OFFSET_BLDCNT, BLDCNT_TGT2_ALL | BLDCNT_EFFECT_BLEND | BLDCNT_TGT1_BG2);
         bgX = gBattle_BG2_X;
         bgY = gBattle_BG2_Y;

--- a/src/battle_anim_ground.c
+++ b/src/battle_anim_ground.c
@@ -463,12 +463,12 @@ static void SetDigScanlineEffect(u8 useBG1, s16 y, s16 endY)
     if (useBG1 == 1)
     {
         bgX = gBattle_BG1_X;
-        scanlineParams.dmaDest = &REG_BG1HOFS;
+        scanlineParams.dmaDest = (void *)REG_ADDR_BG1HOFS;
     }
     else
     {
         bgX = gBattle_BG2_X;
-        scanlineParams.dmaDest = &REG_BG2HOFS;
+        scanlineParams.dmaDest = (void *)REG_ADDR_BG2HOFS;
     }
 
     if (y < 0)

--- a/src/battle_anim_psychic.c
+++ b/src/battle_anim_psychic.c
@@ -989,12 +989,12 @@ void AnimTask_ExtrasensoryDistortion(u8 taskId)
     if (GetBattlerSpriteBGPriorityRank(gBattleAnimTarget) == 1)
     {
         task->data[10] = gBattle_BG1_X;
-        scanlineParams.dmaDest = &REG_BG1HOFS;
+        scanlineParams.dmaDest = (void *)REG_ADDR_BG1HOFS;
     }
     else
     {
         task->data[10] = gBattle_BG2_X;
-        scanlineParams.dmaDest = &REG_BG2HOFS;
+        scanlineParams.dmaDest = (void *)REG_ADDR_BG2HOFS;
     }
 
     i = task->data[14];

--- a/src/battle_anim_water.c
+++ b/src/battle_anim_water.c
@@ -961,7 +961,7 @@ static void AnimTask_SurfWaveScanlineEffect(u8 taskId)
         else
             gScanlineEffectRegBuffers[0][i] = gScanlineEffectRegBuffers[1][i] = task->data[2];
 
-        params.dmaDest = (vu16 *)REG_ADDR_BLDALPHA;
+        params.dmaDest = (void *)REG_ADDR_BLDALPHA;
         params.dmaControl = SCANLINE_EFFECT_DMACNT_16BIT;
         params.initState = 1;
         params.unused9 = 0;

--- a/src/battle_transition.c
+++ b/src/battle_transition.c
@@ -1602,13 +1602,13 @@ static void Transition_BigPokeball_Vblank(void)
 static void VBlankCB0_Phase2_BigPokeball(void)
 {
     Transition_BigPokeball_Vblank();
-    DmaSet(0, gScanlineEffectRegBuffers[1], &REG_BG0HOFS, 0xA2400001);
+    DmaSet(0, gScanlineEffectRegBuffers[1], REG_ADDR_BG0HOFS, 0xA2400001);
 }
 
 static void VBlankCB1_Phase2_BigPokeball(void)
 {
     Transition_BigPokeball_Vblank();
-    DmaSet(0, gScanlineEffectRegBuffers[1], &REG_WIN0H, 0xA2400001);
+    DmaSet(0, gScanlineEffectRegBuffers[1], REG_ADDR_WIN0H, 0xA2400001);
 }
 
 static void Phase2Task_PokeballsTrail(u8 taskId)
@@ -1909,7 +1909,7 @@ static void VBlankCB_Phase2_Clockwise_BlackFade(void)
     REG_WINOUT = sTransitionStructPtr->WINOUT;
     REG_WIN0V = sTransitionStructPtr->WIN0V;
     REG_WIN0H = gScanlineEffectRegBuffers[1][0];
-    DmaSet(0, gScanlineEffectRegBuffers[1], &REG_WIN0H, 0xA2400001);
+    DmaSet(0, gScanlineEffectRegBuffers[1], REG_ADDR_WIN0H, 0xA2400001);
 }
 
 static void Phase2Task_Ripple(u8 taskId)
@@ -2062,7 +2062,7 @@ static void VBlankCB_Phase2_Wave(void)
     REG_WININ = sTransitionStructPtr->WININ;
     REG_WINOUT = sTransitionStructPtr->WINOUT;
     REG_WIN0V = sTransitionStructPtr->WIN0V;
-    DmaSet(0, gScanlineEffectRegBuffers[1], &REG_WIN0H, 0xA2400001);
+    DmaSet(0, gScanlineEffectRegBuffers[1], REG_ADDR_WIN0H, 0xA2400001);
 }
 
 static void Phase2Task_Sidney(u8 taskId)
@@ -2347,7 +2347,7 @@ static void VBlankCB0_Phase2_Mugshots(void)
     REG_WININ = sTransitionStructPtr->WININ;
     REG_WINOUT = sTransitionStructPtr->WINOUT;
     REG_WIN0V = sTransitionStructPtr->WIN0V;
-    DmaSet(0, gScanlineEffectRegBuffers[1], &REG_WIN0H, 0xA2400001);
+    DmaSet(0, gScanlineEffectRegBuffers[1], REG_ADDR_WIN0H, 0xA2400001);
 }
 
 static void VBlankCB1_Phase2_Mugshots(void)
@@ -2357,7 +2357,7 @@ static void VBlankCB1_Phase2_Mugshots(void)
     if (sTransitionStructPtr->VBlank_DMA != 0)
         DmaCopy16(3, gScanlineEffectRegBuffers[0], gScanlineEffectRegBuffers[1], 320);
     REG_BLDCNT = sTransitionStructPtr->BLDCNT;
-    DmaSet(0, gScanlineEffectRegBuffers[1], &REG_BLDY, 0xA2400001);
+    DmaSet(0, gScanlineEffectRegBuffers[1], REG_ADDR_BLDY, 0xA2400001);
 }
 
 static void HBlankCB_Phase2_Mugshots(void)
@@ -2580,7 +2580,7 @@ static void VBlankCB_Phase2_Slice(void)
     REG_WIN0V = sTransitionStructPtr->WIN0V;
     if (sTransitionStructPtr->VBlank_DMA)
         DmaCopy16(3, gScanlineEffectRegBuffers[0], gScanlineEffectRegBuffers[1], 640);
-    DmaSet(0, &gScanlineEffectRegBuffers[1][160], &REG_WIN0H, 0xA2400001);
+    DmaSet(0, &gScanlineEffectRegBuffers[1][160], REG_ADDR_WIN0H, 0xA2400001);
 }
 
 static void HBlankCB_Phase2_Slice(void)
@@ -3240,7 +3240,7 @@ static void VBlankCB_Phase2_Rayquaza(void)
     else
         dmaSrc = gScanlineEffectRegBuffers[0];
 
-    DmaSet(0, dmaSrc, &REG_BG0VOFS, 0xA2400001);
+    DmaSet(0, dmaSrc, REG_ADDR_BG0VOFS, 0xA2400001);
 }
 
 static void Phase2Task_WhiteFade(u8 taskId)
@@ -3345,7 +3345,7 @@ static void VBlankCB0_Phase2_WhiteFade(void)
     REG_WIN0V = sTransitionStructPtr->WIN0V;
     if (sTransitionStructPtr->VBlank_DMA)
         DmaCopy16(3, gScanlineEffectRegBuffers[0], gScanlineEffectRegBuffers[1], 640);
-    DmaSet(0, &gScanlineEffectRegBuffers[1][160], &REG_WIN0H, 0xA2400001);
+    DmaSet(0, &gScanlineEffectRegBuffers[1][160], REG_ADDR_WIN0H, 0xA2400001);
 }
 
 static void VBlankCB1_Phase2_WhiteFade(void)
@@ -3574,7 +3574,7 @@ static void VBlankCB_Phase2_Shards(void)
     REG_WINOUT = sTransitionStructPtr->WINOUT;
     REG_WIN0V = sTransitionStructPtr->WIN0V;
     REG_WIN0H = gScanlineEffectRegBuffers[1][0];
-    DmaSet(0, gScanlineEffectRegBuffers[1], &REG_WIN0H, 0xA2400001);
+    DmaSet(0, gScanlineEffectRegBuffers[1], REG_ADDR_WIN0H, 0xA2400001);
 }
 
 // sub-task for phase2

--- a/src/librfu_sio32id.c
+++ b/src/librfu_sio32id.c
@@ -79,7 +79,7 @@ static s32 Sio32IDMain(void)
         REG_IE |= INTR_FLAG_SERIAL;
         REG_IME = 1;
         gRfuSIO32Id.state = 1;
-        *(vu8 *)&REG_SIOCNT |= SIO_ENABLE;
+        *(vu8 *)REG_ADDR_SIOCNT |= SIO_ENABLE;
         break;
     case 1:
         if (gRfuSIO32Id.lastId == 0)

--- a/src/m4a.c
+++ b/src/m4a.c
@@ -352,10 +352,10 @@ void SoundInit(struct SoundInfo *soundInfo)
                    | SOUND_ALL_MIX_FULL;
     REG_SOUNDBIAS_H = (REG_SOUNDBIAS_H & 0x3F) | 0x40;
 
-    REG_DMA1SAD = (s32)soundInfo->pcmBuffer;
-    REG_DMA1DAD = (s32)&REG_FIFO_A;
-    REG_DMA2SAD = (s32)soundInfo->pcmBuffer + PCM_DMA_BUF_SIZE;
-    REG_DMA2DAD = (s32)&REG_FIFO_B;
+    REG_DMA1SAD = (u32)soundInfo->pcmBuffer;
+    REG_DMA1DAD = (u32)REG_ADDR_FIFO_A;
+    REG_DMA2SAD = (u32)soundInfo->pcmBuffer + PCM_DMA_BUF_SIZE;
+    REG_DMA2DAD = (u32)REG_ADDR_FIFO_B;
 
     SOUND_INFO_PTR = soundInfo;
     CpuFill32(0, soundInfo, sizeof(struct SoundInfo));

--- a/src/rayquaza_scene.c
+++ b/src/rayquaza_scene.c
@@ -490,7 +490,7 @@ static const struct SpriteTemplate sSpriteTemplate_DuoFightPre_KyogreDorsalFin =
 
 static const struct ScanlineEffectParams sScanlineParams_DuoFight_Clouds =
 {
-    .dmaDest = (vu16 *)REG_ADDR_BG1HOFS,
+    .dmaDest = (void *)REG_ADDR_BG1HOFS,
     .dmaControl = SCANLINE_EFFECT_DMACNT_16BIT,
     .initState = 1
 };

--- a/src/reshow_battle_screen.c
+++ b/src/reshow_battle_screen.c
@@ -173,10 +173,10 @@ static void sub_80A95F4(void)
 {
     struct BGCntrlBitfield *regBgcnt1, *regBgcnt2;
 
-    regBgcnt1 = (struct BGCntrlBitfield *)(&REG_BG1CNT);
+    regBgcnt1 = (struct BGCntrlBitfield *)(REG_ADDR_BG1CNT);
     regBgcnt1->charBaseBlock = 0;
 
-    regBgcnt2 = (struct BGCntrlBitfield *)(&REG_BG2CNT);
+    regBgcnt2 = (struct BGCntrlBitfield *)(REG_ADDR_BG2CNT);
     regBgcnt2->charBaseBlock = 0;
 }
 

--- a/src/union_room_chat.c
+++ b/src/union_room_chat.c
@@ -3106,7 +3106,7 @@ static void InitScanlineEffect(void)
 {
     struct ScanlineEffectParams params;
     params.dmaControl = SCANLINE_EFFECT_DMACNT_16BIT;
-    params.dmaDest = &REG_BG1HOFS;
+    params.dmaDest = (void *)REG_ADDR_BG1HOFS;
     params.initState = 1;
     params.unused9 = 0;
     sDisplay->bg1hofs = 0;


### PR DESCRIPTION
There are multiple variables with the volatile qualifier, for good reason. However in the past, this still wasn't enough. Which was why PR #1197 was made. This changed it so the copying process would be volatile. It turns out, this was all that needed to be done, since the variable itself is not memory mapped, only when copying via the DMA should the access be volatile.

The same were done with unneeded pointers. The CONTENTS of the registers need to be volatile, not a variable storing the register's memory address. For this reason, I changed the &<register name> to use the ADDR #define.

To ensure this worked and nothing actually broke, I built a modern version of the game using this repo, and 100% the game, all gyms, all battles, and no issues.

It was a thorough test to ensure nothing actually needed to be volatile.

This should be helpful for better MODERN builds.