### PR TITLE
Eliminate the last fakematching (Sio32IDIntr). We are free of nonmatchings/fakematchings!

### DIFF
--- a/src/librfu_rfu.c
+++ b/src/librfu_rfu.c
@@ -1758,9 +1758,6 @@ static void rfu_constructSendLLFrame(void)
             {
                 u8 *maxSize = llf_p - offsetof(struct RfuFixed, LLFBuffer[1]);
 
-                // Does the volatile qualifier make sense?
-                // It's the same as:
-                // asm("":::"memory");
                 pakcketSize = maxSize - *(u8 *volatile *)&gRfuFixed;
             }
         }


### PR DESCRIPTION
Match Sio32IDIntr

## Description
Reversing the count check and adding an extra localized temp into it was needed.

NONMATCHINGs was released outside. Bye-bye, NONMATCHINGs!

## **Discord contact info**
Revo#7090
