### PR TITLE
Fix finding libpng in gbagfx and rsfont on macOS M1

### DIFF
--- a/tools/gbagfx/Makefile
+++ b/tools/gbagfx/Makefile
@@ -1,8 +1,10 @@
 CC = gcc
 
 CFLAGS = -Wall -Wextra -Werror -Wno-sign-compare -std=c11 -O2 -DPNG_SKIP_SETJMP_CHECK
+CFLAGS += $(shell pkg-config --cflags libpng)
 
 LIBS = -lpng -lz
+LDFLAGS += $(shell pkg-config --libs-only-L libpng)
 
 SRCS = main.c convert_png.c gfx.c jasc_pal.c lz.c rl.c util.c font.c huff.c
 

--- a/tools/rsfont/Makefile
+++ b/tools/rsfont/Makefile
@@ -1,8 +1,10 @@
 CC ?= gcc
 
 CFLAGS = -Wall -Wextra -Werror -std=c11 -O2 -DPNG_SKIP_SETJMP_CHECK
+CFLAGS += $(shell pkg-config --cflags libpng)
 
 LIBS = -lpng -lz
+LDFLAGS += $(shell pkg-config --libs-only-L libpng)
 
 SRCS = main.c convert_png.c util.c font.c
 


### PR DESCRIPTION
On macOS 12 M1, Homebrew installs libpng in a custom location.

## Description
<!--- Describe your changes in detail -->
Use `pkg-config` to find libpng library and headers.
This should generally work on any *nix system, but I only tested this on macOS 12 on M1.
This is related to #1592.

Note that I'm able to compile everything just fine natively on arm64/aarch64 with pret/agbcc#52.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
acidghost#8150
<!--- Contributors must join https://discord.gg/d5dubZ3 -->