### PR TITLE
Improve IDE Support

### DIFF
--- a/berry_fix/payload/include/global.h
+++ b/berry_fix/payload/include/global.h
@@ -6,16 +6,17 @@
 // global.h from pokemon ruby
 
 // IDE support
-#if defined (__APPLE__) || defined (__CYGWIN__) || defined (__INTELLISENSE__)
-#define _(x) x
-#define __(x) x
-#define INCBIN(x) {0}
-#define INCBIN_U8 INCBIN
-#define INCBIN_U16 INCBIN
-#define INCBIN_U32 INCBIN
-#define INCBIN_S8 INCBIN
-#define INCBIN_S16 INCBIN
-#define INCBIN_S32 INCBIN
+#if defined(__APPLE__) || defined(__CYGWIN__) || defined(__INTELLISENSE__)
+// We define these when using certain IDEs to fool preproc
+#define _(x)        (x)
+#define __(x)       (x)
+#define INCBIN(...) {0}
+#define INCBIN_U8   INCBIN
+#define INCBIN_U16  INCBIN
+#define INCBIN_U32  INCBIN
+#define INCBIN_S8   INCBIN
+#define INCBIN_S16  INCBIN
+#define INCBIN_S32  INCBIN
 #endif // IDE support
 
 // Prevent cross-jump optimization.

--- a/include/global.h
+++ b/include/global.h
@@ -19,17 +19,18 @@
 #define asm_unified(x) asm(".syntax unified\n" x "\n.syntax divided")
 #define NAKED __attribute__((naked))
 
-// IDE support
-#if defined (__APPLE__) || defined (__CYGWIN__) || defined (__INTELLISENSE__)
-#define _(x) x
-#define __(x) x
-#define INCBIN(x) {0}
-#define INCBIN_U8 INCBIN
-#define INCBIN_U16 INCBIN
-#define INCBIN_U32 INCBIN
-#define INCBIN_S8 INCBIN
-#define INCBIN_S16 INCBIN
-#define INCBIN_S32 INCBIN
+/// IDE support
+#if defined(__APPLE__) || defined(__CYGWIN__) || defined(__INTELLISENSE__)
+// We define these when using certain IDEs to fool preproc
+#define _(x)        (x)
+#define __(x)       (x)
+#define INCBIN(...) {0}
+#define INCBIN_U8   INCBIN
+#define INCBIN_U16  INCBIN
+#define INCBIN_U32  INCBIN
+#define INCBIN_S8   INCBIN
+#define INCBIN_S16  INCBIN
+#define INCBIN_S32  INCBIN
 #endif // IDE support
 
 #define ARRAY_COUNT(array) (size_t)(sizeof(array) / sizeof((array)[0]))


### PR DESCRIPTION
Small change to replace `(_MSC_VER)` with `(__INTELLISENSE__)` to fix compatibility with VSCode.

## Description
`_MSC_VER` is only defined when using Visual Studio, however `__INTELLISENSE__` is defined when using both it and VSCode. It's mentioned here, specifically to be used for this sort of thing - https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160#microsoft-specific-predefined-macros

Since IntelliSense is the thing that causes the errors on both Visual Studio and VSCode, this should fix all of the `function call is not allowed in a constant expressionC/C++(59)` for both of them.


## **Discord contact info**
Jademalo#3486