### PR TITLE
Fixed ChangeBgY_ScreenOff‘s signature.

### DIFF
--- a/gflib/bg.c
+++ b/gflib/bg.c
@@ -252,7 +252,6 @@ static void SetBgAffineInternal(u8 bg, s32 srcCenterX, s32 srcCenterY, s16 dispC
 
     switch (sGpuBgConfigs.bgVisibilityAndMode & 0x7)
     {
-
     default:
     case 0:
         return;
@@ -281,10 +280,10 @@ static void SetBgAffineInternal(u8 bg, s32 srcCenterX, s32 srcCenterY, s16 dispC
     SetGpuReg(REG_OFFSET_BG2PC, dest.pc);
     SetGpuReg(REG_OFFSET_BG2PD, dest.pd);
     SetGpuReg(REG_OFFSET_BG2PA, dest.pa);
-    SetGpuReg(REG_OFFSET_BG2X_L, (u16)(dest.dx));
-    SetGpuReg(REG_OFFSET_BG2X_H, (u16)(dest.dx >> 16));
-    SetGpuReg(REG_OFFSET_BG2Y_L, (u16)(dest.dy));
-    SetGpuReg(REG_OFFSET_BG2Y_H, (u16)(dest.dy >> 16));
+    SetGpuReg(REG_OFFSET_BG2X_L, (s16)(dest.dx));
+    SetGpuReg(REG_OFFSET_BG2X_H, (s16)(dest.dx >> 16));
+    SetGpuReg(REG_OFFSET_BG2Y_L, (s16)(dest.dy));
+    SetGpuReg(REG_OFFSET_BG2Y_H, (s16)(dest.dy >> 16));
 }
 
 bool8 IsInvalidBg(u8 bg)

--- a/gflib/bg.c
+++ b/gflib/bg.c
@@ -252,17 +252,18 @@ static void SetBgAffineInternal(u8 bg, s32 srcCenterX, s32 srcCenterY, s16 dispC
 
     switch (sGpuBgConfigs.bgVisibilityAndMode & 0x7)
     {
+
+    default:
+    case 0:
+        return;
     case 1:
         if (bg != 2)
             return;
         break;
     case 2:
-        if (bg < 2 || bg >= NUM_BACKGROUNDS)
+        if (bg != 2 && bg != 3)
             return;
         break;
-    case 0:
-    default:
-        return;
     }
 
     src.texX = srcCenterX;
@@ -280,10 +281,10 @@ static void SetBgAffineInternal(u8 bg, s32 srcCenterX, s32 srcCenterY, s16 dispC
     SetGpuReg(REG_OFFSET_BG2PC, dest.pc);
     SetGpuReg(REG_OFFSET_BG2PD, dest.pd);
     SetGpuReg(REG_OFFSET_BG2PA, dest.pa);
-    SetGpuReg(REG_OFFSET_BG2X_L, (s16)(dest.dx));
-    SetGpuReg(REG_OFFSET_BG2X_H, (s16)(dest.dx >> 16));
-    SetGpuReg(REG_OFFSET_BG2Y_L, (s16)(dest.dy));
-    SetGpuReg(REG_OFFSET_BG2Y_H, (s16)(dest.dy >> 16));
+    SetGpuReg(REG_OFFSET_BG2X_L, (u16)(dest.dx));
+    SetGpuReg(REG_OFFSET_BG2X_H, (u16)(dest.dx >> 16));
+    SetGpuReg(REG_OFFSET_BG2Y_L, (u16)(dest.dy));
+    SetGpuReg(REG_OFFSET_BG2Y_H, (u16)(dest.dy >> 16));
 }
 
 bool8 IsInvalidBg(u8 bg)
@@ -695,7 +696,7 @@ s32 ChangeBgY(u8 bg, s32 value, u8 op)
     return sGpuBgConfigs2[bg].bg_y;
 }
 
-s32 ChangeBgY_ScreenOff(u8 bg, u32 value, u8 op)
+s32 ChangeBgY_ScreenOff(u8 bg, s32 value, u8 op)
 {
     u8 mode;
     u16 temp1;

--- a/gflib/bg.h
+++ b/gflib/bg.h
@@ -59,7 +59,7 @@ u16 GetBgAttribute(u8 bg, u8 attributeId);
 s32 ChangeBgX(u8 bg, s32 value, u8 op);
 s32 GetBgX(u8 bg);
 s32 ChangeBgY(u8 bg, s32 value, u8 op);
-s32 ChangeBgY_ScreenOff(u8 bg, u32 value, u8 op);
+s32 ChangeBgY_ScreenOff(u8 bg, s32 value, u8 op);
 s32 GetBgY(u8 bg);
 void SetBgAffine(u8 bg, s32 srcCenterX, s32 srcCenterY, s16 dispCenterX, s16 dispCenterY, s16 scaleX, s16 scaleY, u16 rotationAngle);
 u8 Unused_AdjustBgMosaic(u8 a1, u8 a2);

--- a/src/battle_factory.c
+++ b/src/battle_factory.c
@@ -38,7 +38,7 @@ static void GenerateInitialRentalMons(void);
 static void GetOpponentMostCommonMonType(void);
 static void GetOpponentBattleStyle(void);
 static void RestorePlayerPartyHeldItems(void);
-static u16 GetFactoryMonId(u8 lvlMode, u8 challengeNum, bool8 arg2);
+static u16 GetFactoryMonId(u8 lvlMode, u8 challengeNum, bool8 useBetterRange);
 static u8 GetMoveBattleStyle(u16 move);
 
 // Number of moves needed on the team to be considered using a certain battle style

--- a/src/palette.c
+++ b/src/palette.c
@@ -556,7 +556,7 @@ void BeginFastPaletteFade(u8 submode)
 static void BeginFastPaletteFadeInternal(u8 submode)
 {
     gPaletteFade.y = 31;
-    gPaletteFade_submode = submode & 0x3F;
+    gPaletteFade_submode = submode;
     gPaletteFade.active = 1;
     gPaletteFade.mode = FAST_FADE;
 

--- a/src/palette.c
+++ b/src/palette.c
@@ -556,7 +556,7 @@ void BeginFastPaletteFade(u8 submode)
 static void BeginFastPaletteFadeInternal(u8 submode)
 {
     gPaletteFade.y = 31;
-    gPaletteFade_submode = submode;
+    gPaletteFade_submode = submode & 0x3F;
     gPaletteFade.active = 1;
     gPaletteFade.mode = FAST_FADE;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
It’s the only function of the “ChangeBy” functions that uses a u32 for value when it should be s32 like the rest.

## Description
<!--- Describe your changes in detail -->

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
AlfonsoB#1500