### PR TITLE
Format newline in BattleFrontier_BattlePikeLobby/scripts.inc

### DIFF
--- a/data/maps/BattleFrontier_BattlePikeLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeLobby/scripts.inc
@@ -364,7 +364,8 @@ BattleFrontier_BattlePikeLobby_Text_AwardYouTheseBattlePoints2:
 @ Unused
 BattleFrontier_BattlePikeLobby_Text_ReachedBattlePointLimit:
 	.string "You appear to have reached the limit\n"
-	.string "for Battle Points…\pPlease exchange some Battle Points\n"
+	.string "for Battle Points…\p"
+	.string "Please exchange some Battle Points\n"
 	.string "for prizes, then return…$"
 
 BattleFrontier_BattlePikeLobby_Text_FailedToSaveBeforeQuitting:


### PR DESCRIPTION
One of the strings declared in BattleFrontier_BattlePikeLobby/scripts.inc was poorly formatted.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some of the strings declared in BattleFrontier_BattlePikeLobby/scripts.inc contained newline characters in the middle of the .string line, opposing the format used by every string in the `data/text` directory, I just updated them to match the format, making it more readable.
## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
chloerawr(female symbol)#5011