### PR TITLE
Use constants to further document fldeff

### DIFF
--- a/src/field_special_scene.c
+++ b/src/field_special_scene.c
@@ -50,9 +50,9 @@ static void Task_Truck3(u8);
 
 s16 GetTruckCameraBobbingY(int a1)
 {
-    if (!(a1 % 120))
+    if ((a1 % 120) == 0)
         return -1;
-    else if ((a1 % 10) <= 4)
+    else if ((a1 % 10) < 5)
         return 1;
 
     return 0;
@@ -60,7 +60,7 @@ s16 GetTruckCameraBobbingY(int a1)
 
 s16 GetTruckBoxMovement(int a1) // for the box movement?
 {
-    if (!((a1 + 120) % 180))
+    if (((a1 + 120) % 180) == 0)
         return -1;
 
     return 0;
@@ -103,7 +103,7 @@ void Task_Truck2(u8 taskId)
         data[0] = 0;
         data[1]++;
     }
-    if ((u16)data[1] == 19)
+    if (data[1] == ARRAY_COUNT(gTruckCamera_HorizontalTable))
     {
         DestroyTask(taskId);
     }
@@ -138,7 +138,7 @@ static void Task_Truck3(u8 taskId)
        data[1]++;
    }
 
-   if ((u16)data[1] == 19)
+   if (data[1] == ARRAY_COUNT(gTruckCamera_HorizontalTable))
    {
        DestroyTask(taskId);
    }
@@ -234,7 +234,7 @@ void ExecuteTruckSequence(void)
     MapGridSetMetatileIdAt(4 + MAP_OFFSET, 3 + MAP_OFFSET, METATILE_InsideOfTruck_DoorClosedFloor_Bottom);
     DrawWholeMapView();
     ScriptContext2_Enable();
-    CpuFastFill(0, gPlttBufferFaded, 0x400);
+    CpuFastFill(0, gPlttBufferFaded, PLTT_SIZE);
     CreateTask(Task_HandleTruckSequence, 0xA);
 }
 

--- a/src/fldeff_cut.c
+++ b/src/fldeff_cut.c
@@ -141,6 +141,7 @@ bool8 SetUpFieldMove_Cut(void)
     u8 i, j;
     u8 tileBehavior;
     u8 userAbility;
+    u8 tile;
     bool8 cutTiles[CUT_NORMAL_AREA];
     bool8 ret;
 
@@ -188,23 +189,23 @@ bool8 SetUpFieldMove_Cut(void)
                     || MetatileBehavior_IsAshGrass(tileBehavior) == TRUE)
                     {
                         // Standing in front of grass.
-                        sHyperCutTiles[6 + (i * 5) + j] = TRUE;
+                        sHyperCutTiles[CUT_HYPER_SIDE + (i * CUT_HYPER_SIDE) + ((CUT_HYPER_SIDE - CUT_NORMAL_SIDE) / 2 + j)] = TRUE;
                         ret = TRUE;
                     }
                     if (MapGridIsImpassableAt(x, y) == TRUE)
                     {
-                        cutTiles[i * 3 + j] = FALSE;
+                        cutTiles[i * CUT_NORMAL_SIDE + j] = FALSE;
                     }
                     else
                     {
-                        cutTiles[i * 3 + j] = TRUE;
+                        cutTiles[i * CUT_NORMAL_SIDE + j] = TRUE;
                         if (MetatileBehavior_IsCuttableGrass(tileBehavior) == TRUE)
-                            sHyperCutTiles[6 + (i * 5) + j] = TRUE;
+                            sHyperCutTiles[CUT_HYPER_SIDE + (i * CUT_HYPER_SIDE) + ((CUT_HYPER_SIDE - CUT_NORMAL_SIDE) / 2 + j)] = TRUE;
                     }
                 }
                 else
                 {
-                    cutTiles[i * 3 + j] = FALSE;
+                    cutTiles[i * CUT_NORMAL_SIDE + j] = FALSE;
                 }
             }
         }
@@ -229,7 +230,8 @@ bool8 SetUpFieldMove_Cut(void)
                 for (j = 0; j < 2; ++j)
                 {
                     if (sHyperCutStruct[i].unk2[j] == 0) break; // one line required to match -g
-                    if (cutTiles[(u8)(sHyperCutStruct[i].unk2[j] - 1)] == FALSE)
+                    tile = sHyperCutStruct[i].unk2[j] - 1;
+                    if (cutTiles[tile] == FALSE)
                     {
                         tileCuttable = FALSE;
                         break;
@@ -250,10 +252,9 @@ bool8 SetUpFieldMove_Cut(void)
                             sHyperCutTiles[tileArrayId] = TRUE;
                             ret = TRUE;
                         }
-                        else
+                        else if (MetatileBehavior_IsCuttableGrass(tileBehavior) == TRUE)
                         {
-                            if (MetatileBehavior_IsCuttableGrass(tileBehavior) == TRUE)
-                                sHyperCutTiles[tileArrayId] = TRUE;
+                            sHyperCutTiles[tileArrayId] = TRUE;
                         }
                     }
                 }
@@ -319,8 +320,8 @@ bool8 FldEff_CutGrass(void)
     {
         if (sHyperCutTiles[i] == TRUE)
         {
-            s8 xAdd = (i % 5) - 2;
-            s8 yAdd = (i / 5) - 2;
+            s8 xAdd = (s8)(i % CUT_HYPER_SIDE) - 2;
+            s8 yAdd = (s8)(i / CUT_HYPER_SIDE) - 2;
 
             x = xAdd + gPlayerFacingPosition.x;
             y = yAdd + gPlayerFacingPosition.y;

--- a/src/fldeff_cut.c
+++ b/src/fldeff_cut.c
@@ -221,7 +221,7 @@ bool8 SetUpFieldMove_Cut(void)
         else
         {
             bool8 tileCuttable;
-            for (i = 0; i < 16; i++)
+            for (i = 0; i < ARRAY_COUNT(sHyperCutStruct); i++)
             {
                 x = gPlayerFacingPosition.x + sHyperCutStruct[i].x;
                 y = gPlayerFacingPosition.y + sHyperCutStruct[i].y;
@@ -475,7 +475,7 @@ static void HandleLongGrassOnHyper(u8 caseId, s16 x, s16 y)
         arr[0] = sHyperCutTiles[9];
         arr[1] = sHyperCutTiles[14];
         arr[2] = sHyperCutTiles[19];
-        newX = x + 4;
+        newX = x + (CUT_HYPER_SIDE - 1);
     }
     else // invalid case
     {

--- a/src/fldeff_sweetscent.c
+++ b/src/fldeff_sweetscent.c
@@ -52,8 +52,8 @@ static void StartSweetScentFieldEffect(void)
     u8 taskId;
 
     PlaySE(SE_M_SWEET_SCENT);
-    CpuFastSet(gPlttBufferUnfaded, gPaletteDecompressionBuffer, 0x100);
-    CpuFastSet(gPlttBufferFaded, gPlttBufferUnfaded, 0x100);
+    CpuFastCopy(gPlttBufferUnfaded, gPaletteDecompressionBuffer, PLTT_SIZE);
+    CpuFastCopy(gPlttBufferFaded, gPlttBufferUnfaded, PLTT_SIZE);
     BeginNormalPaletteFade(~(1 << (gSprites[GetPlayerAvatarSpriteId()].oam.paletteNum + 16)), 4, 0, 8, RGB_RED);
     taskId = CreateTask(TrySweetScentEncounter, 0);
     gTasks[taskId].data[0] = 0;
@@ -91,7 +91,7 @@ static void FailSweetScentEncounter(u8 taskId)
 {
     if (!gPaletteFade.active)
     {
-        CpuFastSet(gPaletteDecompressionBuffer, gPlttBufferUnfaded, 0x100);
+        CpuFastCopy(gPaletteDecompressionBuffer, gPlttBufferUnfaded, PLTT_SIZE);
         SetWeatherPalStateIdle();
         ScriptContext1_SetupScript(EventScript_FailSweetScent);
         DestroyTask(taskId);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A minuscule selection of minor documentation enhancements using previously established pret macros and constants that came up while I was porting the emerald english debug menus to pret
## Description
<!--- Describe your changes in detail -->
Notable change: use CpuFastCopy macro instead of CpuFastSet directly
Notable change: Use known constants in fldeff_cut
Notable change: Use array_count of gTruckCamera_HorizontalTable in conditional to check before destroying task instead of a hard-coded literal of value 19
## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
Pizza Delivery Irida (Rose)#7522
<!--- Contributors must join https://discord.gg/d5dubZ3 -->