### PR TITLE
Declare gHeap in malloc.c, so it doesn't have to be explicitly mentioned in the linker script

### DIFF
--- a/gflib/malloc.c
+++ b/gflib/malloc.c
@@ -1,4 +1,7 @@
 #include "global.h"
+#include "malloc.h"
+
+EWRAM_DATA ALIGNED(4) u8 gHeap [HEAP_SIZE] = {0};
 
 static void *sHeapStart;
 static u32 sHeapSize;

--- a/gflib/malloc.h
+++ b/gflib/malloc.h
@@ -14,7 +14,7 @@
 
 #define TRY_FREE_AND_SET_NULL(ptr) if (ptr != NULL) FREE_AND_SET_NULL(ptr)
 
-extern u8 gHeap[];
+extern u8 gHeap[HEAP_SIZE];
 
 void *Alloc(u32 size);
 void *AllocZeroed(u32 size);

--- a/ld_script.txt
+++ b/ld_script.txt
@@ -15,14 +15,10 @@ SECTIONS {
     ewram (NOLOAD) :
     ALIGN(4)
     {
-        gHeap = .;
-
-        . = 0x1C000;
-
         INCLUDE "sym_ewram.ld"
 
         . = 0x40000;
-}
+    }
 
     . = 0x3000000;
 

--- a/ld_script_modern.txt
+++ b/ld_script_modern.txt
@@ -9,15 +9,16 @@ SECTIONS {
     ewram (NOLOAD) :
     ALIGN(4)
     {
-        gHeap = .;
+        gflib/malloc.o(ewram_data)
+        src/decompress.o(ewram_data)
 
-        . = 0x1C000;
+        . = 0x20000;
 
         src/*.o(ewram_data);
         gflib/*.o(ewram_data);
 
         . = 0x40000;
-}
+    }
 
     . = 0x3000000;
 

--- a/sym_ewram.txt
+++ b/sym_ewram.txt
@@ -1,3 +1,4 @@
+	.include "gflib/malloc.o"
 	.include "src/decompress.o"
 	.include "src/main.o"
 	.include "gflib/window.o"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As is, gHeap is not explicitly defined outside of being a nebulous extern that requires the linkerscript to know what to do with it. 
There ought to be a place where it if defined, so let's declare it in malloc.c
## Description
<!--- Describe your changes in detail -->
Because gHeap is first on the list, malloc EWRAM data must be linked first in the ROM. I changed the link order so that gflib .o files would be linked first so that the memory location of gflib code (since that is where gDecompressBuffer and gHeap are modified) is not too far away from the code accessing said arrays/buffers. I will be happy to make any changes if so needed.

## **Discord contact info**
Pizza Delivery Irida (Rose)#7522
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->