### PR TITLE
Use the `IS_TYPE_PHYSICAL` macro in `AddMovePoints`

### DIFF
--- a/src/battle_tv.c
+++ b/src/battle_tv.c
@@ -1246,7 +1246,7 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
         break;
     case PTS_REFLECT:
         // If hit Reflect with damaging physical move
-        if (type < TYPE_MYSTERY && power != 0 && tvPtr->side[defSide].reflectMonId != 0)
+        if (IS_TYPE_PHYSICAL(type) && power != 0 && tvPtr->side[defSide].reflectMonId != 0)
         {
             u32 id = (tvPtr->side[defSide].reflectMonId - 1) * 4;
             movePoints->points[defSide][id + tvPtr->side[defSide].reflectMoveSlot] += sPointsArray[caseId][0];
@@ -1254,7 +1254,7 @@ static void AddMovePoints(u8 caseId, u16 arg1, u8 arg2, u8 arg3)
         break;
     case PTS_LIGHT_SCREEN:
         // If hit Light Screen with damaging special move
-        if (type >= TYPE_MYSTERY && power != 0 && tvPtr->side[defSide].lightScreenMonId != 0)
+        if (!IS_TYPE_PHYSICAL(type) && power != 0 && tvPtr->side[defSide].lightScreenMonId != 0)
         {
             u32 id = (tvPtr->side[defSide].lightScreenMonId - 1) * 4;
             movePoints->points[defSide][id + tvPtr->side[defSide].lightScreenMoveSlot] += sPointsArray[caseId][0];


### PR DESCRIPTION
## Description
This commit just switches to using `IS_TYPE_PHYSICAL` to make it more intuitive what these comparisons are testing.

## **Discord contact info**
Lodestar#9437