### PR TITLE
Fix UB in RotatingGate_RotateInDirection

### DIFF
--- a/src/rotating_gate.c
+++ b/src/rotating_gate.c
@@ -670,7 +670,8 @@ static void RotatingGate_RotateInDirection(u8 gateId, u32 rotationDirection)
     }
     else
     {
-        orientation = ++orientation % GATE_ORIENTATION_MAX;
+        orientation++;
+        orientation = orientation % GATE_ORIENTATION_MAX;
     }
     RotatingGate_SetGateOrientation(gateId, orientation);
 }


### PR DESCRIPTION
Writing to the same location twice like this is UB. This also fixes a warning when compiling with clang