### PR TITLE
Added BUGFIX for pokenav option glow on return from condition graph

### DIFF
--- a/src/pokenav_menu_handler_gfx.c
+++ b/src/pokenav_menu_handler_gfx.c
@@ -397,6 +397,12 @@ bool32 OpenPokenavMenuNotInitial(void)
         return FALSE;
 
     gfx->pokenavAlreadyOpen = TRUE;
+    #ifdef BUGFIX
+    // BUG: When returning from the condition graph to the menu, on some platforms the option glow may cut off
+    // midway through the screen. The condition graph changes REG_WIN0V, so we reset the window height when returning
+    // to fix this.
+    SetGpuReg(REG_OFFSET_WIN0V, WIN_RANGE(0, DISPLAY_HEIGHT));
+    #endif
     return TRUE;
 }
 


### PR DESCRIPTION
## Description
This is a bugfix for the graphical glitch that occurs with the option menu glow when returning from the PokéNav's Condition graph. This seems to occur on some emulators and possibly real hardware?

Vanilla:
![Vanilla PokeNav menu](https://i.imgur.com/w0WISDg.png)

Fixed:
![Fixed menu](https://i.imgur.com/YkgLmOT.png)