### PR TITLE
Disallow negative sizes in SAVEBLOCK_CHUNK

### DIFF
--- a/src/save.c
+++ b/src/save.c
@@ -43,11 +43,12 @@ static u8 HandleWriteSector(u16 a1, const struct SaveSectionLocation *location);
 // (u8 *)structure was removed from the first statement of the macro in Emerald.
 // This is because malloc is used to allocate addresses so storing the raw
 // addresses should not be done in the offsets information.
-#define SAVEBLOCK_CHUNK(structure, chunkNum)                                \
-{                                                                           \
-    chunkNum * SECTOR_DATA_SIZE,                                            \
-    min(sizeof(structure) - chunkNum * SECTOR_DATA_SIZE, SECTOR_DATA_SIZE)  \
-}                                                                           \
+#define SAVEBLOCK_CHUNK(structure, chunkNum)                                   \
+{                                                                              \
+    chunkNum * SECTOR_DATA_SIZE,                                               \
+    sizeof(structure) >= chunkNum * SECTOR_DATA_SIZE ?                         \
+    min(sizeof(structure) - chunkNum * SECTOR_DATA_SIZE, SECTOR_DATA_SIZE) : 0 \
+}
 
 static const struct SaveSectionOffsets sSaveSectionOffsets[] =
 {


### PR DESCRIPTION
The previous version of the macro allows negative numbers if `chunkNum * SECTOR_DATA_SIZE` exceeds the size of the given struct. A negative number there can result in an unsigned size larger than `SECTOR_DATA_SIZE`. 

This can happen if more sectors are allotted to a struct than needed, such as if the number of PC boxes is reduced to below 14 and `sSaveSectionOffsets` is not updated.

Unnecessarily allocated sectors will now have a size of 0 instead.