### PR TITLE
Fix missing COPYWIN_FULL constant use

### DIFF
--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -2270,7 +2270,7 @@ static void NewGameBirchSpeech_ShowDialogueWindow(u8 windowId, u8 copyToVram)
     FillWindowPixelBuffer(windowId, PIXEL_FILL(1));
     PutWindowTilemap(windowId);
     if (copyToVram == TRUE)
-        CopyWindowToVram(windowId, 3);
+        CopyWindowToVram(windowId, COPYWIN_FULL);
 }
 
 static void NewGameBirchSpeech_CreateDialogueWindowBorder(u8 bg, u8 x, u8 y, u8 width, u8 height, u8 palNum)


### PR DESCRIPTION
Fix a missing `COPYWIN_FULL` constant use in `src/main_menu.c`'s `NewGameBirchSpeech_ShowDialogueWindow` function.

## **Discord contact info**
Spherical Ice#4683