### PR TITLE
Make sSpriteTileRanges a 2d array and use bitwise functions for operations on bitmaps

### DIFF
--- a/gflib/sprite.c
+++ b/gflib/sprite.c
@@ -12,22 +12,21 @@
 
 #define SET_SPRITE_TILE_RANGE(index, start, count) \
 {                                                  \
-    sSpriteTileRanges[index * 2] = start;          \
-    (sSpriteTileRanges + 1)[index * 2] = count;    \
+    sSpriteTileRanges[index][0] = start;           \
+    sSpriteTileRanges[index][1] = count;           \
 }
 
-#define ALLOC_SPRITE_TILE(n)                             \
-{                                                        \
-    sSpriteTileAllocBitmap[(n) / 8] |= (1 << ((n) % 8)); \
-}
-
-#define FREE_SPRITE_TILE(n)                               \
+#define ALLOC_SPRITE_TILE(n)                              \
 {                                                         \
-    sSpriteTileAllocBitmap[(n) / 8] &= ~(1 << ((n) % 8)); \
+    sSpriteTileAllocBitmap[(n) >> 3] |= (1 << ((n) & 7)); \
 }
 
-#define SPRITE_TILE_IS_ALLOCATED(n) ((sSpriteTileAllocBitmap[(n) / 8] >> ((n) % 8)) & 1)
+#define FREE_SPRITE_TILE(n)                                \
+{                                                          \
+    sSpriteTileAllocBitmap[(n) >> 3] &= ~(1 << ((n) & 7)); \
+}
 
+#define SPRITE_TILE_IS_ALLOCATED(n) (sSpriteTileAllocBitmap[(n) >> 3] & (1 << ((n) & 7)))
 
 struct SpriteCopyRequest
 {
@@ -271,7 +270,7 @@ static const struct OamDimensions sOamDimensions[3][4] =
 
 // iwram bss
 static u16 sSpriteTileRangeTags[MAX_SPRITES];
-static u16 sSpriteTileRanges[MAX_SPRITES * 2];
+static u16 sSpriteTileRanges[MAX_SPRITES][2];
 static struct AffineAnimState sAffineAnimStates[OAM_MATRIX_COUNT];
 static u16 sSpritePaletteTags[16];
 
@@ -1513,14 +1512,8 @@ void FreeSpriteTilesByTag(u16 tag)
     if (index != 0xFF)
     {
         u16 i;
-        u16 *rangeStarts;
-        u16 *rangeCounts;
-        u16 start;
-        u16 count;
-        rangeStarts = sSpriteTileRanges;
-        start = rangeStarts[index * 2];
-        rangeCounts = sSpriteTileRanges + 1;
-        count = rangeCounts[index * 2];
+        u16 start = sSpriteTileRanges[index][0];
+        u16 count = sSpriteTileRanges[index][1];
 
         for (i = start; i < start + count; i++)
             FREE_SPRITE_TILE(i);
@@ -1545,7 +1538,7 @@ u16 GetSpriteTileStartByTag(u16 tag)
     u8 index = IndexOfSpriteTileTag(tag);
     if (index == 0xFF)
         return 0xFFFF;
-    return sSpriteTileRanges[index * 2];
+    return sSpriteTileRanges[index][0];
 }
 
 u8 IndexOfSpriteTileTag(u16 tag)
@@ -1565,7 +1558,7 @@ u16 GetSpriteTileTagByTileStart(u16 start)
 
     for (i = 0; i < MAX_SPRITES; i++)
     {
-        if (sSpriteTileRangeTags[i] != TAG_NONE && sSpriteTileRanges[i * 2] == start)
+        if (sSpriteTileRangeTags[i] != TAG_NONE && sSpriteTileRanges[i][0] == start)
             return sSpriteTileRangeTags[i];
     }
 
@@ -1701,8 +1694,8 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
     else
     {
         u16 tileNum;
-        u16 baseX;
-        u16 baseY;
+        s16 baseX;
+        s16 baseY;
         u8 subspriteCount;
         u8 hFlip;
         u8 vFlip;
@@ -1710,15 +1703,15 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
 
         tileNum = oam->tileNum;
         subspriteCount = subspriteTable->subspriteCount;
-        hFlip = ((s32)oam->matrixNum >> 3) & 1;
-        vFlip = ((s32)oam->matrixNum >> 4) & 1;
+        hFlip = (oam->matrixNum >> 3) & 1;
+        vFlip = (oam->matrixNum >> 4) & 1;
         baseX = oam->x - sprite->centerToCornerVecX;
         baseY = oam->y - sprite->centerToCornerVecY;
 
         for (i = 0; i < subspriteCount; i++, (*oamIndex)++)
         {
-            u16 x;
-            u16 y;
+            s16 x;
+            s16 y;
 
             if (*oamIndex >= gOamLimit)
                 return 1;
@@ -1728,26 +1721,20 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
 
             if (hFlip)
             {
-                s8 width = sOamDimensions[subspriteTable->subsprites[i].shape][subspriteTable->subsprites[i].size].width;
-                s16 right = x;
-                right += width;
-                x = right;
+                x += sOamDimensions[subspriteTable->subsprites[i].shape][subspriteTable->subsprites[i].size].width;
                 x = ~x + 1;
             }
 
             if (vFlip)
             {
-                s8 height = sOamDimensions[subspriteTable->subsprites[i].shape][subspriteTable->subsprites[i].size].height;
-                s16 bottom = y;
-                bottom += height;
-                y = bottom;
+                y += sOamDimensions[subspriteTable->subsprites[i].shape][subspriteTable->subsprites[i].size].height;
                 y = ~y + 1;
             }
 
             destOam[i] = *oam;
             destOam[i].shape = subspriteTable->subsprites[i].shape;
             destOam[i].size = subspriteTable->subsprites[i].size;
-            destOam[i].x = (s16)baseX + (s16)x;
+            destOam[i].x = baseX + x;
             destOam[i].y = baseY + y;
             destOam[i].tileNum = tileNum + subspriteTable->subsprites[i].tileOffset;
 

--- a/gflib/sprite.c
+++ b/gflib/sprite.c
@@ -135,7 +135,7 @@ static const u8 sUnknownData[24] =
     0x02, 0x04, 0x08, 0x20,
 };
 
-static const u8 sCenterToCornerVecTable[3][4][2] =
+static const s8 sCenterToCornerVecTable[3][4][2] =
 {
     {   // square
         {  -4,  -4 },
@@ -690,8 +690,8 @@ void ResetSprite(struct Sprite *sprite)
 
 void CalcCenterToCornerVec(struct Sprite *sprite, u8 shape, u8 size, u8 affineMode)
 {
-    u8 x = sCenterToCornerVecTable[shape][size][0];
-    u8 y = sCenterToCornerVecTable[shape][size][1];
+    s8 x = sCenterToCornerVecTable[shape][size][0];
+    s8 y = sCenterToCornerVecTable[shape][size][1];
 
     if (affineMode & ST_OAM_AFFINE_DOUBLE_MASK)
     {
@@ -720,7 +720,7 @@ s16 AllocSpriteTiles(u16 tileCount)
 
     i = gReservedSpriteTileCount;
 
-    for (;;)
+    do
     {
         while (SPRITE_TILE_IS_ALLOCATED(i))
         {
@@ -745,10 +745,7 @@ s16 AllocSpriteTiles(u16 tileCount)
             else
                 break;
         }
-
-        if (numTilesFound == tileCount)
-            break;
-    }
+    } while (numTilesFound != tileCount);
 
     for (i = start; i < tileCount + start; i++)
         ALLOC_SPRITE_TILE(i);
@@ -760,23 +757,23 @@ u8 SpriteTileAllocBitmapOp(u16 bit, u8 op)
 {
     u8 index = bit / 8;
     u8 shift = bit % 8;
-    u8 val = bit % 8;
     u8 retVal = 0;
+    u8 val;
 
     if (op == 0)
     {
-        val = ~(1 << val);
+        val = ~(1 << shift);
         sSpriteTileAllocBitmap[index] &= val;
     }
     else if (op == 1)
     {
-        val = (1 << val);
+        val = 1 << shift;
         sSpriteTileAllocBitmap[index] |= val;
     }
     else
     {
-        retVal = 1 << shift;
-        retVal &= sSpriteTileAllocBitmap[index];
+        val = 1 << shift;
+        retVal = sSpriteTileAllocBitmap[index] & val;
     }
 
     return retVal;


### PR DESCRIPTION
Cleanup AddSubspritesToOamBuffer too.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In short, these changes aren't simply stylistic. These changes better capture the essence of what is going on.

The program is checking for a specific bit to be set to know if the tile is allocated or not, so bitwise operations absolutely make sense here.

The 2d array gets rid of a lot of the manual index operations required to access and set data if the array were just one.

Finally, AddSubspritesToOamBuffer has been cleaned up without multiple variables hiding away or obscuring what is truly happening.

If these changes aren't ideal, you are free to make a comment and give feedback!

Thank you guys so much!

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
Pizza Delivery Irida (Rose)#7522
<!--- Contributors must join https://discord.gg/d5dubZ3 -->