### PR TITLE
Get reelPixelOffsetsWhileStopping to be an s16 array

### DIFF
--- a/gflib/sprite.h
+++ b/gflib/sprite.h
@@ -48,11 +48,11 @@ struct AnimFrameCmd
 {
     // If the sprite has an array of images, this is the array index.
     // If the sprite has a sheet, this is the tile offset.
-    u32 imageValue:16;
+    s16 imageValue;
 
-    u32 duration:6;
-    u32 hFlip:1;
-    u32 vFlip:1;
+    u8 duration:6;
+    u8 hFlip:1;
+    u8 vFlip:1;
 };
 
 struct AnimLoopCmd

--- a/gflib/sprite.h
+++ b/gflib/sprite.h
@@ -57,14 +57,14 @@ struct AnimFrameCmd
 
 struct AnimLoopCmd
 {
-    u32 type:16;
-    u32 count:6;
+    s16 type;
+    u8 count:6;
 };
 
 struct AnimJumpCmd
 {
-    u32 type:16;
-    u32 target:6;
+    s16 type;
+    u8 target:6;
 };
 
 // The first halfword of this union specifies the type of command.

--- a/src/slot_machine.c
+++ b/src/slot_machine.c
@@ -257,7 +257,7 @@ struct SlotMachine
     /*0x18*/ s16 currReel;
     /*0x1A*/ s16 reelIncrement; // speed of reel
     /*0x1C*/ s16 reelPixelOffsets[NUM_REELS];
-    /*0x22*/ u16 reelPixelOffsetsWhileStopping[NUM_REELS];
+    /*0x22*/ s16 reelPixelOffsetsWhileStopping[NUM_REELS];
     /*0x28*/ s16 reelPositions[NUM_REELS];
     /*0x2E*/ s16 reelExtraTurns[NUM_REELS];
     /*0x34*/ s16 winnerRows[NUM_REELS];
@@ -3601,7 +3601,7 @@ static void SpriteCB_ReelSymbol(struct Sprite *sprite)
 {
     sprite->data[2] = sSlotMachine->reelPixelOffsets[sprite->data[0]] + sprite->data[1];
     sprite->data[2] %= 120;
-    sprite->y = sSlotMachine->reelPixelOffsetsWhileStopping[sprite->data[0]] + 28 + sprite->data[2];
+    sprite->y = sprite->data[2] + 28 + sSlotMachine->reelPixelOffsetsWhileStopping[sprite->data[0]];
     sprite->sheetTileStart = GetSpriteTileStartByTag(GetTagAtRest(sprite->data[0], sprite->data[2] / 24));
     SetSpriteSheetFrameTileNum(sprite);
 }


### PR DESCRIPTION
Not only does this make it more in-line with the other fields, but reduces UB since the data used to calculate the field's values are also s16, and assigning a s16 to an u16 is UB.

<!--- Provide a general summary of your changes in the Title above -->
And yes the other change is needed to match in this case too, as much as I hate it.

## **Discord contact info**
Pizza Delivery Irida (Rose)#7522
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->