### PR TITLE
Add some missing pocket constant usage

### DIFF
--- a/src/item_menu_icons.c
+++ b/src/item_menu_icons.c
@@ -93,12 +93,12 @@ static const union AnimCmd sSpriteAnim_Bag_Berries[] =
 
 static const union AnimCmd *const sBagSpriteAnimTable[] =
 {
-    sSpriteAnim_Bag_Closed,
-    sSpriteAnim_Bag_Items,
-    sSpriteAnim_Bag_Pokeballs,
-    sSpriteAnim_Bag_TMsHMs,
-    sSpriteAnim_Bag_Berries,
-    sSpriteAnim_Bag_KeyItems
+    [POCKET_NONE]       = sSpriteAnim_Bag_Closed,
+    [POCKET_ITEMS]      = sSpriteAnim_Bag_Items,
+    [POCKET_POKE_BALLS] = sSpriteAnim_Bag_Pokeballs,
+    [POCKET_TM_HM]      = sSpriteAnim_Bag_TMsHMs,
+    [POCKET_BERRIES]    = sSpriteAnim_Bag_Berries,
+    [POCKET_KEY_ITEMS]  = sSpriteAnim_Bag_KeyItems,
 };
 
 static const union AffineAnimCmd sSpriteAffineAnim_BagNormal[] =
@@ -116,10 +116,15 @@ static const union AffineAnimCmd sSpriteAffineAnim_BagShake[] =
     AFFINEANIMCMD_END
 };
 
+enum {
+    ANIM_BAG_NORMAL,
+    ANIM_BAG_SHAKE,
+};
+
 static const union AffineAnimCmd *const sBagAffineAnimCmds[] =
 {
-    sSpriteAffineAnim_BagNormal,
-    sSpriteAffineAnim_BagShake
+    [ANIM_BAG_NORMAL] = sSpriteAffineAnim_BagNormal,
+    [ANIM_BAG_SHAKE]  = sSpriteAffineAnim_BagShake
 };
 
 const struct CompressedSpriteSheet gBagMaleSpriteSheet =
@@ -436,6 +441,8 @@ void AddBagVisualSprite(u8 bagPocketId)
     SetBagVisualPocketId(bagPocketId, FALSE);
 }
 
+#define sPocketId data[0]
+
 void SetBagVisualPocketId(u8 bagPocketId, bool8 isSwitchingPockets)
 {
     struct Sprite *sprite = &gSprites[gBagMenu->spriteIds[ITEMMENUSPRITE_BAG]];
@@ -443,8 +450,8 @@ void SetBagVisualPocketId(u8 bagPocketId, bool8 isSwitchingPockets)
     {
         sprite->y2 = -5;
         sprite->callback = SpriteCB_BagVisualSwitchingPockets;
-        sprite->data[0] = bagPocketId + 1;
-        StartSpriteAnim(sprite, 0);
+        sprite->sPocketId = bagPocketId + 1;
+        StartSpriteAnim(sprite, POCKET_NONE);
     }
     else
     {
@@ -460,26 +467,29 @@ static void SpriteCB_BagVisualSwitchingPockets(struct Sprite *sprite)
     }
     else
     {
-        StartSpriteAnim(sprite, sprite->data[0]);
+        StartSpriteAnim(sprite, sprite->sPocketId);
         sprite->callback = SpriteCallbackDummy;
     }
 }
+
+#undef sPocketId
 
 void ShakeBagSprite(void)
 {
     struct Sprite *sprite = &gSprites[gBagMenu->spriteIds[ITEMMENUSPRITE_BAG]];
     if (sprite->affineAnimEnded)
     {
-        StartSpriteAffineAnim(sprite, 1);
+        StartSpriteAffineAnim(sprite, ANIM_BAG_SHAKE);
         sprite->callback = SpriteCB_ShakeBagSprite;
     }
 }
 
 static void SpriteCB_ShakeBagSprite(struct Sprite *sprite)
 {
+    // Wait for shaking to end
     if (sprite->affineAnimEnded)
     {
-        StartSpriteAffineAnim(sprite, 0);
+        StartSpriteAffineAnim(sprite, ANIM_BAG_NORMAL);
         sprite->callback = SpriteCallbackDummy;
     }
 }


### PR DESCRIPTION
*Technically* these are usage of `*_POCKET + 1`, but the whole "unnecessarily having two sets of pocket constants" is it's own thing. 