### PR TITLE
Use volatile when talking to hardware

### DIFF
--- a/gflib/dma3_manager.c
+++ b/gflib/dma3_manager.c
@@ -55,7 +55,7 @@ void ProcessDma3Requests(void)
 
         if (bytesTransferred > 40 * 1024)
             return; // don't transfer more than 40 KiB
-        if (*(u8 *)REG_ADDR_VCOUNT > 224)
+        if (*(vu8 *)REG_ADDR_VCOUNT > 224)
             return; // we're about to leave vblank, stop
 
         switch (sDma3Requests[sDma3RequestCursor].mode)

--- a/include/gba/defines.h
+++ b/include/gba/defines.h
@@ -18,9 +18,9 @@
 
 #define ALIGNED(n) __attribute__((aligned(n)))
 
-#define SOUND_INFO_PTR (*(struct SoundInfo **)0x3007FF0)
-#define INTR_CHECK     (*(u16 *)0x3007FF8)
-#define INTR_VECTOR    (*(void **)0x3007FFC)
+#define SOUND_INFO_PTR (*(struct SoundInfo * volatile*)0x3007FF0)
+#define INTR_CHECK     (*(vu16 *)0x3007FF8)
+#define INTR_VECTOR    (*(void * volatile*)0x3007FFC)
 
 #define EWRAM_START 0x02000000
 #define EWRAM_END   (EWRAM_START + 0x40000)

--- a/include/link.h
+++ b/include/link.h
@@ -129,7 +129,7 @@ struct LinkStatus
 #define SLAVE_HANDSHAKE   0xB9A0
 #define EREADER_HANDSHAKE 0xCCD0
 
-#define SIO_MULTI_CNT ((struct SioMultiCnt *)REG_ADDR_SIOCNT)
+#define SIO_MULTI_CNT ((struct SioMultiCnt * volatile )REG_ADDR_SIOCNT)
 
 enum
 {

--- a/src/ereader_helpers.c
+++ b/src/ereader_helpers.c
@@ -775,7 +775,7 @@ void EReaderHelper_SerialCallback(void)
     {
     case EREADER_XFR_STATE_HANDSHAKE:
         REG_SIOMLT_SEND = 0xCCD0; // Handshake id
-        *(u64 *)recv = REG_SIOMLT_RECV;
+        *(vu64 *)recv = REG_SIOMLT_RECV;
         for (i = 0, cnt1 = 0, cnt2 = 0; i < 4; i++)
         {
             if (recv[i] == 0xCCD0)

--- a/src/ereader_screen.c
+++ b/src/ereader_screen.c
@@ -105,7 +105,7 @@ static void OpenEReaderLink(void)
 
 static bool32 ValidateEReaderConnection(void)
 {
-    volatile u16 backupIME;
+    vu16 backupIME;
     u16 handshakes[MAX_LINK_PLAYERS];
 
     backupIME = REG_IME;

--- a/src/intro.c
+++ b/src/intro.c
@@ -1072,7 +1072,7 @@ static u8 SetUpCopyrightScreen(void)
         SetGpuReg(REG_OFFSET_BLDCNT, 0);
         SetGpuReg(REG_OFFSET_BLDALPHA, 0);
         SetGpuReg(REG_OFFSET_BLDY, 0);
-        *(u16 *)PLTT = RGB_WHITE;
+        *(vu16 *)PLTT = RGB_WHITE;
         SetGpuReg(REG_OFFSET_DISPCNT, 0);
         SetGpuReg(REG_OFFSET_BG0HOFS, 0);
         SetGpuReg(REG_OFFSET_BG0VOFS, 0);
@@ -1119,10 +1119,10 @@ static u8 SetUpCopyrightScreen(void)
             if (gMultibootProgramStruct.gcmb_field_2 == 2)
             {
                 // check the multiboot ROM header game code to see if we already did this
-                if (*(u32 *)(EWRAM_START + 0xAC) == COLOSSEUM_GAME_CODE)
+                if (*(vu32 *)(EWRAM_START + 0xAC) == COLOSSEUM_GAME_CODE)
                 {
                     CpuCopy16(&gMultiBootProgram_PokemonColosseum_Start, (void *)EWRAM_START, sizeof(gMultiBootProgram_PokemonColosseum_Start));
-                    *(u32 *)(EWRAM_START + 0xAC) = COLOSSEUM_GAME_CODE;
+                    *(vu32 *)(EWRAM_START + 0xAC) = COLOSSEUM_GAME_CODE;
                 }
                 GameCubeMultiBoot_ExecuteProgram(&gMultibootProgramStruct);
             }

--- a/src/link.c
+++ b/src/link.c
@@ -2191,7 +2191,7 @@ static bool8 DoHandshake(void)
     {
         REG_SIOMLT_SEND = SLAVE_HANDSHAKE;
     }
-    *(u64 *)gLink.handshakeBuffer = REG_SIOMLT_RECV;
+    *(vu64 *)gLink.handshakeBuffer = REG_SIOMLT_RECV;
     REG_SIOMLT_RECV = 0;
     gLink.handshakeAsMaster = FALSE;
     for (i = 0; i < MAX_LINK_PLAYERS; i++)
@@ -2232,7 +2232,7 @@ static void DoRecv(void)
     u8 i;
     u8 index;
 
-    *(u64 *)recv = REG_SIOMLT_RECV;
+    *(vu64 *)recv = REG_SIOMLT_RECV;
     if (gLink.sendCmdIndex == 0)
     {
         for (i = 0; i < gLink.playerCount; i++)

--- a/src/title_screen.c
+++ b/src/title_screen.c
@@ -527,7 +527,7 @@ void CB2_InitTitleScreen(void)
         SetGpuReg(REG_OFFSET_BLDCNT, 0);
         SetGpuReg(REG_OFFSET_BLDALPHA, 0);
         SetGpuReg(REG_OFFSET_BLDY, 0);
-        *((u16 *)PLTT) = RGB_WHITE;
+        *((vu16 *)PLTT) = RGB_WHITE;
         SetGpuReg(REG_OFFSET_DISPCNT, 0);
         SetGpuReg(REG_OFFSET_BG2CNT, 0);
         SetGpuReg(REG_OFFSET_BG1CNT, 0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
agbcc is slightly modified to at the very least know than to optimize register reads. However, this is not guaranteed with newer compilers, so let's do the right think and use volatile when talking with the hardware
## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
Pizza Delivery Irida (Rose)#7522
<!--- Contributors must join https://discord.gg/d5dubZ3 -->