### PR TITLE
Rename GetBattlePyramindTrainerEncounterMusicId to fix typo

### DIFF
--- a/include/battle_pyramid.h
+++ b/include/battle_pyramid.h
@@ -14,7 +14,7 @@ void SoftResetInBattlePyramid(void);
 void CopyPyramidTrainerSpeechBefore(u16 trainerId);
 void CopyPyramidTrainerWinSpeech(u16 trainerId);
 void CopyPyramidTrainerLoseSpeech(u16 trainerId);
-u8 GetBattlePyramindTrainerEncounterMusicId(u16 trainerId);
+u8 GetTrainerEncounterMusicIdInBattlePyramid(u16 trainerId);
 void GenerateBattlePyramidFloorLayout(u16 *mapArg, bool8 setPlayerPosition);
 void LoadBattlePyramidObjectEventTemplates(void);
 void LoadBattlePyramidFloorObjectEventScripts(void);

--- a/src/battle_pyramid.c
+++ b/src/battle_pyramid.c
@@ -1465,7 +1465,7 @@ void CopyPyramidTrainerLoseSpeech(u16 trainerId)
     FrontierSpeechToString(gFacilityTrainers[trainerId].speechLose);
 }
 
-u8 GetBattlePyramindTrainerEncounterMusicId(u16 trainerId)
+u8 GetTrainerEncounterMusicIdInBattlePyramid(u16 trainerId)
 {
     int i;
 

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -5810,7 +5810,7 @@ s32 GetBattlerMultiplayerId(u16 a1)
 u8 GetTrainerEncounterMusicId(u16 trainerOpponentId)
 {
     if (InBattlePyramid())
-        return GetBattlePyramindTrainerEncounterMusicId(trainerOpponentId);
+        return GetTrainerEncounterMusicIdInBattlePyramid(trainerOpponentId);
     else if (InTrainerHillChallenge())
         return GetTrainerEncounterMusicIdInTrainerHill(trainerOpponentId);
     else


### PR DESCRIPTION
`GetBattlePyramindTrainerEncounterMusicId` -> `GetTrainerEncounterMusicIdInBattlePyramid`, which fixes the `Pyramind` typo and adds parity with the similar `GetTrainerEncounterMusicIdInTrainerHill` function.

## **Discord contact info**
Spherical Ice#4683