### PR TITLE
Wildcards in ld_script.txt

### DIFF
--- a/ld_script.txt
+++ b/ld_script.txt
@@ -20,6 +20,9 @@ SECTIONS {
         . = 0x1C000;
 
         INCLUDE "sym_ewram.ld"
+        src/*.o(.ewram_data);
+        gflib/*.o(.ewram_data);
+
         *libc.a:impure.o(.data);
         *libc.a:locale.o(.data);
         *libc.a:mallocr.o(.data);
@@ -33,12 +36,18 @@ SECTIONS {
     {
         /* .bss starts at 0x3000000 */
         INCLUDE "sym_bss.ld"
+        src/*.o(.bss);
+        gflib/*.o(.bss);
+        data/*.o(.bss);
 
         /* .bss.code starts at 0x3001AA8 */
         src/m4a.o(.bss.code);
 
         /* COMMON starts at 0x30022A8 */
         INCLUDE "sym_common.ld"
+        src/*.o(COMMON);
+        gflib/*.o(COMMON);
+
         *libc.a:sbrkr.o(COMMON);
         end = .;
         . = 0x8000;
@@ -1308,6 +1317,16 @@ SECTIONS {
     {
         src/graphics.o(.rodata);
     } =0
+
+    extra :
+    ALIGN(4)
+    {
+        src/*.o(.text);
+        gflib/*.o(.text);
+        src/*.o(.rodata);
+        gflib/*.o(.rodata);
+        data/*.o(.rodata);
+    } = 0
 
     /* DWARF debug sections.
        Symbols in the DWARF debugging sections are relative to the beginning


### PR DESCRIPTION
We frequently have people asking why their new source file doesn't work, or why they can't declare variables in existing source files. So this change stuffs all new `.text` and `.rodata` at the end of the ROM (in a `non_vanilla` section, feel free to change to a better name); and puts `.bss` and `COMMON` in iwram.

This still matches because currently nothing (with any size) gets put in that section:
```
non_vanilla     0x0000000008e3cf64        0x0
 src/*.o(.text)
 .text          0x0000000008e3cf64        0x0 src/rom_header_gf.o
 .text          0x0000000008e3cf64        0x0 src/mystery_gift_scripts.o
 .text          0x0000000008e3cf64        0x0 src/data.o
 .text          0x0000000008e3cf64        0x0 src/strings.o
 .text          0x0000000008e3cf64        0x0 src/text_input_strings.o
 .text          0x0000000008e3cf64        0x0 src/fonts.o
 .text          0x0000000008e3cf64        0x0 src/mystery_event_msg.o
 .text          0x0000000008e3cf64        0x0 src/m4a_tables.o
 .text          0x0000000008e3cf64        0x0 src/agb_flash_le.o
 .text          0x0000000008e3cf64        0x0 src/anim_mon_front_pics.o
 .text          0x0000000008e3cf64        0x0 src/graphics.o
 gflib/*.o(.text)
 .text          0x0000000008e3cf64        0x0 gflib/io_reg.o
 src/*.o(.rodata)
 gflib/*.o(.rodata)
 data/*.o(.rodata)
```