### PR TITLE
Include config.h in siirtc.c

### DIFF
--- a/src/siirtc.c
+++ b/src/siirtc.c
@@ -4,6 +4,7 @@
 
 #include "gba/gba.h"
 #include "siirtc.h"
+#include "config.h"
 
 #define STATUS_INTFE  0x02 // frequency interrupt enable
 #define STATUS_INTME  0x08 // per-minute interrupt enable


### PR DESCRIPTION
The bugfix [here](https://github.com/pret/pokeemerald/blob/master/src/siirtc.c#L102) does not apply because the definition of BUGFIX is not included.

Duke#5614