### PR TITLE
Port pokefirered `LoadObjectEventPalette` bugfix to pokeemerald

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1980,7 +1980,11 @@ static void LoadObjectEventPalette(u16 paletteTag)
 {
     u16 i = FindObjectEventPaletteIndexByTag(paletteTag);
 
+#ifdef BUGFIX
+    if (sObjectEventSpritePalettes[i].tag != OBJ_EVENT_PAL_TAG_NONE)
+#else
     if (i != OBJ_EVENT_PAL_TAG_NONE) // always true
+#endif
         LoadSpritePaletteIfTagExists(&sObjectEventSpritePalettes[i]);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As noted by ShinyDragonHunter in Discord chat
(relevant chat link: https://discord.com/channels/442462691542695948/442465020291317760/991968342921449565),
the bugfix for `LoadObjectEventPalette` in `pokefirered` was not ported to `pokeemerald` for whatever reason (see https://github.com/pret/pokefirered/blob/master/src/event_object_movement.c#L2153).
This small PR fixes this issue in `pokeemerald` as well and syncs the bugfix across the two repos.
## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
chloerawr(female symbol)#5011