### PR TITLE
Format newlines in pc_transfer.inc

### DIFF
--- a/data/text/pc_transfer.inc
+++ b/data/text/pc_transfer.inc
@@ -5,7 +5,8 @@ gText_PkmnTransferredSomeonesPC::
 	.string "BOX “{STR_VAR_1}.”$"
 
 gText_PkmnTransferredLanettesPC::
-	.string "{STR_VAR_2} was transferred to\nLANETTE'S PC.\p"
+	.string "{STR_VAR_2} was transferred to\n"
+	.string "LANETTE'S PC.\p"
 	.string "It was placed in \n"
 	.string "BOX “{STR_VAR_1}.”$"
 


### PR DESCRIPTION
Some of the strings declared in contest_string.inc were poorly formatted.

## Description
One of the strings declared in pc_transfer.inc contained newline characters in the middle of the .string line, opposing the format used by every string in the `data/text` directory, I just updated them to match the format, making it more readable.

## Discord contact info
The Kraken 🐙#9478