### PR TITLE
BUGFIX: Fix roamer status field

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -569,14 +569,27 @@ struct Roamer
     /*0x08*/ u16 species;
     /*0x0A*/ u16 hp;
     /*0x0C*/ u8 level;
+// The roamer's status field is u8, but SetMonData expects status to be u32, so it sets the roamer's status
+// using the status field and the following 3 bytes (cool, beauty, and cute).
+// This seems to be a mistake as it's the only field inconsistent with what it copes to the pokemon struct
+#ifdef BUGFIX
+             u32 status;
+#else
     /*0x0D*/ u8 status;
+#endif
     /*0x0E*/ u8 cool;
     /*0x0F*/ u8 beauty;
     /*0x10*/ u8 cute;
     /*0x11*/ u8 smart;
     /*0x12*/ u8 tough;
     /*0x13*/ bool8 active;
+
+ // Whole struct has to be 28 bytes due to hard-coded save/load logic
+#ifdef BUGFIX
+             u8 filler[0x5];
+#else
     /*0x14*/ u8 filler[0x8];
+#endif
 };
 
 struct RamScriptData

--- a/src/roamer.c
+++ b/src/roamer.c
@@ -197,14 +197,8 @@ void CreateRoamerMonInstance(void)
     struct Pokemon *mon = &gEnemyParty[0];
     ZeroEnemyPartyMons();
     CreateMonWithIVsPersonality(mon, ROAMER->species, ROAMER->level, ROAMER->ivs, ROAMER->personality);
-// The roamer's status field is u8, but SetMonData expects status to be u32, so will set the roamer's status
-// using the status field and the following 3 bytes (cool, beauty, and cute).
-#ifdef BUGFIX
-    status = ROAMER->status;
-    SetMonData(mon, MON_DATA_STATUS, &status);
-#else
+
     SetMonData(mon, MON_DATA_STATUS, &ROAMER->status);
-#endif
     SetMonData(mon, MON_DATA_HP, &ROAMER->hp);
     SetMonData(mon, MON_DATA_COOL, &ROAMER->cool);
     SetMonData(mon, MON_DATA_BEAUTY, &ROAMER->beauty);


### PR DESCRIPTION
Since GetMonData and SetMonData both deal with u32s when it comes to status, the status for the roamer ought to be u32. This seems to be an oversight where the devs assumed the status was a u8. This does more than fix the previous bugfix, but also the bugfix missed in pret where the status field is set to the output of GetMonData whenever UpdateRoamerHPStatus is called.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->