### PR TITLE
Nonmatching resoltuion

### DIFF
--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -2089,12 +2089,7 @@ static void Cmd_get_used_held_item(void)
     else
         battlerId = gBattlerTarget;
 
-    // This is likely a leftover from Ruby's code and its ugly ewram access.
-    #ifdef NONMATCHING
-        AI_THINKING_STRUCT->funcResult = gBattleStruct->usedHeldItems[battlerId];
-    #else
-        AI_THINKING_STRUCT->funcResult = *(u8*)((u8*)(gBattleStruct) + offsetof(struct BattleStruct, usedHeldItems) + (battlerId * 2));
-    #endif // NONMATCHING
+    AI_THINKING_STRUCT->funcResult = *(u8 *)&gBattleStruct->usedHeldItems[battlerId];
 
     gAIScriptPtr += 2;
 }

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -68,9 +68,6 @@ extern const struct BgTemplate gBattleBgTemplates[];
 extern const struct WindowTemplate *const gBattleWindowTemplates[];
 
 // this file's functions
-#if !defined(NONMATCHING) && MODERN
-#define static
-#endif
 static void CB2_InitBattleInternal(void);
 static void CB2_PreInitMultiBattle(void);
 static void CB2_PreInitIngamePlayerPartnerBattle(void);

--- a/src/item.c
+++ b/src/item.c
@@ -19,9 +19,6 @@
 extern u16 gUnknown_0203CF30[];
 
 // this file's functions
-#if !defined(NONMATCHING) && MODERN
-#define static
-#endif
 static bool8 CheckPyramidBagHasItem(u16 itemId, u16 count);
 static bool8 CheckPyramidBagHasSpace(u16 itemId, u16 count);
 

--- a/src/trade.c
+++ b/src/trade.c
@@ -165,9 +165,6 @@ static EWRAM_DATA struct {
     /*0xFE*/ u8 wirelessWinBottom;
 } *sTradeData = {NULL};
 
-#if !defined(NONMATCHING) && MODERN
-#define static
-#endif
 static bool32 IsWirelessTrade(void);
 static void CB2_CreateTradeMenu(void);
 static void VBlankCB_TradeMenu(void);

--- a/src/tv.c
+++ b/src/tv.c
@@ -75,9 +75,6 @@ EWRAM_DATA ALIGNED(4) u8 sTVShowState = 0;
 EWRAM_DATA u8 sTVSecretBaseSecretsRandomValues[3] = {};
 
 // Static ROM declarations
-#if !defined(NONMATCHING) && MODERN
-#define static
-#endif
 void ClearPokemonNews(void);
 u8 GetTVChannelByShowType(u8 kind);
 u8 FindFirstActiveTVShowThatIsNotAMassOutbreak(void);


### PR DESCRIPTION
- Fix fakematch in Cmd_get_used_held_item
- Remove `static` overrides in MODERN in four objects

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## **Discord contact info**
<!--- formatted as name#numbers, e.g. --> PikalaxALT#5823
<!--- Contributors must join https://discord.gg/d5dubZ3 -->