### PR TITLE
Fix symbols branch commit message, limit to upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Checkout syms
+        if: ${{ github.event_name == 'push' && github.repository_owner == 'pret' }}
         uses: actions/checkout@master
         with:
           path: symbols
@@ -52,7 +53,7 @@ jobs:
         run: make -j${nproc} all
 
       - name: Webhook
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.repository_owner == 'pret' }}
         env:
           CALCROM_DISCORD_WEBHOOK_USERNAME: OK
           CALCROM_DISCORD_WEBHOOK_AVATAR_URL: https://i.imgur.com/38BQHdd.png
@@ -60,16 +61,16 @@ jobs:
         run: sh .github/calcrom/webhook.sh pokeemerald
 
       - name: Move symfiles
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.repository_owner == 'pret' }}
         run: |
           cp -v *.sym symbols/
-          export GITHUB_COMMIT_MSG="$( git log --format=%s ${GITHUB_SHA} )"
+          echo "SYMBOLS_COMMIT_MSG=$( git log --format=%s ${GITHUB_SHA} )" >> $GITHUB_ENV
 
       - name: Update symfiles
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && github.repository_owner == 'pret' }}
         uses: EndBug/add-and-commit@v7
         with:
           branch: symbols
           cwd: "./symbols"
           add: "*.sym"
-          message: $GITHUB_COMMIT_MSG
+          message: ${{ env.SYMBOLS_COMMIT_MSG }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Checkout syms
-        if: ${{ github.event_name == 'push' && github.repository_owner == 'pret' }}
+        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@master
         with:
           path: symbols
@@ -61,13 +61,13 @@ jobs:
         run: sh .github/calcrom/webhook.sh pokeemerald
 
       - name: Move symfiles
-        if: ${{ github.event_name == 'push' && github.repository_owner == 'pret' }}
+        if: ${{ github.event_name == 'push' }}
         run: |
           cp -v *.sym symbols/
           echo "SYMBOLS_COMMIT_MSG=$( git log --format=%s ${GITHUB_SHA} )" >> $GITHUB_ENV
 
       - name: Update symfiles
-        if: ${{ github.event_name == 'push' && github.repository_owner == 'pret' }}
+        if: ${{ github.event_name == 'push' }}
         uses: EndBug/add-and-commit@v7
         with:
           branch: symbols


### PR DESCRIPTION
Hopefully the final fix needed for the symbols branch. Sets the symbols branch commit message as the last commit to master. Also limits the webhook step to pret to stop automatic CI failures for forks.