### PR TITLE
Resolve sio32intr_clock_slave fakematching. One left!

### DIFF
--- a/src/librfu_intr.c
+++ b/src/librfu_intr.c
@@ -148,11 +148,7 @@ static void sio32intr_clock_slave(void)
 {
     u32 regSIODATA32;
     u32 r0;
-    #ifndef NONMATCHING
-        register u32 reqLen asm("r2");
-    #else
-        u32 reqLen;
-    #endif
+    u32 reqLen;
 
     gSTWIStatus->timerActive = 0;
     STWI_set_timer_in_RAM(100);
@@ -165,10 +161,14 @@ static void sio32intr_clock_slave(void)
         ((u32*)gSTWIStatus->rxPacket)[0] = regSIODATA32;
         gSTWIStatus->reqNext = 1;
         r0 = 0x99660000;
-        if ((regSIODATA32 >> 16) == (r0 >> 16))
+        // variable reuse required
+        reqLen = (regSIODATA32 >> 16);
+        if (reqLen == (r0 >> 16))
         {
-            gSTWIStatus->reqLength = reqLen = regSIODATA32 >> 8;
-            gSTWIStatus->reqActiveCommand = regSIODATA32;
+            // only reqLen = regSIODATA32 >> 8 is needed to match, but it looks a bit
+            // more consistent when both lines update the variables. Might have been a macro?
+            gSTWIStatus->reqLength = reqLen = (regSIODATA32 >> 8);
+            gSTWIStatus->reqActiveCommand = reqLen = (regSIODATA32 >> 0);
             if (gSTWIStatus->reqLength == 0)
             {
                 if (


### PR DESCRIPTION
Ding dong. The witch is dead again. One nonmatching/fakematching left.

## Description
Variable reuse is required. Updated the reqLen usages to clarify it could have been a macro.

## **Discord contact info**
Revo#7090