### PR TITLE
Rename item script labels to fit the established name scheme

### DIFF
--- a/data/maps/MagmaHideout_2F_2R/map.json
+++ b/data/maps/MagmaHideout_2F_2R/map.json
@@ -50,7 +50,7 @@
       "movement_range_y": 1,
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
-      "script": "MagmaHideout_2F_2R_EventScript_MaxElixir",
+      "script": "MagmaHideout_2F_2R_EventScript_ItemMaxElixir",
       "flag": "FLAG_ITEM_MAGMA_HIDEOUT_2F_2R_MAX_ELIXIR"
     },
     {

--- a/data/maps/MagmaHideout_4F/map.json
+++ b/data/maps/MagmaHideout_4F/map.json
@@ -115,7 +115,7 @@
       "movement_range_y": 1,
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
-      "script": "MagmaHideout_4F_EventScript_MaxRevive",
+      "script": "MagmaHideout_4F_EventScript_ItemMaxRevive",
       "flag": "FLAG_ITEM_MAGMA_HIDEOUT_4F_MAX_REVIVE"
     }
   ],

--- a/data/scripts/item_ball_scripts.inc
+++ b/data/scripts/item_ball_scripts.inc
@@ -634,7 +634,7 @@ MagmaHideout_1F_EventScript_ItemRareCandy:: @ 82914DE
 	finditem ITEM_RARE_CANDY
 	end
 
-MagmaHideout_2F_2R_EventScript_MaxElixir:: @ 82914EB
+MagmaHideout_2F_2R_EventScript_ItemMaxElixir:: @ 82914EB
 	finditem ITEM_MAX_ELIXIR
 	end
 
@@ -650,7 +650,7 @@ MagmaHideout_3F_2R_EventScript_ItemPPMax:: @ 8291512
 	finditem ITEM_PP_MAX
 	end
 
-MagmaHideout_4F_EventScript_MaxRevive:: @ 829151F
+MagmaHideout_4F_EventScript_ItemMaxRevive:: @ 829151F
 	finditem ITEM_MAX_REVIVE
 	end
 


### PR DESCRIPTION
## Description
There were two item scripts in `item_ball_scripts.inc` with labels that didn't fit the established name scheme, missing the `Item` prefix. This simply fixes that.

## **Discord contact info**
Spherical Ice#4683
