### PR TITLE
Remove UBFIX related to task destruction

### DIFF
--- a/src/battle_anim_sound_tasks.c
+++ b/src/battle_anim_sound_tasks.c
@@ -135,10 +135,12 @@ void SoundTask_PlayCryHighPitch(u8 taskId)
     {
         if (gBattleAnimArgs[0] == ANIM_ATTACKER)
             species = gContestResources->moveAnim->species;
-        #ifndef UBFIX
+    // Destroying the task twice (here and at end of function)
+    // results in an incorrect value for gAnimVisualTaskCount
+    #ifndef BUGFIX
         else
-            DestroyAnimVisualTask(taskId); // UB: task gets destroyed twice.
-        #endif
+            DestroyAnimVisualTask(taskId);
+    #endif
     }
     else
     {
@@ -181,10 +183,12 @@ void SoundTask_PlayDoubleCry(u8 taskId)
     {
         if (gBattleAnimArgs[0] == ANIM_ATTACKER)
             species = gContestResources->moveAnim->species;
-        #ifndef UBFIX
+    // Destroying the task twice (here and at end of function)
+    // results in an incorrect value for gAnimVisualTaskCount
+    #ifndef BUGFIX
         else
-            DestroyAnimVisualTask(taskId); // UB: task gets destroyed twice.
-        #endif
+            DestroyAnimVisualTask(taskId);
+    #endif
     }
     else
     {

--- a/src/battle_factory_screen.c
+++ b/src/battle_factory_screen.c
@@ -4220,17 +4220,12 @@ static void Task_OpenMonPic(u8 taskId)
             return;
         break;
     default:
-        #ifndef UBFIX
         DestroyTask(taskId);
-        #endif
-        // UB: Should not use the task after it has been deleted.
+        // Accessing data of destroyed task. Task data isn't reset until a new task needs that task id.
         if (gTasks[taskId].tIsSwapScreen == TRUE)
             Swap_CreateMonSprite();
         else
             Select_CreateMonSprite();
-        #ifdef UBFIX
-        DestroyTask(taskId);
-        #endif
         return;
     }
     task->tState++;

--- a/src/battle_transition.c
+++ b/src/battle_transition.c
@@ -4762,10 +4762,8 @@ static bool8 FrontierSquaresScroll_End(struct Task *task)
     BlendPalettes(PALETTES_ALL, 16, RGB_BLACK);
 
     DestroyTask(FindTaskIdByFunc(task->func));
+    task->tState++; // Changing value of a destroyed task
 
-#ifndef UBFIX
-    task->tState++; // UB: changing value of a destroyed task
-#endif
     return FALSE;
 }
 


### PR DESCRIPTION
These UBFIXs are based on misunderstandings of how tasks work. The following are not UB:
- Destroying a task that has already been destroyed. Destroyed tasks are marked inactive, and inactive tasks are ignored by `DestroyTask`.
- Reading/writing task data of a destroyed task. The memory for this data is not freed, and it will still contain the same data until a new task is created in that slot.