### PR TITLE
Fix UB: Destoyed task is modified.

### DIFF
--- a/src/battle_transition.c
+++ b/src/battle_transition.c
@@ -4328,7 +4328,10 @@ static bool8 Phase2_FrontierSquaresScroll_Func5(struct Task *task)
     BlendPalettes(PALETTES_ALL, 0x10, 0);
 
     DestroyTask(FindTaskIdByFunc(task->func));
+
+#ifndef UBFIX
     task->tState++; // UB: changing value of a destroyed task
+#endif
     return FALSE;
 }
 


### PR DESCRIPTION
After destruction, task is no longer used, so updating its values is worthless.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->