### PR TITLE
Clarify when to use make compare

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -418,20 +418,24 @@ If you aren't in the pokeemerald directory already, then **change directory** to
 ```bash
 cd pokeemerald
 ```
-To build **pokeemerald.gba** for the first time and confirm it matches the official ROM image (Note: to speed up builds, see [Parallel builds](#parallel-builds)):
+To build **pokeemerald.gba** for the first time and confirm it matches the official ROM image (Note: to speed up builds, see [Parallel builds](#parallel-builds)). **You should only use `make compare` when verifying if your built ROM matches the vanilla game. If the repo has been modified for a hack and produces a different ROM, this command will fail**:
 ```bash
 make compare
 ```
+        
 If an OK is returned, then the installation went smoothly.
+
+
+Once the repository has been modified, build the repo with this instead:
+```bash
+make
+```
+        
 <details>
 <summary>Note for Windows...</summary>
 > If you switched terminals since the last build (e.g. from msys2 to WSL1), you must run `make clean-tools` once before any subsequent `make` commands.
 </details>
-
-To build **pokeemerald.gba** with your changes:
-```bash
-make
-```
+        
 
 # Building guidance
 


### PR DESCRIPTION
After discord discussions, I clarified that compare should only be used for vanilla emerald and not for modifications like hacks. Also made some language later a bit more explicit. This should cause less confusion about make compare

Some notes: I bolded the notice to put emphasis on it, and I put it before the command so if someone stops reading at the command they will know it will fail after modifications. I also moved the note for windows later to put more emphasis on the instructions

I'm not opposed to doing the other option of removing compare and mentioning it elsewhere, but I believe make compare is a useful sanity check to verify that not only did the ROM build, it built exactly what is expected and our installation is correct. I also believe it's a valuable enough sanity check worth knowing about for any hacker (it has caught errors for me in the past), not necessarily only for contributors