### PR TITLE
Fix BUGFIX return statement in battle_dome.c

### DIFF
--- a/src/battle_dome.c
+++ b/src/battle_dome.c
@@ -2763,7 +2763,7 @@ static int GetTypeEffectivenessPoints(int move, int targetSpecies, int mode)
         {
             typePower = 8;
         #ifdef BUGFIX
-            return;
+            return typePower;
         #endif
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update `GetTypeEffectivenessPoints` to return `typePower` in the `BUGFIX` section. This removes a warning when compiling with modern and `BUGFIX` enabled.

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
WhenGryphonsFly#2089