### PR TITLE
Use Floats and Round Correctly in Tempo Calculation

### DIFF
--- a/tools/mid2agb/agb.cpp
+++ b/tools/mid2agb/agb.cpp
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include <cmath>
 #include <cstdio>
 #include <cstdarg>
 #include <cstring>
@@ -503,7 +504,7 @@ void PrintAgbTrack(std::vector<Event>& events)
             ResetTrackVars();
             break;
         case EventType::Tempo:
-            PrintByte("TEMPO , %u*%s_tbs/2", 60000000 / event.param2, g_asmLabel.c_str());
+            PrintByte("TEMPO , %u*%s_tbs/2", static_cast<int>(round(60000000.0f / static_cast<float>(event.param2))), g_asmLabel.c_str());
             PrintWait(event.time);
             break;
         case EventType::InstrumentChange:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, tempo calculation uses only integer types, so any fractional value is truncated. This means that a tempo of 119.99999 in a midi file will end up outputting a BPM of 119 in the final .s file even though the value is much closer to 120 (which was almost certainly what was intended by the user). This PR makes the calculation use floats to properly round to the nearest integer instead.

## **Discord contact info**
Kurausukun#9923