### PR TITLE
Updated the value of MAX_MAP_DATA_SIZE

### DIFF
--- a/include/fieldmap.h
+++ b/include/fieldmap.h
@@ -7,7 +7,7 @@
 #define NUM_METATILES_TOTAL 1024
 #define NUM_PALS_IN_PRIMARY 6
 #define NUM_PALS_TOTAL 13
-#define MAX_MAP_DATA_SIZE 0x2800
+#define MAX_MAP_DATA_SIZE 10240
 
 // Map coordinates are offset by 7 when using the map
 // buffer because it needs to load sufficient border


### PR DESCRIPTION
## Description
The value of `MAX_MAP_DATA_SIZE` was written as a hex value rather than a dec value, which is inconsistent with the other constants in the same file.

## **Discord contact info**
Lunos#4026