### PR TITLE
Miscellaneous fixes

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1931,3 +1931,11 @@
 	waitbuttonpress
 	closebraillemessage
 	.endm
+
+	@ Creates an "event legal" Pokémon for an encounter
+	.macro seteventmon species:req, level:req, item=ITEM_NONE
+	setvar VAR_0x8004, \species
+	setvar VAR_0x8005, \level
+	setvar VAR_0x8006, \item
+	special CreateEventLegalEnemyMon
+	.endm

--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -604,9 +604,8 @@
 	.endm
 
 	@ Blocks script execution until the movements being applied to the specified (localId) object finish.
-	@ If the specified object is 0, then the command will block script execution until all objects
-	@ affected by applymovement finish their movements. If the specified object is not currently being
-	@ manipulated with applymovement, then this command does nothing.
+	@ If localId is 0, then the id of the last-moved object will be used instead. If the specified object
+	@ is not currently being manipulated with applymovement, then this command does nothing.
 	@ If no map is specified, then the current map is used.
 	.macro waitmovement localId:req, map
 		.ifb \map

--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -986,7 +986,7 @@
 
 	@ Gives the player a Pokémon of the specified species and level, holding the specified item. The trailing 0s are unused parameters.
 	@ VAR_RESULT will be set to MON_GIVEN_TO_PARTY, MON_GIVEN_TO_PC, or MON_CANT_GIVE depending on the outcome. 
-	.macro givemon species:req, level:req, item:req
+	.macro givemon species:req, level:req, item=ITEM_NONE
 	.byte 0x79
 	.2byte \species
 	.byte \level
@@ -1432,7 +1432,7 @@
 
 	@ Prepares to start a wild battle against a 'species' at 'level' holding 'item'. Running this command will not affect
 	@ normal wild battles. You start the prepared battle with dowildbattle.
-	.macro setwildbattle species:req, level:req, item:req
+	.macro setwildbattle species:req, level:req, item=ITEM_NONE
 	.byte 0xb6
 	.2byte \species
 	.byte \level

--- a/data/maps/AncientTomb/scripts.inc
+++ b/data/maps/AncientTomb/scripts.inc
@@ -61,7 +61,7 @@ AncientTomb_EventScript_Registeel::
 	playmoncry SPECIES_REGISTEEL, CRY_MODE_ENCOUNTER
 	delay 40
 	waitmoncry
-	setwildbattle SPECIES_REGISTEEL, 40, ITEM_NONE
+	setwildbattle SPECIES_REGISTEEL, 40
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special StartRegiBattle
 	waitstate

--- a/data/maps/AquaHideout_B1F/scripts.inc
+++ b/data/maps/AquaHideout_B1F/scripts.inc
@@ -29,7 +29,7 @@ AquaHideout_B1F_EventScript_ShowElectrode2::
 AquaHideout_B1F_EventScript_Electrode1::
 	lock
 	faceplayer
-	setwildbattle SPECIES_ELECTRODE, 30, ITEM_NONE
+	setwildbattle SPECIES_ELECTRODE, 30
 	waitse
 	playmoncry SPECIES_ELECTRODE, CRY_MODE_ENCOUNTER
 	delay 40
@@ -53,7 +53,7 @@ AquaHideout_B1F_EventScript_DefeatedElectrode1::
 AquaHideout_B1F_EventScript_Electrode2::
 	lock
 	faceplayer
-	setwildbattle SPECIES_ELECTRODE, 30, ITEM_NONE
+	setwildbattle SPECIES_ELECTRODE, 30
 	waitse
 	playmoncry SPECIES_ELECTRODE, CRY_MODE_ENCOUNTER
 	delay 40

--- a/data/maps/BattleFrontier_BattlePikeLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeLobby/scripts.inc
@@ -31,7 +31,7 @@ BattleFrontier_BattlePikeLobby_EventScript_QuitWithoutSaving::
 	lockall
 	msgbox BattleFrontier_BattlePikeLobby_Text_FailedToSaveBeforeQuitting, MSGBOX_DEFAULT
 	closemessage
-	pike_set PIKE_DATA_WIN_STREAK 0
+	pike_set PIKE_DATA_WIN_STREAK, 0
 	pike_set PIKE_DATA_WIN_STREAK_ACTIVE, FALSE
 	frontier_set FRONTIER_DATA_CHALLENGE_STATUS, 0
 	setvar VAR_TEMP_0, 255

--- a/data/maps/BattleFrontier_BattlePikeRoomNormal/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeRoomNormal/scripts.inc
@@ -193,7 +193,7 @@ BattleFrontier_BattlePikeRoomNormal_EventScript_DefeatedLucy::
 	waitmovement 0
 	pike_get PIKE_DATA_WIN_STREAK
 	addvar VAR_RESULT, 1
-	pike_set PIKE_DATA_WIN_STREAK VAR_RESULT
+	pike_set PIKE_DATA_WIN_STREAK, VAR_RESULT
 	call BattleFrontier_BattlePikeRoom_EventScript_WarpToFinalRoom
 	waitstate
 	end

--- a/data/maps/BattleFrontier_OutsideEast/scripts.inc
+++ b/data/maps/BattleFrontier_OutsideEast/scripts.inc
@@ -129,7 +129,7 @@ BattleFrontier_OutsideEast_EventScript_WaterSudowoodo::
 	delay 40
 	waitmoncry
 	setvar VAR_LAST_TALKED, LOCALID_SUDOWOODO
-	setwildbattle SPECIES_SUDOWOODO, 40, ITEM_NONE
+	setwildbattle SPECIES_SUDOWOODO, 40
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	dowildbattle
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE

--- a/data/maps/BirthIsland_Exterior/scripts.inc
+++ b/data/maps/BirthIsland_Exterior/scripts.inc
@@ -82,10 +82,7 @@ BirthIsland_Exterior_EventScript_Deoxys::
 	delay 40
 	waitmoncry
 	setvar VAR_LAST_TALKED, LOCALID_DEOXYS
-	setvar VAR_0x8004, SPECIES_DEOXYS
-	setvar VAR_0x8005, 30 @ level
-	setvar VAR_0x8006, ITEM_NONE
-	special CreateEventLegalEnemyMon
+	seteventmon SPECIES_DEOXYS, 30
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
 	waitstate

--- a/data/maps/DesertRuins/scripts.inc
+++ b/data/maps/DesertRuins/scripts.inc
@@ -61,7 +61,7 @@ DesertRuins_EventScript_Regirock::
 	playmoncry SPECIES_REGIROCK, CRY_MODE_ENCOUNTER
 	delay 40
 	waitmoncry
-	setwildbattle SPECIES_REGIROCK, 40, ITEM_NONE
+	setwildbattle SPECIES_REGIROCK, 40
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special StartRegiBattle
 	waitstate

--- a/data/maps/FarawayIsland_Interior/scripts.inc
+++ b/data/maps/FarawayIsland_Interior/scripts.inc
@@ -129,10 +129,7 @@ FarawayIsland_Interior_EventScript_Mew::
 	special DestroyMewEmergingGrassSprite
 	delay 40
 	waitmoncry
-	setvar VAR_0x8004, SPECIES_MEW
-	setvar VAR_0x8005, 30 @ level
-	setvar VAR_0x8006, ITEM_NONE
-	special CreateEventLegalEnemyMon
+	seteventmon SPECIES_MEW, 30
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
 	waitstate

--- a/data/maps/IslandCave/scripts.inc
+++ b/data/maps/IslandCave/scripts.inc
@@ -94,7 +94,7 @@ IslandCave_EventScript_Regice::
 	playmoncry SPECIES_REGICE, CRY_MODE_ENCOUNTER
 	delay 40
 	waitmoncry
-	setwildbattle SPECIES_REGICE, 40, ITEM_NONE
+	setwildbattle SPECIES_REGICE, 40
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special StartRegiBattle
 	waitstate

--- a/data/maps/LavaridgeTown_Gym_1F/scripts.inc
+++ b/data/maps/LavaridgeTown_Gym_1F/scripts.inc
@@ -19,7 +19,7 @@ LavaridgeTown_Gym_1F_EventScript_SetTrainerTempVars::
 	setvar VAR_TEMP_D, 0
 	setvar VAR_TEMP_E, 0
 	setvar VAR_TEMP_F, 0
-	goto_if_defeated TRAINER_COLE LavaridgeTown_Gym_1F_EventScript_SetGeraldTempVar
+	goto_if_defeated TRAINER_COLE, LavaridgeTown_Gym_1F_EventScript_SetGeraldTempVar
 	setvar VAR_TEMP_B, 1
 LavaridgeTown_Gym_1F_EventScript_SetGeraldTempVar::
 	goto_if_defeated TRAINER_GERALD, LavaridgeTown_Gym_1F_EventScript_SetAxleTempVar
@@ -105,7 +105,7 @@ LavaridgeTown_Gym_1F_EventScript_FlanneryRematch::
 
 LavaridgeTown_Gym_1F_EventScript_Cole::
 	trainerbattle TRAINER_BATTLE_CONTINUE_SCRIPT, TRAINER_COLE, LOCALID_COLE, LavaridgeTown_Gym_1F_Text_ColeIntro, LavaridgeTown_Gym_1F_Text_ColeDefeat, LavaridgeTown_Gym_EventScript_CheckTrainerScript
-	msgbox LavaridgeTown_Gym_1F_Text_ColePostBattle MSGBOX_AUTOCLOSE
+	msgbox LavaridgeTown_Gym_1F_Text_ColePostBattle, MSGBOX_AUTOCLOSE
 	end
 
 LavaridgeTown_Gym_EventScript_CheckTrainerScript::

--- a/data/maps/LittlerootTown_BrendansHouse_2F/scripts.inc
+++ b/data/maps/LittlerootTown_BrendansHouse_2F/scripts.inc
@@ -22,7 +22,7 @@ LittlerootTown_BrendansHouse_2F_EventScript_TryUpdateBrendanPos::
 	checkplayergender
 	goto_if_eq VAR_RESULT, MALE, LittlerootTown_BrendansHouse_2F_EventScript_Ret
 	@ Odd that the MaysHouse equivalent was used below instead
-	goto_if_ge VAR_DEX_UPGRADE_JOHTO_STARTER_STATE, 2 LittlerootTown_MaysHouse_2F_EventScript_Ret
+	goto_if_ge VAR_DEX_UPGRADE_JOHTO_STARTER_STATE, 2, LittlerootTown_MaysHouse_2F_EventScript_Ret
 	setobjectxyperm LOCALID_RIVAL, 0, 2
 	setobjectmovementtype LOCALID_RIVAL, MOVEMENT_TYPE_FACE_UP
 	return

--- a/data/maps/LittlerootTown_ProfessorBirchsLab/scripts.inc
+++ b/data/maps/LittlerootTown_ProfessorBirchsLab/scripts.inc
@@ -340,7 +340,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_TakeYourTime::
 LittlerootTown_ProfessorBirchsLab_EventScript_GiveCyndaquil::
 	bufferspeciesname STR_VAR_1, SPECIES_CYNDAQUIL
 	setvar VAR_TEMP_1, SPECIES_CYNDAQUIL
-	givemon SPECIES_CYNDAQUIL, 5, ITEM_NONE
+	givemon SPECIES_CYNDAQUIL, 5
 	goto_if_eq VAR_RESULT, 0, LittlerootTown_ProfessorBirchsLab_EventScript_SendCyndaquilToParty
 	goto_if_eq VAR_RESULT, 1, LittlerootTown_ProfessorBirchsLab_EventScript_SendCyndaquilToPC
 	hidemonpic
@@ -381,7 +381,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_ReceivedCyndaquil::
 LittlerootTown_ProfessorBirchsLab_EventScript_GiveTotodile::
 	bufferspeciesname STR_VAR_1, SPECIES_TOTODILE
 	setvar VAR_TEMP_1, SPECIES_TOTODILE
-	givemon SPECIES_TOTODILE, 5, ITEM_NONE
+	givemon SPECIES_TOTODILE, 5
 	goto_if_eq VAR_RESULT, 0, LittlerootTown_ProfessorBirchsLab_EventScript_SendTotodileToParty
 	goto_if_eq VAR_RESULT, 1, LittlerootTown_ProfessorBirchsLab_EventScript_SendTotodileToPC
 	hidemonpic
@@ -422,7 +422,7 @@ LittlerootTown_ProfessorBirchsLab_EventScript_ReceivedTotodile::
 LittlerootTown_ProfessorBirchsLab_EventScript_GiveChikorita::
 	bufferspeciesname STR_VAR_1, SPECIES_CHIKORITA
 	setvar VAR_TEMP_1, SPECIES_CHIKORITA
-	givemon SPECIES_CHIKORITA, 5, ITEM_NONE
+	givemon SPECIES_CHIKORITA, 5
 	goto_if_eq VAR_RESULT, 0, LittlerootTown_ProfessorBirchsLab_EventScript_SendChikoritaToParty
 	goto_if_eq VAR_RESULT, 1, LittlerootTown_ProfessorBirchsLab_EventScript_SendChikoritaToPC
 	hidemonpic

--- a/data/maps/LittlerootTown_ProfessorBirchsLab/scripts.inc
+++ b/data/maps/LittlerootTown_ProfessorBirchsLab/scripts.inc
@@ -341,8 +341,8 @@ LittlerootTown_ProfessorBirchsLab_EventScript_GiveCyndaquil::
 	bufferspeciesname STR_VAR_1, SPECIES_CYNDAQUIL
 	setvar VAR_TEMP_1, SPECIES_CYNDAQUIL
 	givemon SPECIES_CYNDAQUIL, 5
-	goto_if_eq VAR_RESULT, 0, LittlerootTown_ProfessorBirchsLab_EventScript_SendCyndaquilToParty
-	goto_if_eq VAR_RESULT, 1, LittlerootTown_ProfessorBirchsLab_EventScript_SendCyndaquilToPC
+	goto_if_eq VAR_RESULT, MON_GIVEN_TO_PARTY, LittlerootTown_ProfessorBirchsLab_EventScript_SendCyndaquilToParty
+	goto_if_eq VAR_RESULT, MON_GIVEN_TO_PC, LittlerootTown_ProfessorBirchsLab_EventScript_SendCyndaquilToPC
 	hidemonpic
 	goto Common_EventScript_NoMoreRoomForPokemon
 	end
@@ -382,8 +382,8 @@ LittlerootTown_ProfessorBirchsLab_EventScript_GiveTotodile::
 	bufferspeciesname STR_VAR_1, SPECIES_TOTODILE
 	setvar VAR_TEMP_1, SPECIES_TOTODILE
 	givemon SPECIES_TOTODILE, 5
-	goto_if_eq VAR_RESULT, 0, LittlerootTown_ProfessorBirchsLab_EventScript_SendTotodileToParty
-	goto_if_eq VAR_RESULT, 1, LittlerootTown_ProfessorBirchsLab_EventScript_SendTotodileToPC
+	goto_if_eq VAR_RESULT, MON_GIVEN_TO_PARTY, LittlerootTown_ProfessorBirchsLab_EventScript_SendTotodileToParty
+	goto_if_eq VAR_RESULT, MON_GIVEN_TO_PC, LittlerootTown_ProfessorBirchsLab_EventScript_SendTotodileToPC
 	hidemonpic
 	goto Common_EventScript_NoMoreRoomForPokemon
 	end
@@ -423,8 +423,8 @@ LittlerootTown_ProfessorBirchsLab_EventScript_GiveChikorita::
 	bufferspeciesname STR_VAR_1, SPECIES_CHIKORITA
 	setvar VAR_TEMP_1, SPECIES_CHIKORITA
 	givemon SPECIES_CHIKORITA, 5
-	goto_if_eq VAR_RESULT, 0, LittlerootTown_ProfessorBirchsLab_EventScript_SendChikoritaToParty
-	goto_if_eq VAR_RESULT, 1, LittlerootTown_ProfessorBirchsLab_EventScript_SendChikoritaToPC
+	goto_if_eq VAR_RESULT, MON_GIVEN_TO_PARTY, LittlerootTown_ProfessorBirchsLab_EventScript_SendChikoritaToParty
+	goto_if_eq VAR_RESULT, MON_GIVEN_TO_PC, LittlerootTown_ProfessorBirchsLab_EventScript_SendChikoritaToPC
 	hidemonpic
 	goto Common_EventScript_NoMoreRoomForPokemon
 	end

--- a/data/maps/MarineCave_End/scripts.inc
+++ b/data/maps/MarineCave_End/scripts.inc
@@ -35,7 +35,7 @@ MarineCave_End_EventScript_Kyogre::
 	delay 40
 	waitmoncry
 	setvar VAR_LAST_TALKED, LOCALID_KYOGRE
-	setwildbattle SPECIES_KYOGRE, 70, ITEM_NONE
+	setwildbattle SPECIES_KYOGRE, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
 	waitstate

--- a/data/maps/MossdeepCity_StevensHouse/scripts.inc
+++ b/data/maps/MossdeepCity_StevensHouse/scripts.inc
@@ -87,8 +87,8 @@ MossdeepCity_StevensHouse_EventScript_LeaveBeldum::
 MossdeepCity_StevensHouse_EventScript_GiveBeldum::
 	setvar VAR_TEMP_1, SPECIES_BELDUM
 	givemon SPECIES_BELDUM, 5
-	goto_if_eq VAR_RESULT, 0, MossdeepCity_StevensHouse_EventScript_SendBeldumParty
-	goto_if_eq VAR_RESULT, 1, MossdeepCity_StevensHouse_EventScript_SendBeldumPC
+	goto_if_eq VAR_RESULT, MON_GIVEN_TO_PARTY, MossdeepCity_StevensHouse_EventScript_SendBeldumParty
+	goto_if_eq VAR_RESULT, MON_GIVEN_TO_PC, MossdeepCity_StevensHouse_EventScript_SendBeldumPC
 	goto Common_EventScript_NoMoreRoomForPokemon
 	end
 

--- a/data/maps/MossdeepCity_StevensHouse/scripts.inc
+++ b/data/maps/MossdeepCity_StevensHouse/scripts.inc
@@ -86,7 +86,7 @@ MossdeepCity_StevensHouse_EventScript_LeaveBeldum::
 
 MossdeepCity_StevensHouse_EventScript_GiveBeldum::
 	setvar VAR_TEMP_1, SPECIES_BELDUM
-	givemon SPECIES_BELDUM, 5, ITEM_NONE
+	givemon SPECIES_BELDUM, 5
 	goto_if_eq VAR_RESULT, 0, MossdeepCity_StevensHouse_EventScript_SendBeldumParty
 	goto_if_eq VAR_RESULT, 1, MossdeepCity_StevensHouse_EventScript_SendBeldumPC
 	goto Common_EventScript_NoMoreRoomForPokemon

--- a/data/maps/MtPyre_3F/scripts.inc
+++ b/data/maps/MtPyre_3F/scripts.inc
@@ -7,7 +7,7 @@ MtPyre_3F_EventScript_William::
 	end
 
 MtPyre_3F_EventScript_Kayla::
-	trainerbattle_single TRAINER_KAYLA, MtPyre_3F_Text_KaylaIntro MtPyre_3F_Text_KaylaDefeat
+	trainerbattle_single TRAINER_KAYLA, MtPyre_3F_Text_KaylaIntro, MtPyre_3F_Text_KaylaDefeat
 	msgbox MtPyre_3F_Text_KaylaPostBattle, MSGBOX_AUTOCLOSE
 	end
 

--- a/data/maps/NavelRock_Bottom/scripts.inc
+++ b/data/maps/NavelRock_Bottom/scripts.inc
@@ -53,10 +53,7 @@ NavelRock_Bottom_EventScript_Lugia::
 	playmoncry SPECIES_LUGIA, CRY_MODE_ENCOUNTER
 	waitmoncry
 	delay 20
-	setvar VAR_0x8004, SPECIES_LUGIA
-	setvar VAR_0x8005, 70  @ level
-	setvar VAR_0x8006, ITEM_NONE
-	special CreateEventLegalEnemyMon
+	seteventmon SPECIES_LUGIA, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
 	waitstate

--- a/data/maps/NavelRock_Top/scripts.inc
+++ b/data/maps/NavelRock_Top/scripts.inc
@@ -57,10 +57,7 @@ NavelRock_Top_EventScript_HoOh::
 	applymovement LOCALID_HO_OH, NavelRock_Top_Movement_HoOhApproach
 	waitmovement 0
 	special RemoveCameraObject
-	setvar VAR_0x8004, SPECIES_HO_OH
-	setvar VAR_0x8005, 70 @ level
-	setvar VAR_0x8006, ITEM_NONE
-	special CreateEventLegalEnemyMon
+	seteventmon SPECIES_HO_OH, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
 	waitstate

--- a/data/maps/NewMauville_Inside/scripts.inc
+++ b/data/maps/NewMauville_Inside/scripts.inc
@@ -176,7 +176,7 @@ NewMauville_Inside_EventScript_GeneratorOff::
 NewMauville_Inside_EventScript_Voltorb1::
 	lock
 	faceplayer
-	setwildbattle SPECIES_VOLTORB, 25, ITEM_NONE
+	setwildbattle SPECIES_VOLTORB, 25
 	waitse
 	playmoncry SPECIES_VOLTORB, CRY_MODE_ENCOUNTER
 	delay 40
@@ -200,7 +200,7 @@ NewMauville_Inside_EventScript_DefeatedVoltorb1::
 NewMauville_Inside_EventScript_Voltorb2::
 	lock
 	faceplayer
-	setwildbattle SPECIES_VOLTORB, 25, ITEM_NONE
+	setwildbattle SPECIES_VOLTORB, 25
 	waitse
 	playmoncry SPECIES_VOLTORB, CRY_MODE_ENCOUNTER
 	delay 40
@@ -224,7 +224,7 @@ NewMauville_Inside_EventScript_DefeatedVoltorb2::
 NewMauville_Inside_EventScript_Voltorb3::
 	lock
 	faceplayer
-	setwildbattle SPECIES_VOLTORB, 25, ITEM_NONE
+	setwildbattle SPECIES_VOLTORB, 25
 	waitse
 	playmoncry SPECIES_VOLTORB, CRY_MODE_ENCOUNTER
 	delay 40

--- a/data/maps/Route119_WeatherInstitute_2F/scripts.inc
+++ b/data/maps/Route119_WeatherInstitute_2F/scripts.inc
@@ -90,8 +90,8 @@ Route119_WeatherInstitute_2F_EventScript_ReceiveCastform::
 	msgbox Route119_WeatherInstitute_2F_Text_ThanksPleaseTakePokemon, MSGBOX_DEFAULT
 	setvar VAR_TEMP_1, SPECIES_CASTFORM
 	givemon SPECIES_CASTFORM, 25, ITEM_MYSTIC_WATER
-	goto_if_eq VAR_RESULT, 0, Route119_WeatherInstitute_2F_EventScript_ReceiveCastformParty
-	goto_if_eq VAR_RESULT, 1, Route119_WeatherInstitute_2F_EventScript_ReceiveCastformPC
+	goto_if_eq VAR_RESULT, MON_GIVEN_TO_PARTY, Route119_WeatherInstitute_2F_EventScript_ReceiveCastformParty
+	goto_if_eq VAR_RESULT, MON_GIVEN_TO_PC, Route119_WeatherInstitute_2F_EventScript_ReceiveCastformPC
 	goto Common_EventScript_NoMoreRoomForPokemon
 	end
 

--- a/data/maps/Route120/scripts.inc
+++ b/data/maps/Route120/scripts.inc
@@ -193,7 +193,7 @@ Route120_EventScript_StevenBattleKecleon::
 	playmoncry SPECIES_KECLEON, CRY_MODE_ENCOUNTER
 	delay 40
 	waitmoncry
-	setwildbattle SPECIES_KECLEON, 30, ITEM_NONE
+	setwildbattle SPECIES_KECLEON, 30
 	setvar VAR_0x8009, 0
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	dowildbattle

--- a/data/maps/RustboroCity_DevonCorp_2F/scripts.inc
+++ b/data/maps/RustboroCity_DevonCorp_2F/scripts.inc
@@ -145,7 +145,7 @@ RustboroCity_DevonCorp_2F_EventScript_AnorithReady::
 
 RustboroCity_DevonCorp_2F_EventScript_ReceiveLileep::
 	setvar VAR_TEMP_1, SPECIES_LILEEP
-	givemon SPECIES_LILEEP, 20, ITEM_NONE
+	givemon SPECIES_LILEEP, 20
 	goto_if_eq VAR_RESULT, 0, RustboroCity_DevonCorp_2F_EventScript_ReceiveLileepParty
 	goto_if_eq VAR_RESULT, 1, RustboroCity_DevonCorp_2F_EventScript_ReceiveLileepPC
 	goto Common_EventScript_NoMoreRoomForPokemon
@@ -190,7 +190,7 @@ RustboroCity_DevonCorp_2F_EventScript_FinishReceivingLileep::
 
 RustboroCity_DevonCorp_2F_EventScript_ReceiveAnorith::
 	setvar VAR_TEMP_1, SPECIES_ANORITH
-	givemon SPECIES_ANORITH, 20, ITEM_NONE
+	givemon SPECIES_ANORITH, 20
 	goto_if_eq VAR_RESULT, 0, RustboroCity_DevonCorp_2F_EventScript_ReceiveAnorithParty
 	goto_if_eq VAR_RESULT, 1, RustboroCity_DevonCorp_2F_EventScript_ReceiveAnorithPC
 	goto Common_EventScript_NoMoreRoomForPokemon

--- a/data/maps/RustboroCity_DevonCorp_2F/scripts.inc
+++ b/data/maps/RustboroCity_DevonCorp_2F/scripts.inc
@@ -146,8 +146,8 @@ RustboroCity_DevonCorp_2F_EventScript_AnorithReady::
 RustboroCity_DevonCorp_2F_EventScript_ReceiveLileep::
 	setvar VAR_TEMP_1, SPECIES_LILEEP
 	givemon SPECIES_LILEEP, 20
-	goto_if_eq VAR_RESULT, 0, RustboroCity_DevonCorp_2F_EventScript_ReceiveLileepParty
-	goto_if_eq VAR_RESULT, 1, RustboroCity_DevonCorp_2F_EventScript_ReceiveLileepPC
+	goto_if_eq VAR_RESULT, MON_GIVEN_TO_PARTY, RustboroCity_DevonCorp_2F_EventScript_ReceiveLileepParty
+	goto_if_eq VAR_RESULT, MON_GIVEN_TO_PC, RustboroCity_DevonCorp_2F_EventScript_ReceiveLileepPC
 	goto Common_EventScript_NoMoreRoomForPokemon
 	end
 
@@ -191,8 +191,8 @@ RustboroCity_DevonCorp_2F_EventScript_FinishReceivingLileep::
 RustboroCity_DevonCorp_2F_EventScript_ReceiveAnorith::
 	setvar VAR_TEMP_1, SPECIES_ANORITH
 	givemon SPECIES_ANORITH, 20
-	goto_if_eq VAR_RESULT, 0, RustboroCity_DevonCorp_2F_EventScript_ReceiveAnorithParty
-	goto_if_eq VAR_RESULT, 1, RustboroCity_DevonCorp_2F_EventScript_ReceiveAnorithPC
+	goto_if_eq VAR_RESULT, MON_GIVEN_TO_PARTY, RustboroCity_DevonCorp_2F_EventScript_ReceiveAnorithParty
+	goto_if_eq VAR_RESULT, MON_GIVEN_TO_PC, RustboroCity_DevonCorp_2F_EventScript_ReceiveAnorithPC
 	goto Common_EventScript_NoMoreRoomForPokemon
 	end
 

--- a/data/maps/SkyPillar_Top/scripts.inc
+++ b/data/maps/SkyPillar_Top/scripts.inc
@@ -48,7 +48,7 @@ SkyPillar_Top_EventScript_Rayquaza::
 	playmoncry SPECIES_RAYQUAZA, CRY_MODE_ENCOUNTER
 	delay 40
 	waitmoncry
-	setwildbattle SPECIES_RAYQUAZA, 70, ITEM_NONE
+	setwildbattle SPECIES_RAYQUAZA, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
 	waitstate

--- a/data/maps/SouthernIsland_Interior/scripts.inc
+++ b/data/maps/SouthernIsland_Interior/scripts.inc
@@ -47,7 +47,7 @@ SouthernIsland_Interior_EventScript_SetMayGfx::
 
 SouthernIsland_Interior_EventScript_TryLatiEncounter::
 	lockall
-	setvar VAR_0x8008, 12
+	setvar VAR_0x8008, 12  @ Player's Y coordinate. Not read
 	goto SouthernIsland_Interior_EventScript_Lati
 	end
 

--- a/data/maps/SouthernIsland_Interior/scripts.inc
+++ b/data/maps/SouthernIsland_Interior/scripts.inc
@@ -105,17 +105,11 @@ SouthernIsland_Interior_EventScript_Sign::
 	end
 
 SouthernIsland_Interior_EventScript_SetLatiosBattleVars::
-	setvar VAR_0x8004, SPECIES_LATIOS
-	setvar VAR_0x8005, 50 @ level
-	setvar VAR_0x8006, ITEM_SOUL_DEW
-	special CreateEventLegalEnemyMon
+	seteventmon SPECIES_LATIOS, 50, ITEM_SOUL_DEW
 	return
 
 SouthernIsland_Interior_EventScript_SetLatiasBattleVars::
-	setvar VAR_0x8004, SPECIES_LATIAS
-	setvar VAR_0x8005, 50 @ level
-	setvar VAR_0x8006, ITEM_SOUL_DEW
-	special CreateEventLegalEnemyMon
+	seteventmon SPECIES_LATIAS, 50, ITEM_SOUL_DEW
 	return
 
 SouthernIsland_Interior_Movement_CameraPanUp:

--- a/data/maps/TerraCave_End/scripts.inc
+++ b/data/maps/TerraCave_End/scripts.inc
@@ -35,7 +35,7 @@ TerraCave_End_EventScript_Groudon::
 	delay 40
 	waitmoncry
 	setvar VAR_LAST_TALKED, LOCALID_GROUDON
-	setwildbattle SPECIES_GROUDON, 70, ITEM_NONE
+	setwildbattle SPECIES_GROUDON, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
 	waitstate

--- a/data/script_cmd_table.inc
+++ b/data/script_cmd_table.inc
@@ -80,16 +80,16 @@ gScriptCmdTable::
 	.4byte ScrCmd_checkdecor                @ 0x4d
 	.4byte ScrCmd_checkdecorspace           @ 0x4e
 	.4byte ScrCmd_applymovement             @ 0x4f
-	.4byte ScrCmd_applymovement_at          @ 0x50
+	.4byte ScrCmd_applymovementat           @ 0x50
 	.4byte ScrCmd_waitmovement              @ 0x51
-	.4byte ScrCmd_waitmovement_at           @ 0x52
+	.4byte ScrCmd_waitmovementat            @ 0x52
 	.4byte ScrCmd_removeobject              @ 0x53
-	.4byte ScrCmd_removeobject_at           @ 0x54
+	.4byte ScrCmd_removeobjectat            @ 0x54
 	.4byte ScrCmd_addobject                 @ 0x55
-	.4byte ScrCmd_addobject_at              @ 0x56
+	.4byte ScrCmd_addobjectat               @ 0x56
 	.4byte ScrCmd_setobjectxy               @ 0x57
-	.4byte ScrCmd_showobject_at             @ 0x58
-	.4byte ScrCmd_hideobject_at             @ 0x59
+	.4byte ScrCmd_showobjectat              @ 0x58
+	.4byte ScrCmd_hideobjectat              @ 0x59
 	.4byte ScrCmd_faceplayer                @ 0x5a
 	.4byte ScrCmd_turnobject                @ 0x5b
 	.4byte ScrCmd_trainerbattle             @ 0x5c

--- a/data/scripts/kecleon.inc
+++ b/data/scripts/kecleon.inc
@@ -71,7 +71,7 @@ EventScript_BattleKecleon::
 	playmoncry SPECIES_KECLEON, CRY_MODE_ENCOUNTER
 	delay 40
 	waitmoncry
-	setwildbattle SPECIES_KECLEON, 30, ITEM_NONE
+	setwildbattle SPECIES_KECLEON, 30
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	dowildbattle
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE

--- a/include/bike.h
+++ b/include/bike.h
@@ -17,11 +17,11 @@ struct BikeHistoryInputInfo
 // Player speeds
 enum
 {
-    BIKE_SPEED_STANDING,
-    BIKE_SPEED_NORMAL,
-    BIKE_SPEED_FAST,
-    BIKE_SPEED_FASTER,
-    BIKE_SPEED_FASTEST,
+    PLAYER_SPEED_STANDING,
+    PLAYER_SPEED_NORMAL,
+    PLAYER_SPEED_FAST,
+    PLAYER_SPEED_FASTER,
+    PLAYER_SPEED_FASTEST,
 };
 
 // mach bike transitions enum

--- a/src/bike.c
+++ b/src/bike.c
@@ -108,7 +108,7 @@ static u8 (*const sAcroBikeInputHandlers[])(u8 *, u16, u16) =
 };
 
 // used with bikeFrameCounter from mach bike
-static const u16 sMachBikeSpeeds[] = {BIKE_SPEED_NORMAL, BIKE_SPEED_FAST, BIKE_SPEED_FASTEST};
+static const u16 sMachBikeSpeeds[] = {PLAYER_SPEED_NORMAL, PLAYER_SPEED_FAST, PLAYER_SPEED_FASTEST};
 
 // this is a list of timers to compare against later, terminated with 0. the only timer being compared against is 4 frames in this list.
 static const u8 sAcroBikeJumpTimerList[] = {4, 0};
@@ -147,7 +147,7 @@ static u8 GetMachBikeTransition(u8 *dirTraveling)
     if (*dirTraveling == 0)
     {
         *dirTraveling = direction; // update the direction, since below we either faced a direction or we started moving.
-        if (gPlayerAvatar.bikeSpeed == BIKE_SPEED_STANDING)
+        if (gPlayerAvatar.bikeSpeed == PLAYER_SPEED_STANDING)
         {
             gPlayerAvatar.runningState = NOT_MOVING;
             return MACH_TRANS_FACE_DIRECTION;
@@ -159,7 +159,7 @@ static u8 GetMachBikeTransition(u8 *dirTraveling)
     // we need to check if the last traveled direction changed from the new direction as well as ensuring that we dont update the state while the player is moving: see the else check.
     if (*dirTraveling != direction && gPlayerAvatar.runningState != MOVING)
     {
-        if (gPlayerAvatar.bikeSpeed != BIKE_SPEED_STANDING)
+        if (gPlayerAvatar.bikeSpeed != PLAYER_SPEED_STANDING)
         {
             *dirTraveling = direction; // implement the new direction
             gPlayerAvatar.runningState = MOVING;
@@ -246,7 +246,7 @@ static void MachBikeTransition_TrySlowDown(u8 direction)
 {
     u8 collision;
 
-    if (gPlayerAvatar.bikeSpeed != BIKE_SPEED_STANDING)
+    if (gPlayerAvatar.bikeSpeed != PLAYER_SPEED_STANDING)
         gPlayerAvatar.bikeFrameCounter = --gPlayerAvatar.bikeSpeed;
 
     collision = GetBikeCollision(direction);
@@ -306,7 +306,7 @@ static u8 AcroBikeHandleInputNormal(u8 *newDirection, u16 newKeys, u16 heldKeys)
             return ACRO_TRANS_FACE_DIRECTION;
         }
     }
-    if (*newDirection == direction && (heldKeys & B_BUTTON) && gPlayerAvatar.bikeSpeed == BIKE_SPEED_STANDING)
+    if (*newDirection == direction && (heldKeys & B_BUTTON) && gPlayerAvatar.bikeSpeed == PLAYER_SPEED_STANDING)
     {
         gPlayerAvatar.bikeSpeed++;
         gPlayerAvatar.acroBikeState = ACRO_STATE_WHEELIE_MOVING;
@@ -342,7 +342,7 @@ static u8 AcroBikeHandleInputTurning(u8 *newDirection, u16 newKeys, u16 heldKeys
     if (*newDirection == AcroBike_GetJumpDirection())
     {
         Bike_SetBikeStill(); // Bike_SetBikeStill sets speed to standing, but the next line immediately overrides it. could have just reset acroBikeState to 0 here instead of wasting a jump.
-        gPlayerAvatar.bikeSpeed = BIKE_SPEED_NORMAL;
+        gPlayerAvatar.bikeSpeed = PLAYER_SPEED_NORMAL;
         if (*newDirection == GetOppositeDirection(direction))
         {
             // do a turn jump.
@@ -775,7 +775,7 @@ static void AcroBike_TryHistoryUpdate(u16 newKeys, u16 heldKeys) // newKeys is u
     else
     {
         Bike_UpdateDirTimerHistory(direction);
-        gPlayerAvatar.bikeSpeed = BIKE_SPEED_STANDING;
+        gPlayerAvatar.bikeSpeed = PLAYER_SPEED_STANDING;
     }
 
     direction = heldKeys & (A_BUTTON | B_BUTTON | SELECT_BUTTON | START_BUTTON); // directions is reused for some reason.
@@ -787,7 +787,7 @@ static void AcroBike_TryHistoryUpdate(u16 newKeys, u16 heldKeys) // newKeys is u
     else
     {
         Bike_UpdateABStartSelectHistory(direction);
-        gPlayerAvatar.bikeSpeed = BIKE_SPEED_STANDING;
+        gPlayerAvatar.bikeSpeed = PLAYER_SPEED_STANDING;
     }
 }
 
@@ -994,7 +994,7 @@ void BikeClearState(int newDirHistory, int newAbStartHistory)
     gPlayerAvatar.acroBikeState = ACRO_STATE_NORMAL;
     gPlayerAvatar.newDirBackup = DIR_NONE;
     gPlayerAvatar.bikeFrameCounter = 0;
-    gPlayerAvatar.bikeSpeed = BIKE_SPEED_STANDING;
+    gPlayerAvatar.bikeSpeed = PLAYER_SPEED_STANDING;
     gPlayerAvatar.directionHistory = newDirHistory;
     gPlayerAvatar.abStartSelectHistory = newAbStartHistory;
 
@@ -1014,7 +1014,7 @@ void Bike_UpdateBikeCounterSpeed(u8 counter)
 static void Bike_SetBikeStill(void)
 {
     gPlayerAvatar.bikeFrameCounter = 0;
-    gPlayerAvatar.bikeSpeed = BIKE_SPEED_STANDING;
+    gPlayerAvatar.bikeSpeed = PLAYER_SPEED_STANDING;
 }
 
 s16 GetPlayerSpeed(void)
@@ -1027,11 +1027,11 @@ s16 GetPlayerSpeed(void)
     if (gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_MACH_BIKE)
         return machSpeeds[gPlayerAvatar.bikeFrameCounter];
     else if (gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_ACRO_BIKE)
-        return BIKE_SPEED_FASTER;
+        return PLAYER_SPEED_FASTER;
     else if (gPlayerAvatar.flags & (PLAYER_AVATAR_FLAG_SURFING | PLAYER_AVATAR_FLAG_DASH))
-        return BIKE_SPEED_FAST;
+        return PLAYER_SPEED_FAST;
     else
-        return BIKE_SPEED_NORMAL;
+        return PLAYER_SPEED_NORMAL;
 }
 
 void Bike_HandleBumpySlopeJump(void)

--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -94,7 +94,7 @@ void FieldGetPlayerInput(struct FieldInput *input, u16 newKeys, u16 heldKeys)
 
     if ((tileTransitionState == T_TILE_CENTER && forcedMove == FALSE) || tileTransitionState == T_NOT_MOVING)
     {
-        if (GetPlayerSpeed() != 4)
+        if (GetPlayerSpeed() != PLAYER_SPEED_FASTEST)
         {
             if (newKeys & START_BUTTON)
                 input->pressedStartButton = TRUE;

--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -557,7 +557,7 @@ static bool8 ForcedMovement_MuddySlope(void)
 {
     struct ObjectEvent *playerObjEvent = &gObjectEvents[gPlayerAvatar.objectEventId];
 
-    if (playerObjEvent->movementDirection != DIR_NORTH || GetPlayerSpeed() <= 3)
+    if (playerObjEvent->movementDirection != DIR_NORTH || GetPlayerSpeed() < PLAYER_SPEED_FASTEST)
     {
         Bike_UpdateBikeCounterSpeed(0);
         playerObjEvent->facingDirectionLocked = TRUE;

--- a/src/field_tasks.c
+++ b/src/field_tasks.c
@@ -820,7 +820,7 @@ static void CrackedFloorPerStepCallback(u8 taskId)
     tPrevY = y;
     if (MetatileBehavior_IsCrackedFloor(behavior))
     {
-        if (GetPlayerSpeed() != BIKE_SPEED_FASTEST)
+        if (GetPlayerSpeed() != PLAYER_SPEED_FASTEST)
             VarSet(VAR_ICE_STEP_COUNT, 0); // this var does double duty
 
         if (tFloor1Delay == 0)

--- a/src/region_map.c
+++ b/src/region_map.c
@@ -1516,28 +1516,26 @@ static void UnhideRegionMapPlayerIcon(void)
     }
 }
 
+#define sY       data[0]
+#define sX       data[1]
+#define sVisible data[2]
+#define sTimer   data[7]
+
 static void SpriteCB_PlayerIconMapZoomed(struct Sprite *sprite)
 {
     sprite->x2 = -2 * gRegionMap->scrollX;
     sprite->y2 = -2 * gRegionMap->scrollY;
-    sprite->data[0] = sprite->y + sprite->y2 + sprite->centerToCornerVecY;
-    sprite->data[1] = sprite->x + sprite->x2 + sprite->centerToCornerVecX;
-    if (sprite->data[0] < -8 || sprite->data[0] > 0xa8 || sprite->data[1] < -8 || sprite->data[1] > 0xf8)
-    {
-        sprite->data[2] = FALSE;
-    }
+    sprite->sY = sprite->y + sprite->y2 + sprite->centerToCornerVecY;
+    sprite->sX = sprite->x + sprite->x2 + sprite->centerToCornerVecX;
+    if (sprite->sY < -8 || sprite->sY > DISPLAY_HEIGHT + 8 || sprite->sX < -8 || sprite->sX > DISPLAY_WIDTH + 8)
+        sprite->sVisible = FALSE;
     else
-    {
-        sprite->data[2] = TRUE;
-    }
-    if (sprite->data[2] == TRUE)
-    {
+        sprite->sVisible = TRUE;
+
+    if (sprite->sVisible == TRUE)
         SpriteCB_PlayerIcon(sprite);
-    }
     else
-    {
         sprite->invisible = TRUE;
-    }
 }
 
 static void SpriteCB_PlayerIconMapFull(struct Sprite *sprite)
@@ -1549,9 +1547,9 @@ static void SpriteCB_PlayerIcon(struct Sprite *sprite)
 {
     if (gRegionMap->blinkPlayerIcon)
     {
-        if (++sprite->data[7] > 16)
+        if (++sprite->sTimer > 16)
         {
-            sprite->data[7] = 0;
+            sprite->sTimer = 0;
             sprite->invisible = sprite->invisible ? FALSE : TRUE;
         }
     }
@@ -1566,6 +1564,11 @@ void TrySetPlayerIconBlink(void)
     if (gRegionMap->playerIsInCave)
         gRegionMap->blinkPlayerIcon = TRUE;
 }
+
+#undef sY
+#undef sX
+#undef sVisible
+#undef sTimer
 
 u8 *GetMapName(u8 *dest, u16 regionMapId, u16 padLength)
 {
@@ -1709,7 +1712,7 @@ void CB2_OpenFlyMap(void)
         gMain.state++;
         break;
     case 7:
-        LoadPalette(sRegionMapFramePal, 0x10, 0x20);
+        LoadPalette(sRegionMapFramePal, 0x10, sizeof(sRegionMapFramePal));
         PutWindowTilemap(2);
         FillWindowPixelBuffer(2, PIXEL_FILL(0));
         AddTextPrinterParameterized(2, FONT_NORMAL, gText_FlyToWhere, 0, 1, 0, NULL);

--- a/src/rotating_gate.c
+++ b/src/rotating_gate.c
@@ -684,13 +684,11 @@ static void RotatingGate_LoadPuzzleConfig(void)
     {
     case PUZZLE_FORTREE_CITY_GYM:
         gRotatingGate_PuzzleConfig = sRotatingGate_FortreePuzzleConfig;
-        gRotatingGate_PuzzleCount =
-            sizeof(sRotatingGate_FortreePuzzleConfig) / sizeof(struct RotatingGatePuzzle);
+        gRotatingGate_PuzzleCount = ARRAY_COUNT(sRotatingGate_FortreePuzzleConfig);
         break;
     case PUZZLE_ROUTE110_TRICK_HOUSE_PUZZLE6:
         gRotatingGate_PuzzleConfig = sRotatingGate_TrickHousePuzzleConfig;
-        gRotatingGate_PuzzleCount =
-            sizeof(sRotatingGate_TrickHousePuzzleConfig) / sizeof(struct RotatingGatePuzzle);
+        gRotatingGate_PuzzleCount = ARRAY_COUNT(sRotatingGate_TrickHousePuzzleConfig);
         break;
     case PUZZLE_NONE:
     default:
@@ -698,9 +696,7 @@ static void RotatingGate_LoadPuzzleConfig(void)
     }
 
     for (i = 0; i < ROTATING_GATE_PUZZLE_MAX - 1; i++)
-    {
         gRotatingGate_GateSpriteIds[i] = MAX_SPRITES;
-    }
 }
 
 static void RotatingGate_CreateGatesWithinViewport(s16 deltaX, s16 deltaY)
@@ -773,7 +769,7 @@ static void SpriteCallback_RotatingGate(struct Sprite *sprite)
     {
         affineAnimation = orientation + 4;
 
-        if (GetPlayerSpeed() != 1)
+        if (GetPlayerSpeed() != PLAYER_SPEED_NORMAL)
             affineAnimation += 8;
 
         PlaySE(SE_ROTATING_GATE);
@@ -783,7 +779,7 @@ static void SpriteCallback_RotatingGate(struct Sprite *sprite)
     {
         affineAnimation = orientation + 8;
 
-        if (GetPlayerSpeed() != 1)
+        if (GetPlayerSpeed() != PLAYER_SPEED_NORMAL)
             affineAnimation += 8;
 
         PlaySE(SE_ROTATING_GATE);

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -999,7 +999,7 @@ bool8 ScrCmd_applymovement(struct ScriptContext *ctx)
     return FALSE;
 }
 
-bool8 ScrCmd_applymovement_at(struct ScriptContext *ctx)
+bool8 ScrCmd_applymovementat(struct ScriptContext *ctx)
 {
     u16 localId = VarGet(ScriptReadHalfword(ctx));
     const void *movementScript = (const void *)ScriptReadWord(ctx);
@@ -1028,7 +1028,7 @@ bool8 ScrCmd_waitmovement(struct ScriptContext *ctx)
     return TRUE;
 }
 
-bool8 ScrCmd_waitmovement_at(struct ScriptContext *ctx)
+bool8 ScrCmd_waitmovementat(struct ScriptContext *ctx)
 {
     u16 localId = VarGet(ScriptReadHalfword(ctx));
     u8 mapGroup;
@@ -1052,7 +1052,7 @@ bool8 ScrCmd_removeobject(struct ScriptContext *ctx)
     return FALSE;
 }
 
-bool8 ScrCmd_removeobject_at(struct ScriptContext *ctx)
+bool8 ScrCmd_removeobjectat(struct ScriptContext *ctx)
 {
     u16 objectId = VarGet(ScriptReadHalfword(ctx));
     u8 mapGroup = ScriptReadByte(ctx);
@@ -1070,7 +1070,7 @@ bool8 ScrCmd_addobject(struct ScriptContext *ctx)
     return FALSE;
 }
 
-bool8 ScrCmd_addobject_at(struct ScriptContext *ctx)
+bool8 ScrCmd_addobjectat(struct ScriptContext *ctx)
 {
     u16 objectId = VarGet(ScriptReadHalfword(ctx));
     u8 mapGroup = ScriptReadByte(ctx);
@@ -1108,7 +1108,7 @@ bool8 ScrCmd_copyobjectxytoperm(struct ScriptContext *ctx)
     return FALSE;
 }
 
-bool8 ScrCmd_showobject_at(struct ScriptContext *ctx)
+bool8 ScrCmd_showobjectat(struct ScriptContext *ctx)
 {
     u16 localId = VarGet(ScriptReadHalfword(ctx));
     u8 mapGroup = ScriptReadByte(ctx);
@@ -1118,7 +1118,7 @@ bool8 ScrCmd_showobject_at(struct ScriptContext *ctx)
     return FALSE;
 }
 
-bool8 ScrCmd_hideobject_at(struct ScriptContext *ctx)
+bool8 ScrCmd_hideobjectat(struct ScriptContext *ctx)
 {
     u16 localId = VarGet(ScriptReadHalfword(ctx));
     u8 mapGroup = ScriptReadByte(ctx);

--- a/src/wallclock.c
+++ b/src/wallclock.c
@@ -41,6 +41,8 @@ static void SpriteCB_HourHand(struct Sprite *sprite);
 static void SpriteCB_PMIndicator(struct Sprite *sprite);
 static void SpriteCB_AMIndicator(struct Sprite *sprite);
 
+#define sTaskId data[0]
+
 #define tMinuteHandAngle data[0]
 #define tHourHandAngle   data[1]
 #define tHours           data[2]
@@ -696,21 +698,21 @@ void CB2_StartWallClock(void)
     gTasks[taskId].tHourHandAngle = 300;
 
     spriteId = CreateSprite(&sSpriteTemplate_MinuteHand, 120, 80, 1);
-    gSprites[spriteId].data[0] = taskId;
+    gSprites[spriteId].sTaskId = taskId;
     gSprites[spriteId].oam.affineMode = ST_OAM_AFFINE_NORMAL;
     gSprites[spriteId].oam.matrixNum = 0;
 
     spriteId = CreateSprite(&sSpriteTemplate_HourHand, 120, 80, 0);
-    gSprites[spriteId].data[0] = taskId;
+    gSprites[spriteId].sTaskId = taskId;
     gSprites[spriteId].oam.affineMode = ST_OAM_AFFINE_NORMAL;
     gSprites[spriteId].oam.matrixNum = 1;
 
     spriteId = CreateSprite(&sSpriteTemplate_PM, 120, 80, 2);
-    gSprites[spriteId].data[0] = taskId;
+    gSprites[spriteId].sTaskId = taskId;
     gSprites[spriteId].data[1] = 45;
 
     spriteId = CreateSprite(&sSpriteTemplate_AM, 120, 80, 2);
-    gSprites[spriteId].data[0] = taskId;
+    gSprites[spriteId].sTaskId = taskId;
     gSprites[spriteId].data[1] = 90;
 
     WallClockInit();
@@ -744,21 +746,21 @@ void CB2_ViewWallClock(void)
     }
 
     spriteId = CreateSprite(&sSpriteTemplate_MinuteHand, 120, 80, 1);
-    gSprites[spriteId].data[0] = taskId;
+    gSprites[spriteId].sTaskId = taskId;
     gSprites[spriteId].oam.affineMode = ST_OAM_AFFINE_NORMAL;
     gSprites[spriteId].oam.matrixNum = 0;
 
     spriteId = CreateSprite(&sSpriteTemplate_HourHand, 120, 80, 0);
-    gSprites[spriteId].data[0] = taskId;
+    gSprites[spriteId].sTaskId = taskId;
     gSprites[spriteId].oam.affineMode = ST_OAM_AFFINE_NORMAL;
     gSprites[spriteId].oam.matrixNum = 1;
 
     spriteId = CreateSprite(&sSpriteTemplate_PM, 120, 80, 2);
-    gSprites[spriteId].data[0] = taskId;
+    gSprites[spriteId].sTaskId = taskId;
     gSprites[spriteId].data[1] = angle1;
 
     spriteId = CreateSprite(&sSpriteTemplate_AM, 120, 80, 2);
-    gSprites[spriteId].data[0] = taskId;
+    gSprites[spriteId].sTaskId = taskId;
     gSprites[spriteId].data[1] = angle2;
 
     WallClockInit();
@@ -1015,7 +1017,7 @@ static void InitClockWithRtc(u8 taskId)
 
 static void SpriteCB_MinuteHand(struct Sprite *sprite)
 {
-    u16 angle = gTasks[sprite->data[0]].tMinuteHandAngle;
+    u16 angle = gTasks[sprite->sTaskId].tMinuteHandAngle;
     s16 sin = Sin2(angle) / 16;
     s16 cos = Cos2(angle) / 16;
     u16 x, y;
@@ -1035,7 +1037,7 @@ static void SpriteCB_MinuteHand(struct Sprite *sprite)
 
 static void SpriteCB_HourHand(struct Sprite *sprite)
 {
-    u16 angle = gTasks[sprite->data[0]].tHourHandAngle;
+    u16 angle = gTasks[sprite->sTaskId].tHourHandAngle;
     s16 sin = Sin2(angle) / 16;
     s16 cos = Cos2(angle) / 16;
     u16 x, y;
@@ -1053,58 +1055,44 @@ static void SpriteCB_HourHand(struct Sprite *sprite)
     sprite->y2 = y;
 }
 
+#define sAngle data[1]
+
 static void SpriteCB_PMIndicator(struct Sprite *sprite)
 {
-    if (gTasks[sprite->data[0]].tPeriod != PERIOD_AM)
+    if (gTasks[sprite->sTaskId].tPeriod != PERIOD_AM)
     {
-        if (sprite->data[1] >= 60 && sprite->data[1] < 90)
-        {
-            sprite->data[1] += 5;
-        }
-        if (sprite->data[1] < 60)
-        {
-            sprite->data[1]++;
-        }
+        if (sprite->sAngle >= 60 && sprite->sAngle < 90)
+            sprite->sAngle += 5;
+        if (sprite->sAngle < 60)
+            sprite->sAngle++;
     }
     else
     {
-        if (sprite->data[1] >= 46 && sprite->data[1] < 76)
-        {
-            sprite->data[1] -= 5;
-        }
-        if (sprite->data[1] > 75)
-        {
-            sprite->data[1]--;
-        }
+        if (sprite->sAngle >= 46 && sprite->sAngle < 76)
+            sprite->sAngle -= 5;
+        if (sprite->sAngle > 75)
+            sprite->sAngle--;
     }
-    sprite->x2 = Cos2(sprite->data[1]) * 30 / 0x1000;
-    sprite->y2 = Sin2(sprite->data[1]) * 30 / 0x1000;
+    sprite->x2 = Cos2(sprite->sAngle) * 30 / 0x1000;
+    sprite->y2 = Sin2(sprite->sAngle) * 30 / 0x1000;
 }
 
 static void SpriteCB_AMIndicator(struct Sprite *sprite)
 {
-    if (gTasks[sprite->data[0]].tPeriod != PERIOD_AM)
+    if (gTasks[sprite->sTaskId].tPeriod != PERIOD_AM)
     {
-        if (sprite->data[1] >= 105 && sprite->data[1] < 135)
-        {
-            sprite->data[1] += 5;
-        }
-        if (sprite->data[1] < 105)
-        {
-            sprite->data[1]++;
-        }
+        if (sprite->sAngle >= 105 && sprite->sAngle < 135)
+            sprite->sAngle += 5;
+        if (sprite->sAngle < 105)
+            sprite->sAngle++;
     }
     else
     {
-        if (sprite->data[1] >= 91 && sprite->data[1] < 121)
-        {
-            sprite->data[1] -= 5;
-        }
-        if (sprite->data[1] > 120)
-        {
-            sprite->data[1]--;
-        }
+        if (sprite->sAngle >= 91 && sprite->sAngle < 121)
+            sprite->sAngle -= 5;
+        if (sprite->sAngle > 120)
+            sprite->sAngle--;
     }
-    sprite->x2 = Cos2(sprite->data[1]) * 30 / 0x1000;
-    sprite->y2 = Sin2(sprite->data[1]) * 30 / 0x1000;
+    sprite->x2 = Cos2(sprite->sAngle) * 30 / 0x1000;
+    sprite->y2 = Sin2(sprite->sAngle) * 30 / 0x1000;
 }


### PR DESCRIPTION
Branch I had running for some small issues I encountered while doing other things.
- Correct comment for `waitmovement`
- Allow `givemon` and `setwildbattle` to be called without `ITEM_NONE`
- Use `MON_GIVEN_TO_` constants for result of `givemon`
- Add `seteventmon` for setting arguments for / calling `CreateEventLegalEnemyMon`
- Add missing commas in script
- Sync function name of `command_at` functions with macro names `macroat`
- Rename `BIKE_SPEED` to `PLAYER_SPEED`, as it represents speed on and off the bike. Also adds missing usage
- Some new task data defines, and usage of `ARRAY_COUNT` and `sizeof`