### PR TITLE
BUGFIX: Fallthrough when initializing trainer card and mistaking CARD_TYPE_FRLG and CARD_TYPE_RS

### DIFF
--- a/include/trainer_card.h
+++ b/include/trainer_card.h
@@ -44,12 +44,14 @@ struct TrainerCard
     /*0x28*/ u16 easyChatProfile[TRAINER_CARD_PROFILE_LENGTH];
     /*0x30*/ u8 playerName[PLAYER_NAME_LENGTH + 1];
     /*0x38*/ u8 version;
-    /*0x3A*/ bool16 linkHasAllFrontierSymbols;
-    /*0x3C*/ union {
+             // Gamefreak probably meant to put this in the same memory as unionRoomNum, but the compiler put it two bytes away.
+             // It doesn't result in a bug though since these fields aren't affected by memcpy, unlike the fields before it
+             bool16 linkHasAllFrontierSymbols;
+    /*0x3A*/ union {
+                u16 frontierBP;
                 u32 berryCrush;
-                u32 frontier;
              } linkPoints; // This field is used differently by FRLG vs Emerald
-    /*0x40*/ u32 unionRoomNum;
+    /*0x3E*/ u32 unionRoomNum;
     /*0x44*/ u8 filler[8];
     /*0x4C*/ bool8 shouldDrawStickers; // FRLG only
     /*0x4D*/ u8 unused;

--- a/src/trainer_card.c
+++ b/src/trainer_card.c
@@ -601,6 +601,9 @@ static void CB2_InitTrainerCard(void)
         FreeAllSpritePalettes();
         ResetPaletteFade();
         gMain.state++;
+    #ifdef BUGFIX
+        break;
+    #endif
     case 4:
         InitBgsAndWindows();
         gMain.state++;
@@ -732,14 +735,23 @@ static void SetPlayerCardData(struct TrainerCard *trainerCard, u8 cardType)
         trainerCard->battleTowerWins = 0;
         trainerCard->battleTowerStraightWins = 0;
     // Seems like GF got CARD_TYPE_FRLG and CARD_TYPE_RS wrong.
+    #ifdef BUGFIX
+    case CARD_TYPE_RS:
+    #else
     case CARD_TYPE_FRLG:
+    #endif
         trainerCard->contestsWithFriends = GetCappedGameStat(GAME_STAT_WON_LINK_CONTEST, 999);
         trainerCard->pokeblocksWithFriends = GetCappedGameStat(GAME_STAT_POKEBLOCKS_WITH_FRIENDS, 0xFFFF);
         if (CountPlayerMuseumPaintings() >= CONTEST_CATEGORIES_COUNT)
             trainerCard->hasAllPaintings = TRUE;
         trainerCard->stars = GetRubyTrainerStars(trainerCard);
         break;
+    
+    #ifdef BUGFIX
+    case CARD_TYPE_FRLG:
+    #else
     case CARD_TYPE_RS:
+    #endif
         trainerCard->battleTowerWins = 0;
         trainerCard->battleTowerStraightWins = 0;
         trainerCard->contestsWithFriends = 0;
@@ -772,7 +784,7 @@ void TrainerCard_GenerateCardForLinkPlayer(struct TrainerCard *trainerCard)
     trainerCard->version = GAME_VERSION;
     SetPlayerCardData(trainerCard, CARD_TYPE_EMERALD);
     trainerCard->linkHasAllFrontierSymbols = HasAllFrontierSymbols();
-    *((u16*)&trainerCard->linkPoints.frontier) = gSaveBlock2Ptr->frontier.cardBattlePoints;
+    trainerCard->linkPoints.frontierBP = gSaveBlock2Ptr->frontier.cardBattlePoints;
     if (trainerCard->linkHasAllFrontierSymbols)
         trainerCard->stars++;
 
@@ -797,9 +809,9 @@ void CopyTrainerCardData(struct TrainerCard *dst, struct TrainerCard *src, u8 ga
         break;
     case CARD_TYPE_EMERALD:
         memcpy(dst, src, 0x60);
-        dst->linkPoints.frontier = 0;
+        dst->linkPoints.berryCrush = 0;
         dst->hasAllFrontierSymbols = src->linkHasAllFrontierSymbols;
-        dst->frontierBP = *((u16*)&src->linkPoints.frontier);
+        dst->frontierBP = src->linkPoints.frontierBP;
         break;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Gamefreak confused the two card types in one function

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->