### PR TITLE
Fix some division by 0 and an incorrect bug fix

### DIFF
--- a/gflib/sprite.c
+++ b/gflib/sprite.c
@@ -1329,12 +1329,7 @@ void ApplyAffineAnimFrameRelativeAndUpdateMatrix(u8 matrixNum, struct AffineAnim
 s16 ConvertScaleParam(s16 scale)
 {
     s32 val = 0x10000;
-    // UB: possible division by zero
-#ifdef UBFIX
-    if (scale == 0)
-        return 0;
-#endif //UBFIX
-    return val / scale;
+    return SAFE_DIV(val, scale);
 }
 
 void GetAffineAnimFrame(u8 matrixNum, struct Sprite *sprite, struct AffineAnimFrameCmd *frameCmd)

--- a/include/global.h
+++ b/include/global.h
@@ -74,6 +74,14 @@
 #define abs(x) (((x) < 0) ? -(x) : (x))
 #endif
 
+// Used in cases where division by 0 can occur in the retail version.
+// Avoids invalid opcodes on some emulators, and the otherwise UB.
+#ifdef UBFIX
+#define SAFE_DIV(a, b) ((b) ? (a) / (b) : 0)
+#else
+#define SAFE_DIV(a, b) ((a) / (b))
+#endif
+
 // Extracts the upper 16 bits of a 32-bit number
 #define HIHALF(n) (((n) & 0xFFFF0000) >> 16)
 

--- a/src/battle_anim_mons.c
+++ b/src/battle_anim_mons.c
@@ -1815,7 +1815,7 @@ void SetBattlerSpriteYOffsetFromYScale(u8 spriteId)
 {
     int var = 64 - GetBattlerYDeltaFromSpriteId(spriteId) * 2;
     u16 matrix = gSprites[spriteId].oam.matrixNum;
-    int var2 = (var << 8) / gOamMatrices[matrix].d;
+    int var2 = SAFE_DIV(var << 8, gOamMatrices[matrix].d);
 
     if (var2 > 128)
         var2 = 128;
@@ -1828,7 +1828,7 @@ void SetBattlerSpriteYOffsetFromOtherYScale(u8 spriteId, u8 otherSpriteId)
 {
     int var = 64 - GetBattlerYDeltaFromSpriteId(otherSpriteId) * 2;
     u16 matrix = gSprites[spriteId].oam.matrixNum;
-    int var2 = (var << 8) / gOamMatrices[matrix].d;
+    int var2 = SAFE_DIV(var << 8, gOamMatrices[matrix].d);
 
     if (var2 > 128)
         var2 = 128;

--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -3853,16 +3853,8 @@ static void Task_MoveDeoxysRock(u8 taskId)
         case 0:
             data[4] = sprite->pos1.x << 4;
             data[5] = sprite->pos1.y << 4;
-
-            // UB: Possible divide by zero
-            #ifdef UBFIX
-            #define DIVISOR (data[8] ? data[8] : 1);
-            #else
-            #define DIVISOR (data[8])
-            #endif
-
-            data[6] = (data[2] * 16 - data[4]) / DIVISOR;
-            data[7] = (data[3] * 16 - data[5]) / DIVISOR;
+            data[6] = SAFE_DIV(data[2] * 16 - data[4], data[8]);
+            data[7] = SAFE_DIV(data[3] * 16 - data[5], data[8]);
             data[0]++;
         case 1:
             if (data[8] != 0)

--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -2383,13 +2383,13 @@ void ClearRankingHallRecords(void)
 {
     s32 i, j, k;
 
-    // BUG: Passing 0 as a pointer instead of a pointer holding a value of 0.
-    #ifdef BUGFIX
-    u8 zero = 0;
-    #define ZERO (&zero)
-    #else
+    // UB: Passing 0 as a pointer instead of a pointer holding a value of 0.
+#ifdef UBFIX
+    u8 emptyId[TRAINER_ID_LENGTH] = {0};
+    #define ZERO emptyId
+#else
     #define ZERO 0
-    #endif
+#endif
 
     for (i = 0; i < HALL_FACILITIES_COUNT; i++)
     {

--- a/src/intro.c
+++ b/src/intro.c
@@ -1576,7 +1576,7 @@ static void Task_IntroSpinAndZoomPokeball(u8 taskId)
         gTasks[taskId].func = Task_IntroWaitToSetupPart3LegendsFight;
     }
 
-    PanFadeAndZoomScreen(0x78, 0x50, 0x10000 / gTasks[taskId].data[1], gTasks[taskId].data[0]);
+    PanFadeAndZoomScreen(0x78, 0x50, SAFE_DIV(0x10000, gTasks[taskId].data[1]), gTasks[taskId].data[0]);
 
     if (gIntroFrameCounter == 28)
         BeginNormalPaletteFade(PALETTES_ALL, 0, 0, 0x10, RGB_WHITEALPHA);

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -3032,17 +3032,8 @@ static void SpriteCB_PokedexListMonSprite(struct Sprite *sprite)
     else
     {
         u32 var;
-
         sprite->pos2.y = gSineTable[(u8)sprite->data[5]] * 76 / 256;
-        // UB: possible division by zero
-#ifdef UBFIX
-        if (gSineTable[sprite->data[5] + 64] != 0)
-            var = 0x10000 / gSineTable[sprite->data[5] + 64];
-        else
-            var = 0;
-#else
-        var = 0x10000 / gSineTable[sprite->data[5] + 64];
-#endif //UBFIX
+        var = SAFE_DIV(0x10000, gSineTable[sprite->data[5] + 64]);
         if (var > 0xFFFF)
             var = 0xFFFF;
         SetOamMatrix(sprite->data[1] + 1, 0x100, 0, 0, var);


### PR DESCRIPTION
- Use new `SAFE_DIV` macro (first proposed here: https://github.com/pret/pokeemerald/pull/789 ) on existing fixes for divide by 0
- Add some divide by 0 fixes found by the PC port
- Correct a bug fix in `ClearRankingHallRecords`