### PR TITLE
Add Docker build script

### DIFF
--- a/pret_gba_build.sh
+++ b/pret_gba_build.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+SCRIPT="$(basename $0)"
+SUMMARY="$SCRIPT: A script to build GBA roms from pret projects using Docker."
+USAGE="usage: $SCRIPT [project path]"
+DESCRIPTION=$(cat <<EOF
+To use this tool, ensure that Docker is installed and configured on your machine. See https://docs.docker.com/get-docker for details.
+
+Either run this script from the root directory of a pret GBA decompilation repository, or pass in the path to the target repository as a parameter. The build outputs will be located in the root of that directory.
+
+Examples:
+
+  $ cd pokeemerald && $SCRIPT
+
+  $ $SCRIPT /path/to/pokefirered
+EOF
+)
+
+
+if [[ $# -ge 2 ]]; then
+  fmt >&2 << EOF
+Error: Too many arguments!
+
+$USAGE
+EOF
+  exit 2
+fi
+
+if [[ $# -eq 1 ]] && [[ $1 =~ ^(--help|-h)$ ]]; then
+  fmt << EOF
+$SUMMARY
+
+$USAGE
+
+$DESCRIPTION
+EOF
+  exit 0
+fi
+
+SOURCE_DIR=$(realpath ${1:-$PWD})
+PROJECT_DIR="/project"
+AGBCC_DIR="/agbcc"
+
+docker build -t pret-builder \
+             - << EOF
+FROM ubuntu:20.04
+
+RUN apt-get update && apt-get install -y \
+    binutils-arm-none-eabi \
+    build-essential \
+    git \
+    libpng-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/pret/agbcc $AGBCC_DIR \
+  && cd $AGBCC_DIR \
+  && ./build.sh
+EOF
+
+
+docker run --rm \
+           --mount type=bind,source=$SOURCE_DIR,destination=$PROJECT_DIR \
+           pret-builder \
+           bash -c " \
+              cd $AGBCC_DIR \
+              && ./install.sh $PROJECT_DIR \
+              && cd $PROJECT_DIR \
+              && make -j \
+           "


### PR DESCRIPTION
See https://github.com/pret/pokefirered/pull/504 and https://github.com/pret/pokeruby/pull/843
Script originally by @rpadaki

## Description

There was a lot of overhead and package installations for macOS/Windows, but I saw that it was much simpler to build these roms on Ubuntu. So I ended up writing a Dockerfile for myself to build https://github.com/pret/pokefirered, https://github.com/pret/pokeemerald, and the like!

This PR adds a script (with the Dockerfile baked in) which can cleanly build GBA pret projects.

To use the script, you can run in this directory:

```shell
./pret_gba_build.sh
```

To test it, say, on `pokeemerald`, you can either copy it over, or you can run:

```shell
./pret_gba_build.sh /path/to/pokeemerald
```

For more information, just run:

```shell
./pret_gba_build.sh --help
```

If we want to merge this script, it would have to be replicated for each GBA project. If that's too much overhead, then maybe I can just keep the script as a Gist or another repo and it can be linked to in `INSTALL.md`? Let me know your thoughts!
## Issues

The main downside of building with Docker, especially on macOS and Windows without WSL2, are that things will be slow.

Other than that, there's some repeated steps here -- for example, for safety, I re-install `agbcc` into the project directory each time. Perhaps I should just check whether it's installed and up-to-date?
 
Lastly, building could be a little nicer.

- There's currently no build output at all if the build is already up-to-date, meaning that it sort of hangs there silently before exiting successfully.

- Commands like `make clean` can't be run from the container; they need to be run directly in your shell.


Maybe this shouldn't be merged, but still wanted to put it out there in case people find it useful.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a Docker build script
## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
chloerawr(female symbol)#5011