### PR TITLE
Use the correct constant for PSS page comparison

### DIFF
--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -3627,7 +3627,7 @@ static void PrintMoveDetails(u16 move)
     FillWindowPixelBuffer(windowId, PIXEL_FILL(0));
     if (move != MOVE_NONE)
     {
-        if (sMonSummaryScreen->currPageIndex == SUMMARY_MODE_BOX)
+        if (sMonSummaryScreen->currPageIndex == PSS_PAGE_BATTLE_MOVES)
         {
             PrintMovePowerAndAccuracy(move);
             PrintTextOnWindow(windowId, gMoveDescriptionPointers[move - 1], 6, 1, 0, 0);


### PR DESCRIPTION
Fixes a comparison of the current page index with the PSS's current mode, as the incorrect constant `SUMMARY_MODE_BOX` happens to resolve to the same value as `PSS_PAGE_BATTLE_MOVES`.

## **Discord contact info**
Spherical Ice#4683