### PR TITLE
Format newlines in surf.inc

### DIFF
--- a/data/text/surf.inc
+++ b/data/text/surf.inc
@@ -1,5 +1,6 @@
 gText_WantToUseSurf::
-	.string "The water is dyed a deep blue…\nWould you like to SURF?$"
+	.string "The water is dyed a deep blue…\n"
+	.string "Would you like to SURF?$"
 
 gText_PlayerUsedSurf::
 	.string "{STR_VAR_1} used SURF!$"


### PR DESCRIPTION
One of the strings declared in surf.inc was poorly formatted.

## Description
Some of the strings declared in surf.inc contained newline characters in the middle of the .string line, opposing the format used by every string in the `data/text` directory, I just updated them to match the format, making it more readable.

## **Discord contact info**
The Kraken 🐙#9478