### PR TITLE
Change GAME_LANGUAGE to LANGUAGE_ENGLISH

### DIFF
--- a/src/international_string_util.c
+++ b/src/international_string_util.c
@@ -206,7 +206,7 @@ void TVShowConvertInternationalString(u8 *dest, const u8 *src, int language)
     ConvertInternationalString(dest, language);
 }
 
-// It's impossible to distinguish between Latin languages just from a string alone, so the function defaults to LANGUAGE_ENGLISH. This is the case in all of the versions  the game.
+// It's impossible to distinguish between Latin languages just from a string alone, so the function defaults to LANGUAGE_ENGLISH. This is the case in all of the versions of the game.
 int GetNicknameLanguage(u8 *str)
 {
     if (str[0] == EXT_CTRL_CODE_BEGIN && str[1] == EXT_CTRL_CODE_JPN)

--- a/src/international_string_util.c
+++ b/src/international_string_util.c
@@ -206,6 +206,7 @@ void TVShowConvertInternationalString(u8 *dest, const u8 *src, int language)
     ConvertInternationalString(dest, language);
 }
 
+// It's impossible to distinguish between Latin languages just from a string alone, so the function defaults to LANGUAGE_ENGLISH. This is the case in all of the versions  the game.
 int GetNicknameLanguage(u8 *str)
 {
     if (str[0] == EXT_CTRL_CODE_BEGIN && str[1] == EXT_CTRL_CODE_JPN)

--- a/src/international_string_util.c
+++ b/src/international_string_util.c
@@ -211,7 +211,7 @@ int GetNicknameLanguage(u8 *str)
     if (str[0] == EXT_CTRL_CODE_BEGIN && str[1] == EXT_CTRL_CODE_JPN)
         return LANGUAGE_JAPANESE;
     else
-        return GAME_LANGUAGE;
+        return LANGUAGE_ENGLISH;
 }
 
 // Used by Pokénav's Match Call to erase the previous trainer's flavor text when switching between their info pages.


### PR DESCRIPTION
I checked this function in all of the other languages and it actually always returns LANGUAGE_ENGLISH. 
My best assumption is this function was used more of a distinction between japanese and others(possibly to get which font to use, latin or japanese)