### PR TITLE
Update money.c

### DIFF
--- a/src/money.c
+++ b/src/money.c
@@ -132,7 +132,7 @@ void SubtractMoneyFromVar0x8005(void)
 
 void PrintMoneyAmountInMoneyBox(u8 windowId, int amount, u8 speed)
 {
-    PrintMoneyAmount(windowId, 0x26, 1, amount, speed);
+    PrintMoneyAmount(windowId, 38, 1, amount, speed);
 }
 
 void PrintMoneyAmount(u8 windowId, u8 x, u8 y, int amount, u8 speed)


### PR DESCRIPTION
Fix inconsistency in money.c

## Description
This call of PrintMoneyAmount in money.c is the only case where the x parameter is not 38, but 0x26 (which is 38 in hex).
I changed it, so it's more consistent.

## **Discord contact info**
kiliwily#5386