### PR TITLE
Fix inconsistent static s/g names

### DIFF
--- a/data/scripts/gift_altering_cave.inc
+++ b/data/scripts/gift_altering_cave.inc
@@ -12,7 +12,7 @@ MysteryGiftScript_AlteringCave_:
 	release
 	end
 
-sText_MysteryGiftAlteringCave::
+sText_MysteryGiftAlteringCave:
 	.string "Thank you for using the MYSTERY\n"
 	.string "GIFT System.\p"
 	.string "There appears to be a rumor about\n"

--- a/data/text/pokedex_rating.inc
+++ b/data/text/pokedex_rating.inc
@@ -3,7 +3,7 @@ gBirchDexRatingText_AreYouCurious::
 	.string "Are you curious about how your\n"
 	.string "POKéDEX is coming along?$"
 
-gBirchDexRatingText_Cancel:
+gBirchDexRatingText_Cancel::
 	.string "Hm? Oh, you haven't caught enough\n"
 	.string "POKéMON to make it worthwhile.$"
 

--- a/include/constants/battle.h
+++ b/include/constants/battle.h
@@ -319,7 +319,7 @@
 #define B_WIN_TYPE_NORMAL 0
 #define B_WIN_TYPE_ARENA  1
 
-// Window Ids for gStandardBattleWindowTemplates / gBattleArenaWindowTemplates
+// Window Ids for sStandardBattleWindowTemplates / sBattleArenaWindowTemplates
 #define B_WIN_MSG                 0
 #define B_WIN_ACTION_PROMPT       1 // "What will {x} do?"
 #define B_WIN_ACTION_MENU         2 // "Fight/Pokémon/Bag/Run" menu

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -1634,7 +1634,7 @@
 
 #define FLAGS_COUNT (DAILY_FLAGS_END + 1)
 
-// Special Flags (Stored in EWRAM (gSpecialFlags), not in the SaveBlock)
+// Special Flags (Stored in EWRAM (sSpecialFlags), not in the SaveBlock)
 #define SPECIAL_FLAGS_START                     0x4000
 #define FLAG_HIDE_MAP_NAME_POPUP                (SPECIAL_FLAGS_START + 0x0)
 #define FLAG_DONT_TRANSITION_MUSIC              (SPECIAL_FLAGS_START + 0x1)

--- a/include/contest.h
+++ b/include/contest.h
@@ -324,7 +324,6 @@ extern u16 gSpecialVar_ContestRank;
 extern u8 gNumLinkContestPlayers;
 extern u8 gHighestRibbonRank;
 extern struct ContestResources *gContestResources;
-extern u8 sContestBgCopyFlags;
 extern struct ContestWinner gCurContestWinner;
 extern u8 gCurContestWinnerIsForArtist;
 extern u8 gCurContestWinnerSaveIdx;

--- a/src/agb_flash_1m.c
+++ b/src/agb_flash_1m.c
@@ -3,7 +3,7 @@
 
 static const char AgbLibFlashVersion[] = "FLASH1M_V103";
 
-const struct FlashSetupInfo * const sSetupInfos[] =
+static const struct FlashSetupInfo * const sSetupInfos[] =
 {
     &MX29L010,
     &LE26FV10N1TS,

--- a/src/battle_anim_dragon.c
+++ b/src/battle_anim_dragon.c
@@ -15,7 +15,7 @@ static void AnimOverheatFlame_Step(struct Sprite *);
 static void AnimTask_DragonDanceWaver_Step(u8);
 static void UpdateDragonDanceScanlineEffect(struct Task *);
 
-EWRAM_DATA static u16 gUnusedOverheatData[7] = {0};
+EWRAM_DATA static u16 sUnusedOverheatData[7] = {0};
 
 static const union AnimCmd sAnim_OutrageOverheatFire_0[] =
 {
@@ -426,7 +426,7 @@ static void AnimOverheatFlame(struct Sprite *sprite)
     sprite->data[3] = gBattleAnimArgs[3];
     sprite->callback = AnimOverheatFlame_Step;
     for (i = 0; i < 7; i++)
-        gUnusedOverheatData[i] = sprite->data[i];
+        sUnusedOverheatData[i] = sprite->data[i];
 }
 
 static void AnimOverheatFlame_Step(struct Sprite *sprite)

--- a/src/battle_anim_status_effects.c
+++ b/src/battle_anim_status_effects.c
@@ -248,7 +248,7 @@ static const struct SubspriteTable sFrozenIceCubeSubspriteTable[] =
     {ARRAY_COUNT(sFrozenIceCubeSubsprites), sFrozenIceCubeSubsprites},
 };
 
-static const struct SpriteTemplate gFrozenIceCubeSpriteTemplate =
+static const struct SpriteTemplate sFrozenIceCubeSpriteTemplate =
 {
     .tileTag = ANIM_TAG_ICE_CUBE,
     .paletteTag = ANIM_TAG_ICE_CUBE,
@@ -389,7 +389,7 @@ void AnimTask_FrozenIceCube(u8 taskId)
         x -= 6;
     SetGpuReg(REG_OFFSET_BLDCNT, BLDCNT_EFFECT_BLEND | BLDCNT_TGT2_ALL);
     SetGpuReg(REG_OFFSET_BLDALPHA, BLDALPHA_BLEND(0, 16));
-    spriteId = CreateSprite(&gFrozenIceCubeSpriteTemplate, x, y, 4);
+    spriteId = CreateSprite(&sFrozenIceCubeSpriteTemplate, x, y, 4);
     if (GetSpriteTileStartByTag(ANIM_TAG_ICE_CUBE) == 0xFFFF)
         gSprites[spriteId].invisible = TRUE;
     SetSubspriteTables(&gSprites[spriteId], sFrozenIceCubeSubspriteTable);

--- a/src/battle_bg.c
+++ b/src/battle_bg.c
@@ -159,7 +159,7 @@ const struct BgTemplate gBattleBgTemplates[] =
     },
 };
 
-static const struct WindowTemplate gStandardBattleWindowTemplates[] =
+static const struct WindowTemplate sStandardBattleWindowTemplates[] =
 {
     [B_WIN_MSG] = {
         .bg = 0,
@@ -380,7 +380,7 @@ static const struct WindowTemplate gStandardBattleWindowTemplates[] =
     DUMMY_WIN_TEMPLATE
 };
 
-static const struct WindowTemplate gBattleArenaWindowTemplates[] =
+static const struct WindowTemplate sBattleArenaWindowTemplates[] =
 {
     [B_WIN_MSG] = {
         .bg = 0,
@@ -594,8 +594,8 @@ static const struct WindowTemplate gBattleArenaWindowTemplates[] =
 
 const struct WindowTemplate * const gBattleWindowTemplates[] =
 {
-    [B_WIN_TYPE_NORMAL] = gStandardBattleWindowTemplates,
-    [B_WIN_TYPE_ARENA]  = gBattleArenaWindowTemplates,
+    [B_WIN_TYPE_NORMAL] = sStandardBattleWindowTemplates,
+    [B_WIN_TYPE_ARENA]  = sBattleArenaWindowTemplates,
 };
 
 static const struct BattleBackground sBattleTerrainTable[] =

--- a/src/battle_tower.c
+++ b/src/battle_tower.c
@@ -687,7 +687,7 @@ struct
 {
     u32 facilityClass;
     const u8 *const *strings;
-} const sPartnerTrainerTextTables[] =
+} static const sPartnerTrainerTextTables[] =
 {
     {FACILITY_CLASS_LASS,                  sPartnerTextsLass},
     {FACILITY_CLASS_YOUNGSTER,             sPartnerTextsYoungster},
@@ -769,7 +769,7 @@ struct
     u8 nature;
     u8 evs[NUM_STATS];
     u16 moves[MAX_MON_MOVES];
-} const sStevenMons[MULTI_PARTY_SIZE] =
+} static const sStevenMons[MULTI_PARTY_SIZE] =
 {
     {
         .species = SPECIES_METANG,

--- a/src/coins.c
+++ b/src/coins.c
@@ -8,7 +8,7 @@
 #include "international_string_util.h"
 #include "constants/coins.h"
 
-EWRAM_DATA u8 sCoinsWindowId = 0;
+static EWRAM_DATA u8 sCoinsWindowId = 0;
 
 void PrintCoinsString(u32 coinAmount)
 {

--- a/src/contest.c
+++ b/src/contest.c
@@ -352,7 +352,7 @@ EWRAM_DATA u16 gSpecialVar_ContestRank = 0;
 EWRAM_DATA u8 gNumLinkContestPlayers = 0;
 EWRAM_DATA u8 gHighestRibbonRank = 0;
 EWRAM_DATA struct ContestResources *gContestResources = NULL;
-EWRAM_DATA u8 sContestBgCopyFlags = 0;
+static EWRAM_DATA u8 sContestBgCopyFlags = 0;
 EWRAM_DATA struct ContestWinner gCurContestWinner = {0};
 EWRAM_DATA bool8 gCurContestWinnerIsForArtist = 0;
 EWRAM_DATA u8 gCurContestWinnerSaveIdx = 0;
@@ -625,7 +625,7 @@ static const struct SpriteTemplate sSpriteTemplate_ApplauseMeter =
     .callback = SpriteCallbackDummy
 };
 
-const struct OamData sOam_Judge =
+static const struct OamData sOam_Judge =
 {
     .y = 0,
     .affineMode = ST_OAM_AFFINE_OFF,
@@ -639,7 +639,7 @@ const struct OamData sOam_Judge =
     .paletteNum = 2,
 };
 
-const struct SpriteTemplate sSpriteTemplate_Judge =
+static const struct SpriteTemplate sSpriteTemplate_Judge =
 {
     .tileTag = TAG_JUDGE,
     .paletteTag = TAG_JUDGE,
@@ -650,7 +650,7 @@ const struct SpriteTemplate sSpriteTemplate_Judge =
     .callback = SpriteCallbackDummy
 };
 
-const struct CompressedSpriteSheet sSpriteSheet_Judge =
+static const struct CompressedSpriteSheet sSpriteSheet_Judge =
 {
     .data = gContestJudgeGfx,
     .size = 0x800,
@@ -664,13 +664,13 @@ static const struct CompressedSpriteSheet sSpriteSheet_JudgeSymbols =
     .tag = TAG_JUDGE_SYMBOLS_GFX
 };
 
-const struct CompressedSpritePalette sSpritePalette_JudgeSymbols =
+static const struct CompressedSpritePalette sSpritePalette_JudgeSymbols =
 {
     .data = gContestJudgeSymbolsPal,
     .tag = TAG_CONTEST_SYMBOLS_PAL
 };
 
-const struct SpriteTemplate sSpriteTemplate_JudgeSpeechBubble =
+static const struct SpriteTemplate sSpriteTemplate_JudgeSpeechBubble =
 {
     .tileTag = TAG_JUDGE_SYMBOLS_GFX,
     .paletteTag = TAG_CONTEST_SYMBOLS_PAL,
@@ -876,7 +876,7 @@ static const struct SpritePalette sSpritePalettes_ContestantsTurnBlinkEffect[CON
     }
 };
 
-const struct OamData sOam_ContestantsTurnBlinkEffect =
+static const struct OamData sOam_ContestantsTurnBlinkEffect =
 {
     .y = 0,
     .affineMode = ST_OAM_AFFINE_DOUBLE,
@@ -891,13 +891,13 @@ const struct OamData sOam_ContestantsTurnBlinkEffect =
     .affineParam = 0,
 };
 
-const union AffineAnimCmd sAffineAnim_ContestantsTurnBlinkEffect_0[] =
+static const union AffineAnimCmd sAffineAnim_ContestantsTurnBlinkEffect_0[] =
 {
     AFFINEANIMCMD_FRAME(0x100, 0x100, 0, 0),
     AFFINEANIMCMD_END
 };
 
-const union AffineAnimCmd sAffineAnim_ContestantsTurnBlinkEffect_1[] =
+static const union AffineAnimCmd sAffineAnim_ContestantsTurnBlinkEffect_1[] =
 {
     AFFINEANIMCMD_FRAME(3, 3, 0, 15),
     AFFINEANIMCMD_FRAME(-3, -3, 0, 15),
@@ -906,13 +906,13 @@ const union AffineAnimCmd sAffineAnim_ContestantsTurnBlinkEffect_1[] =
     AFFINEANIMCMD_END
 };
 
-const union AffineAnimCmd *const sAffineAnims_ContestantsTurnBlinkEffect[] =
+static const union AffineAnimCmd *const sAffineAnims_ContestantsTurnBlinkEffect[] =
 {
     sAffineAnim_ContestantsTurnBlinkEffect_0,
     sAffineAnim_ContestantsTurnBlinkEffect_1
 };
 
-const struct SpriteTemplate sSpriteTemplates_ContestantsTurnBlinkEffect[CONTESTANT_COUNT] =
+static const struct SpriteTemplate sSpriteTemplates_ContestantsTurnBlinkEffect[CONTESTANT_COUNT] =
 {
     {
         .tileTag = TAG_BLINK_EFFECT_CONTESTANT0,
@@ -952,7 +952,7 @@ const struct SpriteTemplate sSpriteTemplates_ContestantsTurnBlinkEffect[CONTESTA
     }
 };
 
-static const s8 gContestExcitementTable[CONTEST_CATEGORIES_COUNT][CONTEST_CATEGORIES_COUNT] =
+static const s8 sContestExcitementTable[CONTEST_CATEGORIES_COUNT][CONTEST_CATEGORIES_COUNT] =
 {
     [CONTEST_CATEGORY_COOL] = {
         [CONTEST_CATEGORY_COOL]   = +1,
@@ -4744,7 +4744,7 @@ static void UpdateApplauseMeter(void)
 
 s8 Contest_GetMoveExcitement(u16 move)
 {
-    return gContestExcitementTable[gSpecialVar_ContestCategory][gContestMoves[move].contestCategory];
+    return sContestExcitementTable[gSpecialVar_ContestCategory][gContestMoves[move].contestCategory];
 }
 
 static u8 StartApplauseOverflowAnimation(void)

--- a/src/data/field_effects/field_effect_objects.h
+++ b/src/data/field_effects/field_effect_objects.h
@@ -1272,7 +1272,7 @@ static const union AnimCmd *const sAnimTable_RayquazaSpotlightEffect[] = {
     sAnim_RayquazaSpotlightEffect,
 };
 
-const struct SpriteFrameImage  sPicTable_RayquazaSpotlightEffect[] = {
+static const struct SpriteFrameImage sPicTable_RayquazaSpotlightEffect[] = {
     overworld_frame(gObjectEventPic_Rayquaza, 4, 4, 0),
 };
 

--- a/src/data/trade.h
+++ b/src/data/trade.h
@@ -174,10 +174,10 @@ static const struct SpriteTemplate sSpriteTemplate_MenuText =
     .callback = SpriteCallbackDummy,
 };
 
-static const u16 TradeScreenTextPalette[] = INCBIN_U16("graphics/trade/text.gbapal");
-static const struct SpritePalette gSpritePalette_TradeScreenText =
+static const u16 sTradeScreenTextPalette[] = INCBIN_U16("graphics/trade/text.gbapal");
+static const struct SpritePalette sSpritePalette_TradeScreenText =
 {
-    .data = TradeScreenTextPalette,
+    .data = sTradeScreenTextPalette,
     .tag = PALTAG_MENU_TEXT
 };
 

--- a/src/data/trainer_graphics/back_pic_anims.h
+++ b/src/data/trainer_graphics/back_pic_anims.h
@@ -1,4 +1,4 @@
-static const union AnimCmd gAnimCmd_Brendan_1[] =
+static const union AnimCmd sAnimCmd_Brendan_1[] =
 {
     ANIMCMD_FRAME(0, 24),
     ANIMCMD_FRAME(1, 9),
@@ -8,7 +8,7 @@ static const union AnimCmd gAnimCmd_Brendan_1[] =
     ANIMCMD_END,
 };
 
-static const union AnimCmd gAnimCmd_May_Steven_1[] =
+static const union AnimCmd sAnimCmd_May_Steven_1[] =
 {
     ANIMCMD_FRAME(0, 24),
     ANIMCMD_FRAME(1, 9),
@@ -18,7 +18,7 @@ static const union AnimCmd gAnimCmd_May_Steven_1[] =
     ANIMCMD_END,
 };
 
-static const union AnimCmd gAnimCmd_Wally_1[] =
+static const union AnimCmd sAnimCmd_Wally_1[] =
 {
     ANIMCMD_FRAME(0, 24),
     ANIMCMD_FRAME(1, 9),
@@ -28,7 +28,7 @@ static const union AnimCmd gAnimCmd_Wally_1[] =
     ANIMCMD_END,
 };
 
-static const union AnimCmd gAnimCmd_Red_1[] =
+static const union AnimCmd sAnimCmd_Red_1[] =
 {
     ANIMCMD_FRAME(1, 20),
     ANIMCMD_FRAME(2, 6),
@@ -38,7 +38,7 @@ static const union AnimCmd gAnimCmd_Red_1[] =
     ANIMCMD_END,
 };
 
-static const union AnimCmd gAnimCmd_Leaf_1[] =
+static const union AnimCmd sAnimCmd_Leaf_1[] =
 {
     ANIMCMD_FRAME(1, 20),
     ANIMCMD_FRAME(2, 6),
@@ -48,7 +48,7 @@ static const union AnimCmd gAnimCmd_Leaf_1[] =
     ANIMCMD_END,
 };
 
-static const union AnimCmd gAnimCmd_RubySapphireBrendan_1[] =
+static const union AnimCmd sAnimCmd_RubySapphireBrendan_1[] =
 {
     ANIMCMD_FRAME(0, 24),
     ANIMCMD_FRAME(1, 9),
@@ -58,7 +58,7 @@ static const union AnimCmd gAnimCmd_RubySapphireBrendan_1[] =
     ANIMCMD_END,
 };
 
-static const union AnimCmd gAnimCmd_RubySapphireMay_1[] =
+static const union AnimCmd sAnimCmd_RubySapphireMay_1[] =
 {
     ANIMCMD_FRAME(0, 24),
     ANIMCMD_FRAME(1, 9),
@@ -71,49 +71,49 @@ static const union AnimCmd gAnimCmd_RubySapphireMay_1[] =
 static const union AnimCmd *const sBackAnims_Brendan[] =
 {
     sAnim_GeneralFrame3,
-    gAnimCmd_Brendan_1,
+    sAnimCmd_Brendan_1,
 };
 
 static const union AnimCmd *const sBackAnims_May[] =
 {
     sAnim_GeneralFrame3,
-    gAnimCmd_May_Steven_1,
+    sAnimCmd_May_Steven_1,
 };
 
 static const union AnimCmd *const sBackAnims_Red[] =
 {
     sAnim_GeneralFrame0,
-    gAnimCmd_Red_1,
+    sAnimCmd_Red_1,
 };
 
 static const union AnimCmd *const sBackAnims_Leaf[] =
 {
     sAnim_GeneralFrame0,
-    gAnimCmd_Leaf_1,
+    sAnimCmd_Leaf_1,
 };
 
 static const union AnimCmd *const sBackAnims_RubySapphireBrendan[] =
 {
     sAnim_GeneralFrame3,
-    gAnimCmd_RubySapphireBrendan_1,
+    sAnimCmd_RubySapphireBrendan_1,
 };
 
 static const union AnimCmd *const sBackAnims_RubySapphireMay[] =
 {
     sAnim_GeneralFrame3,
-    gAnimCmd_RubySapphireMay_1,
+    sAnimCmd_RubySapphireMay_1,
 };
 
 static const union AnimCmd *const sBackAnims_Wally[] =
 {
     sAnim_GeneralFrame3,
-    gAnimCmd_Wally_1,
+    sAnimCmd_Wally_1,
 };
 
 static const union AnimCmd *const sBackAnims_Steven[] =
 {
     sAnim_GeneralFrame3,
-    gAnimCmd_May_Steven_1,
+    sAnimCmd_May_Steven_1,
 };
 
 const union AnimCmd *const *const gTrainerBackAnimsPtrTable[] =

--- a/src/dodrio_berry_picking.c
+++ b/src/dodrio_berry_picking.c
@@ -4546,7 +4546,7 @@ struct
 {
     u8 id;
     void (*func)(void);
-} const sGfxFuncs[] =
+} static const sGfxFuncs[] =
 {
     {GFXFUNC_LOAD,               LoadGfx}, // Element not used, LoadGfx is passed directly to SetGfxFunc
     {GFXFUNC_SHOW_NAMES,         ShowNames},

--- a/src/event_data.c
+++ b/src/event_data.c
@@ -30,7 +30,7 @@ EWRAM_DATA u16 gSpecialVar_Facing = 0;
 EWRAM_DATA u16 gSpecialVar_MonBoxId = 0;
 EWRAM_DATA u16 gSpecialVar_MonBoxPos = 0;
 EWRAM_DATA u16 gSpecialVar_Unused_0x8014 = 0;
-EWRAM_DATA static u8 gSpecialFlags[SPECIAL_FLAGS_SIZE] = {0};
+EWRAM_DATA static u8 sSpecialFlags[SPECIAL_FLAGS_SIZE] = {0};
 
 extern u16 *const gSpecialVars[];
 
@@ -38,7 +38,7 @@ void InitEventData(void)
 {
     memset(gSaveBlock1Ptr->flags, 0, sizeof(gSaveBlock1Ptr->flags));
     memset(gSaveBlock1Ptr->vars, 0, sizeof(gSaveBlock1Ptr->vars));
-    memset(gSpecialFlags, 0, sizeof(gSpecialFlags));
+    memset(sSpecialFlags, 0, sizeof(sSpecialFlags));
 }
 
 void ClearTempFieldEventData(void)
@@ -205,7 +205,7 @@ u8 *GetFlagPointer(u16 id)
     else if (id < SPECIAL_FLAGS_START)
         return &gSaveBlock1Ptr->flags[id / 8];
     else
-        return &gSpecialFlags[(id - SPECIAL_FLAGS_START) / 8];
+        return &sSpecialFlags[(id - SPECIAL_FLAGS_START) / 8];
 }
 
 u8 FlagSet(u16 id)

--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -481,13 +481,13 @@ static const struct Subsprite sSubsprites_HofMonitorBig[] =
 
 static const struct SubspriteTable sSubspriteTable_HofMonitorBig = subsprite_table(sSubsprites_HofMonitorBig);
 
-const union AnimCmd sAnim_Static[] =
+static const union AnimCmd sAnim_Static[] =
 {
     ANIMCMD_FRAME(.imageValue = 0, .duration = 1),
     ANIMCMD_JUMP(0)
 };
 
-const union AnimCmd sAnim_Flicker[] =
+static const union AnimCmd sAnim_Flicker[] =
 {
     ANIMCMD_FRAME(.imageValue = 0, .duration = 16),
     ANIMCMD_FRAME(.imageValue = 1, .duration = 16),
@@ -501,7 +501,7 @@ const union AnimCmd sAnim_Flicker[] =
 };
 
 // Flicker on and off, for the Pokéballs / monitors during the PokéCenter heal effect
-const union AnimCmd *const sAnims_Flicker[] =
+static const union AnimCmd *const sAnims_Flicker[] =
 {
     sAnim_Static,
     sAnim_Flicker
@@ -556,7 +556,7 @@ static const struct SpriteTemplate sSpriteTemplate_HofMonitorSmall =
     .callback = SpriteCB_HallOfFameMonitor
 };
 
-void (*const sPokecenterHealEffectFuncs[])(struct Task *) =
+static void (*const sPokecenterHealEffectFuncs[])(struct Task *) =
 {
     PokecenterHealEffect_Init,
     PokecenterHealEffect_WaitForBallPlacement,
@@ -564,7 +564,7 @@ void (*const sPokecenterHealEffectFuncs[])(struct Task *) =
     PokecenterHealEffect_WaitForSoundAndEnd
 };
 
-void (*const sHallOfFameRecordEffectFuncs[])(struct Task *) =
+static void (*const sHallOfFameRecordEffectFuncs[])(struct Task *) =
 {
     HallOfFameRecordEffect_Init,
     HallOfFameRecordEffect_WaitForBallPlacement,
@@ -572,7 +572,7 @@ void (*const sHallOfFameRecordEffectFuncs[])(struct Task *) =
     HallOfFameRecordEffect_WaitForSoundAndEnd
 };
 
-void (*const sPokeballGlowEffectFuncs[])(struct Sprite *) =
+static void (*const sPokeballGlowEffectFuncs[])(struct Sprite *) =
 {
     PokeballGlowEffect_PlaceBalls,
     PokeballGlowEffect_TryPlaySe,
@@ -598,7 +598,7 @@ static const u8 sPokeballGlowReds[]   = {16, 12, 8, 0};
 static const u8 sPokeballGlowGreens[] = {16, 12, 8, 0};
 static const u8 sPokeballGlowBlues[]  = { 0,  0, 0, 0};
 
-bool8 (*const sFallWarpFieldEffectFuncs[])(struct Task *) =
+static bool8 (*const sFallWarpFieldEffectFuncs[])(struct Task *) =
 {
     FallWarpEffect_Init,
     FallWarpEffect_WaitWeather,
@@ -609,7 +609,7 @@ bool8 (*const sFallWarpFieldEffectFuncs[])(struct Task *) =
     FallWarpEffect_End,
 };
 
-bool8 (*const sEscalatorWarpOutFieldEffectFuncs[])(struct Task *) =
+static bool8 (*const sEscalatorWarpOutFieldEffectFuncs[])(struct Task *) =
 {
     EscalatorWarpOut_Init,
     EscalatorWarpOut_WaitForPlayer,
@@ -619,7 +619,7 @@ bool8 (*const sEscalatorWarpOutFieldEffectFuncs[])(struct Task *) =
     EscalatorWarpOut_Down_End,
 };
 
-bool8 (*const sEscalatorWarpInFieldEffectFuncs[])(struct Task *) =
+static bool8 (*const sEscalatorWarpInFieldEffectFuncs[])(struct Task *) =
 {
     EscalatorWarpIn_Init,
     EscalatorWarpIn_Down_Init,
@@ -630,7 +630,7 @@ bool8 (*const sEscalatorWarpInFieldEffectFuncs[])(struct Task *) =
     EscalatorWarpIn_End,
 };
 
-bool8 (*const sWaterfallFieldEffectFuncs[])(struct Task *, struct ObjectEvent *) =
+static bool8 (*const sWaterfallFieldEffectFuncs[])(struct Task *, struct ObjectEvent *) =
 {
     WaterfallFieldEffect_Init,
     WaterfallFieldEffect_ShowMon,
@@ -639,14 +639,14 @@ bool8 (*const sWaterfallFieldEffectFuncs[])(struct Task *, struct ObjectEvent *)
     WaterfallFieldEffect_ContinueRideOrEnd,
 };
 
-bool8 (*const sDiveFieldEffectFuncs[])(struct Task *) =
+static bool8 (*const sDiveFieldEffectFuncs[])(struct Task *) =
 {
     DiveFieldEffect_Init,
     DiveFieldEffect_ShowMon,
     DiveFieldEffect_TryWarp,
 };
 
-bool8 (*const sLavaridgeGymB1FWarpEffectFuncs[])(struct Task *, struct ObjectEvent *, struct Sprite *) =
+static bool8 (*const sLavaridgeGymB1FWarpEffectFuncs[])(struct Task *, struct ObjectEvent *, struct Sprite *) =
 {
     LavaridgeGymB1FWarpEffect_Init,
     LavaridgeGymB1FWarpEffect_CameraShake,
@@ -656,7 +656,7 @@ bool8 (*const sLavaridgeGymB1FWarpEffectFuncs[])(struct Task *, struct ObjectEve
     LavaridgeGymB1FWarpEffect_Warp,
 };
 
-bool8 (*const sLavaridgeGymB1FWarpExitEffectFuncs[])(struct Task *, struct ObjectEvent *, struct Sprite *) =
+static bool8 (*const sLavaridgeGymB1FWarpExitEffectFuncs[])(struct Task *, struct ObjectEvent *, struct Sprite *) =
 {
     LavaridgeGymB1FWarpExitEffect_Init,
     LavaridgeGymB1FWarpExitEffect_StartPopOut,
@@ -664,7 +664,7 @@ bool8 (*const sLavaridgeGymB1FWarpExitEffectFuncs[])(struct Task *, struct Objec
     LavaridgeGymB1FWarpExitEffect_End,
 };
 
-bool8 (*const sLavaridgeGym1FWarpEffectFuncs[])(struct Task *, struct ObjectEvent *, struct Sprite *) =
+static bool8 (*const sLavaridgeGym1FWarpEffectFuncs[])(struct Task *, struct ObjectEvent *, struct Sprite *) =
 {
     LavaridgeGym1FWarpEffect_Init,
     LavaridgeGym1FWarpEffect_AshPuff,
@@ -673,7 +673,7 @@ bool8 (*const sLavaridgeGym1FWarpEffectFuncs[])(struct Task *, struct ObjectEven
     LavaridgeGym1FWarpEffect_Warp,
 };
 
-void (*const sEscapeRopeWarpOutEffectFuncs[])(struct Task *) =
+static void (*const sEscapeRopeWarpOutEffectFuncs[])(struct Task *) =
 {
     EscapeRopeWarpOutEffect_Init,
     EscapeRopeWarpOutEffect_Spin,
@@ -2277,7 +2277,7 @@ static void EscapeRopeWarpOutEffect_Spin(struct Task *task)
     }
 }
 
-void (*const sEscapeRopeWarpInEffectFuncs[])(struct Task *) = {
+static void (*const sEscapeRopeWarpInEffectFuncs[])(struct Task *) = {
     EscapeRopeWarpInEffect_Init,
     EscapeRopeWarpInEffect_Spin
 };
@@ -2448,7 +2448,7 @@ static void FieldCallback_TeleportWarpIn(void)
     CreateTask(Task_TeleportWarpIn, 0);
 }
 
-void (*const sTeleportWarpInFieldEffectFuncs[])(struct Task *) = {
+static void (*const sTeleportWarpInFieldEffectFuncs[])(struct Task *) = {
     TeleportWarpInFieldEffect_Init,
     TeleportWarpInFieldEffect_SpinEnter,
     TeleportWarpInFieldEffect_SpinGround
@@ -2582,7 +2582,7 @@ bool8 FldEff_FieldMoveShowMonInit(void)
     return FALSE;
 }
 
-void (*const sFieldMoveShowMonOutdoorsEffectFuncs[])(struct Task *) = {
+static void (*const sFieldMoveShowMonOutdoorsEffectFuncs[])(struct Task *) = {
     FieldMoveShowMonOutdoorsEffect_Init,
     FieldMoveShowMonOutdoorsEffect_LoadGfx,
     FieldMoveShowMonOutdoorsEffect_CreateBanner,
@@ -2750,7 +2750,7 @@ static void LoadFieldMoveOutdoorStreaksTilemap(u16 offs)
 #define tBgOffset    data[4]
 #define tMonSpriteId data[15]
 
-void (*const sFieldMoveShowMonIndoorsEffectFuncs[])(struct Task *) = {
+static void (*const sFieldMoveShowMonIndoorsEffectFuncs[])(struct Task *) = {
     FieldMoveShowMonIndoorsEffect_Init,
     FieldMoveShowMonIndoorsEffect_LoadGfx,
     FieldMoveShowMonIndoorsEffect_SlideBannerOn,
@@ -2978,7 +2978,7 @@ u8 FldEff_UseSurf(void)
     return FALSE;
 }
 
-void (*const sSurfFieldEffectFuncs[])(struct Task *) = {
+static void (*const sSurfFieldEffectFuncs[])(struct Task *) = {
     SurfFieldEffect_Init,
     SurfFieldEffect_FieldMovePose,
     SurfFieldEffect_ShowMon,
@@ -3154,7 +3154,7 @@ u8 FldEff_UseFly(void)
     return 0;
 }
 
-void (*const sFlyOutFieldEffectFuncs[])(struct Task *) = {
+static void (*const sFlyOutFieldEffectFuncs[])(struct Task *) = {
     FlyOutFieldEffect_FieldMovePose,
     FlyOutFieldEffect_ShowMon,
     FlyOutFieldEffect_BirdLeaveBall,
@@ -3444,7 +3444,7 @@ u8 FldEff_FlyIn(void)
     return 0;
 }
 
-void (*const sFlyInFieldEffectFuncs[])(struct Task *) = {
+static void (*const sFlyInFieldEffectFuncs[])(struct Task *) = {
     FlyInFieldEffect_BirdSwoopDown,
     FlyInFieldEffect_FlyInWithBird,
     FlyInFieldEffect_JumpOffBird,
@@ -3675,7 +3675,7 @@ static void StartEndingDeoxysRockCameraShake(u8 taskId)
 #undef tEndDelay
 #undef tEnding
 
-void (*const sDestroyDeoxysRockEffectFuncs[])(s16*, u8) = {
+static void (*const sDestroyDeoxysRockEffectFuncs[])(s16*, u8) = {
     DestroyDeoxysRockEffect_CameraShake,
     DestroyDeoxysRockEffect_RockFragments,
     DestroyDeoxysRockEffect_WaitAndEnd,

--- a/src/field_screen_effect.c
+++ b/src/field_screen_effect.c
@@ -53,7 +53,7 @@ static void Task_EnableScriptAfterMusicFade(u8 taskId);
 static const u16 sFlashLevelToRadius[] = { 200, 72, 64, 56, 48, 40, 32, 24, 0 };
 const s32 gMaxFlashLevel = ARRAY_COUNT(sFlashLevelToRadius) - 1;
 
-const struct ScanlineEffectParams sFlashEffectParams =
+static const struct ScanlineEffectParams sFlashEffectParams =
 {
     &REG_WIN0H,
     ((DMA_ENABLE | DMA_START_HBLANK | DMA_REPEAT | DMA_DEST_RELOAD) << 16) | 1,

--- a/src/field_special_scene.c
+++ b/src/field_special_scene.c
@@ -31,7 +31,7 @@ enum
 };
 
 //. rodata
-static const s8 gTruckCamera_HorizontalTable[] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 2, 2, 2, 2, 2, -1, -1, -1, 0};
+static const s8 sTruckCamera_HorizontalTable[] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 2, 2, 2, 2, 2, -1, -1, -1, 0};
 
 static const u8 sSSTidalSailEastMovementScript[] =
 {
@@ -109,10 +109,10 @@ void Task_Truck2(u8 taskId)
     }
     else
     {
-        if (gTruckCamera_HorizontalTable[data[1]] == 2)
+        if (sTruckCamera_HorizontalTable[data[1]] == 2)
             gTasks[taskId].func = Task_Truck3;
 
-        cameraXpan = gTruckCamera_HorizontalTable[data[1]];
+        cameraXpan = sTruckCamera_HorizontalTable[data[1]];
         cameraYpan = GetTruckCameraBobbingY(data[2]);
         SetCameraPanning(cameraXpan, cameraYpan);
         box1 = GetTruckBoxMovement(data[2] + 30) * 4;
@@ -144,7 +144,7 @@ static void Task_Truck3(u8 taskId)
    }
    else
    {
-       cameraXpan = gTruckCamera_HorizontalTable[data[1]];
+       cameraXpan = sTruckCamera_HorizontalTable[data[1]];
        cameraYpan = 0;
        SetCameraPanning(cameraXpan, 0);
        SetObjectEventSpritePosByLocalIdAndMap(LOCALID_TRUCK_BOX_TOP, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup, 3 - cameraXpan, cameraYpan + 3);

--- a/src/field_weather.c
+++ b/src/field_weather.c
@@ -72,7 +72,7 @@ static const u8 *sPaletteGammaTypes;
 
 // The drought weather effect uses a precalculated color lookup table. Presumably this
 // is because the underlying color shift calculation is slow.
-const u16 sDroughtWeatherColors[][0x1000] = {
+static const u16 sDroughtWeatherColors[][0x1000] = {
     INCBIN_U16("graphics/weather/drought/colors_0.bin"),
     INCBIN_U16("graphics/weather/drought/colors_1.bin"),
     INCBIN_U16("graphics/weather/drought/colors_2.bin"),

--- a/src/field_weather_effect.c
+++ b/src/field_weather_effect.c
@@ -15,8 +15,8 @@
 #include "gpu_regs.h"
 
 // EWRAM
-EWRAM_DATA static u8 gCurrentAbnormalWeather = 0;
-EWRAM_DATA static u16 gUnusedWeatherRelated = 0;
+EWRAM_DATA static u8 sCurrentAbnormalWeather = 0;
+EWRAM_DATA static u16 sUnusedWeatherRelated = 0;
 
 // CONST
 const u16 gCloudsWeatherPalette[] = INCBIN_U16("graphics/weather/cloud.gbapal");
@@ -1815,7 +1815,7 @@ static void UpdateFogDiagonalMovement(void)
     gWeatherPtr->fogDPosY = gSpriteCoordOffsetY + gWeatherPtr->fogDYOffset;
 }
 
-static const struct SpriteSheet gFogDiagonalSpriteSheet =
+static const struct SpriteSheet sFogDiagonalSpriteSheet =
 {
     .data = gWeatherFogDiagonalTiles,
     .size = sizeof(gWeatherFogDiagonalTiles),
@@ -1870,7 +1870,7 @@ static void CreateFogDiagonalSprites(void)
 
     if (!gWeatherPtr->fogDSpritesCreated)
     {
-        fogDiagonalSpriteSheet = gFogDiagonalSpriteSheet;
+        fogDiagonalSpriteSheet = sFogDiagonalSpriteSheet;
         LoadSpriteSheet(&fogDiagonalSpriteSheet);
         for (i = 0; i < NUM_FOG_DIAGONAL_SPRITES; i++)
         {
@@ -2429,8 +2429,8 @@ static void UpdateBubbleSprite(struct Sprite *sprite)
 // Unused function.
 static void UnusedSetCurrentAbnormalWeather(u32 a0, u32 a1)
 {
-    gCurrentAbnormalWeather = a0;
-    gUnusedWeatherRelated = a1;
+    sCurrentAbnormalWeather = a0;
+    sUnusedWeatherRelated = a1;
 }
 
 static void Task_DoAbnormalWeather(u8 taskId)
@@ -2443,7 +2443,7 @@ static void Task_DoAbnormalWeather(u8 taskId)
         if (data[15]-- <= 0)
         {
             SetNextWeather(data[1]);
-            gCurrentAbnormalWeather = data[1];
+            sCurrentAbnormalWeather = data[1];
             data[15] = 600;
             data[0]++;
         }
@@ -2452,7 +2452,7 @@ static void Task_DoAbnormalWeather(u8 taskId)
         if (data[15]-- <= 0)
         {
             SetNextWeather(data[2]);
-            gCurrentAbnormalWeather = data[2];
+            sCurrentAbnormalWeather = data[2];
             data[15] = 600;
             data[0] = 0;
         }
@@ -2466,19 +2466,19 @@ static void CreateAbnormalWeatherTask(void)
     s16 *data = gTasks[taskId].data;
 
     data[15] = 600;
-    if (gCurrentAbnormalWeather == WEATHER_DOWNPOUR)
+    if (sCurrentAbnormalWeather == WEATHER_DOWNPOUR)
     {
         data[1] = WEATHER_DROUGHT;
         data[2] = WEATHER_DOWNPOUR;
     }
-    else if (gCurrentAbnormalWeather == WEATHER_DROUGHT)
+    else if (sCurrentAbnormalWeather == WEATHER_DROUGHT)
     {
         data[1] = WEATHER_DOWNPOUR;
         data[2] = WEATHER_DROUGHT;
     }
     else
     {
-        gCurrentAbnormalWeather = WEATHER_DOWNPOUR;
+        sCurrentAbnormalWeather = WEATHER_DOWNPOUR;
         data[1] = WEATHER_DROUGHT;
         data[2] = WEATHER_DOWNPOUR;
     }
@@ -2526,13 +2526,13 @@ void DoCurrentWeather(void)
     {
         if (!FuncIsActiveTask(Task_DoAbnormalWeather))
             CreateAbnormalWeatherTask();
-        weather = gCurrentAbnormalWeather;
+        weather = sCurrentAbnormalWeather;
     }
     else
     {
         if (FuncIsActiveTask(Task_DoAbnormalWeather))
             DestroyTask(FindTaskIdByFunc(Task_DoAbnormalWeather));
-        gCurrentAbnormalWeather = WEATHER_DOWNPOUR;
+        sCurrentAbnormalWeather = WEATHER_DOWNPOUR;
     }
     SetNextWeather(weather);
 }
@@ -2545,13 +2545,13 @@ void ResumePausedWeather(void)
     {
         if (!FuncIsActiveTask(Task_DoAbnormalWeather))
             CreateAbnormalWeatherTask();
-        weather = gCurrentAbnormalWeather;
+        weather = sCurrentAbnormalWeather;
     }
     else
     {
         if (FuncIsActiveTask(Task_DoAbnormalWeather))
             DestroyTask(FindTaskIdByFunc(Task_DoAbnormalWeather));
-        gCurrentAbnormalWeather = WEATHER_DOWNPOUR;
+        sCurrentAbnormalWeather = WEATHER_DOWNPOUR;
     }
     SetCurrentAndNextWeather(weather);
 }

--- a/src/fieldmap.c
+++ b/src/fieldmap.c
@@ -25,10 +25,10 @@ struct ConnectionFlags
     u8 east:1;
 };
 
-EWRAM_DATA static u16 gBackupMapData[MAX_MAP_DATA_SIZE] = {0};
+EWRAM_DATA static u16 sBackupMapData[MAX_MAP_DATA_SIZE] = {0};
 EWRAM_DATA struct MapHeader gMapHeader = {0};
 EWRAM_DATA struct Camera gCamera = {0};
-EWRAM_DATA static struct ConnectionFlags gMapConnectionFlags = {0};
+EWRAM_DATA static struct ConnectionFlags sMapConnectionFlags = {0};
 EWRAM_DATA static u32 sFiller = 0; // without this, the next file won't align properly
 
 struct BackupMapLayout gBackupMapLayout;
@@ -87,14 +87,14 @@ void InitMapFromSavedGame(void)
 
 void InitBattlePyramidMap(bool8 setPlayerPosition)
 {
-    CpuFastFill(MAPGRID_UNDEFINED << 16 | MAPGRID_UNDEFINED, gBackupMapData, sizeof(gBackupMapData));
-    GenerateBattlePyramidFloorLayout(gBackupMapData, setPlayerPosition);
+    CpuFastFill(MAPGRID_UNDEFINED << 16 | MAPGRID_UNDEFINED, sBackupMapData, sizeof(sBackupMapData));
+    GenerateBattlePyramidFloorLayout(sBackupMapData, setPlayerPosition);
 }
 
 void InitTrainerHillMap(void)
 {
-    CpuFastFill(MAPGRID_UNDEFINED << 16 | MAPGRID_UNDEFINED, gBackupMapData, sizeof(gBackupMapData));
-    GenerateTrainerHillFloorLayout(gBackupMapData);
+    CpuFastFill(MAPGRID_UNDEFINED << 16 | MAPGRID_UNDEFINED, sBackupMapData, sizeof(sBackupMapData));
+    GenerateTrainerHillFloorLayout(sBackupMapData);
 }
 
 static void InitMapLayoutData(struct MapHeader *mapHeader)
@@ -103,8 +103,8 @@ static void InitMapLayoutData(struct MapHeader *mapHeader)
     int width;
     int height;
     mapLayout = mapHeader->mapLayout;
-    CpuFastFill16(MAPGRID_UNDEFINED, gBackupMapData, sizeof(gBackupMapData));
-    gBackupMapLayout.map = gBackupMapData;
+    CpuFastFill16(MAPGRID_UNDEFINED, sBackupMapData, sizeof(sBackupMapData));
+    gBackupMapLayout.map = sBackupMapData;
     width = mapLayout->width + MAP_OFFSET_W;
     gBackupMapLayout.width = width;
     height = mapLayout->height + MAP_OFFSET_H;
@@ -140,7 +140,7 @@ static void InitBackupMapLayoutConnections(struct MapHeader *mapHeader)
     {
         count = mapHeader->connections->count;
         connection = mapHeader->connections->connections;
-        gMapConnectionFlags = sDummyConnectionFlags;
+        sMapConnectionFlags = sDummyConnectionFlags;
         for (i = 0; i < count; i++, connection++)
         {
             struct MapHeader const *cMap = GetMapHeaderFromConnection(connection);
@@ -149,19 +149,19 @@ static void InitBackupMapLayoutConnections(struct MapHeader *mapHeader)
             {
             case CONNECTION_SOUTH:
                 FillSouthConnection(mapHeader, cMap, offset);
-                gMapConnectionFlags.south = TRUE;
+                sMapConnectionFlags.south = TRUE;
                 break;
             case CONNECTION_NORTH:
                 FillNorthConnection(mapHeader, cMap, offset);
-                gMapConnectionFlags.north = TRUE;
+                sMapConnectionFlags.north = TRUE;
                 break;
             case CONNECTION_WEST:
                 FillWestConnection(mapHeader, cMap, offset);
-                gMapConnectionFlags.west = TRUE;
+                sMapConnectionFlags.west = TRUE;
                 break;
             case CONNECTION_EAST:
                 FillEastConnection(mapHeader, cMap, offset);
-                gMapConnectionFlags.east = TRUE;
+                sMapConnectionFlags.east = TRUE;
                 break;
             }
         }
@@ -436,7 +436,7 @@ void SaveMapView(void)
     for (i = y; i < y + MAP_OFFSET_H; i++)
     {
         for (j = x; j < x + MAP_OFFSET_W; j++)
-            *mapView++ = gBackupMapData[width * i + j];
+            *mapView++ = sBackupMapData[width * i + j];
     }
 }
 
@@ -491,8 +491,8 @@ static void LoadSavedMapView(void)
 
             for (j = x; j < x + MAP_OFFSET_W; j++)
             {
-                if (!SkipCopyingMetatileFromSavedMap(&gBackupMapData[j + width * i], width, yMode))
-                    gBackupMapData[j + width * i] = *mapView;
+                if (!SkipCopyingMetatileFromSavedMap(&sBackupMapData[j + width * i], width, yMode))
+                    sBackupMapData[j + width * i] = *mapView;
                 mapView++;
             }
         }
@@ -554,7 +554,7 @@ static void MoveMapViewToBackup(u8 direction)
             desti = width * (y + y0);
             srci = (y + r8) * MAP_OFFSET_W + r9;
             src = &mapView[srci + i];
-            dest = &gBackupMapData[x0 + desti + j];
+            dest = &sBackupMapData[x0 + desti + j];
             *dest = *src;
             i++;
             j++;
@@ -570,28 +570,28 @@ int GetMapBorderIdAt(int x, int y)
 
     if (x >= (gBackupMapLayout.width - (MAP_OFFSET + 1)))
     {
-        if (!gMapConnectionFlags.east)
+        if (!sMapConnectionFlags.east)
             return CONNECTION_INVALID;
 
         return CONNECTION_EAST;
     }
     else if (x < MAP_OFFSET)
     {
-        if (!gMapConnectionFlags.west)
+        if (!sMapConnectionFlags.west)
             return CONNECTION_INVALID;
 
         return CONNECTION_WEST;
     }
     else if (y >= (gBackupMapLayout.height - MAP_OFFSET))
     {
-        if (!gMapConnectionFlags.south)
+        if (!sMapConnectionFlags.south)
             return CONNECTION_INVALID;
 
         return CONNECTION_SOUTH;
     }
     else if (y < MAP_OFFSET)
     {
-        if (!gMapConnectionFlags.north)
+        if (!sMapConnectionFlags.north)
             return CONNECTION_INVALID;
 
         return CONNECTION_NORTH;

--- a/src/item_menu_icons.c
+++ b/src/item_menu_icons.c
@@ -35,8 +35,8 @@ static void SpriteCB_SwitchPocketRotatingBallContinue(struct Sprite *sprite);
 // static const rom data
 static const u16 sRotatingBall_Pal[] = INCBIN_U16("graphics/bag/rotating_ball.gbapal");
 static const u8 sRotatingBall_Gfx[] = INCBIN_U8("graphics/bag/rotating_ball.4bpp");
-static const u8 gCherryUnused[] = INCBIN_U8("graphics/unused/cherry.4bpp");
-static const u16 gCherryUnused_Pal[] = INCBIN_U16("graphics/unused/cherry.gbapal");
+static const u8 sCherryUnused[] = INCBIN_U8("graphics/unused/cherry.4bpp");
+static const u16 sCherryUnused_Pal[] = INCBIN_U16("graphics/unused/cherry.gbapal");
 
 static const struct OamData sBagOamData =
 {
@@ -269,7 +269,7 @@ static const struct SpriteFrameImage sBerryPicSpriteImageTable[] =
     {&gDecompressionBuffer[0], 0x800},
 };
 
-static const struct SpriteTemplate gBerryPicSpriteTemplate =
+static const struct SpriteTemplate sBerryPicSpriteTemplate =
 {
     .tileTag = TAG_NONE,
     .paletteTag = TAG_BERRY_PIC_PAL,
@@ -308,7 +308,7 @@ static const union AffineAnimCmd *const sBerryPicRotatingAnimCmds[] =
     sSpriteAffineAnim_BerryPicRotation2
 };
 
-static const struct SpriteTemplate gBerryPicRotatingSpriteTemplate =
+static const struct SpriteTemplate sBerryPicRotatingSpriteTemplate =
 {
     .tileTag = TAG_NONE,
     .paletteTag = TAG_BERRY_PIC_PAL,
@@ -404,7 +404,7 @@ static const union AnimCmd *const sBerryCheckCircleSpriteAnimTable[] =
     sSpriteAnim_BerryCheckCircle
 };
 
-static const struct SpriteTemplate gBerryCheckCircleSpriteTemplate =
+static const struct SpriteTemplate sBerryCheckCircleSpriteTemplate =
 {
     .tileTag = TAG_BERRY_CHECK_CIRCLE_GFX,
     .paletteTag = TAG_BERRY_CHECK_CIRCLE_GFX,
@@ -609,7 +609,7 @@ static void LoadBerryGfx(u8 berryId)
 u8 CreateBerryTagSprite(u8 id, s16 x, s16 y)
 {
     LoadBerryGfx(id);
-    return CreateSprite(&gBerryPicSpriteTemplate, x, y, 0);
+    return CreateSprite(&sBerryPicSpriteTemplate, x, y, 0);
 }
 
 void FreeBerryTagSpritePalette(void)
@@ -624,7 +624,7 @@ u8 CreateSpinningBerrySprite(u8 berryId, u8 x, u8 y, bool8 startAffine)
 
     FreeSpritePaletteByTag(TAG_BERRY_PIC_PAL);
     LoadBerryGfx(berryId);
-    spriteId = CreateSprite(&gBerryPicRotatingSpriteTemplate, x, y, 0);
+    spriteId = CreateSprite(&sBerryPicRotatingSpriteTemplate, x, y, 0);
     if (startAffine == TRUE)
         StartSpriteAffineAnim(&gSprites[spriteId], 1);
 
@@ -633,5 +633,5 @@ u8 CreateSpinningBerrySprite(u8 berryId, u8 x, u8 y, bool8 startAffine)
 
 u8 CreateBerryFlavorCircleSprite(s16 x)
 {
-    return CreateSprite(&gBerryCheckCircleSpriteTemplate, x, 116, 0);
+    return CreateSprite(&sBerryCheckCircleSpriteTemplate, x, 116, 0);
 }

--- a/src/landmark.c
+++ b/src/landmark.c
@@ -336,7 +336,7 @@ static const struct Landmark *const Landmarks_MtChimney_2[]  =
     NULL,
 };
 
-static const struct LandmarkList gLandmarkLists[] =
+static const struct LandmarkList sLandmarkLists[] =
 {
     {MAPSEC_ROUTE_103, 2, Landmarks_Route103_2},
     {MAPSEC_ROUTE_104, 0, Landmarks_Route104_0},
@@ -420,21 +420,21 @@ static const struct Landmark *const *GetLandmarks(u8 mapSection, u8 id)
 {
     u16 i = 0;
 
-    for (; gLandmarkLists[i].mapSection != MAPSEC_NONE; i++)
+    for (; sLandmarkLists[i].mapSection != MAPSEC_NONE; i++)
     {
-        if (gLandmarkLists[i].mapSection > mapSection)
+        if (sLandmarkLists[i].mapSection > mapSection)
             return NULL;
-        if (gLandmarkLists[i].mapSection == mapSection)
+        if (sLandmarkLists[i].mapSection == mapSection)
             break;
     }
 
-    if (gLandmarkLists[i].mapSection == MAPSEC_NONE)
+    if (sLandmarkLists[i].mapSection == MAPSEC_NONE)
         return NULL;
 
-    for (; gLandmarkLists[i].mapSection == mapSection; i++)
+    for (; sLandmarkLists[i].mapSection == mapSection; i++)
     {
-        if (gLandmarkLists[i].id == id)
-            return gLandmarkLists[i].landmarks;
+        if (sLandmarkLists[i].id == id)
+            return sLandmarkLists[i].landmarks;
     }
 
     return NULL;

--- a/src/m4a_1.s
+++ b/src/m4a_1.s
@@ -680,7 +680,7 @@ SoundMainRAM_Unk2:
 	ldr r1, [r4, o_SoundChannel_wav]
 	add r2, r2, r1
 	add r2, r2, 0x10
-	ldr r5, =gDecodingBuffer
+	ldr r5, =sDecodingBuffer
 	ldr r6, =gDeltaEncodingTable
 	mov r7, 0x40
 	ldrb lr, [r2], 1
@@ -701,7 +701,7 @@ _081DD57C:
 	subs r7, r7, 2
 	bgt _081DD568
 _081DD594:
-	ldr r5, =gDecodingBuffer
+	ldr r5, =sDecodingBuffer
 	and r0, r3, 0x3F
 	ldrsb r1, [r5, r0]
 	pop {r0,r2,r5-r7,pc}
@@ -1911,6 +1911,6 @@ _081DDD90:
 	.align 2, 0 @ Don't pad with nop.
 
 	.bss
-gDecodingBuffer: @ Used as a buffer for audio decoded from compressed DPCM
+sDecodingBuffer: @ Used as a buffer for audio decoded from compressed DPCM
 	.space 0x40
-	.size gDecodingBuffer, .-gDecodingBuffer
+	.size sDecodingBuffer, .-sDecodingBuffer

--- a/src/main.c
+++ b/src/main.c
@@ -69,7 +69,7 @@ u8 gLinkVSyncDisabled;
 u32 IntrMain_Buffer[0x200];
 s8 gPcmDmaCounter;
 
-static EWRAM_DATA u16 gTrainerId = 0;
+static EWRAM_DATA u16 sTrainerId = 0;
 
 //EWRAM_DATA void (**gFlashTimerIntrFunc)(void) = NULL;
 
@@ -201,12 +201,12 @@ void SeedRngAndSetTrainerId(void)
     u16 val = REG_TM1CNT_L;
     SeedRng(val);
     REG_TM1CNT_H = 0;
-    gTrainerId = val;
+    sTrainerId = val;
 }
 
 u16 GetGeneratedTrainerIdLower(void)
 {
-    return gTrainerId;
+    return sTrainerId;
 }
 
 void EnableVCountIntrAtLine150(void)

--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -371,7 +371,7 @@ static const struct WindowTemplate sWindowTemplates_MainMenu[] =
     DUMMY_WIN_TEMPLATE
 };
 
-static const struct WindowTemplate gNewGameBirchSpeechTextWindows[] =
+static const struct WindowTemplate sNewGameBirchSpeechTextWindows[] =
 {
     {
         .bg = 0,
@@ -457,7 +457,7 @@ static const struct MenuAction sMenuActions_Gender[] = {
     {gText_BirchGirl, NULL}
 };
 
-static const u8 *const gMalePresetNames[] = {
+static const u8 *const sMalePresetNames[] = {
     gText_DefaultNameStu,
     gText_DefaultNameMilton,
     gText_DefaultNameTom,
@@ -480,7 +480,7 @@ static const u8 *const gMalePresetNames[] = {
     gText_DefaultNameQuincy
 };
 
-static const u8 *const gFemalePresetNames[] = {
+static const u8 *const sFemalePresetNames[] = {
     gText_DefaultNameKimmy,
     gText_DefaultNameTiara,
     gText_DefaultNameBella,
@@ -1325,7 +1325,7 @@ static void Task_NewGameBirchSpeech_WaitForSpriteFadeInWelcome(u8 taskId)
         }
         else
         {
-            InitWindows(gNewGameBirchSpeechTextWindows);
+            InitWindows(sNewGameBirchSpeechTextWindows);
             LoadMainMenuWindowFrameTiles(0, 0xF3);
             LoadMessageBoxGfx(0, 0xFC, 0xF0);
             NewGameBirchSpeech_ShowDialogueWindow(0, 1);
@@ -1851,7 +1851,7 @@ static void CB2_NewGameBirchSpeech_ReturnFromNamingScreen(void)
     REG_IME = savedIme;
     SetVBlankCallback(VBlankCB_MainMenu);
     SetMainCallback2(CB2_MainMenu);
-    InitWindows(gNewGameBirchSpeechTextWindows);
+    InitWindows(sNewGameBirchSpeechTextWindows);
     LoadMainMenuWindowFrameTiles(0, 0xF3);
     LoadMessageBoxGfx(0, 0xFC, 0xF0);
     PutWindowTilemap(0);
@@ -2087,7 +2087,7 @@ static void NewGameBirchSpeech_StartFadePlatformOut(u8 taskId, u8 delay)
 
 static void NewGameBirchSpeech_ShowGenderMenu(void)
 {
-    DrawMainMenuWindowBorder(&gNewGameBirchSpeechTextWindows[1], 0xF3);
+    DrawMainMenuWindowBorder(&sNewGameBirchSpeechTextWindows[1], 0xF3);
     FillWindowPixelBuffer(1, PIXEL_FILL(1));
     PrintMenuTable(1, ARRAY_COUNT(sMenuActions_Gender), sMenuActions_Gender);
     InitMenuInUpperLeftCornerNormal(1, ARRAY_COUNT(sMenuActions_Gender), 0);
@@ -2106,9 +2106,9 @@ static void NewGameBirchSpeech_SetDefaultPlayerName(u8 nameId)
     u8 i;
 
     if (gSaveBlock2Ptr->playerGender == MALE)
-        name = gMalePresetNames[nameId];
+        name = sMalePresetNames[nameId];
     else
-        name = gFemalePresetNames[nameId];
+        name = sFemalePresetNames[nameId];
     for (i = 0; i < PLAYER_NAME_LENGTH; i++)
         gSaveBlock2Ptr->playerName[i] = name[i];
     gSaveBlock2Ptr->playerName[PLAYER_NAME_LENGTH] = EOS;

--- a/src/map_name_popup.c
+++ b/src/map_name_popup.c
@@ -176,25 +176,25 @@ static const u8 sRegionMapSectionId_To_PopUpThemeIdMapping[] =
     [MAPSEC_TRAINER_HILL - KANTO_MAPSEC_COUNT] = MAPPOPUP_THEME_MARBLE
 };
 
-static const u8 gText_PyramidFloor1[] = _("PYRAMID FLOOR 1");
-static const u8 gText_PyramidFloor2[] = _("PYRAMID FLOOR 2");
-static const u8 gText_PyramidFloor3[] = _("PYRAMID FLOOR 3");
-static const u8 gText_PyramidFloor4[] = _("PYRAMID FLOOR 4");
-static const u8 gText_PyramidFloor5[] = _("PYRAMID FLOOR 5");
-static const u8 gText_PyramidFloor6[] = _("PYRAMID FLOOR 6");
-static const u8 gText_PyramidFloor7[] = _("PYRAMID FLOOR 7");
-static const u8 gText_Pyramid[] = _("PYRAMID");
+static const u8 sText_PyramidFloor1[] = _("PYRAMID FLOOR 1");
+static const u8 sText_PyramidFloor2[] = _("PYRAMID FLOOR 2");
+static const u8 sText_PyramidFloor3[] = _("PYRAMID FLOOR 3");
+static const u8 sText_PyramidFloor4[] = _("PYRAMID FLOOR 4");
+static const u8 sText_PyramidFloor5[] = _("PYRAMID FLOOR 5");
+static const u8 sText_PyramidFloor6[] = _("PYRAMID FLOOR 6");
+static const u8 sText_PyramidFloor7[] = _("PYRAMID FLOOR 7");
+static const u8 sText_Pyramid[] = _("PYRAMID");
 
-static const u8 * const gBattlePyramid_MapHeaderStrings[] =
+static const u8 * const sBattlePyramid_MapHeaderStrings[] =
 {
-    gText_PyramidFloor1,
-    gText_PyramidFloor2,
-    gText_PyramidFloor3,
-    gText_PyramidFloor4,
-    gText_PyramidFloor5,
-    gText_PyramidFloor6,
-    gText_PyramidFloor7,
-    gText_Pyramid,
+    sText_PyramidFloor1,
+    sText_PyramidFloor2,
+    sText_PyramidFloor3,
+    sText_PyramidFloor4,
+    sText_PyramidFloor5,
+    sText_PyramidFloor6,
+    sText_PyramidFloor7,
+    sText_Pyramid,
 };
 
 // Unused
@@ -309,12 +309,12 @@ static void ShowMapNamePopUpWindow(void)
         if (gMapHeader.mapLayoutId == LAYOUT_BATTLE_FRONTIER_BATTLE_PYRAMID_TOP)
         {
             withoutPrefixPtr = &(mapDisplayHeader[3]);
-            mapDisplayHeaderSource = gBattlePyramid_MapHeaderStrings[7];
+            mapDisplayHeaderSource = sBattlePyramid_MapHeaderStrings[7];
         }
         else
         {
             withoutPrefixPtr = &(mapDisplayHeader[3]);
-            mapDisplayHeaderSource = gBattlePyramid_MapHeaderStrings[gSaveBlock2Ptr->frontier.curChallengeBattleNum];
+            mapDisplayHeaderSource = sBattlePyramid_MapHeaderStrings[gSaveBlock2Ptr->frontier.curChallengeBattleNum];
         }
         StringCopy(withoutPrefixPtr, mapDisplayHeaderSource);
     }

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -318,7 +318,7 @@ static u8 MovementEventModeCB_Normal(struct LinkPlayerObjectEvent *, struct Obje
 static u8 MovementEventModeCB_Ignored(struct LinkPlayerObjectEvent *, struct ObjectEvent *, u8);
 static u8 MovementEventModeCB_Scripted(struct LinkPlayerObjectEvent *, struct ObjectEvent *, u8);
 
-static u8 (*const gLinkPlayerMovementModes[])(struct LinkPlayerObjectEvent *, struct ObjectEvent *, u8) =
+static u8 (*const sLinkPlayerMovementModes[])(struct LinkPlayerObjectEvent *, struct ObjectEvent *, u8) =
 {
     [MOVEMENT_MODE_FREE]     = MovementEventModeCB_Normal,
     [MOVEMENT_MODE_FROZEN]   = MovementEventModeCB_Ignored,
@@ -330,7 +330,7 @@ static u8 FacingHandler_DpadMovement(struct LinkPlayerObjectEvent *, struct Obje
 static u8 FacingHandler_ForcedFacingChange(struct LinkPlayerObjectEvent *, struct ObjectEvent *, u8);
 
 // These handlers return TRUE if the movement was scripted and successful, and FALSE otherwise.
-static bool8 (*const gLinkPlayerFacingHandlers[])(struct LinkPlayerObjectEvent *, struct ObjectEvent *, u8) =
+static bool8 (*const sLinkPlayerFacingHandlers[])(struct LinkPlayerObjectEvent *, struct ObjectEvent *, u8) =
 {
     FacingHandler_DoNothing,
     FacingHandler_DpadMovement,
@@ -349,7 +349,7 @@ static void MovementStatusHandler_EnterFreeMode(struct LinkPlayerObjectEvent *, 
 static void MovementStatusHandler_TryAdvanceScript(struct LinkPlayerObjectEvent *, struct ObjectEvent *);
 
 // These handlers are run after an attempted movement.
-static void (*const gMovementStatusHandler[])(struct LinkPlayerObjectEvent *, struct ObjectEvent *) =
+static void (*const sMovementStatusHandler[])(struct LinkPlayerObjectEvent *, struct ObjectEvent *) =
 {
     // FALSE:
     MovementStatusHandler_EnterFreeMode,
@@ -3048,9 +3048,9 @@ static void SetPlayerFacingDirection(u8 linkPlayerId, u8 facing)
         {
             // This is a hack to split this code onto two separate lines, without declaring a local variable.
             // C++ style inline variables would be nice here.
-            #define TEMP gLinkPlayerMovementModes[linkPlayerObjEvent->movementMode](linkPlayerObjEvent, objEvent, facing)
+            #define TEMP sLinkPlayerMovementModes[linkPlayerObjEvent->movementMode](linkPlayerObjEvent, objEvent, facing)
 
-            gMovementStatusHandler[TEMP](linkPlayerObjEvent, objEvent);
+            sMovementStatusHandler[TEMP](linkPlayerObjEvent, objEvent);
 
             // Clean up the hack.
             #undef TEMP
@@ -3061,7 +3061,7 @@ static void SetPlayerFacingDirection(u8 linkPlayerId, u8 facing)
 
 static u8 MovementEventModeCB_Normal(struct LinkPlayerObjectEvent *linkPlayerObjEvent, struct ObjectEvent *objEvent, u8 dir)
 {
-    return gLinkPlayerFacingHandlers[dir](linkPlayerObjEvent, objEvent, dir);
+    return sLinkPlayerFacingHandlers[dir](linkPlayerObjEvent, objEvent, dir);
 }
 
 static u8 MovementEventModeCB_Ignored(struct LinkPlayerObjectEvent *linkPlayerObjEvent, struct ObjectEvent *objEvent, u8 dir)
@@ -3072,7 +3072,7 @@ static u8 MovementEventModeCB_Ignored(struct LinkPlayerObjectEvent *linkPlayerOb
 // Identical to MovementEventModeCB_Normal
 static u8 MovementEventModeCB_Scripted(struct LinkPlayerObjectEvent *linkPlayerObjEvent, struct ObjectEvent *objEvent, u8 dir)
 {
-    return gLinkPlayerFacingHandlers[dir](linkPlayerObjEvent, objEvent, dir);
+    return sLinkPlayerFacingHandlers[dir](linkPlayerObjEvent, objEvent, dir);
 }
 
 static bool8 FacingHandler_DoNothing(struct LinkPlayerObjectEvent *linkPlayerObjEvent, struct ObjectEvent *objEvent, u8 dir)

--- a/src/palette.c
+++ b/src/palette.c
@@ -60,13 +60,13 @@ static void Task_BlendPalettesGradually(u8 taskId);
 // unaligned word reads are issued in BlendPalette otherwise
 ALIGNED(4) EWRAM_DATA u16 gPlttBufferUnfaded[PLTT_BUFFER_SIZE] = {0};
 ALIGNED(4) EWRAM_DATA u16 gPlttBufferFaded[PLTT_BUFFER_SIZE] = {0};
-EWRAM_DATA struct PaletteStruct sPaletteStructs[NUM_PALETTE_STRUCTS] = {0};
+static EWRAM_DATA struct PaletteStruct sPaletteStructs[NUM_PALETTE_STRUCTS] = {0};
 EWRAM_DATA struct PaletteFadeControl gPaletteFade = {0};
 static EWRAM_DATA u32 sFiller = 0;
 static EWRAM_DATA u32 sPlttBufferTransferPending = 0;
 EWRAM_DATA u8 gPaletteDecompressionBuffer[PLTT_DECOMP_BUFFER_SIZE] = {0};
 
-static const struct PaletteStructTemplate gDummyPaletteStructTemplate = {
+static const struct PaletteStructTemplate sDummyPaletteStructTemplate = {
     .id = 0xFFFF,
     .state = 1
 };
@@ -352,7 +352,7 @@ void PaletteStruct_ResetById(u16 id)
 
 static void PaletteStruct_Reset(u8 paletteNum)
 {
-    sPaletteStructs[paletteNum].template = &gDummyPaletteStructTemplate;
+    sPaletteStructs[paletteNum].template = &sDummyPaletteStructTemplate;
     sPaletteStructs[paletteNum].active = FALSE;
     sPaletteStructs[paletteNum].baseDestOffset = 0;
     sPaletteStructs[paletteNum].destOffset = 0;

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -840,7 +840,7 @@ static const u8 sText_No000[] = _("{NO}000");
 static const u8 sCaughtBall_Gfx[] = INCBIN_U8("graphics/pokedex/caught_ball.4bpp");
 static const u8 sText_TenDashes[] = _("----------");
 
-ALIGNED(4) static const u8 gExpandedPlaceholder_PokedexDescription[] = _("");
+ALIGNED(4) static const u8 sExpandedPlaceholder_PokedexDescription[] = _("");
 
 #include "data/pokemon/pokedex_text.h"
 #include "data/pokemon/pokedex_entries.h"
@@ -4138,7 +4138,7 @@ static void PrintMonInfo(u32 num, u32 value, u32 owned, u32 newEntry)
     if (owned)
         description = gPokedexEntries[num].description;
     else
-        description = gExpandedPlaceholder_PokedexDescription;
+        description = sExpandedPlaceholder_PokedexDescription;
     PrintInfoScreenText(description, GetStringCenterAlignXOffset(FONT_NORMAL, description, 0xF0), 0x5F);
 }
 

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -1040,7 +1040,7 @@ static const struct BgTemplate sBgTemplates[] =
     },
 };
 
-static const struct SpritePalette gWaveformSpritePalette =
+static const struct SpritePalette sWaveformSpritePalette =
 {
     sWaveform_Pal, PALTAG_MISC_2
 };
@@ -3844,7 +3844,7 @@ static bool8 InitPokeStorageWindows(void)
 
 static void LoadWaveformSpritePalette(void)
 {
-    LoadSpritePalette(&gWaveformSpritePalette);
+    LoadSpritePalette(&sWaveformSpritePalette);
 }
 
 static void InitPalettesAndSprites(void)

--- a/src/pokenav_main_menu.c
+++ b/src/pokenav_main_menu.c
@@ -105,7 +105,7 @@ static const u8 sHelpBarTextColors[3] =
     TEXT_COLOR_RED, TEXT_COLOR_WHITE, TEXT_COLOR_DARK_GRAY
 };
 
-static const struct CompressedSpriteSheet gSpinningPokenavSpriteSheet[] =
+static const struct CompressedSpriteSheet sSpinningPokenavSpriteSheet[] =
 {
     {
         .data = sSpinningPokenav_Gfx,
@@ -114,7 +114,7 @@ static const struct CompressedSpriteSheet gSpinningPokenavSpriteSheet[] =
     }
 };
 
-static const struct SpritePalette gSpinningNavgearPalettes[] =
+static const struct SpritePalette sSpinningNavgearPalettes[] =
 {
     {
         .data = sSpinningPokenav_Pal,
@@ -583,10 +583,10 @@ static void InitPokenavMainMenuResources(void)
     u8 spriteId;
     struct Pokenav_MainMenu *menu = GetSubstructPtr(POKENAV_SUBSTRUCT_MAIN_MENU);
 
-    for (i = 0; i < ARRAY_COUNT(gSpinningPokenavSpriteSheet); i++)
-        LoadCompressedSpriteSheet(&gSpinningPokenavSpriteSheet[i]);
+    for (i = 0; i < ARRAY_COUNT(sSpinningPokenavSpriteSheet); i++)
+        LoadCompressedSpriteSheet(&sSpinningPokenavSpriteSheet[i]);
 
-    Pokenav_AllocAndLoadPalettes(gSpinningNavgearPalettes);
+    Pokenav_AllocAndLoadPalettes(sSpinningNavgearPalettes);
     menu->palettes = ~1 & ~(0x10000 << IndexOfSpritePaletteTag(0));
     spriteId = CreateSprite(&sSpinningPokenavSpriteTemplate, 220, 12, 0);
     menu->spinningPokenav = &gSprites[spriteId];

--- a/src/pokenav_match_call_data.c
+++ b/src/pokenav_match_call_data.c
@@ -324,7 +324,7 @@ static const match_call_text_data_t sWallyTextScripts[] = {
     { NULL,                  0xFFFF,                              0xFFFF }
 };
 
-const struct MatchCallLocationOverride sWallyLocationData[] = {
+static const struct MatchCallLocationOverride sWallyLocationData[] = {
     { FLAG_HIDE_MAUVILLE_CITY_WALLY,          MAPSEC_VERDANTURF_TOWN },
     { FLAG_GROUDON_AWAKENED_MAGMA_HIDEOUT,    MAPSEC_NONE },
     { FLAG_HIDE_VICTORY_ROAD_ENTRANCE_WALLY,  MAPSEC_VICTORY_ROAD },

--- a/src/pokenav_region_map.c
+++ b/src/pokenav_region_map.c
@@ -146,7 +146,7 @@ static const struct WindowTemplate sMapSecInfoWindowTemplate =
 
 #include "data/region_map/city_map_entries.h"
 
-const struct OamData sCityZoomTextSprite_OamData =
+static const struct OamData sCityZoomTextSprite_OamData =
 {
     .y = 0,
     .affineMode = ST_OAM_AFFINE_OFF,

--- a/src/region_map.c
+++ b/src/region_map.c
@@ -64,7 +64,7 @@ struct MultiNameFlyDest
 
 // Static RAM declarations
 
-static EWRAM_DATA struct RegionMap *gRegionMap = NULL;
+static EWRAM_DATA struct RegionMap *sRegionMap = NULL;
 
 static EWRAM_DATA struct {
     void (*callback)(void);
@@ -516,49 +516,49 @@ void InitRegionMap(struct RegionMap *regionMap, bool8 zoomed)
 
 void InitRegionMapData(struct RegionMap *regionMap, const struct BgTemplate *template, bool8 zoomed)
 {
-    gRegionMap = regionMap;
-    gRegionMap->initStep = 0;
-    gRegionMap->zoomed = zoomed;
-    gRegionMap->inputCallback = zoomed == TRUE ? ProcessRegionMapInput_Zoomed : ProcessRegionMapInput_Full;
+    sRegionMap = regionMap;
+    sRegionMap->initStep = 0;
+    sRegionMap->zoomed = zoomed;
+    sRegionMap->inputCallback = zoomed == TRUE ? ProcessRegionMapInput_Zoomed : ProcessRegionMapInput_Full;
     if (template != NULL)
     {
-        gRegionMap->bgNum = template->bg;
-        gRegionMap->charBaseIdx = template->charBaseIndex;
-        gRegionMap->mapBaseIdx = template->mapBaseIndex;
-        gRegionMap->bgManaged = TRUE;
+        sRegionMap->bgNum = template->bg;
+        sRegionMap->charBaseIdx = template->charBaseIndex;
+        sRegionMap->mapBaseIdx = template->mapBaseIndex;
+        sRegionMap->bgManaged = TRUE;
     }
     else
     {
-        gRegionMap->bgNum = 2;
-        gRegionMap->charBaseIdx = 2;
-        gRegionMap->mapBaseIdx = 28;
-        gRegionMap->bgManaged = FALSE;
+        sRegionMap->bgNum = 2;
+        sRegionMap->charBaseIdx = 2;
+        sRegionMap->mapBaseIdx = 28;
+        sRegionMap->bgManaged = FALSE;
     }
 }
 
 void ShowRegionMapForPokedexAreaScreen(struct RegionMap *regionMap)
 {
-    gRegionMap = regionMap;
+    sRegionMap = regionMap;
     InitMapBasedOnPlayerLocation();
-    gRegionMap->playerIconSpritePosX = gRegionMap->cursorPosX;
-    gRegionMap->playerIconSpritePosY = gRegionMap->cursorPosY;
+    sRegionMap->playerIconSpritePosX = sRegionMap->cursorPosX;
+    sRegionMap->playerIconSpritePosY = sRegionMap->cursorPosY;
 }
 
 bool8 LoadRegionMapGfx(void)
 {
-    switch (gRegionMap->initStep)
+    switch (sRegionMap->initStep)
     {
     case 0:
-        if (gRegionMap->bgManaged)
-            DecompressAndCopyTileDataToVram(gRegionMap->bgNum, sRegionMapBg_GfxLZ, 0, 0, 0);
+        if (sRegionMap->bgManaged)
+            DecompressAndCopyTileDataToVram(sRegionMap->bgNum, sRegionMapBg_GfxLZ, 0, 0, 0);
         else
             LZ77UnCompVram(sRegionMapBg_GfxLZ, (u16 *)BG_CHAR_ADDR(2));
         break;
     case 1:
-        if (gRegionMap->bgManaged)
+        if (sRegionMap->bgManaged)
         {
             if (!FreeTempTileDataBuffersIfPossible())
-                DecompressAndCopyTileDataToVram(gRegionMap->bgNum, sRegionMapBg_TilemapLZ, 0, 0, 1);
+                DecompressAndCopyTileDataToVram(sRegionMap->bgNum, sRegionMapBg_TilemapLZ, 0, 0, 1);
         }
         else
         {
@@ -570,54 +570,54 @@ bool8 LoadRegionMapGfx(void)
             LoadPalette(sRegionMapBg_Pal, 0x70, 0x60);
         break;
     case 3:
-        LZ77UnCompWram(sRegionMapCursorSmallGfxLZ, gRegionMap->cursorSmallImage);
+        LZ77UnCompWram(sRegionMapCursorSmallGfxLZ, sRegionMap->cursorSmallImage);
         break;
     case 4:
-        LZ77UnCompWram(sRegionMapCursorLargeGfxLZ, gRegionMap->cursorLargeImage);
+        LZ77UnCompWram(sRegionMapCursorLargeGfxLZ, sRegionMap->cursorLargeImage);
         break;
     case 5:
         InitMapBasedOnPlayerLocation();
-        gRegionMap->playerIconSpritePosX = gRegionMap->cursorPosX;
-        gRegionMap->playerIconSpritePosY = gRegionMap->cursorPosY;
-        gRegionMap->mapSecId = CorrectSpecialMapSecId_Internal(gRegionMap->mapSecId);
-        gRegionMap->mapSecType = GetMapsecType(gRegionMap->mapSecId);
-        GetMapName(gRegionMap->mapSecName, gRegionMap->mapSecId, MAP_NAME_LENGTH);
+        sRegionMap->playerIconSpritePosX = sRegionMap->cursorPosX;
+        sRegionMap->playerIconSpritePosY = sRegionMap->cursorPosY;
+        sRegionMap->mapSecId = CorrectSpecialMapSecId_Internal(sRegionMap->mapSecId);
+        sRegionMap->mapSecType = GetMapsecType(sRegionMap->mapSecId);
+        GetMapName(sRegionMap->mapSecName, sRegionMap->mapSecId, MAP_NAME_LENGTH);
         break;
     case 6:
-        if (gRegionMap->zoomed == FALSE)
+        if (sRegionMap->zoomed == FALSE)
         {
             CalcZoomScrollParams(0, 0, 0, 0, 0x100, 0x100, 0);
         }
         else
         {
-            gRegionMap->scrollX = gRegionMap->cursorPosX * 8 - 0x34;
-            gRegionMap->scrollY = gRegionMap->cursorPosY * 8 - 0x44;
-            gRegionMap->zoomedCursorPosX = gRegionMap->cursorPosX;
-            gRegionMap->zoomedCursorPosY = gRegionMap->cursorPosY;
-            CalcZoomScrollParams(gRegionMap->scrollX, gRegionMap->scrollY, 0x38, 0x48, 0x80, 0x80, 0);
+            sRegionMap->scrollX = sRegionMap->cursorPosX * 8 - 0x34;
+            sRegionMap->scrollY = sRegionMap->cursorPosY * 8 - 0x44;
+            sRegionMap->zoomedCursorPosX = sRegionMap->cursorPosX;
+            sRegionMap->zoomedCursorPosY = sRegionMap->cursorPosY;
+            CalcZoomScrollParams(sRegionMap->scrollX, sRegionMap->scrollY, 0x38, 0x48, 0x80, 0x80, 0);
         }
         break;
     case 7:
         GetPositionOfCursorWithinMapSec();
         UpdateRegionMapVideoRegs();
-        gRegionMap->cursorSprite = NULL;
-        gRegionMap->playerIconSprite = NULL;
-        gRegionMap->cursorMovementFrameCounter = 0;
-        gRegionMap->blinkPlayerIcon = FALSE;
-        if (gRegionMap->bgManaged)
+        sRegionMap->cursorSprite = NULL;
+        sRegionMap->playerIconSprite = NULL;
+        sRegionMap->cursorMovementFrameCounter = 0;
+        sRegionMap->blinkPlayerIcon = FALSE;
+        if (sRegionMap->bgManaged)
         {
-            SetBgAttribute(gRegionMap->bgNum, BG_ATTR_SCREENSIZE, 2);
-            SetBgAttribute(gRegionMap->bgNum, BG_ATTR_CHARBASEINDEX, gRegionMap->charBaseIdx);
-            SetBgAttribute(gRegionMap->bgNum, BG_ATTR_MAPBASEINDEX, gRegionMap->mapBaseIdx);
-            SetBgAttribute(gRegionMap->bgNum, BG_ATTR_WRAPAROUND, 1);
-            SetBgAttribute(gRegionMap->bgNum, BG_ATTR_PALETTEMODE, 1);
+            SetBgAttribute(sRegionMap->bgNum, BG_ATTR_SCREENSIZE, 2);
+            SetBgAttribute(sRegionMap->bgNum, BG_ATTR_CHARBASEINDEX, sRegionMap->charBaseIdx);
+            SetBgAttribute(sRegionMap->bgNum, BG_ATTR_MAPBASEINDEX, sRegionMap->mapBaseIdx);
+            SetBgAttribute(sRegionMap->bgNum, BG_ATTR_WRAPAROUND, 1);
+            SetBgAttribute(sRegionMap->bgNum, BG_ATTR_PALETTEMODE, 1);
         }
-        gRegionMap->initStep++;
+        sRegionMap->initStep++;
         return FALSE;
     default:
         return FALSE;
     }
-    gRegionMap->initStep++;
+    sRegionMap->initStep++;
     return TRUE;
 }
 
@@ -629,23 +629,23 @@ void BlendRegionMap(u16 color, u32 coeff)
 
 void FreeRegionMapIconResources(void)
 {
-    if (gRegionMap->cursorSprite != NULL)
+    if (sRegionMap->cursorSprite != NULL)
     {
-        DestroySprite(gRegionMap->cursorSprite);
-        FreeSpriteTilesByTag(gRegionMap->cursorTileTag);
-        FreeSpritePaletteByTag(gRegionMap->cursorPaletteTag);
+        DestroySprite(sRegionMap->cursorSprite);
+        FreeSpriteTilesByTag(sRegionMap->cursorTileTag);
+        FreeSpritePaletteByTag(sRegionMap->cursorPaletteTag);
     }
-    if (gRegionMap->playerIconSprite != NULL)
+    if (sRegionMap->playerIconSprite != NULL)
     {
-        DestroySprite(gRegionMap->playerIconSprite);
-        FreeSpriteTilesByTag(gRegionMap->playerIconTileTag);
-        FreeSpritePaletteByTag(gRegionMap->playerIconPaletteTag);
+        DestroySprite(sRegionMap->playerIconSprite);
+        FreeSpriteTilesByTag(sRegionMap->playerIconTileTag);
+        FreeSpritePaletteByTag(sRegionMap->playerIconPaletteTag);
     }
 }
 
 u8 DoRegionMapInputCallback(void)
 {
-    return gRegionMap->inputCallback();
+    return sRegionMap->inputCallback();
 }
 
 static u8 ProcessRegionMapInput_Full(void)
@@ -653,26 +653,26 @@ static u8 ProcessRegionMapInput_Full(void)
     u8 input;
 
     input = MAP_INPUT_NONE;
-    gRegionMap->cursorDeltaX = 0;
-    gRegionMap->cursorDeltaY = 0;
-    if (JOY_HELD(DPAD_UP) && gRegionMap->cursorPosY > MAPCURSOR_Y_MIN)
+    sRegionMap->cursorDeltaX = 0;
+    sRegionMap->cursorDeltaY = 0;
+    if (JOY_HELD(DPAD_UP) && sRegionMap->cursorPosY > MAPCURSOR_Y_MIN)
     {
-        gRegionMap->cursorDeltaY = -1;
+        sRegionMap->cursorDeltaY = -1;
         input = MAP_INPUT_MOVE_START;
     }
-    if (JOY_HELD(DPAD_DOWN) && gRegionMap->cursorPosY < MAPCURSOR_Y_MAX)
+    if (JOY_HELD(DPAD_DOWN) && sRegionMap->cursorPosY < MAPCURSOR_Y_MAX)
     {
-        gRegionMap->cursorDeltaY = +1;
+        sRegionMap->cursorDeltaY = +1;
         input = MAP_INPUT_MOVE_START;
     }
-    if (JOY_HELD(DPAD_LEFT) && gRegionMap->cursorPosX > MAPCURSOR_X_MIN)
+    if (JOY_HELD(DPAD_LEFT) && sRegionMap->cursorPosX > MAPCURSOR_X_MIN)
     {
-        gRegionMap->cursorDeltaX = -1;
+        sRegionMap->cursorDeltaX = -1;
         input = MAP_INPUT_MOVE_START;
     }
-    if (JOY_HELD(DPAD_RIGHT) && gRegionMap->cursorPosX < MAPCURSOR_X_MAX)
+    if (JOY_HELD(DPAD_RIGHT) && sRegionMap->cursorPosX < MAPCURSOR_X_MAX)
     {
-        gRegionMap->cursorDeltaX = +1;
+        sRegionMap->cursorDeltaX = +1;
         input = MAP_INPUT_MOVE_START;
     }
     if (JOY_NEW(A_BUTTON))
@@ -685,8 +685,8 @@ static u8 ProcessRegionMapInput_Full(void)
     }
     if (input == MAP_INPUT_MOVE_START)
     {
-        gRegionMap->cursorMovementFrameCounter = 4;
-        gRegionMap->inputCallback = MoveRegionMapCursor_Full;
+        sRegionMap->cursorMovementFrameCounter = 4;
+        sRegionMap->inputCallback = MoveRegionMapCursor_Full;
     }
     return input;
 }
@@ -695,35 +695,35 @@ static u8 MoveRegionMapCursor_Full(void)
 {
     u16 mapSecId;
 
-    if (gRegionMap->cursorMovementFrameCounter != 0)
+    if (sRegionMap->cursorMovementFrameCounter != 0)
         return MAP_INPUT_MOVE_CONT;
 
-    if (gRegionMap->cursorDeltaX > 0)
+    if (sRegionMap->cursorDeltaX > 0)
     {
-        gRegionMap->cursorPosX++;
+        sRegionMap->cursorPosX++;
     }
-    if (gRegionMap->cursorDeltaX < 0)
+    if (sRegionMap->cursorDeltaX < 0)
     {
-        gRegionMap->cursorPosX--;
+        sRegionMap->cursorPosX--;
     }
-    if (gRegionMap->cursorDeltaY > 0)
+    if (sRegionMap->cursorDeltaY > 0)
     {
-        gRegionMap->cursorPosY++;
+        sRegionMap->cursorPosY++;
     }
-    if (gRegionMap->cursorDeltaY < 0)
+    if (sRegionMap->cursorDeltaY < 0)
     {
-        gRegionMap->cursorPosY--;
+        sRegionMap->cursorPosY--;
     }
 
-    mapSecId = GetMapSecIdAt(gRegionMap->cursorPosX, gRegionMap->cursorPosY);
-    gRegionMap->mapSecType = GetMapsecType(mapSecId);
-    if (mapSecId != gRegionMap->mapSecId)
+    mapSecId = GetMapSecIdAt(sRegionMap->cursorPosX, sRegionMap->cursorPosY);
+    sRegionMap->mapSecType = GetMapsecType(mapSecId);
+    if (mapSecId != sRegionMap->mapSecId)
     {
-        gRegionMap->mapSecId = mapSecId;
-        GetMapName(gRegionMap->mapSecName, gRegionMap->mapSecId, MAP_NAME_LENGTH);
+        sRegionMap->mapSecId = mapSecId;
+        GetMapName(sRegionMap->mapSecName, sRegionMap->mapSecId, MAP_NAME_LENGTH);
     }
     GetPositionOfCursorWithinMapSec();
-    gRegionMap->inputCallback = ProcessRegionMapInput_Full;
+    sRegionMap->inputCallback = ProcessRegionMapInput_Full;
     return MAP_INPUT_MOVE_END;
 }
 
@@ -732,26 +732,26 @@ static u8 ProcessRegionMapInput_Zoomed(void)
     u8 input;
 
     input = MAP_INPUT_NONE;
-    gRegionMap->zoomedCursorDeltaX = 0;
-    gRegionMap->zoomedCursorDeltaY = 0;
-    if (JOY_HELD(DPAD_UP) && gRegionMap->scrollY > -0x34)
+    sRegionMap->zoomedCursorDeltaX = 0;
+    sRegionMap->zoomedCursorDeltaY = 0;
+    if (JOY_HELD(DPAD_UP) && sRegionMap->scrollY > -0x34)
     {
-        gRegionMap->zoomedCursorDeltaY = -1;
+        sRegionMap->zoomedCursorDeltaY = -1;
         input = MAP_INPUT_MOVE_START;
     }
-    if (JOY_HELD(DPAD_DOWN) && gRegionMap->scrollY < 0x3c)
+    if (JOY_HELD(DPAD_DOWN) && sRegionMap->scrollY < 0x3c)
     {
-        gRegionMap->zoomedCursorDeltaY = +1;
+        sRegionMap->zoomedCursorDeltaY = +1;
         input = MAP_INPUT_MOVE_START;
     }
-    if (JOY_HELD(DPAD_LEFT) && gRegionMap->scrollX > -0x2c)
+    if (JOY_HELD(DPAD_LEFT) && sRegionMap->scrollX > -0x2c)
     {
-        gRegionMap->zoomedCursorDeltaX = -1;
+        sRegionMap->zoomedCursorDeltaX = -1;
         input = MAP_INPUT_MOVE_START;
     }
-    if (JOY_HELD(DPAD_RIGHT) && gRegionMap->scrollX < 0xac)
+    if (JOY_HELD(DPAD_RIGHT) && sRegionMap->scrollX < 0xac)
     {
-        gRegionMap->zoomedCursorDeltaX = +1;
+        sRegionMap->zoomedCursorDeltaX = +1;
         input = MAP_INPUT_MOVE_START;
     }
     if (JOY_NEW(A_BUTTON))
@@ -764,8 +764,8 @@ static u8 ProcessRegionMapInput_Zoomed(void)
     }
     if (input == MAP_INPUT_MOVE_START)
     {
-        gRegionMap->inputCallback = MoveRegionMapCursor_Zoomed;
-        gRegionMap->zoomedCursorMovementFrameCounter = 0;
+        sRegionMap->inputCallback = MoveRegionMapCursor_Zoomed;
+        sRegionMap->zoomedCursorMovementFrameCounter = 0;
     }
     return input;
 }
@@ -776,29 +776,29 @@ static u8 MoveRegionMapCursor_Zoomed(void)
     u16 y;
     u16 mapSecId;
 
-    gRegionMap->scrollY += gRegionMap->zoomedCursorDeltaY;
-    gRegionMap->scrollX += gRegionMap->zoomedCursorDeltaX;
-    RegionMap_SetBG2XAndBG2Y(gRegionMap->scrollX, gRegionMap->scrollY);
-    gRegionMap->zoomedCursorMovementFrameCounter++;
-    if (gRegionMap->zoomedCursorMovementFrameCounter == 8)
+    sRegionMap->scrollY += sRegionMap->zoomedCursorDeltaY;
+    sRegionMap->scrollX += sRegionMap->zoomedCursorDeltaX;
+    RegionMap_SetBG2XAndBG2Y(sRegionMap->scrollX, sRegionMap->scrollY);
+    sRegionMap->zoomedCursorMovementFrameCounter++;
+    if (sRegionMap->zoomedCursorMovementFrameCounter == 8)
     {
-        x = (gRegionMap->scrollX + 0x2c) / 8 + 1;
-        y = (gRegionMap->scrollY + 0x34) / 8 + 2;
-        if (x != gRegionMap->zoomedCursorPosX || y != gRegionMap->zoomedCursorPosY)
+        x = (sRegionMap->scrollX + 0x2c) / 8 + 1;
+        y = (sRegionMap->scrollY + 0x34) / 8 + 2;
+        if (x != sRegionMap->zoomedCursorPosX || y != sRegionMap->zoomedCursorPosY)
         {
-            gRegionMap->zoomedCursorPosX = x;
-            gRegionMap->zoomedCursorPosY = y;
+            sRegionMap->zoomedCursorPosX = x;
+            sRegionMap->zoomedCursorPosY = y;
             mapSecId = GetMapSecIdAt(x, y);
-            gRegionMap->mapSecType = GetMapsecType(mapSecId);
-            if (mapSecId != gRegionMap->mapSecId)
+            sRegionMap->mapSecType = GetMapsecType(mapSecId);
+            if (mapSecId != sRegionMap->mapSecId)
             {
-                gRegionMap->mapSecId = mapSecId;
-                GetMapName(gRegionMap->mapSecName, gRegionMap->mapSecId, MAP_NAME_LENGTH);
+                sRegionMap->mapSecId = mapSecId;
+                GetMapName(sRegionMap->mapSecName, sRegionMap->mapSecId, MAP_NAME_LENGTH);
             }
             GetPositionOfCursorWithinMapSec();
         }
-        gRegionMap->zoomedCursorMovementFrameCounter = 0;
-        gRegionMap->inputCallback = ProcessRegionMapInput_Zoomed;
+        sRegionMap->zoomedCursorMovementFrameCounter = 0;
+        sRegionMap->inputCallback = ProcessRegionMapInput_Zoomed;
         return MAP_INPUT_MOVE_END;
     }
     return MAP_INPUT_MOVE_CONT;
@@ -806,35 +806,35 @@ static u8 MoveRegionMapCursor_Zoomed(void)
 
 void SetRegionMapDataForZoom(void)
 {
-    if (gRegionMap->zoomed == FALSE)
+    if (sRegionMap->zoomed == FALSE)
     {
-        gRegionMap->scrollY = 0;
-        gRegionMap->scrollX = 0;
-        gRegionMap->unk_040 = 0;
-        gRegionMap->unk_03c = 0;
-        gRegionMap->unk_060 = gRegionMap->cursorPosX * 8 - 0x34;
-        gRegionMap->unk_062 = gRegionMap->cursorPosY * 8 - 0x44;
-        gRegionMap->unk_044 = (gRegionMap->unk_060 << 8) / 16;
-        gRegionMap->unk_048 = (gRegionMap->unk_062 << 8) / 16;
-        gRegionMap->zoomedCursorPosX = gRegionMap->cursorPosX;
-        gRegionMap->zoomedCursorPosY = gRegionMap->cursorPosY;
-        gRegionMap->unk_04c = 0x10000;
-        gRegionMap->unk_050 = -0x800;
+        sRegionMap->scrollY = 0;
+        sRegionMap->scrollX = 0;
+        sRegionMap->unk_040 = 0;
+        sRegionMap->unk_03c = 0;
+        sRegionMap->unk_060 = sRegionMap->cursorPosX * 8 - 0x34;
+        sRegionMap->unk_062 = sRegionMap->cursorPosY * 8 - 0x44;
+        sRegionMap->unk_044 = (sRegionMap->unk_060 << 8) / 16;
+        sRegionMap->unk_048 = (sRegionMap->unk_062 << 8) / 16;
+        sRegionMap->zoomedCursorPosX = sRegionMap->cursorPosX;
+        sRegionMap->zoomedCursorPosY = sRegionMap->cursorPosY;
+        sRegionMap->unk_04c = 0x10000;
+        sRegionMap->unk_050 = -0x800;
     }
     else
     {
-        gRegionMap->unk_03c = gRegionMap->scrollX * 0x100;
-        gRegionMap->unk_040 = gRegionMap->scrollY * 0x100;
-        gRegionMap->unk_060 = 0;
-        gRegionMap->unk_062 = 0;
-        gRegionMap->unk_044 = -(gRegionMap->unk_03c / 16);
-        gRegionMap->unk_048 = -(gRegionMap->unk_040 / 16);
-        gRegionMap->cursorPosX = gRegionMap->zoomedCursorPosX;
-        gRegionMap->cursorPosY = gRegionMap->zoomedCursorPosY;
-        gRegionMap->unk_04c = 0x8000;
-        gRegionMap->unk_050 = 0x800;
+        sRegionMap->unk_03c = sRegionMap->scrollX * 0x100;
+        sRegionMap->unk_040 = sRegionMap->scrollY * 0x100;
+        sRegionMap->unk_060 = 0;
+        sRegionMap->unk_062 = 0;
+        sRegionMap->unk_044 = -(sRegionMap->unk_03c / 16);
+        sRegionMap->unk_048 = -(sRegionMap->unk_040 / 16);
+        sRegionMap->cursorPosX = sRegionMap->zoomedCursorPosX;
+        sRegionMap->cursorPosY = sRegionMap->zoomedCursorPosY;
+        sRegionMap->unk_04c = 0x8000;
+        sRegionMap->unk_050 = 0x800;
     }
-    gRegionMap->unk_06e = 0;
+    sRegionMap->unk_06e = 0;
     FreeRegionMapCursorSprite();
     HideRegionMapPlayerIcon();
 }
@@ -843,60 +843,60 @@ bool8 UpdateRegionMapZoom(void)
 {
     bool8 retVal;
 
-    if (gRegionMap->unk_06e >= 16)
+    if (sRegionMap->unk_06e >= 16)
     {
         return FALSE;
     }
-    gRegionMap->unk_06e++;
-    if (gRegionMap->unk_06e == 16)
+    sRegionMap->unk_06e++;
+    if (sRegionMap->unk_06e == 16)
     {
-        gRegionMap->unk_044 = 0;
-        gRegionMap->unk_048 = 0;
-        gRegionMap->scrollX = gRegionMap->unk_060;
-        gRegionMap->scrollY = gRegionMap->unk_062;
-        gRegionMap->unk_04c = (gRegionMap->zoomed == FALSE) ? (128 << 8) : (256 << 8);
-        gRegionMap->zoomed = !gRegionMap->zoomed;
-        gRegionMap->inputCallback = (gRegionMap->zoomed == FALSE) ? ProcessRegionMapInput_Full : ProcessRegionMapInput_Zoomed;
-        CreateRegionMapCursor(gRegionMap->cursorTileTag, gRegionMap->cursorPaletteTag);
+        sRegionMap->unk_044 = 0;
+        sRegionMap->unk_048 = 0;
+        sRegionMap->scrollX = sRegionMap->unk_060;
+        sRegionMap->scrollY = sRegionMap->unk_062;
+        sRegionMap->unk_04c = (sRegionMap->zoomed == FALSE) ? (128 << 8) : (256 << 8);
+        sRegionMap->zoomed = !sRegionMap->zoomed;
+        sRegionMap->inputCallback = (sRegionMap->zoomed == FALSE) ? ProcessRegionMapInput_Full : ProcessRegionMapInput_Zoomed;
+        CreateRegionMapCursor(sRegionMap->cursorTileTag, sRegionMap->cursorPaletteTag);
         UnhideRegionMapPlayerIcon();
         retVal = FALSE;
     }
     else
     {
-        gRegionMap->unk_03c += gRegionMap->unk_044;
-        gRegionMap->unk_040 += gRegionMap->unk_048;
-        gRegionMap->scrollX = gRegionMap->unk_03c >> 8;
-        gRegionMap->scrollY = gRegionMap->unk_040 >> 8;
-        gRegionMap->unk_04c += gRegionMap->unk_050;
-        if ((gRegionMap->unk_044 < 0 && gRegionMap->scrollX < gRegionMap->unk_060) || (gRegionMap->unk_044 > 0 && gRegionMap->scrollX > gRegionMap->unk_060))
+        sRegionMap->unk_03c += sRegionMap->unk_044;
+        sRegionMap->unk_040 += sRegionMap->unk_048;
+        sRegionMap->scrollX = sRegionMap->unk_03c >> 8;
+        sRegionMap->scrollY = sRegionMap->unk_040 >> 8;
+        sRegionMap->unk_04c += sRegionMap->unk_050;
+        if ((sRegionMap->unk_044 < 0 && sRegionMap->scrollX < sRegionMap->unk_060) || (sRegionMap->unk_044 > 0 && sRegionMap->scrollX > sRegionMap->unk_060))
         {
-            gRegionMap->scrollX = gRegionMap->unk_060;
-            gRegionMap->unk_044 = 0;
+            sRegionMap->scrollX = sRegionMap->unk_060;
+            sRegionMap->unk_044 = 0;
         }
-        if ((gRegionMap->unk_048 < 0 && gRegionMap->scrollY < gRegionMap->unk_062) || (gRegionMap->unk_048 > 0 && gRegionMap->scrollY > gRegionMap->unk_062))
+        if ((sRegionMap->unk_048 < 0 && sRegionMap->scrollY < sRegionMap->unk_062) || (sRegionMap->unk_048 > 0 && sRegionMap->scrollY > sRegionMap->unk_062))
         {
-            gRegionMap->scrollY = gRegionMap->unk_062;
-            gRegionMap->unk_048 = 0;
+            sRegionMap->scrollY = sRegionMap->unk_062;
+            sRegionMap->unk_048 = 0;
         }
-        if (gRegionMap->zoomed == FALSE)
+        if (sRegionMap->zoomed == FALSE)
         {
-            if (gRegionMap->unk_04c < (128 << 8))
+            if (sRegionMap->unk_04c < (128 << 8))
             {
-                gRegionMap->unk_04c = (128 << 8);
-                gRegionMap->unk_050 = 0;
+                sRegionMap->unk_04c = (128 << 8);
+                sRegionMap->unk_050 = 0;
             }
         }
         else
         {
-            if (gRegionMap->unk_04c > (256 << 8))
+            if (sRegionMap->unk_04c > (256 << 8))
             {
-                gRegionMap->unk_04c = (256 << 8);
-                gRegionMap->unk_050 = 0;
+                sRegionMap->unk_04c = (256 << 8);
+                sRegionMap->unk_050 = 0;
             }
         }
         retVal = TRUE;
     }
-    CalcZoomScrollParams(gRegionMap->scrollX, gRegionMap->scrollY, 0x38, 0x48, gRegionMap->unk_04c >> 8, gRegionMap->unk_04c >> 8, 0);
+    CalcZoomScrollParams(sRegionMap->scrollX, sRegionMap->scrollY, 0x38, 0x48, sRegionMap->unk_04c >> 8, sRegionMap->unk_04c >> 8, 0);
     return retVal;
 }
 
@@ -907,42 +907,42 @@ static void CalcZoomScrollParams(s16 scrollX, s16 scrollY, s16 c, s16 d, u16 e, 
     s32 var3;
     s32 var4;
 
-    gRegionMap->bg2pa = e * gSineTable[rotation + 64] >> 8;
-    gRegionMap->bg2pc = e * -gSineTable[rotation] >> 8;
-    gRegionMap->bg2pb = f * gSineTable[rotation] >> 8;
-    gRegionMap->bg2pd = f * gSineTable[rotation + 64] >> 8;
+    sRegionMap->bg2pa = e * gSineTable[rotation + 64] >> 8;
+    sRegionMap->bg2pc = e * -gSineTable[rotation] >> 8;
+    sRegionMap->bg2pb = f * gSineTable[rotation] >> 8;
+    sRegionMap->bg2pd = f * gSineTable[rotation + 64] >> 8;
 
     var1 = (scrollX << 8) + (c << 8);
-    var2 = d * gRegionMap->bg2pb + gRegionMap->bg2pa * c;
-    gRegionMap->bg2x = var1 - var2;
+    var2 = d * sRegionMap->bg2pb + sRegionMap->bg2pa * c;
+    sRegionMap->bg2x = var1 - var2;
 
     var3 = (scrollY << 8) + (d << 8);
-    var4 = gRegionMap->bg2pd * d + gRegionMap->bg2pc * c;
-    gRegionMap->bg2y = var3 - var4;
+    var4 = sRegionMap->bg2pd * d + sRegionMap->bg2pc * c;
+    sRegionMap->bg2y = var3 - var4;
 
-    gRegionMap->needUpdateVideoRegs = TRUE;
+    sRegionMap->needUpdateVideoRegs = TRUE;
 }
 
 static void RegionMap_SetBG2XAndBG2Y(s16 x, s16 y)
 {
-    gRegionMap->bg2x = (x << 8) + 0x1c00;
-    gRegionMap->bg2y = (y << 8) + 0x2400;
-    gRegionMap->needUpdateVideoRegs = TRUE;
+    sRegionMap->bg2x = (x << 8) + 0x1c00;
+    sRegionMap->bg2y = (y << 8) + 0x2400;
+    sRegionMap->needUpdateVideoRegs = TRUE;
 }
 
 void UpdateRegionMapVideoRegs(void)
 {
-    if (gRegionMap->needUpdateVideoRegs)
+    if (sRegionMap->needUpdateVideoRegs)
     {
-        SetGpuReg(REG_OFFSET_BG2PA, gRegionMap->bg2pa);
-        SetGpuReg(REG_OFFSET_BG2PB, gRegionMap->bg2pb);
-        SetGpuReg(REG_OFFSET_BG2PC, gRegionMap->bg2pc);
-        SetGpuReg(REG_OFFSET_BG2PD, gRegionMap->bg2pd);
-        SetGpuReg(REG_OFFSET_BG2X_L, gRegionMap->bg2x);
-        SetGpuReg(REG_OFFSET_BG2X_H, gRegionMap->bg2x >> 16);
-        SetGpuReg(REG_OFFSET_BG2Y_L, gRegionMap->bg2y);
-        SetGpuReg(REG_OFFSET_BG2Y_H, gRegionMap->bg2y >> 16);
-        gRegionMap->needUpdateVideoRegs = FALSE;
+        SetGpuReg(REG_OFFSET_BG2PA, sRegionMap->bg2pa);
+        SetGpuReg(REG_OFFSET_BG2PB, sRegionMap->bg2pb);
+        SetGpuReg(REG_OFFSET_BG2PC, sRegionMap->bg2pc);
+        SetGpuReg(REG_OFFSET_BG2PD, sRegionMap->bg2pd);
+        SetGpuReg(REG_OFFSET_BG2X_L, sRegionMap->bg2x);
+        SetGpuReg(REG_OFFSET_BG2X_H, sRegionMap->bg2x >> 16);
+        SetGpuReg(REG_OFFSET_BG2Y_L, sRegionMap->bg2y);
+        SetGpuReg(REG_OFFSET_BG2Y_H, sRegionMap->bg2y >> 16);
+        sRegionMap->needUpdateVideoRegs = FALSE;
     }
 }
 
@@ -950,10 +950,10 @@ void PokedexAreaScreen_UpdateRegionMapVariablesAndVideoRegs(s16 x, s16 y)
 {
     CalcZoomScrollParams(x, y, 0x38, 0x48, 0x100, 0x100, 0);
     UpdateRegionMapVideoRegs();
-    if (gRegionMap->playerIconSprite != NULL)
+    if (sRegionMap->playerIconSprite != NULL)
     {
-        gRegionMap->playerIconSprite->x2 = -x;
-        gRegionMap->playerIconSprite->y2 = -y;
+        sRegionMap->playerIconSprite->x2 = -x;
+        sRegionMap->playerIconSprite->y2 = -y;
     }
 }
 
@@ -996,22 +996,22 @@ static void InitMapBasedOnPlayerLocation(void)
     case MAP_TYPE_ROUTE:
     case MAP_TYPE_UNDERWATER:
     case MAP_TYPE_OCEAN_ROUTE:
-        gRegionMap->mapSecId = gMapHeader.regionMapSectionId;
-        gRegionMap->playerIsInCave = FALSE;
+        sRegionMap->mapSecId = gMapHeader.regionMapSectionId;
+        sRegionMap->playerIsInCave = FALSE;
         mapWidth = gMapHeader.mapLayout->width;
         mapHeight = gMapHeader.mapLayout->height;
         x = gSaveBlock1Ptr->pos.x;
         y = gSaveBlock1Ptr->pos.y;
-        if (gRegionMap->mapSecId == MAPSEC_UNDERWATER_SEAFLOOR_CAVERN || gRegionMap->mapSecId == MAPSEC_UNDERWATER_MARINE_CAVE)
-            gRegionMap->playerIsInCave = TRUE;
+        if (sRegionMap->mapSecId == MAPSEC_UNDERWATER_SEAFLOOR_CAVERN || sRegionMap->mapSecId == MAPSEC_UNDERWATER_MARINE_CAVE)
+            sRegionMap->playerIsInCave = TRUE;
         break;
     case MAP_TYPE_UNDERGROUND:
     case MAP_TYPE_UNKNOWN:
         if (gMapHeader.allowEscaping)
         {
             mapHeader = Overworld_GetMapHeaderByGroupAndId(gSaveBlock1Ptr->escapeWarp.mapGroup, gSaveBlock1Ptr->escapeWarp.mapNum);
-            gRegionMap->mapSecId = mapHeader->regionMapSectionId;
-            gRegionMap->playerIsInCave = TRUE;
+            sRegionMap->mapSecId = mapHeader->regionMapSectionId;
+            sRegionMap->playerIsInCave = TRUE;
             mapWidth = mapHeader->mapLayout->width;
             mapHeight = mapHeader->mapLayout->height;
             x = gSaveBlock1Ptr->escapeWarp.x;
@@ -1019,8 +1019,8 @@ static void InitMapBasedOnPlayerLocation(void)
         }
         else
         {
-            gRegionMap->mapSecId = gMapHeader.regionMapSectionId;
-            gRegionMap->playerIsInCave = TRUE;
+            sRegionMap->mapSecId = gMapHeader.regionMapSectionId;
+            sRegionMap->playerIsInCave = TRUE;
             mapWidth = 1;
             mapHeight = 1;
             x = 1;
@@ -1029,16 +1029,16 @@ static void InitMapBasedOnPlayerLocation(void)
         break;
     case MAP_TYPE_SECRET_BASE:
         mapHeader = Overworld_GetMapHeaderByGroupAndId((u16)gSaveBlock1Ptr->dynamicWarp.mapGroup, (u16)gSaveBlock1Ptr->dynamicWarp.mapNum);
-        gRegionMap->mapSecId = mapHeader->regionMapSectionId;
-        gRegionMap->playerIsInCave = TRUE;
+        sRegionMap->mapSecId = mapHeader->regionMapSectionId;
+        sRegionMap->playerIsInCave = TRUE;
         mapWidth = mapHeader->mapLayout->width;
         mapHeight = mapHeader->mapLayout->height;
         x = gSaveBlock1Ptr->dynamicWarp.x;
         y = gSaveBlock1Ptr->dynamicWarp.y;
         break;
     case MAP_TYPE_INDOOR:
-        gRegionMap->mapSecId = gMapHeader.regionMapSectionId;
-        if (gRegionMap->mapSecId != MAPSEC_DYNAMIC)
+        sRegionMap->mapSecId = gMapHeader.regionMapSectionId;
+        if (sRegionMap->mapSecId != MAPSEC_DYNAMIC)
         {
             warp = &gSaveBlock1Ptr->escapeWarp;
             mapHeader = Overworld_GetMapHeaderByGroupAndId(warp->mapGroup, warp->mapNum);
@@ -1047,13 +1047,13 @@ static void InitMapBasedOnPlayerLocation(void)
         {
             warp = &gSaveBlock1Ptr->dynamicWarp;
             mapHeader = Overworld_GetMapHeaderByGroupAndId(warp->mapGroup, warp->mapNum);
-            gRegionMap->mapSecId = mapHeader->regionMapSectionId;
+            sRegionMap->mapSecId = mapHeader->regionMapSectionId;
         }
 
-        if (IsPlayerInAquaHideout(gRegionMap->mapSecId))
-            gRegionMap->playerIsInCave = TRUE;
+        if (IsPlayerInAquaHideout(sRegionMap->mapSecId))
+            sRegionMap->playerIsInCave = TRUE;
         else
-            gRegionMap->playerIsInCave = FALSE;
+            sRegionMap->playerIsInCave = FALSE;
 
         mapWidth = mapHeader->mapLayout->width;
         mapHeight = mapHeader->mapLayout->height;
@@ -1064,29 +1064,29 @@ static void InitMapBasedOnPlayerLocation(void)
 
     xOnMap = x;
 
-    dimensionScale = mapWidth / gRegionMapEntries[gRegionMap->mapSecId].width;
+    dimensionScale = mapWidth / gRegionMapEntries[sRegionMap->mapSecId].width;
     if (dimensionScale == 0)
     {
         dimensionScale = 1;
     }
     x /= dimensionScale;
-    if (x >= gRegionMapEntries[gRegionMap->mapSecId].width)
+    if (x >= gRegionMapEntries[sRegionMap->mapSecId].width)
     {
-        x = gRegionMapEntries[gRegionMap->mapSecId].width - 1;
+        x = gRegionMapEntries[sRegionMap->mapSecId].width - 1;
     }
 
-    dimensionScale = mapHeight / gRegionMapEntries[gRegionMap->mapSecId].height;
+    dimensionScale = mapHeight / gRegionMapEntries[sRegionMap->mapSecId].height;
     if (dimensionScale == 0)
     {
         dimensionScale = 1;
     }
     y /= dimensionScale;
-    if (y >= gRegionMapEntries[gRegionMap->mapSecId].height)
+    if (y >= gRegionMapEntries[sRegionMap->mapSecId].height)
     {
-        y = gRegionMapEntries[gRegionMap->mapSecId].height - 1;
+        y = gRegionMapEntries[sRegionMap->mapSecId].height - 1;
     }
 
-    switch (gRegionMap->mapSecId)
+    switch (sRegionMap->mapSecId)
     {
     case MAPSEC_ROUTE_114:
         if (y != 0)
@@ -1116,11 +1116,11 @@ static void InitMapBasedOnPlayerLocation(void)
             x++;
         break;
     case MAPSEC_UNDERWATER_MARINE_CAVE:
-        GetMarineCaveCoords(&gRegionMap->cursorPosX, &gRegionMap->cursorPosY);
+        GetMarineCaveCoords(&sRegionMap->cursorPosX, &sRegionMap->cursorPosY);
         return;
     }
-    gRegionMap->cursorPosX = gRegionMapEntries[gRegionMap->mapSecId].x + x + MAPCURSOR_X_MIN;
-    gRegionMap->cursorPosY = gRegionMapEntries[gRegionMap->mapSecId].y + y + MAPCURSOR_Y_MIN;
+    sRegionMap->cursorPosX = gRegionMapEntries[sRegionMap->mapSecId].x + x + MAPCURSOR_X_MIN;
+    sRegionMap->cursorPosY = gRegionMapEntries[sRegionMap->mapSecId].y + y + MAPCURSOR_Y_MIN;
 }
 
 static void RegionMap_InitializeStateBasedOnSSTidalLocation(void)
@@ -1139,40 +1139,40 @@ static void RegionMap_InitializeStateBasedOnSSTidalLocation(void)
     switch (GetSSTidalLocation(&mapGroup, &mapNum, &xOnMap, &yOnMap))
     {
     case SS_TIDAL_LOCATION_SLATEPORT:
-        gRegionMap->mapSecId = MAPSEC_SLATEPORT_CITY;
+        sRegionMap->mapSecId = MAPSEC_SLATEPORT_CITY;
         break;
     case SS_TIDAL_LOCATION_LILYCOVE:
-        gRegionMap->mapSecId = MAPSEC_LILYCOVE_CITY;
+        sRegionMap->mapSecId = MAPSEC_LILYCOVE_CITY;
         break;
     case SS_TIDAL_LOCATION_ROUTE124:
-        gRegionMap->mapSecId = MAPSEC_ROUTE_124;
+        sRegionMap->mapSecId = MAPSEC_ROUTE_124;
         break;
     case SS_TIDAL_LOCATION_ROUTE131:
-        gRegionMap->mapSecId = MAPSEC_ROUTE_131;
+        sRegionMap->mapSecId = MAPSEC_ROUTE_131;
         break;
     default:
     case SS_TIDAL_LOCATION_CURRENTS:
         mapHeader = Overworld_GetMapHeaderByGroupAndId(mapGroup, mapNum);
 
-        gRegionMap->mapSecId = mapHeader->regionMapSectionId;
-        dimensionScale = mapHeader->mapLayout->width / gRegionMapEntries[gRegionMap->mapSecId].width;
+        sRegionMap->mapSecId = mapHeader->regionMapSectionId;
+        dimensionScale = mapHeader->mapLayout->width / gRegionMapEntries[sRegionMap->mapSecId].width;
         if (dimensionScale == 0)
             dimensionScale = 1;
         x = xOnMap / dimensionScale;
-        if (x >= gRegionMapEntries[gRegionMap->mapSecId].width)
-            x = gRegionMapEntries[gRegionMap->mapSecId].width - 1;
+        if (x >= gRegionMapEntries[sRegionMap->mapSecId].width)
+            x = gRegionMapEntries[sRegionMap->mapSecId].width - 1;
 
-        dimensionScale = mapHeader->mapLayout->height / gRegionMapEntries[gRegionMap->mapSecId].height;
+        dimensionScale = mapHeader->mapLayout->height / gRegionMapEntries[sRegionMap->mapSecId].height;
         if (dimensionScale == 0)
             dimensionScale = 1;
         y = yOnMap / dimensionScale;
-        if (y >= gRegionMapEntries[gRegionMap->mapSecId].height)
-            y = gRegionMapEntries[gRegionMap->mapSecId].height - 1;
+        if (y >= gRegionMapEntries[sRegionMap->mapSecId].height)
+            y = gRegionMapEntries[sRegionMap->mapSecId].height - 1;
         break;
     }
-    gRegionMap->playerIsInCave = FALSE;
-    gRegionMap->cursorPosX = gRegionMapEntries[gRegionMap->mapSecId].x + x + MAPCURSOR_X_MIN;
-    gRegionMap->cursorPosY = gRegionMapEntries[gRegionMap->mapSecId].y + y + MAPCURSOR_Y_MIN;
+    sRegionMap->playerIsInCave = FALSE;
+    sRegionMap->cursorPosX = gRegionMapEntries[sRegionMap->mapSecId].x + x + MAPCURSOR_X_MIN;
+    sRegionMap->cursorPosY = gRegionMapEntries[sRegionMap->mapSecId].y + y + MAPCURSOR_Y_MIN;
 }
 
 static u8 GetMapsecType(u16 mapSecId)
@@ -1300,20 +1300,20 @@ static void GetPositionOfCursorWithinMapSec(void)
     u16 y;
     u16 posWithinMapSec;
 
-    if (gRegionMap->mapSecId == MAPSEC_NONE)
+    if (sRegionMap->mapSecId == MAPSEC_NONE)
     {
-        gRegionMap->posWithinMapSec = 0;
+        sRegionMap->posWithinMapSec = 0;
         return;
     }
-    if (!gRegionMap->zoomed)
+    if (!sRegionMap->zoomed)
     {
-        x = gRegionMap->cursorPosX;
-        y = gRegionMap->cursorPosY;
+        x = sRegionMap->cursorPosX;
+        y = sRegionMap->cursorPosY;
     }
     else
     {
-        x = gRegionMap->zoomedCursorPosX;
-        y = gRegionMap->zoomedCursorPosY;
+        x = sRegionMap->zoomedCursorPosX;
+        y = sRegionMap->zoomedCursorPosY;
     }
     posWithinMapSec = 0;
     while (1)
@@ -1333,13 +1333,13 @@ static void GetPositionOfCursorWithinMapSec(void)
         else
         {
             x--;
-            if (GetMapSecIdAt(x, y) == gRegionMap->mapSecId)
+            if (GetMapSecIdAt(x, y) == sRegionMap->mapSecId)
             {
                 posWithinMapSec++;
             }
         }
     }
-    gRegionMap->posWithinMapSec = posWithinMapSec;
+    sRegionMap->posWithinMapSec = posWithinMapSec;
 }
 
 static bool8 RegionMap_IsMapSecIdInNextRow(u16 y)
@@ -1352,7 +1352,7 @@ static bool8 RegionMap_IsMapSecIdInNextRow(u16 y)
     }
     for (x = MAPCURSOR_X_MIN; x <= MAPCURSOR_X_MAX; x++)
     {
-        if (GetMapSecIdAt(x, y) == gRegionMap->mapSecId)
+        if (GetMapSecIdAt(x, y) == sRegionMap->mapSecId)
         {
             return TRUE;
         }
@@ -1362,11 +1362,11 @@ static bool8 RegionMap_IsMapSecIdInNextRow(u16 y)
 
 static void SpriteCB_CursorMapFull(struct Sprite *sprite)
 {
-    if (gRegionMap->cursorMovementFrameCounter != 0)
+    if (sRegionMap->cursorMovementFrameCounter != 0)
     {
-        sprite->x += 2 * gRegionMap->cursorDeltaX;
-        sprite->y += 2 * gRegionMap->cursorDeltaY;
-        gRegionMap->cursorMovementFrameCounter--;
+        sprite->x += 2 * sRegionMap->cursorDeltaX;
+        sprite->y += 2 * sRegionMap->cursorDeltaY;
+        sRegionMap->cursorMovementFrameCounter--;
     }
 }
 
@@ -1386,20 +1386,20 @@ void CreateRegionMapCursor(u16 tileTag, u16 paletteTag)
     template = sRegionMapCursorSpriteTemplate;
     sheet.tag = tileTag;
     template.tileTag = tileTag;
-    gRegionMap->cursorTileTag = tileTag;
+    sRegionMap->cursorTileTag = tileTag;
     palette.tag = paletteTag;
     template.paletteTag = paletteTag;
-    gRegionMap->cursorPaletteTag = paletteTag;
-    if (!gRegionMap->zoomed)
+    sRegionMap->cursorPaletteTag = paletteTag;
+    if (!sRegionMap->zoomed)
     {
-        sheet.data = gRegionMap->cursorSmallImage;
-        sheet.size = sizeof(gRegionMap->cursorSmallImage);
+        sheet.data = sRegionMap->cursorSmallImage;
+        sheet.size = sizeof(sRegionMap->cursorSmallImage);
         template.callback = SpriteCB_CursorMapFull;
     }
     else
     {
-        sheet.data = gRegionMap->cursorLargeImage;
-        sheet.size = sizeof(gRegionMap->cursorLargeImage);
+        sheet.data = sRegionMap->cursorLargeImage;
+        sheet.size = sizeof(sRegionMap->cursorLargeImage);
         template.callback = SpriteCB_CursorMapZoomed;
     }
     LoadSpriteSheet(&sheet);
@@ -1407,46 +1407,46 @@ void CreateRegionMapCursor(u16 tileTag, u16 paletteTag)
     spriteId = CreateSprite(&template, 0x38, 0x48, 0);
     if (spriteId != MAX_SPRITES)
     {
-        gRegionMap->cursorSprite = &gSprites[spriteId];
-        if (gRegionMap->zoomed == TRUE)
+        sRegionMap->cursorSprite = &gSprites[spriteId];
+        if (sRegionMap->zoomed == TRUE)
         {
-            gRegionMap->cursorSprite->oam.size = SPRITE_SIZE(32x32);
-            gRegionMap->cursorSprite->x -= 8;
-            gRegionMap->cursorSprite->y -= 8;
-            StartSpriteAnim(gRegionMap->cursorSprite, 1);
+            sRegionMap->cursorSprite->oam.size = SPRITE_SIZE(32x32);
+            sRegionMap->cursorSprite->x -= 8;
+            sRegionMap->cursorSprite->y -= 8;
+            StartSpriteAnim(sRegionMap->cursorSprite, 1);
         }
         else
         {
-            gRegionMap->cursorSprite->oam.size = SPRITE_SIZE(16x16);
-            gRegionMap->cursorSprite->x = 8 * gRegionMap->cursorPosX + 4;
-            gRegionMap->cursorSprite->y = 8 * gRegionMap->cursorPosY + 4;
+            sRegionMap->cursorSprite->oam.size = SPRITE_SIZE(16x16);
+            sRegionMap->cursorSprite->x = 8 * sRegionMap->cursorPosX + 4;
+            sRegionMap->cursorSprite->y = 8 * sRegionMap->cursorPosY + 4;
         }
-        gRegionMap->cursorSprite->data[1] = 2;
-        gRegionMap->cursorSprite->data[2] = (IndexOfSpritePaletteTag(paletteTag) << 4) + 0x101;
-        gRegionMap->cursorSprite->data[3] = TRUE;
+        sRegionMap->cursorSprite->data[1] = 2;
+        sRegionMap->cursorSprite->data[2] = (IndexOfSpritePaletteTag(paletteTag) << 4) + 0x101;
+        sRegionMap->cursorSprite->data[3] = TRUE;
     }
 }
 
 static void FreeRegionMapCursorSprite(void)
 {
-    if (gRegionMap->cursorSprite != NULL)
+    if (sRegionMap->cursorSprite != NULL)
     {
-        DestroySprite(gRegionMap->cursorSprite);
-        FreeSpriteTilesByTag(gRegionMap->cursorTileTag);
-        FreeSpritePaletteByTag(gRegionMap->cursorPaletteTag);
+        DestroySprite(sRegionMap->cursorSprite);
+        FreeSpriteTilesByTag(sRegionMap->cursorTileTag);
+        FreeSpritePaletteByTag(sRegionMap->cursorPaletteTag);
     }
 }
 
 // Unused
 static void SetUnkCursorSpriteData(void)
 {
-    gRegionMap->cursorSprite->data[3] = TRUE;
+    sRegionMap->cursorSprite->data[3] = TRUE;
 }
 
 // Unused
 static void ClearUnkCursorSpriteData(void)
 {
-    gRegionMap->cursorSprite->data[3] = FALSE;
+    sRegionMap->cursorSprite->data[3] = FALSE;
 }
 
 void CreateRegionMapPlayerIcon(u16 tileTag, u16 paletteTag)
@@ -1458,7 +1458,7 @@ void CreateRegionMapPlayerIcon(u16 tileTag, u16 paletteTag)
 
     if (IsEventIslandMapSecId(gMapHeader.regionMapSectionId))
     {
-        gRegionMap->playerIconSprite = NULL;
+        sRegionMap->playerIconSprite = NULL;
         return;
     }
     if (gSaveBlock2Ptr->playerGender == FEMALE)
@@ -1469,49 +1469,49 @@ void CreateRegionMapPlayerIcon(u16 tileTag, u16 paletteTag)
     LoadSpriteSheet(&sheet);
     LoadSpritePalette(&palette);
     spriteId = CreateSprite(&template, 0, 0, 1);
-    gRegionMap->playerIconSprite = &gSprites[spriteId];
-    if (!gRegionMap->zoomed)
+    sRegionMap->playerIconSprite = &gSprites[spriteId];
+    if (!sRegionMap->zoomed)
     {
-        gRegionMap->playerIconSprite->x = gRegionMap->playerIconSpritePosX * 8 + 4;
-        gRegionMap->playerIconSprite->y = gRegionMap->playerIconSpritePosY * 8 + 4;
-        gRegionMap->playerIconSprite->callback = SpriteCB_PlayerIconMapFull;
+        sRegionMap->playerIconSprite->x = sRegionMap->playerIconSpritePosX * 8 + 4;
+        sRegionMap->playerIconSprite->y = sRegionMap->playerIconSpritePosY * 8 + 4;
+        sRegionMap->playerIconSprite->callback = SpriteCB_PlayerIconMapFull;
     }
     else
     {
-        gRegionMap->playerIconSprite->x = gRegionMap->playerIconSpritePosX * 16 - 0x30;
-        gRegionMap->playerIconSprite->y = gRegionMap->playerIconSpritePosY * 16 - 0x42;
-        gRegionMap->playerIconSprite->callback = SpriteCB_PlayerIconMapZoomed;
+        sRegionMap->playerIconSprite->x = sRegionMap->playerIconSpritePosX * 16 - 0x30;
+        sRegionMap->playerIconSprite->y = sRegionMap->playerIconSpritePosY * 16 - 0x42;
+        sRegionMap->playerIconSprite->callback = SpriteCB_PlayerIconMapZoomed;
     }
 }
 
 static void HideRegionMapPlayerIcon(void)
 {
-    if (gRegionMap->playerIconSprite != NULL)
+    if (sRegionMap->playerIconSprite != NULL)
     {
-        gRegionMap->playerIconSprite->invisible = TRUE;
-        gRegionMap->playerIconSprite->callback = SpriteCallbackDummy;
+        sRegionMap->playerIconSprite->invisible = TRUE;
+        sRegionMap->playerIconSprite->callback = SpriteCallbackDummy;
     }
 }
 
 static void UnhideRegionMapPlayerIcon(void)
 {
-    if (gRegionMap->playerIconSprite != NULL)
+    if (sRegionMap->playerIconSprite != NULL)
     {
-        if (gRegionMap->zoomed == TRUE)
+        if (sRegionMap->zoomed == TRUE)
         {
-            gRegionMap->playerIconSprite->x = gRegionMap->playerIconSpritePosX * 16 - 0x30;
-            gRegionMap->playerIconSprite->y = gRegionMap->playerIconSpritePosY * 16 - 0x42;
-            gRegionMap->playerIconSprite->callback = SpriteCB_PlayerIconMapZoomed;
-            gRegionMap->playerIconSprite->invisible = FALSE;
+            sRegionMap->playerIconSprite->x = sRegionMap->playerIconSpritePosX * 16 - 0x30;
+            sRegionMap->playerIconSprite->y = sRegionMap->playerIconSpritePosY * 16 - 0x42;
+            sRegionMap->playerIconSprite->callback = SpriteCB_PlayerIconMapZoomed;
+            sRegionMap->playerIconSprite->invisible = FALSE;
         }
         else
         {
-            gRegionMap->playerIconSprite->x = gRegionMap->playerIconSpritePosX * 8 + 4;
-            gRegionMap->playerIconSprite->y = gRegionMap->playerIconSpritePosY * 8 + 4;
-            gRegionMap->playerIconSprite->x2 = 0;
-            gRegionMap->playerIconSprite->y2 = 0;
-            gRegionMap->playerIconSprite->callback = SpriteCB_PlayerIconMapFull;
-            gRegionMap->playerIconSprite->invisible = FALSE;
+            sRegionMap->playerIconSprite->x = sRegionMap->playerIconSpritePosX * 8 + 4;
+            sRegionMap->playerIconSprite->y = sRegionMap->playerIconSpritePosY * 8 + 4;
+            sRegionMap->playerIconSprite->x2 = 0;
+            sRegionMap->playerIconSprite->y2 = 0;
+            sRegionMap->playerIconSprite->callback = SpriteCB_PlayerIconMapFull;
+            sRegionMap->playerIconSprite->invisible = FALSE;
         }
     }
 }
@@ -1523,8 +1523,8 @@ static void UnhideRegionMapPlayerIcon(void)
 
 static void SpriteCB_PlayerIconMapZoomed(struct Sprite *sprite)
 {
-    sprite->x2 = -2 * gRegionMap->scrollX;
-    sprite->y2 = -2 * gRegionMap->scrollY;
+    sprite->x2 = -2 * sRegionMap->scrollX;
+    sprite->y2 = -2 * sRegionMap->scrollY;
     sprite->sY = sprite->y + sprite->y2 + sprite->centerToCornerVecY;
     sprite->sX = sprite->x + sprite->x2 + sprite->centerToCornerVecX;
     if (sprite->sY < -8 || sprite->sY > DISPLAY_HEIGHT + 8 || sprite->sX < -8 || sprite->sX > DISPLAY_WIDTH + 8)
@@ -1545,7 +1545,7 @@ static void SpriteCB_PlayerIconMapFull(struct Sprite *sprite)
 
 static void SpriteCB_PlayerIcon(struct Sprite *sprite)
 {
-    if (gRegionMap->blinkPlayerIcon)
+    if (sRegionMap->blinkPlayerIcon)
     {
         if (++sprite->sTimer > 16)
         {
@@ -1561,8 +1561,8 @@ static void SpriteCB_PlayerIcon(struct Sprite *sprite)
 
 void TrySetPlayerIconBlink(void)
 {
-    if (gRegionMap->playerIsInCave)
-        gRegionMap->blinkPlayerIcon = TRUE;
+    if (sRegionMap->playerIsInCave)
+        sRegionMap->blinkPlayerIcon = TRUE;
 }
 
 #undef sY
@@ -1634,7 +1634,7 @@ static void GetMapSecDimensions(u16 mapSecId, u16 *x, u16 *y, u16 *width, u16 *h
 
 bool8 IsRegionMapZoomed(void)
 {
-    return gRegionMap->zoomed;
+    return sRegionMap->zoomed;
 }
 
 bool32 IsEventIslandMapSecId(u8 mapSecId)

--- a/src/rotating_gate.c
+++ b/src/rotating_gate.c
@@ -612,12 +612,10 @@ static const u8 sRotatingGate_ArmLayout[][4 * 2] =
     },
 };
 
-// ewram
-static EWRAM_DATA u8 gRotatingGate_GateSpriteIds[ROTATING_GATE_PUZZLE_MAX] = {0};
-static EWRAM_DATA const struct RotatingGatePuzzle *gRotatingGate_PuzzleConfig = NULL;
-static EWRAM_DATA u8 gRotatingGate_PuzzleCount = 0;
+static EWRAM_DATA u8 sRotatingGate_GateSpriteIds[ROTATING_GATE_PUZZLE_MAX] = {0};
+static EWRAM_DATA const struct RotatingGatePuzzle *sRotatingGate_PuzzleConfig = NULL;
+static EWRAM_DATA u8 sRotatingGate_PuzzleCount = 0;
 
-// text
 static s32 GetCurrentMapRotatingGatePuzzleType(void)
 {
     if (gSaveBlock1Ptr->location.mapGroup == MAP_GROUP(FORTREE_CITY_GYM) &&
@@ -640,9 +638,9 @@ static void RotatingGate_ResetAllGateOrientations(void)
     s32 i;
     u8 *ptr = (u8 *)GetVarPointer(VAR_TEMP_0);
 
-    for (i = 0; i < gRotatingGate_PuzzleCount; i++)
+    for (i = 0; i < sRotatingGate_PuzzleCount; i++)
     {
-        ptr[i] = gRotatingGate_PuzzleConfig[i].orientation;
+        ptr[i] = sRotatingGate_PuzzleConfig[i].orientation;
     }
 }
 
@@ -683,12 +681,12 @@ static void RotatingGate_LoadPuzzleConfig(void)
     switch (puzzleType)
     {
     case PUZZLE_FORTREE_CITY_GYM:
-        gRotatingGate_PuzzleConfig = sRotatingGate_FortreePuzzleConfig;
-        gRotatingGate_PuzzleCount = ARRAY_COUNT(sRotatingGate_FortreePuzzleConfig);
+        sRotatingGate_PuzzleConfig = sRotatingGate_FortreePuzzleConfig;
+        sRotatingGate_PuzzleCount = ARRAY_COUNT(sRotatingGate_FortreePuzzleConfig);
         break;
     case PUZZLE_ROUTE110_TRICK_HOUSE_PUZZLE6:
-        gRotatingGate_PuzzleConfig = sRotatingGate_TrickHousePuzzleConfig;
-        gRotatingGate_PuzzleCount = ARRAY_COUNT(sRotatingGate_TrickHousePuzzleConfig);
+        sRotatingGate_PuzzleConfig = sRotatingGate_TrickHousePuzzleConfig;
+        sRotatingGate_PuzzleCount = ARRAY_COUNT(sRotatingGate_TrickHousePuzzleConfig);
         break;
     case PUZZLE_NONE:
     default:
@@ -696,7 +694,7 @@ static void RotatingGate_LoadPuzzleConfig(void)
     }
 
     for (i = 0; i < ROTATING_GATE_PUZZLE_MAX - 1; i++)
-        gRotatingGate_GateSpriteIds[i] = MAX_SPRITES;
+        sRotatingGate_GateSpriteIds[i] = MAX_SPRITES;
 }
 
 static void RotatingGate_CreateGatesWithinViewport(s16 deltaX, s16 deltaY)
@@ -710,15 +708,15 @@ static void RotatingGate_CreateGatesWithinViewport(s16 deltaX, s16 deltaY)
     s16 y = gSaveBlock1Ptr->pos.y - 2;
     s16 y2 = gSaveBlock1Ptr->pos.y + MAP_OFFSET_H;
 
-    for (i = 0; i < gRotatingGate_PuzzleCount; i++)
+    for (i = 0; i < sRotatingGate_PuzzleCount; i++)
     {
-        s16 x3 = gRotatingGate_PuzzleConfig[i].x + MAP_OFFSET;
-        s16 y3 = gRotatingGate_PuzzleConfig[i].y + MAP_OFFSET;
+        s16 x3 = sRotatingGate_PuzzleConfig[i].x + MAP_OFFSET;
+        s16 y3 = sRotatingGate_PuzzleConfig[i].y + MAP_OFFSET;
 
         if (y <= y3 && y2 >= y3 && x <= x3 && x2 >= x3 &&
-            gRotatingGate_GateSpriteIds[i] == MAX_SPRITES)
+            sRotatingGate_GateSpriteIds[i] == MAX_SPRITES)
         {
-            gRotatingGate_GateSpriteIds[i] = RotatingGate_CreateGate(i, deltaX, deltaY);
+            sRotatingGate_GateSpriteIds[i] = RotatingGate_CreateGate(i, deltaX, deltaY);
         }
     }
 }
@@ -730,7 +728,7 @@ static u8 RotatingGate_CreateGate(u8 gateId, s16 deltaX, s16 deltaY)
     u8 spriteId;
     s16 x, y;
 
-    const struct RotatingGatePuzzle *gate = &gRotatingGate_PuzzleConfig[gateId];
+    const struct RotatingGatePuzzle *gate = &sRotatingGate_PuzzleConfig[gateId];
 
     if (gate->shape == GATE_SHAPE_L1 || gate->shape == GATE_SHAPE_T1)
         template = sSpriteTemplate_RotatingGateRegular;
@@ -827,20 +825,20 @@ static void RotatingGate_DestroyGatesOutsideViewport(void)
     s16 y = gSaveBlock1Ptr->pos.y - 2;
     s16 y2 = gSaveBlock1Ptr->pos.y + MAP_OFFSET_H;
 
-    for (i = 0; i < gRotatingGate_PuzzleCount; i++)
+    for (i = 0; i < sRotatingGate_PuzzleCount; i++)
     {
-        s16 xGate = gRotatingGate_PuzzleConfig[i].x + MAP_OFFSET;
-        s16 yGate = gRotatingGate_PuzzleConfig[i].y + MAP_OFFSET;
+        s16 xGate = sRotatingGate_PuzzleConfig[i].x + MAP_OFFSET;
+        s16 yGate = sRotatingGate_PuzzleConfig[i].y + MAP_OFFSET;
 
-        if (gRotatingGate_GateSpriteIds[i] == MAX_SPRITES)
+        if (sRotatingGate_GateSpriteIds[i] == MAX_SPRITES)
             continue;
 
         if (xGate < x || xGate > x2 || yGate < y || yGate > y2)
         {
-            struct Sprite *sprite = &gSprites[gRotatingGate_GateSpriteIds[i]];
+            struct Sprite *sprite = &gSprites[sRotatingGate_GateSpriteIds[i]];
             FreeSpriteOamMatrix(sprite);
             DestroySprite(sprite);
-            gRotatingGate_GateSpriteIds[i] = MAX_SPRITES;
+            sRotatingGate_GateSpriteIds[i] = MAX_SPRITES;
         }
     }
 }
@@ -862,9 +860,9 @@ static s32 RotatingGate_CanRotate(u8 gateId, s32 rotationDirection)
 
     orientation = RotatingGate_GetGateOrientation(gateId);
 
-    shape = gRotatingGate_PuzzleConfig[gateId].shape;
-    x = gRotatingGate_PuzzleConfig[gateId].x + MAP_OFFSET;
-    y = gRotatingGate_PuzzleConfig[gateId].y + MAP_OFFSET;
+    shape = sRotatingGate_PuzzleConfig[gateId].shape;
+    x = sRotatingGate_PuzzleConfig[gateId].x + MAP_OFFSET;
+    y = sRotatingGate_PuzzleConfig[gateId].y + MAP_OFFSET;
 
     // Loop through the gate's "arms" clockwise (north, south, east, west)
     for (i = GATE_ARM_NORTH; i <= GATE_ARM_WEST; i++)
@@ -891,15 +889,15 @@ static s32 RotatingGate_HasArm(u8 gateId, u8 armInfo)
     s32 isLongArm = armInfo % 2;
 
     s8 armOrientation = (arm - RotatingGate_GetGateOrientation(gateId) + 4) % 4;
-    s32 shape = gRotatingGate_PuzzleConfig[gateId].shape;
+    s32 shape = sRotatingGate_PuzzleConfig[gateId].shape;
     return sRotatingGate_ArmLayout[shape][armOrientation * 2 + isLongArm];
 }
 
 static void RotatingGate_TriggerRotationAnimation(u8 gateId, s32 rotationDirection)
 {
-    if (gRotatingGate_GateSpriteIds[gateId] != MAX_SPRITES)
+    if (sRotatingGate_GateSpriteIds[gateId] != MAX_SPRITES)
     {
-        struct Sprite *sprite = &gSprites[gRotatingGate_GateSpriteIds[gateId]];
+        struct Sprite *sprite = &gSprites[sRotatingGate_GateSpriteIds[gateId]];
         sprite->data[1] = rotationDirection;
         sprite->data[2] = RotatingGate_GetGateOrientation(gateId);
     }
@@ -957,10 +955,10 @@ bool8 CheckForRotatingGatePuzzleCollision(u8 direction, s16 x, s16 y)
 
     if (!GetCurrentMapRotatingGatePuzzleType())
         return FALSE;
-    for (i = 0; i < gRotatingGate_PuzzleCount; i++)
+    for (i = 0; i < sRotatingGate_PuzzleCount; i++)
     {
-        s16 gateX = gRotatingGate_PuzzleConfig[i].x + MAP_OFFSET;
-        s16 gateY = gRotatingGate_PuzzleConfig[i].y + MAP_OFFSET;
+        s16 gateX = sRotatingGate_PuzzleConfig[i].x + MAP_OFFSET;
+        s16 gateY = sRotatingGate_PuzzleConfig[i].y + MAP_OFFSET;
 
         if (gateX - 2 <= x && x <= gateX + 1 && gateY - 2 <= y && y <= gateY + 1)
         {
@@ -995,10 +993,10 @@ bool8 CheckForRotatingGatePuzzleCollisionWithoutAnimation(u8 direction, s16 x, s
 
     if (!GetCurrentMapRotatingGatePuzzleType())
         return FALSE;
-    for (i = 0; i < gRotatingGate_PuzzleCount; i++)
+    for (i = 0; i < sRotatingGate_PuzzleCount; i++)
     {
-        s16 gateX = gRotatingGate_PuzzleConfig[i].x + MAP_OFFSET;
-        s16 gateY = gRotatingGate_PuzzleConfig[i].y + MAP_OFFSET;
+        s16 gateX = sRotatingGate_PuzzleConfig[i].x + MAP_OFFSET;
+        s16 gateY = sRotatingGate_PuzzleConfig[i].y + MAP_OFFSET;
 
         if (gateX - 2 <= x && x <= gateX + 1 && gateY - 2 <= y && y <= gateY + 1)
         {

--- a/src/script_movement.c
+++ b/src/script_movement.c
@@ -6,7 +6,6 @@
 #include "constants/event_objects.h"
 #include "constants/event_object_movement.h"
 
-// static functions
 static void ScriptMovement_StartMoveObjects(u8 priority);
 static u8 GetMoveObjectsTaskId(void);
 static bool8 ScriptMovement_TryAddNewMovement(u8 taskId, u8 objEventId, const u8 *movementScript);
@@ -17,10 +16,8 @@ static void ScriptMovement_UnfreezeActiveObjects(u8 taskId);
 static void ScriptMovement_MoveObjects(u8 taskId);
 static void ScriptMovement_TakeStep(u8 taskId, u8 moveScrId, u8 objEventId, const u8 *movementScript);
 
-// EWRAM_DATA
-static EWRAM_DATA const u8 *gMovementScripts[OBJECT_EVENTS_COUNT] = {0};
+static EWRAM_DATA const u8 *sMovementScripts[OBJECT_EVENTS_COUNT] = {0};
 
-// text
 bool8 ScriptMovement_StartObjectMovementScript(u8 localId, u8 mapNum, u8 mapGroup, const u8 *movementScript)
 {
     u8 objEventId;
@@ -167,12 +164,12 @@ static bool8 IsMovementScriptFinished(u8 taskId, u8 moveScrId)
 
 static void SetMovementScript(u8 moveScrId, const u8 *movementScript)
 {
-    gMovementScripts[moveScrId] = movementScript;
+    sMovementScripts[moveScrId] = movementScript;
 }
 
 static const u8 *GetMovementScript(u8 moveScrId)
 {
-    return gMovementScripts[moveScrId];
+    return sMovementScripts[moveScrId];
 }
 
 static void ScriptMovement_AddNewMovement(u8 taskId, u8 moveScrId, u8 objEventId, const u8 *movementScript)

--- a/src/tileset_anims.c
+++ b/src/tileset_anims.c
@@ -537,7 +537,7 @@ const u16 *const gTilesetAnims_BattlePyramid_StatueShadow[] = {
     gTilesetAnims_BattlePyramid_StatueShadow_Frame2
 };
 
-static const u16 *const gTilesetAnims_BattleDomeFloorLightPals[] = {
+static const u16 *const sTilesetAnims_BattleDomeFloorLightPals[] = {
     gTilesetAnims_BattleDomePals0_0,
     gTilesetAnims_BattleDomePals0_1,
     gTilesetAnims_BattleDomePals0_2,
@@ -1167,7 +1167,7 @@ static void QueueAnimTiles_BattlePyramid_StatueShadow(u16 timer)
 
 static void BlendAnimPalette_BattleDome_FloorLights(u16 timer)
 {
-    CpuCopy16(gTilesetAnims_BattleDomeFloorLightPals[timer % ARRAY_COUNT(gTilesetAnims_BattleDomeFloorLightPals)], &gPlttBufferUnfaded[0x80], 32);
+    CpuCopy16(sTilesetAnims_BattleDomeFloorLightPals[timer % ARRAY_COUNT(sTilesetAnims_BattleDomeFloorLightPals)], &gPlttBufferUnfaded[0x80], 32);
     BlendPalette(0x80, 16, gPaletteFade.y, gPaletteFade.blendColor & 0x7FFF);
     if ((u8)FindTaskIdByFunc(Task_BattleTransition_Intro) != TASK_NONE)
     {
@@ -1178,7 +1178,7 @@ static void BlendAnimPalette_BattleDome_FloorLights(u16 timer)
 
 static void BlendAnimPalette_BattleDome_FloorLightsNoBlend(u16 timer)
 {
-    CpuCopy16(gTilesetAnims_BattleDomeFloorLightPals[timer % ARRAY_COUNT(gTilesetAnims_BattleDomeFloorLightPals)], &gPlttBufferUnfaded[0x80], 32);
+    CpuCopy16(sTilesetAnims_BattleDomeFloorLightPals[timer % ARRAY_COUNT(sTilesetAnims_BattleDomeFloorLightPals)], &gPlttBufferUnfaded[0x80], 32);
     if ((u8)FindTaskIdByFunc(Task_BattleTransition_Intro) == TASK_NONE)
     {
         BlendPalette(0x80, 16, gPaletteFade.y, gPaletteFade.blendColor & 0x7FFF);

--- a/src/trade.c
+++ b/src/trade.c
@@ -2195,7 +2195,7 @@ static bool8 LoadTradeMenuSpriteSheetsAndPalettes(void)
         sTradeMenuData->timer++;
         break;
     case GFXTAG_MENU_TEXT_COUNT:
-        LoadSpritePalette(&gSpritePalette_TradeScreenText);
+        LoadSpritePalette(&sSpritePalette_TradeScreenText);
         sTradeMenuData->timer++;
         break;
     case GFXTAG_MENU_TEXT_COUNT + 1:

--- a/src/tv.c
+++ b/src/tv.c
@@ -723,7 +723,7 @@ static const u8 *const sTVInSearchOfTrainersTextGroup[] = {
 
 // Secret Base Secrets TV Show states for actions that can be taken in a secret base
 // The flags that determine whether or not the action was taken are commented
-const u8 sTVSecretBaseSecretsActions[NUM_SECRET_BASE_FLAGS] =
+static const u8 sTVSecretBaseSecretsActions[NUM_SECRET_BASE_FLAGS] =
 {
     SBSECRETS_STATE_USED_CHAIR,             // SECRET_BASE_USED_CHAIR
     SBSECRETS_STATE_USED_BALLOON,           // SECRET_BASE_USED_BALLOON


### PR DESCRIPTION
Fixes names where the prefix disagrees with the scope, i.e. static symbols with the prefix `g` and non-static symbols with the prefix `s`.

There are certainly plenty more symbols that could be made static, but as long as the name is consistent this PR won't change them.