### PR TITLE
Don't Build Modern with -g by Default

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -451,14 +451,6 @@ Replace `<output of nproc>` with the number that the `nproc` command returned.
 
 `nproc` is not available on macOS. The alternative is `sysctl -n hw.ncpu` ([relevant Stack Overflow thread](https://stackoverflow.com/questions/1715580)).
 
-## Debug info
-
-To build **pokeemerald.elf** with enhanced debug info:
-```bash
-make DINFO=1
-```
-Note that this is only necessary for the `modern` target; the regular target has debug info enabled by default.
-
 ## devkitARM's C compiler
 
 This project supports the `arm-none-eabi-gcc` compiler included with devkitARM. If devkitARM (a.k.a. gba-dev) has already been installed as part of the platform-specific instructions, simply run:
@@ -535,7 +527,7 @@ devkitARM is now installed.
 
 devkitARM is now installed.
 
-## Installing devkitARM on Arch Linux
+### Installing devkitARM on Arch Linux
         
 1. Follow [devkitPro's instructions](https://devkitpro.org/wiki/devkitPro_pacman#Customising_Existing_Pacman_Install) to configure `pacman` to download devkitPro packages.
 2. Install `gba-dev`: run the following command as root.
@@ -553,7 +545,7 @@ devkitARM is now installed.
 
 devkitARM is now installed.
 
-## Other toolchains
+### Other toolchains
 
 To build using a toolchain other than devkitARM, override the `TOOLCHAIN` environment variable with the path to your toolchain, which must contain the subdirectory `bin`.
 ```bash
@@ -564,6 +556,14 @@ The following is an example:
 make TOOLCHAIN="/usr/local/arm-none-eabi"
 ```
 To compile the `modern` target with this toolchain, the subdirectories `lib`, `include`, and `arm-none-eabi` must also be present.
+
+### Building with debug info under a modern toolchain
+
+To build **pokeemerald.elf** with debug symbols under a modern toolchain:
+```bash
+make DINFO=1
+```
+Note that this is not necessary for a non-modern build since those are built with debug symbols by default.
 
 # Useful additional tools
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -457,6 +457,7 @@ To build **pokeemerald.elf** with enhanced debug info:
 ```bash
 make DINFO=1
 ```
+Note that this is only necessary for the `modern` target; the regular target has debug info enabled by default.
 
 ## devkitARM's C compiler
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -561,7 +561,7 @@ To compile the `modern` target with this toolchain, the subdirectories `lib`, `i
 
 To build **pokeemerald.elf** with debug symbols under a modern toolchain:
 ```bash
-make DINFO=1
+make modern DINFO=1
 ```
 Note that this is not necessary for a non-modern build since those are built with debug symbols by default.
 

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ LIBPATH := -L ../../tools/agbcc/lib
 LIB := $(LIBPATH) -lgcc -lc -L../../libagbsyscall -lagbsyscall
 else
 CC1              = $(shell $(PATH_MODERNCC) --print-prog-name=cc1) -quiet
-override CFLAGS += -mthumb -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast -g
+override CFLAGS += -mthumb -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
 ROM := $(MODERN_ROM_NAME)
 OBJ_DIR := $(MODERN_OBJ_DIR_NAME)
 LIBPATH := -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libgcc.a))" -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libnosys.a))" -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libc.a))"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The only reason -g is enabled for the regular target is for that weird nonmatching case; there's no good reason to enable debug symbols by default for the modern target, plus this makes DINFO actually useful (it does nothing currently). Also adds a note in INSTALL.md about this only being necessary for modern.

## **Discord contact info**
Kurausukun#9923