### PR TITLE
Rename IsNotEventLegalMewOrDeoxys to IsMonEventLegal

### DIFF
--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3949,7 +3949,7 @@ u8 GetMoveTarget(u16 move, u8 setTarget)
     return targetBattler;
 }
 
-static bool32 IsNotEventLegalMewOrDeoxys(u8 battlerId)
+static bool32 IsMonEventLegal(u8 battlerId)
 {
     if (GetBattlerSide(battlerId) == B_SIDE_OPPONENT)
         return TRUE;
@@ -3970,7 +3970,7 @@ u8 IsMonDisobedient(void)
     if (GetBattlerSide(gBattlerAttacker) == B_SIDE_OPPONENT)
         return 0;
 
-    if (IsNotEventLegalMewOrDeoxys(gBattlerAttacker)) // only if species is Mew or Deoxys
+    if (IsMonEventLegal(gBattlerAttacker)) // only false if illegal Mew or Deoxys
     {
         if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER && GetBattlerPosition(gBattlerAttacker) == 2)
             return 0;


### PR DESCRIPTION
IsNotEventLegalMewOrDeoxys returns true given an Event Legal Mew or Deoxys. The comment next to its use in an if statement also implies it only returns true if given the species Mew/Deoxys when it returns true if given anything but Illegal Mew/Deoxys. "IsMonEventLegal" is correct and more descriptive.

On Discord I'm:
Hungry Pickle#8523