### PR TITLE
Fix modern target when libc functions are used.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,14 @@ override CFLAGS += -mthumb-interwork -Wimplicit -Wparentheses -Werror -O2 -fhex-
 ROM := pokeemerald.gba
 OBJ_DIR := build/emerald
 LIBPATH := -L ../../tools/agbcc/lib
+LIB := $(LIBPATH) -lgcc -lc -L../../libagbsyscall -lagbsyscall
 else
 CC1              = $(shell $(CC) --print-prog-name=cc1) -quiet
 override CFLAGS += -mthumb -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast -g
 ROM := pokeemerald_modern.gba
 OBJ_DIR := build/modern
 LIBPATH := -L "$(dir $(shell $(CC) -mthumb -print-file-name=libgcc.a))" -L "$(dir $(shell $(CC) -mthumb -print-file-name=libnosys.a))" -L "$(dir $(shell $(CC) -mthumb -print-file-name=libc.a))"
+LIB := $(LIBPATH) -lc -lnosys -lgcc -L../../libagbsyscall -lagbsyscall
 endif
 
 CPPFLAGS := -iquote include -iquote $(GFLIB_SUBDIR) -Wno-trigraphs -DMODERN=$(MODERN)
@@ -81,8 +83,6 @@ CPPFLAGS += -I tools/agbcc/include -I tools/agbcc
 endif
 
 LDFLAGS = -Map ../../$(MAP)
-
-LIB := $(LIBPATH) -lc -lnosys -lgcc -L../../libagbsyscall -lagbsyscall
 
 SHA1 := $(shell { command -v sha1sum || command -v shasum; } 2>/dev/null) -c
 GFX := tools/gbagfx/gbagfx$(EXE)

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ CC1              = $(shell $(CC) --print-prog-name=cc1) -quiet
 override CFLAGS += -mthumb -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast -g
 ROM := pokeemerald_modern.gba
 OBJ_DIR := build/modern
-LIBPATH := -L "$(dir $(shell $(CC) -mthumb -print-file-name=libgcc.a))" -L "$(dir $(shell $(CC) -mthumb -print-file-name=libc.a))"
+LIBPATH := -L "$(dir $(shell $(CC) -mthumb -print-file-name=libgcc.a))" -L "$(dir $(shell $(CC) -mthumb -print-file-name=libnosys.a))" -L "$(dir $(shell $(CC) -mthumb -print-file-name=libc.a))"
 endif
 
 CPPFLAGS := -iquote include -iquote $(GFLIB_SUBDIR) -Wno-trigraphs -DMODERN=$(MODERN)
@@ -82,7 +82,7 @@ endif
 
 LDFLAGS = -Map ../../$(MAP)
 
-LIB := $(LIBPATH) -lc -lgcc -L../../libagbsyscall -lagbsyscall
+LIB := $(LIBPATH) -lc -lnosys -lgcc -L../../libagbsyscall -lagbsyscall
 
 SHA1 := $(shell { command -v sha1sum || command -v shasum; } 2>/dev/null) -c
 GFX := tools/gbagfx/gbagfx$(EXE)

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ endif
 
 LDFLAGS = -Map ../../$(MAP)
 
-LIB := $(LIBPATH) -lgcc -lc -L../../libagbsyscall -lagbsyscall
+LIB := $(LIBPATH) -lc -lgcc -L../../libagbsyscall -lagbsyscall
 
 SHA1 := $(shell { command -v sha1sum || command -v shasum; } 2>/dev/null) -c
 GFX := tools/gbagfx/gbagfx$(EXE)

--- a/ld_script_modern.txt
+++ b/ld_script_modern.txt
@@ -27,6 +27,8 @@ SECTIONS {
         /* .bss starts at 0x3000000 */
         src/*.o(.bss);
         gflib/*.o(.bss);
+        *libc.a:*.o(.bss);
+        *libnosys.a:*.o(.bss);
 
         /* .bss.code starts at 0x3001AA8 */
         src/m4a.o(.bss.code);
@@ -34,7 +36,8 @@ SECTIONS {
         /* COMMON starts at 0x30022A8 */
         src/*.o(COMMON);
         gflib/*.o(COMMON);
-        *libc.a:sbrkr.o(COMMON);
+        *libc.a:*.o(COMMON);
+        *libnosys.a:*.o(COMMON);
         end = .;
         . = 0x8000;
     }
@@ -82,6 +85,7 @@ SECTIONS {
         *libagbsyscall.a:*.o(.text*);
         *libgcc.a:*.o(.text*);
         *libc.a:*.o(.text*);
+        *libnosys.a:*.o(.text*);
         src/libisagbprn.o(.text);
     } =0
 

--- a/ld_script_modern.txt
+++ b/ld_script_modern.txt
@@ -27,8 +27,8 @@ SECTIONS {
         /* .bss starts at 0x3000000 */
         src/*.o(.bss);
         gflib/*.o(.bss);
-        *libc.a:*.o(.bss);
-        *libnosys.a:*.o(.bss);
+        *libc.a:*.o(.bss*);
+        *libnosys.a:*.o(.bss*);
 
         /* .bss.code starts at 0x3001AA8 */
         src/m4a.o(.bss.code);
@@ -47,19 +47,10 @@ SECTIONS {
     .text :
     ALIGN(4)
     {
-        src/crt0.o(.text);
-        src/*.o(.text);
-        gflib/*.o(.text);
-        asm/*.o(.text);
-    } =0
-
-    .text.unlikely :
-    ALIGN(4)
-    {
-        src/crt0.o(.text.unlikely);
-        src/*.o(.text.unlikely);
-        gflib/*.o(.text.unlikely);
-        asm/*.o(.text.unlikely);
+        src/crt0.o(.text*);
+        src/*.o(.text*);
+        gflib/*.o(.text*);
+        asm/*.o(.text*);
     } =0
 
     script_data :


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I came accross this problem when I tried to compile pokeemerald with modern and with NDEBUG disabled. Because what happens is that suddenly libisagbprn is used and references vsprintf, which is a libc function.

The problem with that is newlib vsprintf internally references a bunch of other things resulting in a lot of linker errors. This includes missing functions and discarded sections.

The missing functions can be fixed by linking against libnosys, which provides stub implementation for various system calls. This is what microcontroller programs usually do since they usually don't need the functionality, even if it may be indirectly referenced.

The discarded sections are fixed by adjusting the modern linker script. The most interesting part here is that a couple of bytes are added to IWRAM which add up to 0x3C bytes in total. Since it's reasonably low, I didn't see a real problem with that.

0x34 of those bytes are used for newlibs malloc implementation. I'm not quite certain if it's actually able to function since no heap boundaries are actually defined anywhere.