### PR TITLE
Untangled CheckPartnersMonForRibbons

### DIFF
--- a/src/trade.c
+++ b/src/trade.c
@@ -4813,7 +4813,7 @@ static void CheckPartnersMonForRibbons(void)
 {
     u8 i;
     u8 numRibbons = 0;
-    for (i = 0; i < 12; i ++)
+    for (i = 0; i < (MON_DATA_UNUSED_RIBBONS - MON_DATA_CHAMPION_RIBBON); i ++)
     {
         numRibbons += GetMonData(&gEnemyParty[gSelectedTradeMonPositions[TRADE_PARTNER] % PARTY_SIZE], MON_DATA_CHAMPION_RIBBON + i);
     }


### PR DESCRIPTION
## Description
`CheckPartnersMonForRibbons` has a hardcoded check for ribbons instead of using their constant labels for readability.
This hardcoded number can be troublesome for users that may remove certain ribbons from the code and then find out down the road that their trades InGame got stuck nearing the end of the process.
... One of those users may have been me ![pleasedMasudaEmoji](https://user-images.githubusercontent.com/4485172/172914600-2376a3c5-efef-49f1-a852-6469ae86618b.jpg)

MGriffin is the one who found out about this and suggested me to submit a PR so other people wouldn't need to go through the same thing in the future which sounds like a good idea, so here I am :eyes:

## **Discord contact info**
Lunos#4026