### PR TITLE
Remove duplicated CB2_InitCopyrightScreenAfterBootup

### DIFF
--- a/include/intro.h
+++ b/include/intro.h
@@ -7,7 +7,6 @@
 
 // Exported ROM declarations
 void CB2_InitCopyrightScreenAfterBootup(void);
-void CB2_InitCopyrightScreenAfterBootup(void);
 void CB2_InitCopyrightScreenAfterTitleScreen(void);
 void PanFadeAndZoomScreen(u16, u16, u16, u16);
 


### PR DESCRIPTION
I was told that this would match and this was a typo.

## **Discord contact info**
JaizuFangaming#2172