### PR TITLE
Fix some object lock names

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -812,12 +812,12 @@
 	.byte 0x68
 	.endm
 
-	@ Ceases movement for all Objects on-screen.
+	@ Freezes all objects immediately except the player. The player is frozen once their movement is finished.
 	.macro lockall
 	.byte 0x69
 	.endm
 
-	@ If the script was called by an Object, then that Object's movement will cease.
+	@ Freezes all objects immediately except the player and the selected object. The player and selected object are frozen once their movement is finished.
 	.macro lock
 	.byte 0x6a
 	.endm

--- a/include/event_object_lock.h
+++ b/include/event_object_lock.h
@@ -2,9 +2,9 @@
 #define GUARD_EVENT_OBJECT_LOCK_H
 
 bool8 IsFreezePlayerFinished(void);
-void ScriptFreezeObjectEvents(void);
 bool8 IsFreezeSelectedObjectAndPlayerFinished(void);
-void LockSelectedObjectEvent(void);
+void FreezeObjects_WaitForPlayer(void);
+void FreezeObjects_WaitForPlayerAndSelected(void);
 void FreezeForApproachingTrainers(void);
 bool8 IsFreezeObjectAndPlayerFinished(void);
 void ScriptUnfreezeObjectEvents(void);

--- a/src/event_object_lock.c
+++ b/src/event_object_lock.c
@@ -40,7 +40,7 @@ bool8 IsFreezePlayerFinished(void)
 }
 
 
-void ScriptFreezeObjectEvents(void)
+void FreezeObjects_WaitForPlayer(void)
 {
     FreezeObjectEvents();
     CreateTask(Task_FreezePlayer, 80);
@@ -82,7 +82,9 @@ bool8 IsFreezeSelectedObjectAndPlayerFinished(void)
     }
 }
 
-void LockSelectedObjectEvent(void)
+// Freeze all objects immediately except the selected object and the player.
+// The selected object and player are frozen once their movement is finished.
+void FreezeObjects_WaitForPlayerAndSelected(void)
 {
     u8 taskId;
     FreezeObjectEventsExceptOne(gSelectedObjectEvent);
@@ -144,6 +146,8 @@ static void Task_FreezeObjectAndPlayer(u8 taskId)
         DestroyTask(taskId);
 }
 
+// Freeze all objects immediately except the player and the approaching trainers.
+// The approaching trainers and player are frozen once their movement is finished
 void FreezeForApproachingTrainers(void)
 {
     u8 trainerObjectId1, trainerObjectId2, taskId;

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1203,6 +1203,8 @@ bool8 ScrCmd_turnvobject(struct ScriptContext *ctx)
     return FALSE;
 }
 
+// lockall freezes all object events except the player immediately.
+// The player is frozen after waiting for their current movement to finish.
 bool8 ScrCmd_lockall(struct ScriptContext *ctx)
 {
     if (IsUpdateLinkStateCBActive())
@@ -1211,12 +1213,14 @@ bool8 ScrCmd_lockall(struct ScriptContext *ctx)
     }
     else
     {
-        ScriptFreezeObjectEvents();
+        FreezeObjects_WaitForPlayer();
         SetupNativeScript(ctx, IsFreezePlayerFinished);
         return TRUE;
     }
 }
 
+// lock freezes all object events except the player and the selected object immediately.
+// The player and selected object are frozen after waiting for their current movement to finish.
 bool8 ScrCmd_lock(struct ScriptContext *ctx)
 {
     if (IsUpdateLinkStateCBActive())
@@ -1227,12 +1231,12 @@ bool8 ScrCmd_lock(struct ScriptContext *ctx)
     {
         if (gObjectEvents[gSelectedObjectEvent].active)
         {
-            LockSelectedObjectEvent();
+            FreezeObjects_WaitForPlayerAndSelected();
             SetupNativeScript(ctx, IsFreezeSelectedObjectAndPlayerFinished);
         }
         else
         {
-            ScriptFreezeObjectEvents();
+            FreezeObjects_WaitForPlayer();
             SetupNativeScript(ctx, IsFreezePlayerFinished);
         }
         return TRUE;

--- a/src/union_room.c
+++ b/src/union_room.c
@@ -4415,7 +4415,7 @@ static void HandleCancelActivity(bool32 setData)
 static void UR_EnableScriptContext2AndFreezeObjectEvents(void)
 {
     ScriptContext2_Enable();
-    ScriptFreezeObjectEvents();
+    FreezeObjects_WaitForPlayer();
 }
 
 static u8 GetActivePartnerSpriteGenderParam(struct WirelessLink_URoom *data)


### PR DESCRIPTION
Committed this a while ago and forgot to push.

Keeping the names `lock` and `lockall` but clarifying with comments where applicable, as the names are slightly misleading (`lock` also freezes all the objects). 

Additionally the name `LockSelectedObjectEvent` is wrong, it freezes all objects and waits to freeze the player and selected object after their movements.