### PR TITLE
Standardize the UI code

### DIFF
--- a/gflib/sprite.c
+++ b/gflib/sprite.c
@@ -1615,7 +1615,7 @@ void LoadSpritePalettes(const struct SpritePalette *palettes)
 
 void DoLoadSpritePalette(const u16 *src, u16 paletteOffset)
 {
-    LoadPalette(src, paletteOffset + 0x100, 32);
+    LoadPalette(src, OBJ_PLTT_OFFSET + paletteOffset, PLTT_SIZE_4BPP);
 }
 
 u8 AllocSpritePalette(u16 tag)

--- a/include/gba/defines.h
+++ b/include/gba/defines.h
@@ -67,6 +67,12 @@
 #define DISPLAY_WIDTH  240
 #define DISPLAY_HEIGHT 160
 
+#define PLTT_SIZEOF(n) ((n) * sizeof(u16))
+#define PLTT_SIZE_4BPP PLTT_SIZEOF(16)
+#define PLTT_SIZE_8BPP PLTT_SIZEOF(256)
+
+#define PLTT_OFFSET_4BPP(n) ((n) * PLTT_SIZE_4BPP)
+
 #define TILE_SIZE_4BPP 32
 #define TILE_SIZE_8BPP 64
 

--- a/include/palette.h
+++ b/include/palette.h
@@ -18,6 +18,13 @@
 #define PALETTES_OBJECTS 0xFFFF0000
 #define PALETTES_ALL     (PALETTES_BG | PALETTES_OBJECTS)
 
+#define PLTT_ID(n) ((n) * 16)
+#define BG_PLTT_OFFSET 0x000
+#define OBJ_PLTT_OFFSET 0x100
+#define BG_PLTT_ID(n) (BG_PLTT_OFFSET + PLTT_ID(n))
+#define OBJ_PLTT_ID(n) (OBJ_PLTT_OFFSET + PLTT_ID(n))
+#define OBJ_PLTT_ID2(n) (PLTT_ID((n) + 16))
+
 enum
 {
     FAST_FADE_IN_FROM_WHITE,
@@ -73,5 +80,15 @@ void TintPalette_GrayScale(u16 *palette, u16 count);
 void TintPalette_GrayScale2(u16 *palette, u16 count);
 void TintPalette_SepiaTone(u16 *palette, u16 count);
 void TintPalette_CustomTone(u16 *palette, u16 count, u16 rTone, u16 gTone, u16 bTone);
+
+extern inline void SetBackdropFromColor(u16 color)
+{
+  FillPalette(color, 0x00, PLTT_SIZEOF(1));
+}
+
+extern inline void SetBackdropFromPalette(const u16 *palette)
+{
+  LoadPalette(palette, 0x00, PLTT_SIZEOF(1));
+}
 
 #endif // GUARD_PALETTE_H

--- a/src/battle_anim.c
+++ b/src/battle_anim.c
@@ -706,8 +706,8 @@ void MoveBattlerSpriteToBG(u8 battlerId, bool8 toBG_2, bool8 setSpriteInvisible)
         SetGpuReg(REG_OFFSET_BG1HOFS, gBattle_BG1_X);
         SetGpuReg(REG_OFFSET_BG1VOFS, gBattle_BG1_Y);
 
-        LoadPalette(&gPlttBufferUnfaded[0x100 + battlerId * 16], animBg.paletteId * 16, 0x20);
-        CpuCopy32(&gPlttBufferUnfaded[0x100 + battlerId * 16], (void *)(BG_PLTT + animBg.paletteId * 32), 0x20);
+        LoadPalette(&gPlttBufferUnfaded[OBJ_PLTT_ID(battlerId)], BG_PLTT_ID(animBg.paletteId), PLTT_SIZE_4BPP);
+        CpuCopy32(&gPlttBufferUnfaded[OBJ_PLTT_ID(battlerId)], (void *)(BG_PLTT + PLTT_OFFSET_4BPP(animBg.paletteId)), PLTT_SIZE_4BPP);
 
         if (IsContest())
             battlerPosition = 0;
@@ -741,8 +741,8 @@ void MoveBattlerSpriteToBG(u8 battlerId, bool8 toBG_2, bool8 setSpriteInvisible)
         SetGpuReg(REG_OFFSET_BG2HOFS, gBattle_BG2_X);
         SetGpuReg(REG_OFFSET_BG2VOFS, gBattle_BG2_Y);
 
-        LoadPalette(&gPlttBufferUnfaded[0x100 + battlerId * 16], 0x90, 0x20);
-        CpuCopy32(&gPlttBufferUnfaded[0x100 + battlerId * 16], (void *)(BG_PLTT + 0x120), 0x20);
+        LoadPalette(&gPlttBufferUnfaded[OBJ_PLTT_ID(battlerId)], BG_PLTT_ID(0x9), PLTT_SIZE_4BPP);
+        CpuCopy32(&gPlttBufferUnfaded[OBJ_PLTT_ID(battlerId)], (void *)(BG_PLTT + PLTT_OFFSET_4BPP(0x9)), PLTT_SIZE_4BPP);
 
         DrawBattlerOnBg(2, 0, 0, GetBattlerPosition(battlerId), animBg.paletteId, animBg.bgTiles + 0x1000, animBg.bgTilemap + 0x400, animBg.tilesOffset);
     }
@@ -1208,13 +1208,13 @@ static void LoadMoveBg(u16 bgId)
         dmaDest = (void *)BG_SCREEN_ADDR(26);
         DmaCopy32(3, dmaSrc, dmaDest, 0x800);
         LZDecompressVram(gBattleAnimBackgroundTable[bgId].image, (void *)BG_SCREEN_ADDR(4));
-        LoadCompressedPalette(gBattleAnimBackgroundTable[bgId].palette, GetBattleBgPaletteNum() * 16, 32);
+        LoadCompressedPalette(gBattleAnimBackgroundTable[bgId].palette, BG_PLTT_ID(GetBattleBgPaletteNum()), PLTT_SIZE_4BPP);
     }
     else
     {
         LZDecompressVram(gBattleAnimBackgroundTable[bgId].tilemap, (void *)BG_SCREEN_ADDR(26));
         LZDecompressVram(gBattleAnimBackgroundTable[bgId].image, (void *)BG_CHAR_ADDR(2));
-        LoadCompressedPalette(gBattleAnimBackgroundTable[bgId].palette, 32, 32);
+        LoadCompressedPalette(gBattleAnimBackgroundTable[bgId].palette, BG_PLTT_ID(0x2), PLTT_SIZE_4BPP);
     }
 }
 

--- a/src/battle_anim_dark.c
+++ b/src/battle_anim_dark.c
@@ -426,7 +426,7 @@ void AnimTask_MoveAttackerMementoShadow(u8 taskId)
         GetBattleAnimBg1Data(&animBg);
         task->data[10] = gBattle_BG1_Y;
         SetGpuReg(REG_OFFSET_BLDCNT, BLDCNT_TGT2_ALL | BLDCNT_EFFECT_BLEND | BLDCNT_TGT1_BG1);
-        FillPalette(RGB_BLACK, animBg.paletteId * 16, 32);
+        FillPalette(RGB_BLACK, BG_PLTT_ID(animBg.paletteId), PLTT_SIZE_4BPP);
         scanlineParams.dmaDest = &REG_BG1VOFS;
         var0 = WINOUT_WIN01_BG1;
         if (!IsContest())
@@ -436,7 +436,7 @@ void AnimTask_MoveAttackerMementoShadow(u8 taskId)
     {
         task->data[10] = gBattle_BG2_Y;
         SetGpuReg(REG_OFFSET_BLDCNT, BLDCNT_TGT2_ALL | BLDCNT_EFFECT_BLEND | BLDCNT_TGT1_BG2);
-        FillPalette(RGB_BLACK, 144, 32);
+        FillPalette(RGB_BLACK, BG_PLTT_ID(0x9), PLTT_SIZE_4BPP);
         scanlineParams.dmaDest = &REG_BG2VOFS;
         var0 = WINOUT_WIN01_BG2;
         if (!IsContest())
@@ -566,12 +566,12 @@ void AnimTask_MoveTargetMementoShadow(u8 taskId)
         {
             GetBattleAnimBg1Data(&animBg);
             task->data[10] = gBattle_BG1_Y;
-            FillPalette(RGB_BLACK, animBg.paletteId * 16, 32);
+            FillPalette(RGB_BLACK, BG_PLTT_ID(animBg.paletteId), PLTT_SIZE_4BPP);
         }
         else
         {
             task->data[10] = gBattle_BG2_Y;
-            FillPalette(RGB_BLACK, 9 * 16, 32);
+            FillPalette(RGB_BLACK, BG_PLTT_ID(0x9), PLTT_SIZE_4BPP);
         }
 
         SetAllBattlersSpritePriority(3);
@@ -863,7 +863,7 @@ void AnimTask_MetallicShine(u8 taskId)
     GetBattleAnimBg1Data(&animBg);
     AnimLoadCompressedBgTilemap(animBg.bgId, gMetalShineTilemap);
     AnimLoadCompressedBgGfx(animBg.bgId, gMetalShineGfx, animBg.tilesOffset);
-    LoadCompressedPalette(gMetalShinePalette, animBg.paletteId * 16, 32);
+    LoadCompressedPalette(gMetalShinePalette, BG_PLTT_ID(animBg.paletteId), PLTT_SIZE_4BPP);
 
     gBattle_BG1_X = -gSprites[spriteId].x + 96;
     gBattle_BG1_Y = -gSprites[spriteId].y + 32;
@@ -872,7 +872,7 @@ void AnimTask_MetallicShine(u8 taskId)
     if (gBattleAnimArgs[1] == 0)
         SetGrayscaleOrOriginalPalette(paletteNum, FALSE);
     else
-        BlendPalette(paletteNum * 16, 16, 11, gBattleAnimArgs[2]);
+        BlendPalette(BG_PLTT_ID(paletteNum), 16, 11, gBattleAnimArgs[2]);
 
     gTasks[taskId].data[0] = newSpriteId;
     gTasks[taskId].data[1] = gBattleAnimArgs[0];

--- a/src/battle_anim_effects_1.c
+++ b/src/battle_anim_effects_1.c
@@ -3641,8 +3641,8 @@ void AnimTask_CycleMagicalLeafPal(u8 taskId)
     switch (task->data[0])
     {
     case 0:
-        task->data[8] = IndexOfSpritePaletteTag(ANIM_TAG_LEAF) * 16 + 256;
-        task->data[12] = IndexOfSpritePaletteTag(ANIM_TAG_RAZOR_LEAF) * 16 + 256;
+        task->data[8] = OBJ_PLTT_ID(IndexOfSpritePaletteTag(ANIM_TAG_LEAF));
+        task->data[12] = OBJ_PLTT_ID(IndexOfSpritePaletteTag(ANIM_TAG_RAZOR_LEAF));
         task->data[0]++;
         break;
     case 1:
@@ -4349,7 +4349,7 @@ static void AnimLockOnTarget_Step4(struct Sprite *sprite)
         int pal;
         sprite->data[2]++;
         pal = sprite->oam.paletteNum;
-        LoadPalette(&gPlttBufferUnfaded[0x108 + pal * 16], pal * 16 | 0x101, 4);
+        LoadPalette(&gPlttBufferUnfaded[OBJ_PLTT_ID(pal) + 8], OBJ_PLTT_ID(pal) + 1, PLTT_SIZEOF(2));
         PlaySE12WithPanning(SE_M_LEER, BattleAnimAdjustPanning(63));
     }
     else if (sprite->data[1] == 0)
@@ -5173,8 +5173,8 @@ void AnimTask_DoubleTeam(u8 taskId)
     struct Task *task = &gTasks[taskId];
     task->data[0] = GetAnimBattlerSpriteId(ANIM_ATTACKER);
     task->data[1] = AllocSpritePalette(ANIM_TAG_BENT_SPOON);
-    r3 = (task->data[1] * 16) + 0x100;
-    r4 = (gSprites[task->data[0]].oam.paletteNum + 16) << 4;
+    r3 = OBJ_PLTT_ID(task->data[1]);
+    r4 = OBJ_PLTT_ID2(gSprites[task->data[0]].oam.paletteNum);
     for (i = 1; i < 16; i++)
         gPlttBufferUnfaded[r3 + i] = gPlttBufferUnfaded[r4 + i];
 

--- a/src/battle_anim_effects_2.c
+++ b/src/battle_anim_effects_2.c
@@ -2678,7 +2678,7 @@ static void AnimUproarRing(struct Sprite *sprite)
     u8 index = IndexOfSpritePaletteTag(ANIM_TAG_THIN_RING);
     if (index != 0xFF)
     {
-        BlendPalette(((index << 20) + 0x1010000) >> 16, 15, gBattleAnimArgs[5], gBattleAnimArgs[4]);
+        BlendPalette((OBJ_PLTT_ID(index) + 1), 15, gBattleAnimArgs[5], gBattleAnimArgs[4]);
     }
 
     StartSpriteAffineAnim(sprite, 1);
@@ -3026,7 +3026,7 @@ void AnimTask_LoadMusicNotesPals(u8 taskId)
     gMonSpritesGfxPtr->buffer = AllocZeroed(0x2000);
     LZDecompressWram(gBattleAnimSpritePal_MusicNotes2, gMonSpritesGfxPtr->buffer);
     for (i = 0; i < NUM_MUSIC_NOTE_PAL_TAGS; i++)
-        LoadPalette(&gMonSpritesGfxPtr->buffer[i * 32], (u16)((paletteNums[i] << 4) + 0x100), 32);
+        LoadPalette(&gMonSpritesGfxPtr->buffer[i * 32], (u16)(OBJ_PLTT_ID(paletteNums[i])), PLTT_SIZE_4BPP);
 
     FREE_AND_SET_NULL(gMonSpritesGfxPtr->buffer);
     DestroyAnimVisualTask(taskId);
@@ -3261,7 +3261,7 @@ void AnimTask_HeartsBackground(u8 taskId)
     GetBattleAnimBg1Data(&animBg);
     AnimLoadCompressedBgGfx(animBg.bgId, gBattleAnimBgImage_Attract, animBg.tilesOffset);
     AnimLoadCompressedBgTilemapHandleContest(&animBg, gBattleAnimBgTilemap_Attract, FALSE);
-    LoadCompressedPalette(gBattleAnimBgPalette_Attract, animBg.paletteId * 16, 32);
+    LoadCompressedPalette(gBattleAnimBgPalette_Attract, BG_PLTT_ID(animBg.paletteId), PLTT_SIZE_4BPP);
     gTasks[taskId].func = AnimTask_HeartsBackground_Step;
 }
 
@@ -3345,7 +3345,7 @@ void AnimTask_ScaryFace(u8 taskId)
         AnimLoadCompressedBgTilemapHandleContest(&animBg, &gBattleAnimBgTilemap_ScaryFaceOpponent, FALSE);
 
     AnimLoadCompressedBgGfx(animBg.bgId, gBattleAnimBgImage_ScaryFace, animBg.tilesOffset);
-    LoadCompressedPalette(gBattleAnimBgPalette_ScaryFace, animBg.paletteId * 16, 32);
+    LoadCompressedPalette(gBattleAnimBgPalette_ScaryFace, BG_PLTT_ID(animBg.paletteId), PLTT_SIZE_4BPP);
     gTasks[taskId].func = AnimTask_ScaryFace_Step;
 }
 

--- a/src/battle_anim_effects_3.c
+++ b/src/battle_anim_effects_3.c
@@ -2405,7 +2405,7 @@ void AnimTask_MorningSunLightBeam(u8 taskId)
         }
 
         AnimLoadCompressedBgGfx(animBg.bgId, gBattleAnimMaskImage_LightBeam, animBg.tilesOffset);
-        LoadCompressedPalette(gBattleAnimMaskPalette_LightBeam, animBg.paletteId * 16, 32);
+        LoadCompressedPalette(gBattleAnimMaskPalette_LightBeam, BG_PLTT_ID(animBg.paletteId), PLTT_SIZE_4BPP);
 
         gTasks[taskId].data[10] = gBattle_BG1_X;
         gTasks[taskId].data[11] = gBattle_BG1_Y;
@@ -2601,7 +2601,7 @@ void AnimTask_DoomDesireLightBeam(u8 taskId)
         }
 
         AnimLoadCompressedBgGfx(animBg.bgId, gBattleAnimMaskImage_LightBeam, animBg.tilesOffset);
-        LoadCompressedPalette(gBattleAnimMaskPalette_LightBeam, animBg.paletteId * 16, 32);
+        LoadCompressedPalette(gBattleAnimMaskPalette_LightBeam, BG_PLTT_ID(animBg.paletteId), PLTT_SIZE_4BPP);
         gTasks[taskId].data[10] = gBattle_BG1_X;
         gTasks[taskId].data[11] = gBattle_BG1_Y;
         gTasks[taskId].data[0]++;
@@ -3252,7 +3252,7 @@ void AnimTask_RolePlaySilhouette(u8 taskId)
 
     gSprites[spriteId].oam.priority = priority;
     gSprites[spriteId].oam.objMode = ST_OAM_OBJ_BLEND;
-    FillPalette(RGB_WHITE, (gSprites[spriteId].oam.paletteNum << 4) + 0x100, 32);
+    FillPalette(RGB_WHITE, OBJ_PLTT_ID(gSprites[spriteId].oam.paletteNum), PLTT_SIZE_4BPP);
     gSprites[spriteId].oam.priority = priority;
     SetGpuReg(REG_OFFSET_BLDCNT, BLDCNT_EFFECT_BLEND | BLDCNT_TGT2_ALL);
     SetGpuReg(REG_OFFSET_BLDALPHA, BLDALPHA_BLEND(gTasks[taskId].data[1], 16 - gTasks[taskId].data[1]));
@@ -3880,7 +3880,7 @@ void AnimTask_FacadeColorBlend(u8 taskId)
     gTasks[taskId].data[0] = 0;
     gTasks[taskId].data[1] = gBattleAnimArgs[1];
     spriteId = GetAnimBattlerSpriteId(gBattleAnimArgs[0]);
-    gTasks[taskId].data[2] = 0x100 + gSprites[spriteId].oam.paletteNum * 16;
+    gTasks[taskId].data[2] = OBJ_PLTT_ID(gSprites[spriteId].oam.paletteNum);
     gTasks[taskId].func = AnimTask_FacadeColorBlend_Step;
 }
 
@@ -5145,7 +5145,7 @@ void AnimTask_SnatchOpposingMonMove(u8 taskId)
 
         spriteId2 = CreateAdditionalMonSpriteForMoveAnim(species, isBackPic, 0, x, GetBattlerSpriteCoord(gBattleAnimTarget, BATTLER_COORD_Y), subpriority, personality, otId, gBattleAnimAttacker, FALSE);
         if (gBattleSpritesDataPtr->battlerData[gBattleAnimAttacker].transformSpecies != SPECIES_NONE)
-            BlendPalette((gSprites[spriteId2].oam.paletteNum * 16) | 0x100, 16, 6, RGB_WHITE);
+            BlendPalette(OBJ_PLTT_ID(gSprites[spriteId2].oam.paletteNum), 16, 6, RGB_WHITE);
 
         gTasks[taskId].data[15] = spriteId2;
         gTasks[taskId].data[0]++;

--- a/src/battle_anim_fire.c
+++ b/src/battle_anim_fire.c
@@ -2,6 +2,7 @@
 #include "battle_anim.h"
 #include "constants/rgb.h"
 #include "constants/songs.h"
+#include "palette.h"
 #include "sound.h"
 #include "util.h"
 #include "task.h"
@@ -1329,7 +1330,7 @@ void AnimTask_BlendBackground(u8 taskId)
 {
     struct BattleAnimBgData animBg;
     GetBattleAnimBg1Data(&animBg);
-    BlendPalette(animBg.paletteId * 16, 16, gBattleAnimArgs[0], gBattleAnimArgs[1]);
+    BlendPalette(BG_PLTT_ID(animBg.paletteId), 16, gBattleAnimArgs[0], gBattleAnimArgs[1]);
     DestroyAnimVisualTask(taskId);
 }
 

--- a/src/battle_anim_ghost.c
+++ b/src/battle_anim_ghost.c
@@ -642,8 +642,8 @@ static void AnimTask_SpiteTargetShadow_Step1(u8 taskId)
         }
         break;
     case 1:
-        task->data[14] = (task->data[14] + 16) * 16;
-        CpuCopy32(&gPlttBufferUnfaded[task->data[4]], &gPlttBufferFaded[task->data[14]], 32);
+        task->data[14] = OBJ_PLTT_ID2(task->data[14]);
+        CpuCopy32(&gPlttBufferUnfaded[task->data[4]], &gPlttBufferFaded[task->data[14]], PLTT_SIZE_4BPP);
         BlendPalette(task->data[4], 16, 10, RGB(13, 0, 15));
         task->data[15]++;
         break;

--- a/src/battle_anim_ice.c
+++ b/src/battle_anim_ice.c
@@ -1001,7 +1001,7 @@ void AnimTask_HazeScrollingFog(u8 taskId)
     GetBattleAnimBg1Data(&animBg);
     LoadBgTiles(animBg.bgId, gWeatherFogHorizontalTiles, 0x800, animBg.tilesOffset);
     AnimLoadCompressedBgTilemapHandleContest(&animBg, gBattleAnimFogTilemap, FALSE);
-    LoadPalette(&gFogPalette, animBg.paletteId * 16, 32);
+    LoadPalette(&gFogPalette, BG_PLTT_ID(animBg.paletteId), PLTT_SIZE_4BPP);
 
     gTasks[taskId].func = AnimTask_HazeScrollingFog_Step;
 }
@@ -1106,7 +1106,7 @@ void AnimTask_LoadMistTiles(u8 taskId)
     GetBattleAnimBg1Data(&animBg);
     LoadBgTiles(animBg.bgId, gWeatherFogHorizontalTiles, 0x800, animBg.tilesOffset);
     AnimLoadCompressedBgTilemapHandleContest(&animBg, gBattleAnimFogTilemap, FALSE);
-    LoadPalette(&gFogPalette, animBg.paletteId * 16, 32);
+    LoadPalette(&gFogPalette, BG_PLTT_ID(animBg.paletteId), PLTT_SIZE_4BPP);
 
     gTasks[taskId].data[15] = -1;
     gTasks[taskId].func = AnimTask_LoadMistTiles_Step;

--- a/src/battle_anim_mons.c
+++ b/src/battle_anim_mons.c
@@ -1726,7 +1726,7 @@ void AnimTask_BlendMonInAndOut(u8 task)
         DestroyAnimVisualTask(task);
         return;
     }
-    gTasks[task].data[0] = (gSprites[spriteId].oam.paletteNum * 0x10) + 0x101;
+    gTasks[task].data[0] = OBJ_PLTT_ID(gSprites[spriteId].oam.paletteNum) + 1;
     AnimTask_BlendPalInAndOutSetup(&gTasks[task]);
 }
 
@@ -2104,7 +2104,7 @@ u8 CreateAdditionalMonSpriteForMoveAnim(u16 species, bool8 isBackpic, u8 id, s16
         gMonSpritesGfxPtr->buffer = AllocZeroed(0x2000);
     if (!isBackpic)
     {
-        LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, trainerId, personality), (palette * 0x10) + 0x100, 0x20);
+        LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, trainerId, personality), OBJ_PLTT_ID(palette), PLTT_SIZE_4BPP);
         if (ignoreDeoxysForm == TRUE || ShouldIgnoreDeoxysForm(5, battlerId) == TRUE || gBattleSpritesDataPtr->battlerData[battlerId].transformSpecies != 0)
             LoadSpecialPokePic_DontHandleDeoxys(&gMonFrontPicTable[species],
                                                 gMonSpritesGfxPtr->buffer,
@@ -2120,7 +2120,7 @@ u8 CreateAdditionalMonSpriteForMoveAnim(u16 species, bool8 isBackpic, u8 id, s16
     }
     else
     {
-        LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, trainerId, personality), (palette * 0x10) + 0x100, 0x20);
+        LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, trainerId, personality), OBJ_PLTT_ID(palette), PLTT_SIZE_4BPP);
         if (ignoreDeoxysForm == TRUE || ShouldIgnoreDeoxysForm(5, battlerId) == TRUE || gBattleSpritesDataPtr->battlerData[battlerId].transformSpecies != 0)
             LoadSpecialPokePic_DontHandleDeoxys(&gMonBackPicTable[species],
                                                 gMonSpritesGfxPtr->buffer,
@@ -2427,9 +2427,9 @@ void AnimTask_AttackerPunchWithTrace(u8 taskId)
     task->tPaletteNum = AllocSpritePalette(ANIM_TAG_BENT_SPOON);
     task->tNumTracesActive = 0;
 
-    dest = (task->tPaletteNum + 16) * 16;
-    src = (gSprites[task->tBattlerSpriteId].oam.paletteNum + 0x10) * 0x10;
-    
+    dest = OBJ_PLTT_ID2(task->tPaletteNum);
+    src = OBJ_PLTT_ID2(gSprites[task->tBattlerSpriteId].oam.paletteNum);
+
     // Set trace's priority based on battler's subpriority
     task->tPriority = GetBattlerSpriteSubpriority(gBattleAnimAttacker);
     if (task->tPriority == 20 || task->tPriority == 40)
@@ -2437,7 +2437,7 @@ void AnimTask_AttackerPunchWithTrace(u8 taskId)
     else
         task->tPriority = 3;
 
-    CpuCopy32(&gPlttBufferUnfaded[src], &gPlttBufferFaded[dest], 0x20);
+    CpuCopy32(&gPlttBufferUnfaded[src], &gPlttBufferFaded[dest], PLTT_SIZE_4BPP);
     BlendPalette(dest, 16, gBattleAnimArgs[1], gBattleAnimArgs[0]);
     task->func = AnimTask_AttackerPunchWithTrace_Step;
 }

--- a/src/battle_anim_rock.c
+++ b/src/battle_anim_rock.c
@@ -410,7 +410,7 @@ void AnimTask_LoadSandstormBackground(u8 taskId)
     GetBattleAnimBg1Data(&animBg);
     AnimLoadCompressedBgGfx(animBg.bgId, gBattleAnimBgImage_Sandstorm, animBg.tilesOffset);
     AnimLoadCompressedBgTilemapHandleContest(&animBg, gBattleAnimBgTilemap_Sandstorm, FALSE);
-    LoadCompressedPalette(gBattleAnimSpritePal_FlyingDirt, animBg.paletteId * 16, 32);
+    LoadCompressedPalette(gBattleAnimSpritePal_FlyingDirt, BG_PLTT_ID(animBg.paletteId), PLTT_SIZE_4BPP);
 
     if (gBattleAnimArgs[0] && GetBattlerSide(gBattleAnimAttacker) != B_SIDE_PLAYER)
         var0 = 1;

--- a/src/battle_anim_status_effects.c
+++ b/src/battle_anim_status_effects.c
@@ -316,7 +316,7 @@ static void Task_UpdateFlashingCircleImpacts(u8 taskId)
     if (gTasks[taskId].data[2] == 2)
     {
         gTasks[taskId].data[2] = 0;
-        BlendPalette(0x100 + gTasks[taskId].data[0] * 16, 16, gTasks[taskId].data[4], gTasks[taskId].data[1]);
+        BlendPalette(OBJ_PLTT_ID(gTasks[taskId].data[0]), 16, gTasks[taskId].data[4], gTasks[taskId].data[1]);
         if (gTasks[taskId].data[5] == 0)
         {
             gTasks[taskId].data[4]++;

--- a/src/battle_anim_throw.c
+++ b/src/battle_anim_throw.c
@@ -471,7 +471,7 @@ void AnimTask_UnusedLevelUpHealthBox(u8 taskId)
     GetBattleAnimBg1Data(&animBgData);
     AnimLoadCompressedBgTilemap(animBgData.bgId, UnusedLevelupAnimationTilemap);
     AnimLoadCompressedBgGfx(animBgData.bgId, UnusedLevelupAnimationGfx, animBgData.tilesOffset);
-    LoadCompressedPalette(gCureBubblesPal, animBgData.paletteId << 4, 32);
+    LoadCompressedPalette(gCureBubblesPal, BG_PLTT_ID(animBgData.paletteId), PLTT_SIZE_4BPP);
 
     gBattle_BG1_X = -gSprites[spriteId3].x + 32;
     gBattle_BG1_Y = -gSprites[spriteId3].y - 32;
@@ -553,10 +553,10 @@ static void LoadHealthboxPalsForLevelUp(u8 *paletteId1, u8 *paletteId2, u8 battl
     *paletteId1 = AllocSpritePalette(0xD709);
     *paletteId2 = AllocSpritePalette(0xD70A);
 
-    offset1 = (gSprites[healthBoxSpriteId].oam.paletteNum * 16) + 0x100;
-    offset2 = (gSprites[spriteId2].oam.paletteNum * 16) + 0x100;
-    LoadPalette(&gPlttBufferUnfaded[offset1], *paletteId1 * 16 + 0x100, 0x20);
-    LoadPalette(&gPlttBufferUnfaded[offset2], *paletteId2 * 16 + 0x100, 0x20);
+    offset1 = OBJ_PLTT_ID(gSprites[healthBoxSpriteId].oam.paletteNum);
+    offset2 = OBJ_PLTT_ID(gSprites[spriteId2].oam.paletteNum);
+    LoadPalette(&gPlttBufferUnfaded[offset1], OBJ_PLTT_ID(*paletteId1), PLTT_SIZE_4BPP);
+    LoadPalette(&gPlttBufferUnfaded[offset2], OBJ_PLTT_ID(*paletteId2), PLTT_SIZE_4BPP);
 
     gSprites[healthBoxSpriteId].oam.paletteNum = *paletteId1;
     gSprites[spriteId1].oam.paletteNum = *paletteId1;
@@ -620,7 +620,7 @@ static void AnimTask_FlashHealthboxOnLevelUp_Step(u8 taskId)
             if (gTasks[taskId].data[2] > 16)
                 gTasks[taskId].data[2] = 16;
 
-            paletteOffset = paletteNum * 16 + 0x100;
+            paletteOffset = OBJ_PLTT_ID(paletteNum);
             BlendPalette(paletteOffset + colorOffset, 1, gTasks[taskId].data[2], RGB(20, 27, 31));
             if (gTasks[taskId].data[2] == 16)
                 gTasks[taskId].data[1]++;
@@ -630,7 +630,7 @@ static void AnimTask_FlashHealthboxOnLevelUp_Step(u8 taskId)
             if (gTasks[taskId].data[2] < 0)
                 gTasks[taskId].data[2] = 0;
 
-            paletteOffset = paletteNum * 16 + 0x100;
+            paletteOffset = OBJ_PLTT_ID(paletteNum);
             BlendPalette(paletteOffset + colorOffset, 1, gTasks[taskId].data[2], RGB(20, 27, 31));
             if (gTasks[taskId].data[2] == 0)
                 DestroyAnimVisualTask(taskId);
@@ -2030,12 +2030,12 @@ u8 LaunchBallFadeMonTask(bool8 unfadeLater, u8 spritePalNum, u32 selectedPalette
 
     if (!unfadeLater)
     {
-        BlendPalette(spritePalNum * 16 + 0x100, 16, 0, gBallOpenFadeColors[ballId]);
+        BlendPalette(OBJ_PLTT_ID(spritePalNum), 16, 0, gBallOpenFadeColors[ballId]);
         gTasks[taskId].tdCoeff = 1;
     }
     else
     {
-        BlendPalette(spritePalNum * 16 + 0x100, 16, 16, gBallOpenFadeColors[ballId]);
+        BlendPalette(OBJ_PLTT_ID(spritePalNum), 16, 16, gBallOpenFadeColors[ballId]);
         gTasks[taskId].tCoeff = 16;
         gTasks[taskId].tdCoeff = -1;
         gTasks[taskId].func = Task_FadeMon_ToNormal;
@@ -2051,7 +2051,7 @@ static void Task_FadeMon_ToBallColor(u8 taskId)
 
     if (gTasks[taskId].tTimer <= 16)
     {
-        BlendPalette(gTasks[taskId].tPalOffset * 16 + 0x100, 16, gTasks[taskId].tCoeff, gBallOpenFadeColors[ballId]);
+        BlendPalette(OBJ_PLTT_ID(gTasks[taskId].tPalOffset), 16, gTasks[taskId].tCoeff, gBallOpenFadeColors[ballId]);
         gTasks[taskId].tCoeff += gTasks[taskId].tdCoeff;
         gTasks[taskId].tTimer++;
     }
@@ -2079,7 +2079,7 @@ static void Task_FadeMon_ToNormal_Step(u8 taskId)
 
     if (gTasks[taskId].tTimer <= 16)
     {
-        BlendPalette(gTasks[taskId].tPalOffset * 16 + 0x100, 16, gTasks[taskId].tCoeff, gBallOpenFadeColors[ballId]);
+        BlendPalette(OBJ_PLTT_ID(gTasks[taskId].tPalOffset), 16, gTasks[taskId].tCoeff, gBallOpenFadeColors[ballId]);
         gTasks[taskId].tCoeff += gTasks[taskId].tdCoeff;
         gTasks[taskId].tTimer++;
     }

--- a/src/battle_anim_utility_funcs.c
+++ b/src/battle_anim_utility_funcs.c
@@ -166,7 +166,7 @@ void StartBlendAnimSpriteColor(u8 taskId, u32 selectedPalettes)
 static void AnimTask_BlendSpriteColor_Step2(u8 taskId)
 {
     u32 selectedPalettes;
-    u16 singlePaletteMask = 0;
+    u16 singlePaletteOffset = 0x00;
 
     if (gTasks[taskId].data[9] == gTasks[taskId].data[2])
     {
@@ -175,8 +175,8 @@ static void AnimTask_BlendSpriteColor_Step2(u8 taskId)
         while (selectedPalettes != 0)
         {
             if (selectedPalettes & 1)
-                BlendPalette(singlePaletteMask, 16, gTasks[taskId].data[10], gTasks[taskId].data[5]);
-            singlePaletteMask += 0x10;
+                BlendPalette(singlePaletteOffset, 16, gTasks[taskId].data[10], gTasks[taskId].data[5]);
+            singlePaletteOffset += 0x10;
             selectedPalettes >>= 1;
         }
 
@@ -333,7 +333,7 @@ void AnimTask_DrawFallingWhiteLinesOnAttacker(u8 taskId)
     GetBattleAnimBg1Data(&animBgData);
     AnimLoadCompressedBgTilemapHandleContest(&animBgData, gBattleAnimMaskTilemap_Curse, FALSE);
     AnimLoadCompressedBgGfx(animBgData.bgId, gBattleAnimMaskImage_Curse, animBgData.tilesOffset);
-    LoadPalette(sCurseLinesPalette, animBgData.paletteId * 16 + 1, 2);
+    LoadPalette(sCurseLinesPalette, BG_PLTT_ID(animBgData.paletteId) + 1, PLTT_SIZEOF(1));
 
     gBattle_BG1_X = -gSprites[spriteId].x + 32;
     gBattle_BG1_Y = -gSprites[spriteId].y + 32;
@@ -478,28 +478,28 @@ static void StatsChangeAnimation_Step2(u8 taskId)
     switch (sAnimStatsChangeData->data[1])
     {
     case 0:
-        LoadCompressedPalette(gBattleStatMask2_Pal, animBgData.paletteId * 16, 32);
+        LoadCompressedPalette(gBattleStatMask2_Pal, BG_PLTT_ID(animBgData.paletteId), PLTT_SIZE_4BPP);
         break;
     case 1:
-        LoadCompressedPalette(gBattleStatMask1_Pal, animBgData.paletteId * 16, 32);
+        LoadCompressedPalette(gBattleStatMask1_Pal, BG_PLTT_ID(animBgData.paletteId), PLTT_SIZE_4BPP);
         break;
     case 2:
-        LoadCompressedPalette(gBattleStatMask3_Pal, animBgData.paletteId * 16, 32);
+        LoadCompressedPalette(gBattleStatMask3_Pal, BG_PLTT_ID(animBgData.paletteId), PLTT_SIZE_4BPP);
         break;
     case 3:
-        LoadCompressedPalette(gBattleStatMask4_Pal, animBgData.paletteId * 16, 32);
+        LoadCompressedPalette(gBattleStatMask4_Pal, BG_PLTT_ID(animBgData.paletteId), PLTT_SIZE_4BPP);
         break;
     case 4:
-        LoadCompressedPalette(gBattleStatMask6_Pal, animBgData.paletteId * 16, 32);
+        LoadCompressedPalette(gBattleStatMask6_Pal, BG_PLTT_ID(animBgData.paletteId), PLTT_SIZE_4BPP);
         break;
     case 5:
-        LoadCompressedPalette(gBattleStatMask7_Pal, animBgData.paletteId * 16, 32);
+        LoadCompressedPalette(gBattleStatMask7_Pal, BG_PLTT_ID(animBgData.paletteId), PLTT_SIZE_4BPP);
         break;
     case 6:
-        LoadCompressedPalette(gBattleStatMask8_Pal, animBgData.paletteId * 16, 32);
+        LoadCompressedPalette(gBattleStatMask8_Pal, BG_PLTT_ID(animBgData.paletteId), PLTT_SIZE_4BPP);
         break;
     default:
-        LoadCompressedPalette(gBattleStatMask5_Pal, animBgData.paletteId * 16, 32);
+        LoadCompressedPalette(gBattleStatMask5_Pal, BG_PLTT_ID(animBgData.paletteId), PLTT_SIZE_4BPP);
         break;
     }
 
@@ -639,16 +639,10 @@ static void AnimTask_Flash_Step(u8 taskId)
             for (i = 0; i < 16; i++)
             {
                 if ((task->data[15] >> i) & 1)
-                {
-                    u16 paletteOffset = i * 16;
-                    BlendPalette(paletteOffset, 16, task->data[2], 0xFFFF);
-                }
+                    BlendPalette(BG_PLTT_ID(i), 16, task->data[2], 0xFFFF);
 
                 if ((task->data[14] >> i) & 1)
-                {
-                    u16 paletteOffset = i * 16 + 0x100;
-                    BlendPalette(paletteOffset, 16, task->data[2], 0);
-                }
+                    BlendPalette(OBJ_PLTT_ID(i), 16, task->data[2], 0);
             }
 
             if (task->data[2] == 0)
@@ -822,7 +816,7 @@ void StartMonScrollingBgMask(u8 taskId, int unused, u16 scrollSpeed, u8 battler,
     GetBattleAnimBg1Data(&animBgData);
     AnimLoadCompressedBgTilemapHandleContest(&animBgData, tilemap, FALSE);
     AnimLoadCompressedBgGfx(animBgData.bgId, gfx, animBgData.tilesOffset);
-    LoadCompressedPalette(palette, animBgData.paletteId * 16, 32);
+    LoadCompressedPalette(palette, BG_PLTT_ID(animBgData.paletteId), PLTT_SIZE_4BPP);
 
     gBattle_BG1_X = 0;
     gBattle_BG1_Y = 0;

--- a/src/battle_anim_water.c
+++ b/src/battle_anim_water.c
@@ -825,9 +825,9 @@ void AnimTask_CreateSurfWave(u8 taskId)
     }
     AnimLoadCompressedBgGfx(animBg.bgId, gBattleAnimBgImage_Surf, animBg.tilesOffset);
     if (gBattleAnimArgs[0] == 0)
-        LoadCompressedPalette(gBattleAnimBgPalette_Surf, animBg.paletteId * 16, 32);
+        LoadCompressedPalette(gBattleAnimBgPalette_Surf, BG_PLTT_ID(animBg.paletteId), PLTT_SIZE_4BPP);
     else
-        LoadCompressedPalette(gBattleAnimBackgroundImageMuddyWater_Pal, animBg.paletteId * 16, 32);
+        LoadCompressedPalette(gBattleAnimBackgroundImageMuddyWater_Pal, BG_PLTT_ID(animBg.paletteId), PLTT_SIZE_4BPP);
     taskId2 = CreateTask(AnimTask_SurfWaveScanlineEffect, gTasks[taskId].priority + 1);
     gTasks[taskId].data[15] = taskId2;
     gTasks[taskId2].data[0] = 0;

--- a/src/battle_arena.c
+++ b/src/battle_arena.c
@@ -514,7 +514,7 @@ u8 BattleArena_ShowJudgmentWindow(u8 *state)
         BeginNormalPaletteFade(0x7FFFFF1C, 4, 0, 8, RGB_BLACK);
         SetGpuReg(REG_OFFSET_WININ, WININ_WIN0_BG1 | WININ_WIN0_BG2 | WININ_WIN0_BG3 | WININ_WIN0_OBJ | WININ_WIN0_CLR | WININ_WIN1_BG_ALL | WININ_WIN1_OBJ | WININ_WIN1_CLR);
         LoadCompressedSpriteSheet(sBattleArenaJudgementSymbolsSpriteSheet);
-        LoadCompressedPalette(gBattleArenaJudgementSymbolsPalette, 0x1F0, 0x20);
+        LoadCompressedPalette(gBattleArenaJudgementSymbolsPalette, OBJ_PLTT_ID(0xF), PLTT_SIZE_4BPP);
         gBattle_WIN0H = 0xFF;
         gBattle_WIN0V = 0x70;
         (*state)++;
@@ -894,7 +894,7 @@ static void BufferArenaOpponentName(void)
 void DrawArenaRefereeTextBox(void)
 {
     u8 width = 27;
-    u8 palNum = 7;
+    u8 palNum = 0x7;
 
     FillBgTilemapBufferRect(0, 0,    254, 14, 1,  6, palNum);
     FillBgTilemapBufferRect(0, 0,    32,  14, 1,  6, palNum);
@@ -918,7 +918,7 @@ void EraseArenaRefereeTextBox(void)
 {
     u8 width;
     u8 height;
-    u8 palNum = 0;
+    u8 palNum = 0x0;
 
     FillBgTilemapBufferRect(0, 3, 0, 14, 1, 1, palNum);
     height = 4;

--- a/src/battle_bg.c
+++ b/src/battle_bg.c
@@ -167,7 +167,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 15,
         .width = 26,
         .height = 4,
-        .paletteNum = 0,
+        .paletteNum = 0x0,
         .baseBlock = 0x0090,
     },
     [B_WIN_ACTION_PROMPT] = {
@@ -176,7 +176,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 35,
         .width = 14,
         .height = 4,
-        .paletteNum = 0,
+        .paletteNum = 0x0,
         .baseBlock = 0x01c0,
     },
     [B_WIN_ACTION_MENU] = {
@@ -185,7 +185,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 35,
         .width = 12,
         .height = 4,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0190,
     },
     [B_WIN_MOVE_NAME_1] = {
@@ -194,7 +194,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 55,
         .width = 8,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0300,
     },
     [B_WIN_MOVE_NAME_2] = {
@@ -203,7 +203,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 55,
         .width = 8,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0310,
     },
     [B_WIN_MOVE_NAME_3] = {
@@ -212,7 +212,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 57,
         .width = 8,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0320,
     },
     [B_WIN_MOVE_NAME_4] = {
@@ -221,7 +221,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 57,
         .width = 8,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0330,
     },
     [B_WIN_PP] = {
@@ -230,7 +230,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 55,
         .width = 4,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0290,
     },
     [B_WIN_DUMMY] = {
@@ -239,7 +239,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 57,
         .width = 0,
         .height = 0,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0298,
     },
     [B_WIN_PP_REMAINING] = {
@@ -248,7 +248,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 55,
         .width = 4,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0298,
     },
     [B_WIN_MOVE_TYPE] = {
@@ -257,7 +257,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 57,
         .width = 8,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x02a0,
     },
     [B_WIN_SWITCH_PROMPT] = {
@@ -266,7 +266,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 55,
         .width = 8,
         .height = 4,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x02b0,
     },
     [B_WIN_YESNO] = {
@@ -275,7 +275,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 9,
         .width = 3,
         .height = 4,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0100,
     },
     [B_WIN_LEVEL_UP_BOX] = {
@@ -284,7 +284,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 8,
         .width = 10,
         .height = 11,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0100,
     },
     [B_WIN_LEVEL_UP_BANNER] = {
@@ -293,7 +293,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 0,
         .width = 12,
         .height = 3,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 0x016e,
     },
     [B_WIN_VS_PLAYER] = {
@@ -302,7 +302,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 3,
         .width = 6,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0020,
     },
     [B_WIN_VS_OPPONENT] = {
@@ -311,7 +311,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 3,
         .width = 6,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0040,
     },
     [B_WIN_VS_MULTI_PLAYER_1] = {
@@ -320,7 +320,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 2,
         .width = 6,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0020,
     },
     [B_WIN_VS_MULTI_PLAYER_2] = {
@@ -329,7 +329,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 2,
         .width = 6,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0040,
     },
     [B_WIN_VS_MULTI_PLAYER_3] = {
@@ -338,7 +338,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 6,
         .width = 6,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0060,
     },
     [B_WIN_VS_MULTI_PLAYER_4] = {
@@ -347,7 +347,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 6,
         .width = 6,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0080,
     },
     [B_WIN_VS_OUTCOME_DRAW] = {
@@ -356,7 +356,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 2,
         .width = 6,
         .height = 2,
-        .paletteNum = 0,
+        .paletteNum = 0x0,
         .baseBlock = 0x00a0,
     },
     [B_WIN_VS_OUTCOME_LEFT] = {
@@ -365,7 +365,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 2,
         .width = 7,
         .height = 2,
-        .paletteNum = 0,
+        .paletteNum = 0x0,
         .baseBlock = 0x00a0,
     },
     [B_WIN_VS_OUTCOME_RIGHT] = {
@@ -374,7 +374,7 @@ static const struct WindowTemplate sStandardBattleWindowTemplates[] =
         .tilemapTop = 2,
         .width = 7,
         .height = 2,
-        .paletteNum = 0,
+        .paletteNum = 0x0,
         .baseBlock = 0x00b0,
     },
     DUMMY_WIN_TEMPLATE
@@ -388,7 +388,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 15,
         .width = 26,
         .height = 4,
-        .paletteNum = 0,
+        .paletteNum = 0x0,
         .baseBlock = 0x0090,
     },
     [B_WIN_ACTION_PROMPT] = {
@@ -397,7 +397,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 35,
         .width = 14,
         .height = 4,
-        .paletteNum = 0,
+        .paletteNum = 0x0,
         .baseBlock = 0x01c0,
     },
     [B_WIN_ACTION_MENU] = {
@@ -406,7 +406,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 35,
         .width = 12,
         .height = 4,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0190,
     },
     [B_WIN_MOVE_NAME_1] = {
@@ -415,7 +415,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 55,
         .width = 8,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0300,
     },
     [B_WIN_MOVE_NAME_2] = {
@@ -424,7 +424,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 55,
         .width = 8,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0310,
     },
     [B_WIN_MOVE_NAME_3] = {
@@ -433,7 +433,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 57,
         .width = 8,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0320,
     },
     [B_WIN_MOVE_NAME_4] = {
@@ -442,7 +442,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 57,
         .width = 8,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0330,
     },
     [B_WIN_PP] = {
@@ -451,7 +451,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 55,
         .width = 4,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0290,
     },
     [B_WIN_DUMMY] = {
@@ -460,7 +460,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 57,
         .width = 0,
         .height = 0,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0298,
     },
     [B_WIN_PP_REMAINING] = {
@@ -469,7 +469,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 55,
         .width = 4,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0298,
     },
     [B_WIN_MOVE_TYPE] = {
@@ -478,7 +478,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 57,
         .width = 8,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x02a0,
     },
     [B_WIN_SWITCH_PROMPT] = {
@@ -487,7 +487,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 55,
         .width = 8,
         .height = 4,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x02b0,
     },
     [B_WIN_YESNO] = {
@@ -496,7 +496,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 9,
         .width = 3,
         .height = 4,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0100,
     },
     [B_WIN_LEVEL_UP_BOX] = {
@@ -505,7 +505,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 8,
         .width = 10,
         .height = 11,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0100,
     },
     [B_WIN_LEVEL_UP_BANNER] = {
@@ -514,7 +514,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 0,
         .width = 12,
         .height = 3,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 0x016e,
     },
     [ARENA_WIN_PLAYER_NAME] = {
@@ -523,7 +523,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 1,
         .width = 8,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0100,
     },
     [ARENA_WIN_VS] = {
@@ -532,7 +532,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 1,
         .width = 2,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0110,
     },
     [ARENA_WIN_OPPONENT_NAME] = {
@@ -541,7 +541,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 1,
         .width = 8,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0114,
     },
     [ARENA_WIN_MIND] = {
@@ -550,7 +550,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 4,
         .width = 6,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0124,
     },
     [ARENA_WIN_SKILL] = {
@@ -559,7 +559,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 6,
         .width = 6,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0130,
     },
     [ARENA_WIN_BODY] = {
@@ -568,7 +568,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 8,
         .width = 6,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x013c,
     },
     [ARENA_WIN_JUDGEMENT_TITLE] = {
@@ -577,7 +577,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 11,
         .width = 14,
         .height = 2,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0x0148,
     },
     [ARENA_WIN_JUDGEMENT_TEXT] = {
@@ -586,7 +586,7 @@ static const struct WindowTemplate sBattleArenaWindowTemplates[] =
         .tilemapTop = 15,
         .width = 26,
         .height = 4,
-        .paletteNum = 7,
+        .paletteNum = 0x7,
         .baseBlock = 0x0090,
     },
     DUMMY_WIN_TEMPLATE
@@ -742,17 +742,17 @@ void InitBattleBgsVideo(void)
 
 void LoadBattleMenuWindowGfx(void)
 {
-    LoadUserWindowBorderGfx(2, 0x12, 0x10);
-    LoadUserWindowBorderGfx(2, 0x22, 0x10);
-    LoadCompressedPalette(gBattleWindowTextPalette, 0x50, 0x20);
+    LoadUserWindowBorderGfx(2, 0x12, BG_PLTT_ID(0x1));
+    LoadUserWindowBorderGfx(2, 0x22, BG_PLTT_ID(0x1));
+    LoadCompressedPalette(gBattleWindowTextPalette, BG_PLTT_ID(0x5), PLTT_SIZE_4BPP);
 
     if (gBattleTypeFlags & BATTLE_TYPE_ARENA)
     {
         // Load graphics for the Battle Arena referee's mid-battle messages.
-        Menu_LoadStdPalAt(0x70);
-        LoadMessageBoxGfx(0, 0x30, 0x70);
-        gPlttBufferUnfaded[0x76] = 0;
-        CpuCopy16(&gPlttBufferUnfaded[0x76], &gPlttBufferFaded[0x76], 2);
+        Menu_LoadStdPalAt(BG_PLTT_ID(0x7));
+        LoadMessageBoxGfx(0, 0x30, BG_PLTT_ID(0x7));
+        gPlttBufferUnfaded[BG_PLTT_ID(0x7) + 6] = 0;
+        CpuCopy16(&gPlttBufferUnfaded[BG_PLTT_ID(0x7) + 6], &gPlttBufferFaded[BG_PLTT_ID(0x7) + 6], PLTT_SIZEOF(1));
     }
 }
 
@@ -762,25 +762,25 @@ void DrawMainBattleBackground(void)
     {
         LZDecompressVram(gBattleTerrainTiles_Building, (void *)(BG_CHAR_ADDR(2)));
         LZDecompressVram(gBattleTerrainTilemap_Building, (void *)(BG_SCREEN_ADDR(26)));
-        LoadCompressedPalette(gBattleTerrainPalette_Frontier, 0x20, 0x60);
+        LoadCompressedPalette(gBattleTerrainPalette_Frontier, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
     }
     else if (gBattleTypeFlags & BATTLE_TYPE_GROUDON)
     {
         LZDecompressVram(gBattleTerrainTiles_Cave, (void *)(BG_CHAR_ADDR(2)));
         LZDecompressVram(gBattleTerrainTilemap_Cave, (void *)(BG_SCREEN_ADDR(26)));
-        LoadCompressedPalette(gBattleTerrainPalette_Groudon, 0x20, 0x60);
+        LoadCompressedPalette(gBattleTerrainPalette_Groudon, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
     }
     else if (gBattleTypeFlags & BATTLE_TYPE_KYOGRE)
     {
         LZDecompressVram(gBattleTerrainTiles_Water, (void *)(BG_CHAR_ADDR(2)));
         LZDecompressVram(gBattleTerrainTilemap_Water, (void *)(BG_SCREEN_ADDR(26)));
-        LoadCompressedPalette(gBattleTerrainPalette_Kyogre, 0x20, 0x60);
+        LoadCompressedPalette(gBattleTerrainPalette_Kyogre, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
     }
     else if (gBattleTypeFlags & BATTLE_TYPE_RAYQUAZA)
     {
         LZDecompressVram(gBattleTerrainTiles_Rayquaza, (void *)(BG_CHAR_ADDR(2)));
         LZDecompressVram(gBattleTerrainTilemap_Rayquaza, (void *)(BG_SCREEN_ADDR(26)));
-        LoadCompressedPalette(gBattleTerrainPalette_Rayquaza, 0x20, 0x60);
+        LoadCompressedPalette(gBattleTerrainPalette_Rayquaza, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
     }
     else
     {
@@ -791,14 +791,14 @@ void DrawMainBattleBackground(void)
             {
                 LZDecompressVram(gBattleTerrainTiles_Building, (void *)(BG_CHAR_ADDR(2)));
                 LZDecompressVram(gBattleTerrainTilemap_Building, (void *)(BG_SCREEN_ADDR(26)));
-                LoadCompressedPalette(gBattleTerrainPalette_BuildingLeader, 0x20, 0x60);
+                LoadCompressedPalette(gBattleTerrainPalette_BuildingLeader, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
                 return;
             }
             else if (trainerClass == TRAINER_CLASS_CHAMPION)
             {
                 LZDecompressVram(gBattleTerrainTiles_Stadium, (void *)(BG_CHAR_ADDR(2)));
                 LZDecompressVram(gBattleTerrainTilemap_Stadium, (void *)(BG_SCREEN_ADDR(26)));
-                LoadCompressedPalette(gBattleTerrainPalette_StadiumWallace, 0x20, 0x60);
+                LoadCompressedPalette(gBattleTerrainPalette_StadiumWallace, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
                 return;
             }
         }
@@ -809,47 +809,47 @@ void DrawMainBattleBackground(void)
         case MAP_BATTLE_SCENE_NORMAL:
             LZDecompressVram(sBattleTerrainTable[gBattleTerrain].tileset, (void *)(BG_CHAR_ADDR(2)));
             LZDecompressVram(sBattleTerrainTable[gBattleTerrain].tilemap, (void *)(BG_SCREEN_ADDR(26)));
-            LoadCompressedPalette(sBattleTerrainTable[gBattleTerrain].palette, 0x20, 0x60);
+            LoadCompressedPalette(sBattleTerrainTable[gBattleTerrain].palette, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
             break;
         case MAP_BATTLE_SCENE_GYM:
             LZDecompressVram(gBattleTerrainTiles_Building, (void *)(BG_CHAR_ADDR(2)));
             LZDecompressVram(gBattleTerrainTilemap_Building, (void *)(BG_SCREEN_ADDR(26)));
-            LoadCompressedPalette(gBattleTerrainPalette_BuildingGym, 0x20, 0x60);
+            LoadCompressedPalette(gBattleTerrainPalette_BuildingGym, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
             break;
         case MAP_BATTLE_SCENE_MAGMA:
             LZDecompressVram(gBattleTerrainTiles_Stadium, (void *)(BG_CHAR_ADDR(2)));
             LZDecompressVram(gBattleTerrainTilemap_Stadium, (void *)(BG_SCREEN_ADDR(26)));
-            LoadCompressedPalette(gBattleTerrainPalette_StadiumMagma, 0x20, 0x60);
+            LoadCompressedPalette(gBattleTerrainPalette_StadiumMagma, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
             break;
         case MAP_BATTLE_SCENE_AQUA:
             LZDecompressVram(gBattleTerrainTiles_Stadium, (void *)(BG_CHAR_ADDR(2)));
             LZDecompressVram(gBattleTerrainTilemap_Stadium, (void *)(BG_SCREEN_ADDR(26)));
-            LoadCompressedPalette(gBattleTerrainPalette_StadiumAqua, 0x20, 0x60);
+            LoadCompressedPalette(gBattleTerrainPalette_StadiumAqua, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
             break;
         case MAP_BATTLE_SCENE_SIDNEY:
             LZDecompressVram(gBattleTerrainTiles_Stadium, (void *)(BG_CHAR_ADDR(2)));
             LZDecompressVram(gBattleTerrainTilemap_Stadium, (void *)(BG_SCREEN_ADDR(26)));
-            LoadCompressedPalette(gBattleTerrainPalette_StadiumSidney, 0x20, 0x60);
+            LoadCompressedPalette(gBattleTerrainPalette_StadiumSidney, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
             break;
         case MAP_BATTLE_SCENE_PHOEBE:
             LZDecompressVram(gBattleTerrainTiles_Stadium, (void *)(BG_CHAR_ADDR(2)));
             LZDecompressVram(gBattleTerrainTilemap_Stadium, (void *)(BG_SCREEN_ADDR(26)));
-            LoadCompressedPalette(gBattleTerrainPalette_StadiumPhoebe, 0x20, 0x60);
+            LoadCompressedPalette(gBattleTerrainPalette_StadiumPhoebe, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
             break;
         case MAP_BATTLE_SCENE_GLACIA:
             LZDecompressVram(gBattleTerrainTiles_Stadium, (void *)(BG_CHAR_ADDR(2)));
             LZDecompressVram(gBattleTerrainTilemap_Stadium, (void *)(BG_SCREEN_ADDR(26)));
-            LoadCompressedPalette(gBattleTerrainPalette_StadiumGlacia, 0x20, 0x60);
+            LoadCompressedPalette(gBattleTerrainPalette_StadiumGlacia, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
             break;
         case MAP_BATTLE_SCENE_DRAKE:
             LZDecompressVram(gBattleTerrainTiles_Stadium, (void *)(BG_CHAR_ADDR(2)));
             LZDecompressVram(gBattleTerrainTilemap_Stadium, (void *)(BG_SCREEN_ADDR(26)));
-            LoadCompressedPalette(gBattleTerrainPalette_StadiumDrake, 0x20, 0x60);
+            LoadCompressedPalette(gBattleTerrainPalette_StadiumDrake, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
             break;
         case MAP_BATTLE_SCENE_FRONTIER:
             LZDecompressVram(gBattleTerrainTiles_Building, (void *)(BG_CHAR_ADDR(2)));
             LZDecompressVram(gBattleTerrainTilemap_Building, (void *)(BG_SCREEN_ADDR(26)));
-            LoadCompressedPalette(gBattleTerrainPalette_Frontier, 0x20, 0x60);
+            LoadCompressedPalette(gBattleTerrainPalette_Frontier, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
             break;
         }
     }
@@ -860,7 +860,7 @@ void LoadBattleTextboxAndBackground(void)
     LZDecompressVram(gBattleTextboxTiles, (void *)(BG_CHAR_ADDR(0)));
     CopyToBgTilemapBuffer(0, gBattleTextboxTilemap, 0, 0);
     CopyBgTilemapBufferToVram(0);
-    LoadCompressedPalette(gBattleTextboxPalette, 0, 0x40);
+    LoadCompressedPalette(gBattleTextboxPalette, BG_PLTT_ID(0x0), 2 * PLTT_SIZE_4BPP);
     LoadBattleMenuWindowGfx();
     DrawMainBattleBackground();
 }
@@ -1126,7 +1126,7 @@ void DrawBattleEntryBackground(void)
     {
         LZDecompressVram(gBattleVSFrame_Gfx, (void *)(BG_CHAR_ADDR(1)));
         LZDecompressVram(gVsLettersGfx, (void *)OBJ_VRAM0);
-        LoadCompressedPalette(gBattleVSFrame_Pal, 0x60, 0x20);
+        LoadCompressedPalette(gBattleVSFrame_Pal, BG_PLTT_ID(0x6), PLTT_SIZE_4BPP);
         SetBgAttribute(1, BG_ATTR_SCREENSIZE, 1);
         SetGpuReg(REG_OFFSET_BG1CNT, 0x5C04);
         CopyToBgTilemapBuffer(1, gBattleVSFrame_Tilemap, 0, 0);
@@ -1219,7 +1219,7 @@ bool8 LoadChosenBattleElement(u8 caseId)
         CopyBgTilemapBufferToVram(0);
         break;
     case 2:
-        LoadCompressedPalette(gBattleTextboxPalette, 0, 0x40);
+        LoadCompressedPalette(gBattleTextboxPalette, BG_PLTT_ID(0x0), 2 * PLTT_SIZE_4BPP);
         break;
     case 3:
         if (gBattleTypeFlags & (BATTLE_TYPE_FRONTIER | BATTLE_TYPE_LINK | BATTLE_TYPE_RECORDED_LINK | BATTLE_TYPE_EREADER_TRAINER))
@@ -1345,14 +1345,14 @@ bool8 LoadChosenBattleElement(u8 caseId)
     case 5:
         if (gBattleTypeFlags & (BATTLE_TYPE_FRONTIER | BATTLE_TYPE_LINK | BATTLE_TYPE_RECORDED_LINK | BATTLE_TYPE_EREADER_TRAINER))
         {
-            LoadCompressedPalette(gBattleTerrainPalette_Frontier, 0x20, 0x60);
+            LoadCompressedPalette(gBattleTerrainPalette_Frontier, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
         }
         else if (gBattleTypeFlags & BATTLE_TYPE_KYOGRE_GROUDON)
         {
             if (gGameVersion == VERSION_RUBY)
-                LoadCompressedPalette(gBattleTerrainPalette_Groudon, 0x20, 0x60);
+                LoadCompressedPalette(gBattleTerrainPalette_Groudon, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
             else
-                LoadCompressedPalette(gBattleTerrainPalette_Kyogre, 0x20, 0x60);
+                LoadCompressedPalette(gBattleTerrainPalette_Kyogre, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
         }
         else
         {
@@ -1361,12 +1361,12 @@ bool8 LoadChosenBattleElement(u8 caseId)
                 u8 trainerClass = gTrainers[gTrainerBattleOpponent_A].trainerClass;
                 if (trainerClass == TRAINER_CLASS_LEADER)
                 {
-                    LoadCompressedPalette(gBattleTerrainPalette_BuildingLeader, 0x20, 0x60);
+                    LoadCompressedPalette(gBattleTerrainPalette_BuildingLeader, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
                     break;
                 }
                 else if (trainerClass == TRAINER_CLASS_CHAMPION)
                 {
-                    LoadCompressedPalette(gBattleTerrainPalette_StadiumWallace, 0x20, 0x60);
+                    LoadCompressedPalette(gBattleTerrainPalette_StadiumWallace, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
                     break;
                 }
             }
@@ -1375,31 +1375,31 @@ bool8 LoadChosenBattleElement(u8 caseId)
             {
             default:
             case MAP_BATTLE_SCENE_NORMAL:
-                LoadCompressedPalette(sBattleTerrainTable[gBattleTerrain].palette, 0x20, 0x60);
+                LoadCompressedPalette(sBattleTerrainTable[gBattleTerrain].palette, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
                 break;
             case MAP_BATTLE_SCENE_GYM:
-                LoadCompressedPalette(gBattleTerrainPalette_BuildingGym, 0x20, 0x60);
+                LoadCompressedPalette(gBattleTerrainPalette_BuildingGym, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
                 break;
             case MAP_BATTLE_SCENE_MAGMA:
-                LoadCompressedPalette(gBattleTerrainPalette_StadiumMagma, 0x20, 0x60);
+                LoadCompressedPalette(gBattleTerrainPalette_StadiumMagma, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
                 break;
             case MAP_BATTLE_SCENE_AQUA:
-                LoadCompressedPalette(gBattleTerrainPalette_StadiumAqua, 0x20, 0x60);
+                LoadCompressedPalette(gBattleTerrainPalette_StadiumAqua, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
                 break;
             case MAP_BATTLE_SCENE_SIDNEY:
-                LoadCompressedPalette(gBattleTerrainPalette_StadiumSidney, 0x20, 0x60);
+                LoadCompressedPalette(gBattleTerrainPalette_StadiumSidney, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
                 break;
             case MAP_BATTLE_SCENE_PHOEBE:
-                LoadCompressedPalette(gBattleTerrainPalette_StadiumPhoebe, 0x20, 0x60);
+                LoadCompressedPalette(gBattleTerrainPalette_StadiumPhoebe, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
                 break;
             case MAP_BATTLE_SCENE_GLACIA:
-                LoadCompressedPalette(gBattleTerrainPalette_StadiumGlacia, 0x20, 0x60);
+                LoadCompressedPalette(gBattleTerrainPalette_StadiumGlacia, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
                 break;
             case MAP_BATTLE_SCENE_DRAKE:
-                LoadCompressedPalette(gBattleTerrainPalette_StadiumDrake, 0x20, 0x60);
+                LoadCompressedPalette(gBattleTerrainPalette_StadiumDrake, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
                 break;
             case MAP_BATTLE_SCENE_FRONTIER:
-                LoadCompressedPalette(gBattleTerrainPalette_Frontier, 0x20, 0x60);
+                LoadCompressedPalette(gBattleTerrainPalette_Frontier, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
                 break;
             }
         }

--- a/src/battle_controller_link_partner.c
+++ b/src/battle_controller_link_partner.c
@@ -1558,7 +1558,7 @@ static void LinkPartnerHandleIntroTrainerBallThrow(void)
         trainerPicId = gLinkPlayers[GetBattlerMultiplayerId(gActiveBattler)].gender;
     }
 
-    LoadCompressedPalette(gTrainerBackPicPaletteTable[trainerPicId].data, 0x100 + paletteNum * 16, 32);
+    LoadCompressedPalette(gTrainerBackPicPaletteTable[trainerPicId].data, OBJ_PLTT_ID(paletteNum), PLTT_SIZE_4BPP);
 
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.paletteNum = paletteNum;
 

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -2960,7 +2960,7 @@ static void PlayerHandleIntroTrainerBallThrow(void)
     StartSpriteAnim(&gSprites[gBattlerSpriteIds[gActiveBattler]], 1);
 
     paletteNum = AllocSpritePalette(0xD6F8);
-    LoadCompressedPalette(gTrainerBackPicPaletteTable[gSaveBlock2Ptr->playerGender].data, 0x100 + paletteNum * 16, 32);
+    LoadCompressedPalette(gTrainerBackPicPaletteTable[gSaveBlock2Ptr->playerGender].data, OBJ_PLTT_ID(paletteNum), PLTT_SIZE_4BPP);
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.paletteNum = paletteNum;
 
     taskId = CreateTask(Task_StartSendOutAnim, 5);

--- a/src/battle_controller_player_partner.c
+++ b/src/battle_controller_player_partner.c
@@ -1794,12 +1794,12 @@ static void PlayerPartnerHandleIntroTrainerBallThrow(void)
     if (gPartnerTrainerId == TRAINER_STEVEN_PARTNER)
     {
         u8 spriteId = TRAINER_BACK_PIC_STEVEN;
-        LoadCompressedPalette(gTrainerBackPicPaletteTable[spriteId].data, 0x100 + paletteNum * 16, 32);
+        LoadCompressedPalette(gTrainerBackPicPaletteTable[spriteId].data, OBJ_PLTT_ID(paletteNum), PLTT_SIZE_4BPP);
     }
     else
     {
         u8 spriteId = GetFrontierTrainerFrontSpriteId(gPartnerTrainerId);
-        LoadCompressedPalette(gTrainerFrontPicPaletteTable[spriteId].data, 0x100 + paletteNum * 16, 32);
+        LoadCompressedPalette(gTrainerFrontPicPaletteTable[spriteId].data, OBJ_PLTT_ID(paletteNum), PLTT_SIZE_4BPP);
     }
 
 

--- a/src/battle_controller_recorded_player.c
+++ b/src/battle_controller_recorded_player.c
@@ -1678,7 +1678,7 @@ static void RecordedPlayerHandleIntroTrainerBallThrow(void)
     else
         trainerPicId = gSaveBlock2Ptr->playerGender;
 
-    LoadCompressedPalette(gTrainerBackPicPaletteTable[trainerPicId].data, 0x100 + paletteNum * 16, 32);
+    LoadCompressedPalette(gTrainerBackPicPaletteTable[trainerPicId].data, OBJ_PLTT_ID(paletteNum), PLTT_SIZE_4BPP);
 
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.paletteNum = paletteNum;
 

--- a/src/battle_controller_wally.c
+++ b/src/battle_controller_wally.c
@@ -1445,7 +1445,7 @@ static void WallyHandleIntroTrainerBallThrow(void)
     StartSpriteAnim(&gSprites[gBattlerSpriteIds[gActiveBattler]], 1);
 
     paletteNum = AllocSpritePalette(0xD6F8);
-    LoadCompressedPalette(gTrainerBackPicPaletteTable[TRAINER_BACK_PIC_WALLY].data, 0x100 + paletteNum * 16, 32);
+    LoadCompressedPalette(gTrainerBackPicPaletteTable[TRAINER_BACK_PIC_WALLY].data, OBJ_PLTT_ID(paletteNum), PLTT_SIZE_4BPP);
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.paletteNum = paletteNum;
 
     taskId = CreateTask(Task_StartSendOutAnim, 5);

--- a/src/battle_dome.c
+++ b/src/battle_dome.c
@@ -676,7 +676,7 @@ static const struct WindowTemplate sTourneyTreeWindowTemplates[] =
         .tilemapTop = 3,
         .width = 8,
         .height = 16,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 16,
     },
     {
@@ -685,7 +685,7 @@ static const struct WindowTemplate sTourneyTreeWindowTemplates[] =
         .tilemapTop = 3,
         .width = 8,
         .height = 16,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 144,
     },
     {
@@ -694,7 +694,7 @@ static const struct WindowTemplate sTourneyTreeWindowTemplates[] =
         .tilemapTop = 1,
         .width = 14,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 272,
     },
     DUMMY_WIN_TEMPLATE,
@@ -708,7 +708,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 2,
         .width = 26,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1,
     },
     {
@@ -717,7 +717,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 5,
         .width = 8,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 53,
     },
     {
@@ -726,7 +726,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 7,
         .width = 9,
         .height = 3,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 69,
     },
     {
@@ -735,7 +735,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 10,
         .width = 8,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 96,
     },
     {
@@ -744,7 +744,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 12,
         .width = 26,
         .height = 7,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 112,
     },
     {
@@ -753,7 +753,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 2,
         .width = 23,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 294,
     },
     {
@@ -762,7 +762,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 5,
         .width = 8,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 340,
     },
     {
@@ -771,7 +771,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 5,
         .width = 8,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 356,
     },
     {
@@ -780,7 +780,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 16,
         .width = 26,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 372,
     },
     {
@@ -789,7 +789,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 2,
         .width = 26,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1,
     },
     {
@@ -798,7 +798,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 5,
         .width = 8,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 53,
     },
     {
@@ -807,7 +807,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 7,
         .width = 9,
         .height = 3,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 69,
     },
     {
@@ -816,7 +816,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 10,
         .width = 8,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 96,
     },
     {
@@ -825,7 +825,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 12,
         .width = 26,
         .height = 7,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 112,
     },
     {
@@ -834,7 +834,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 2,
         .width = 23,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 294,
     },
     {
@@ -843,7 +843,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 5,
         .width = 8,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 340,
     },
     {
@@ -852,7 +852,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 5,
         .width = 8,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 356,
     },
     {
@@ -861,7 +861,7 @@ static const struct WindowTemplate sInfoCardWindowTemplates[] =
         .tilemapTop = 16,
         .width = 26,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 372,
     },
     #ifdef UBFIX
@@ -3048,12 +3048,12 @@ static void Task_ShowTourneyInfoCard(u8 taskId)
         DecompressAndLoadBgGfxUsingHeap(2, gDomeTourneyInfoCard_Tilemap, 0x2000, 0, 1);
         DecompressAndLoadBgGfxUsingHeap(3, gDomeTourneyInfoCardBg_Tilemap, 0x800, 0, 1);
         LoadCompressedSpriteSheet(sTourneyTreeButtonsSpriteSheet);
-        LoadCompressedPalette(gDomeTourneyTree_Pal, 0, 0x200);
-        LoadCompressedPalette(gDomeTourneyTreeButtons_Pal, 0x100, 0x200);
-        LoadCompressedPalette(gBattleWindowTextPalette, 0xF0, 0x20);
+        LoadCompressedPalette(gDomeTourneyTree_Pal, BG_PLTT_OFFSET, BG_PLTT_SIZE);
+        LoadCompressedPalette(gDomeTourneyTreeButtons_Pal, OBJ_PLTT_OFFSET, OBJ_PLTT_SIZE);
+        LoadCompressedPalette(gBattleWindowTextPalette, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
         if (mode == INFOCARD_MATCH)
-            LoadCompressedPalette(gDomeTourneyMatchCardBg_Pal, 0x50, 0x20); // Changes the moving info card bg to orange when in match card mode
-        CpuFill32(0, gPlttBufferFaded, 0x400);
+            LoadCompressedPalette(gDomeTourneyMatchCardBg_Pal, BG_PLTT_ID(0x5), PLTT_SIZE_4BPP); // Changes the moving info card bg to orange when in match card mode
+        CpuFill32(0, gPlttBufferFaded, PLTT_SIZE);
         ShowBg(0);
         ShowBg(1);
         ShowBg(2);
@@ -5327,10 +5327,10 @@ static void Task_ShowTourneyTree(u8 taskId)
         DecompressAndLoadBgGfxUsingHeap(2, gDomeTourneyLine_Gfx, 0x2000, 0, 0);
         DecompressAndLoadBgGfxUsingHeap(2, gDomeTourneyLineDown_Tilemap, 0x2000, 0, 1);
         DecompressAndLoadBgGfxUsingHeap(3, gDomeTourneyLineUp_Tilemap, 0x2000, 0, 1);
-        LoadCompressedPalette(gDomeTourneyTree_Pal, 0, 0x200);
-        LoadCompressedPalette(gDomeTourneyTreeButtons_Pal, 0x100, 0x200);
-        LoadCompressedPalette(gBattleWindowTextPalette, 0xF0, 0x20);
-        CpuFill32(0, gPlttBufferFaded, 0x400);
+        LoadCompressedPalette(gDomeTourneyTree_Pal, BG_PLTT_OFFSET, BG_PLTT_SIZE);
+        LoadCompressedPalette(gDomeTourneyTreeButtons_Pal, OBJ_PLTT_OFFSET, OBJ_PLTT_SIZE);
+        LoadCompressedPalette(gBattleWindowTextPalette, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
+        CpuFill32(0, gPlttBufferFaded, PLTT_SIZE);
         ShowBg(0);
         ShowBg(1);
         ShowBg(2);

--- a/src/battle_factory_screen.c
+++ b/src/battle_factory_screen.c
@@ -350,7 +350,7 @@ static const struct WindowTemplate sSelect_WindowTemplates[] =
         .tilemapTop = 2,
         .width = 12,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0001,
     },
     [SELECT_WIN_SPECIES] = {
@@ -359,7 +359,7 @@ static const struct WindowTemplate sSelect_WindowTemplates[] =
         .tilemapTop = 2,
         .width = 11,
         .height = 2,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x0019,
     },
     [SELECT_WIN_INFO] = {
@@ -368,7 +368,7 @@ static const struct WindowTemplate sSelect_WindowTemplates[] =
         .tilemapTop = 15,
         .width = 20,
         .height = 3,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x002f,
     },
     [SELECT_WIN_OPTIONS] = {
@@ -377,7 +377,7 @@ static const struct WindowTemplate sSelect_WindowTemplates[] =
         .tilemapTop = 14,
         .width = 8,
         .height = 6,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x006b,
     },
     [SELECT_WIN_YES_NO] = {
@@ -386,7 +386,7 @@ static const struct WindowTemplate sSelect_WindowTemplates[] =
         .tilemapTop = 14,
         .width = 8,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x009b,
     },
     [SELECT_WIN_MON_CATEGORY] = {
@@ -395,7 +395,7 @@ static const struct WindowTemplate sSelect_WindowTemplates[] =
         .tilemapTop = 0,
         .width = 15,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x00bb,
     },
     DUMMY_WIN_TEMPLATE,
@@ -945,7 +945,7 @@ static const struct WindowTemplate sSwap_WindowTemplates[] =
         .tilemapTop = 2,
         .width = 12,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0001,
     },
     [SWAP_WIN_SPECIES] = {
@@ -954,7 +954,7 @@ static const struct WindowTemplate sSwap_WindowTemplates[] =
         .tilemapTop = 2,
         .width = 11,
         .height = 2,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x0019,
     },
     [SWAP_WIN_INFO] = {
@@ -963,7 +963,7 @@ static const struct WindowTemplate sSwap_WindowTemplates[] =
         .tilemapTop = 15,
         .width = 20,
         .height = 3,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x002f,
     },
     [SWAP_WIN_OPTIONS] = {
@@ -972,7 +972,7 @@ static const struct WindowTemplate sSwap_WindowTemplates[] =
         .tilemapTop = 14,
         .width = 9,
         .height = 6,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x006b,
     },
     [SWAP_WIN_YES_NO] = {
@@ -981,7 +981,7 @@ static const struct WindowTemplate sSwap_WindowTemplates[] =
         .tilemapTop = 14,
         .width = 8,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x00a1,
     },
     [SWAP_WIN_ACTION_FADE] = {
@@ -990,7 +990,7 @@ static const struct WindowTemplate sSwap_WindowTemplates[] =
         .tilemapTop = 15,
         .width = 9,
         .height = 5,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x006b,
     },
     [SWAP_WIN_UNUSED] = {
@@ -999,7 +999,7 @@ static const struct WindowTemplate sSwap_WindowTemplates[] =
         .tilemapTop = 2,
         .width = 4,
         .height = 2,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x00c1,
     },
     [SWAP_WIN_SPECIES_AT_FADE] = {
@@ -1008,7 +1008,7 @@ static const struct WindowTemplate sSwap_WindowTemplates[] =
         .tilemapTop = 2,
         .width = 11,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x00c9,
     },
     [SWAP_WIN_MON_CATEGORY] = {
@@ -1017,7 +1017,7 @@ static const struct WindowTemplate sSwap_WindowTemplates[] =
         .tilemapTop = 0,
         .width = 15,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x00df,
     },
     DUMMY_WIN_TEMPLATE,
@@ -1175,16 +1175,16 @@ static void CB2_InitSelectScreen(void)
         LoadBgTiles(3, sSelectMonPicBgTilesetBuffer, 0x60, 0);
         CpuCopy16(gFrontierFactorySelectMenu_Tilemap, sSelectMenuTilemapBuffer, BG_SCREEN_SIZE);
         LoadBgTilemap(1, sSelectMenuTilemapBuffer, BG_SCREEN_SIZE, 0);
-        LoadPalette(gFrontierFactorySelectMenu_Pal, 0, 0x40);
-        LoadPalette(sSelectText_Pal, 0xF0, 8);
-        LoadPalette(sSelectText_Pal, 0xE0, 10);
+        LoadPalette(gFrontierFactorySelectMenu_Pal, 0, 2 * PLTT_SIZE_4BPP);
+        LoadPalette(sSelectText_Pal, BG_PLTT_ID(0xF), PLTT_SIZEOF(4));
+        LoadPalette(sSelectText_Pal, BG_PLTT_ID(0xE), PLTT_SIZEOF(5));
 #ifdef UBFIX
         if (sFactorySelectScreen && sFactorySelectScreen->fromSummaryScreen)
 #else
         if (sFactorySelectScreen->fromSummaryScreen == TRUE)
 #endif
             gPlttBufferUnfaded[228] = sFactorySelectScreen->speciesNameColorBackup;
-        LoadPalette(sMonPicBg_Pal, 0x20, 4);
+        LoadPalette(sMonPicBg_Pal, BG_PLTT_ID(0x2), PLTT_SIZEOF(2));
         gMain.state++;
         break;
     case 3:
@@ -2748,7 +2748,7 @@ static void Swap_Task_FadeOutSpeciesName(u8 taskId)
         gTasks[taskId].tState++;
         break;
     case 1:
-        LoadPalette(&gPlttBufferUnfaded[0xF0], 0xE0, 0xA);
+        LoadPalette(&gPlttBufferUnfaded[BG_PLTT_ID(0xF)], BG_PLTT_ID(0xE), PLTT_SIZEOF(5));
         gTasks[taskId].tState++;
         break;
     case 2:
@@ -2994,7 +2994,7 @@ static void Swap_Task_ScreenInfoTransitionOut(u8 taskId)
     switch (gTasks[taskId].tState)
     {
     case 0:
-        LoadPalette(sSwapText_Pal, 0xE0, sizeof(sSwapText_Pal));
+        LoadPalette(sSwapText_Pal, BG_PLTT_ID(0xE), sizeof(sSwapText_Pal));
         Swap_PrintActionStrings();
         PutWindowTilemap(SWAP_WIN_ACTION_FADE);
         gTasks[taskId].tState++;
@@ -3309,10 +3309,10 @@ static void CB2_InitSwapScreen(void)
         LoadBgTiles(3, sSwapMonPicBgTilesetBuffer, 0x60, 0);
         CpuCopy16(gFrontierFactorySelectMenu_Tilemap, sSwapMenuTilemapBuffer, BG_SCREEN_SIZE);
         LoadBgTilemap(1, sSwapMenuTilemapBuffer, BG_SCREEN_SIZE, 0);
-        LoadPalette(gFrontierFactorySelectMenu_Pal, 0, 0x40);
-        LoadPalette(sSwapText_Pal, 0xF0, sizeof(sSwapText_Pal));
-        LoadPalette(sSwapText_Pal, 0xE0, sizeof(sSwapText_Pal));
-        LoadPalette(sMonPicBg_Pal, 0x20, 4);
+        LoadPalette(gFrontierFactorySelectMenu_Pal, 0, 2 * PLTT_SIZE_4BPP);
+        LoadPalette(sSwapText_Pal, BG_PLTT_ID(0xF), sizeof(sSwapText_Pal));
+        LoadPalette(sSwapText_Pal, BG_PLTT_ID(0xE), sizeof(sSwapText_Pal));
+        LoadPalette(sMonPicBg_Pal, BG_PLTT_ID(0x2), PLTT_SIZEOF(2));
         gMain.state++;
         break;
     case 3:
@@ -3867,7 +3867,7 @@ static void Swap_PrintMonSpeciesAtFade(void)
         pal[4] = gPlttBufferFaded[228];
     else
         pal[4] = sFactorySwapScreen->speciesNameColorBackup;
-    LoadPalette(pal, 0xF0, sizeof(sSwapText_Pal));
+    LoadPalette(pal, BG_PLTT_ID(0xF), sizeof(sSwapText_Pal));
 
     PutWindowTilemap(SWAP_WIN_SPECIES_AT_FADE);
     FillWindowPixelBuffer(SWAP_WIN_SPECIES_AT_FADE, PIXEL_FILL(0));
@@ -3895,8 +3895,8 @@ static void Swap_PrintMonSpeciesForTransition(void)
     u16 species;
     u8 x;
 
-    LoadPalette(sSwapText_Pal, 0xE0, sizeof(sSwapText_Pal));
-    CpuCopy16(&gPlttBufferUnfaded[240], &gPlttBufferFaded[224], 10);
+    LoadPalette(sSwapText_Pal, BG_PLTT_ID(0xE), sizeof(sSwapText_Pal));
+    CpuCopy16(&gPlttBufferUnfaded[BG_PLTT_ID(0xF)], &gPlttBufferFaded[BG_PLTT_ID(0xE)], PLTT_SIZEOF(5));
 
     if (sFactorySwapScreen->cursorPos >= FRONTIER_PARTY_SIZE)
     {

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -576,7 +576,7 @@ void BattleLoadOpponentMonSpriteGfx(struct Pokemon *mon, u8 battlerId)
                                               gMonSpritesGfxPtr->sprites.ptr[position],
                                               species, currentPersonality);
 
-    paletteOffset = 0x100 + battlerId * 16;
+    paletteOffset = OBJ_PLTT_ID(battlerId);
 
     if (gBattleSpritesDataPtr->battlerData[battlerId].transformSpecies == SPECIES_NONE)
         lzPaletteData = GetMonFrontSpritePal(mon);
@@ -584,21 +584,21 @@ void BattleLoadOpponentMonSpriteGfx(struct Pokemon *mon, u8 battlerId)
         lzPaletteData = GetMonSpritePalFromSpeciesAndPersonality(species, otId, monsPersonality);
 
     LZDecompressWram(lzPaletteData, gDecompressionBuffer);
-    LoadPalette(gDecompressionBuffer, paletteOffset, 0x20);
-    LoadPalette(gDecompressionBuffer, 0x80 + battlerId * 16, 0x20);
+    LoadPalette(gDecompressionBuffer, paletteOffset, PLTT_SIZE_4BPP);
+    LoadPalette(gDecompressionBuffer, 0x80 + BG_PLTT_ID(battlerId), PLTT_SIZE_4BPP);
 
     if (species == SPECIES_CASTFORM)
     {
-        paletteOffset = 0x100 + battlerId * 16;
+        paletteOffset = OBJ_PLTT_ID(battlerId);
         LZDecompressWram(lzPaletteData, gBattleStruct->castformPalette);
-        LoadPalette(gBattleStruct->castformPalette[gBattleMonForms[battlerId]], paletteOffset, 0x20);
+        LoadPalette(gBattleStruct->castformPalette[gBattleMonForms[battlerId]], paletteOffset, PLTT_SIZE_4BPP);
     }
 
     // transform's pink color
     if (gBattleSpritesDataPtr->battlerData[battlerId].transformSpecies != SPECIES_NONE)
     {
         BlendPalette(paletteOffset, 16, 6, RGB_WHITE);
-        CpuCopy32(gPlttBufferFaded + paletteOffset, gPlttBufferUnfaded + paletteOffset, 32);
+        CpuCopy32(gPlttBufferFaded + paletteOffset, gPlttBufferUnfaded + paletteOffset, PLTT_SIZEOF(16));
     }
 }
 
@@ -639,7 +639,7 @@ void BattleLoadPlayerMonSpriteGfx(struct Pokemon *mon, u8 battlerId)
                                 species, currentPersonality);
     }
 
-    paletteOffset = 0x100 + battlerId * 16;
+    paletteOffset = OBJ_PLTT_ID(battlerId);
 
     if (gBattleSpritesDataPtr->battlerData[battlerId].transformSpecies == SPECIES_NONE)
         lzPaletteData = GetMonFrontSpritePal(mon);
@@ -647,21 +647,21 @@ void BattleLoadPlayerMonSpriteGfx(struct Pokemon *mon, u8 battlerId)
         lzPaletteData = GetMonSpritePalFromSpeciesAndPersonality(species, otId, monsPersonality);
 
     LZDecompressWram(lzPaletteData, gDecompressionBuffer);
-    LoadPalette(gDecompressionBuffer, paletteOffset, 0x20);
-    LoadPalette(gDecompressionBuffer, 0x80 + battlerId * 16, 0x20);
+    LoadPalette(gDecompressionBuffer, paletteOffset, PLTT_SIZE_4BPP);
+    LoadPalette(gDecompressionBuffer, 0x80 + BG_PLTT_ID(battlerId), PLTT_SIZE_4BPP);
 
     if (species == SPECIES_CASTFORM)
     {
-        paletteOffset = 0x100 + battlerId * 16;
+        paletteOffset = OBJ_PLTT_ID(battlerId);
         LZDecompressWram(lzPaletteData, gBattleStruct->castformPalette);
-        LoadPalette(gBattleStruct->castformPalette[gBattleMonForms[battlerId]], paletteOffset, 0x20);
+        LoadPalette(gBattleStruct->castformPalette[gBattleMonForms[battlerId]], paletteOffset, PLTT_SIZE_4BPP);
     }
 
     // transform's pink color
     if (gBattleSpritesDataPtr->battlerData[battlerId].transformSpecies != SPECIES_NONE)
     {
         BlendPalette(paletteOffset, 16, 6, RGB_WHITE);
-        CpuCopy32(gPlttBufferFaded + paletteOffset, gPlttBufferUnfaded + paletteOffset, 32);
+        CpuCopy32(gPlttBufferFaded + paletteOffset, gPlttBufferUnfaded + paletteOffset, PLTT_SIZEOF(16));
     }
 }
 
@@ -690,7 +690,7 @@ void DecompressTrainerBackPic(u16 backPicId, u8 battlerId)
                              gMonSpritesGfxPtr->sprites.ptr[position],
                              SPECIES_NONE);
     LoadCompressedPalette(gTrainerBackPicPaletteTable[backPicId].data,
-                          0x100 + 16 * battlerId, 0x20);
+                          OBJ_PLTT_ID(battlerId), PLTT_SIZE_4BPP);
 }
 
 void BattleGfxSfxDummy3(u8 gender)
@@ -903,13 +903,13 @@ void HandleSpeciesGfxDataChange(u8 battlerAtk, u8 battlerDef, bool8 castform)
     if (castform)
     {
         StartSpriteAnim(&gSprites[gBattlerSpriteIds[battlerAtk]], gBattleSpritesDataPtr->animationData->animArg);
-        paletteOffset = 0x100 + battlerAtk * 16;
-        LoadPalette(gBattleStruct->castformPalette[gBattleSpritesDataPtr->animationData->animArg], paletteOffset, 32);
+        paletteOffset = OBJ_PLTT_ID(battlerAtk);
+        LoadPalette(gBattleStruct->castformPalette[gBattleSpritesDataPtr->animationData->animArg], paletteOffset, PLTT_SIZE_4BPP);
         gBattleMonForms[battlerAtk] = gBattleSpritesDataPtr->animationData->animArg;
         if (gBattleSpritesDataPtr->battlerData[battlerAtk].transformSpecies != SPECIES_NONE)
         {
             BlendPalette(paletteOffset, 16, 6, RGB_WHITE);
-            CpuCopy32(gPlttBufferFaded + paletteOffset, gPlttBufferUnfaded + paletteOffset, 32);
+            CpuCopy32(gPlttBufferFaded + paletteOffset, gPlttBufferUnfaded + paletteOffset, PLTT_SIZEOF(16));
         }
         gSprites[gBattlerSpriteIds[battlerAtk]].y = GetBattlerSpriteDefault_Y(battlerAtk);
     }
@@ -965,20 +965,20 @@ void HandleSpeciesGfxDataChange(u8 battlerAtk, u8 battlerDef, bool8 castform)
         src = gMonSpritesGfxPtr->sprites.ptr[position];
         dst = (void *)(OBJ_VRAM0 + gSprites[gBattlerSpriteIds[battlerAtk]].oam.tileNum * 32);
         DmaCopy32(3, src, dst, MON_PIC_SIZE);
-        paletteOffset = 0x100 + battlerAtk * 16;
+        paletteOffset = OBJ_PLTT_ID(battlerAtk);
         lzPaletteData = GetMonSpritePalFromSpeciesAndPersonality(targetSpecies, otId, personalityValue);
         LZDecompressWram(lzPaletteData, gDecompressionBuffer);
-        LoadPalette(gDecompressionBuffer, paletteOffset, 32);
+        LoadPalette(gDecompressionBuffer, paletteOffset, PLTT_SIZE_4BPP);
 
         if (targetSpecies == SPECIES_CASTFORM)
         {
             gSprites[gBattlerSpriteIds[battlerAtk]].anims = gMonFrontAnimsPtrTable[targetSpecies];
             LZDecompressWram(lzPaletteData, gBattleStruct->castformPalette);
-            LoadPalette(gBattleStruct->castformPalette[gBattleMonForms[battlerDef]], paletteOffset, 32);
+            LoadPalette(gBattleStruct->castformPalette[gBattleMonForms[battlerDef]], paletteOffset, PLTT_SIZE_4BPP);
         }
 
         BlendPalette(paletteOffset, 16, 6, RGB_WHITE);
-        CpuCopy32(gPlttBufferFaded + paletteOffset, gPlttBufferUnfaded + paletteOffset, 32);
+        CpuCopy32(gPlttBufferFaded + paletteOffset, gPlttBufferUnfaded + paletteOffset, PLTT_SIZEOF(16));
 
         if (!IsContest())
         {
@@ -1014,8 +1014,8 @@ void BattleLoadSubstituteOrMonSpriteGfx(u8 battlerId, bool8 loadMonSprite)
             Dma3CopyLarge32_(gMonSpritesGfxPtr->sprites.ptr[position], &gMonSpritesGfxPtr->sprites.byte[position][MON_PIC_SIZE * i], MON_PIC_SIZE);
         }
 
-        palOffset = (battlerId * 16) + 0x100;
-        LoadCompressedPalette(gSubstituteDollPal, palOffset, 32);
+        palOffset = OBJ_PLTT_ID(battlerId);
+        LoadCompressedPalette(gSubstituteDollPal, palOffset, PLTT_SIZE_4BPP);
     }
     else
     {

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -2027,11 +2027,11 @@ static void UpdateStatusIconInHealthbox(u8 healthboxSpriteId)
         return;
     }
 
-    pltAdder = gSprites[healthboxSpriteId].oam.paletteNum * 16;
+    pltAdder = PLTT_ID(gSprites[healthboxSpriteId].oam.paletteNum);
     pltAdder += battlerId + 12;
 
-    FillPalette(sStatusIconColors[statusPalId], pltAdder + 0x100, 2);
-    CpuCopy16(gPlttBufferUnfaded + 0x100 + pltAdder, (void *)(OBJ_PLTT + pltAdder * 2), 2);
+    FillPalette(sStatusIconColors[statusPalId], OBJ_PLTT_OFFSET + pltAdder, PLTT_SIZEOF(1));
+    CpuCopy16(gPlttBufferUnfaded + OBJ_PLTT_OFFSET + pltAdder, (u16 *)OBJ_PLTT + pltAdder, PLTT_SIZEOF(1));
     CpuCopy32(statusGfxPtr, (void *)(OBJ_VRAM0 + (gSprites[healthboxSpriteId].oam.tileNum + tileNumAdder) * TILE_SIZE_4BPP), 96);
     if (IsDoubleBattle() == TRUE || GetBattlerSide(battlerId) == B_SIDE_OPPONENT)
     {

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -2215,7 +2215,7 @@ void CB2_InitEndLinkBattle(void)
         gBattle_BG3_Y = 0;
 
         InitBattleBgsVideo();
-        LoadCompressedPalette(gBattleTextboxPalette, 0, 64);
+        LoadCompressedPalette(gBattleTextboxPalette, BG_PLTT_ID(0x0), 2 * PLTT_SIZE_4BPP);
         LoadBattleMenuWindowGfx();
         ResetSpriteData();
         ResetTasks();

--- a/src/battle_pyramid_bag.c
+++ b/src/battle_pyramid_bag.c
@@ -214,7 +214,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 2,
         .width = 15,
         .height = 16,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 30
     },
     [WIN_INFO] = {
@@ -223,7 +223,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 13,
         .width = 14,
         .height = 6,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 270
     },
     [WIN_MSG] = {
@@ -232,7 +232,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 15,
         .width = 27,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 354
     },
     [WIN_TOSS_NUM] = {
@@ -241,7 +241,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 17,
         .width = 5,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 462
     },
     DUMMY_WIN_TEMPLATE,
@@ -263,7 +263,7 @@ static const struct WindowTemplate sWindowTemplates_MenuActions[] =
         .tilemapTop = 17,
         .width = 7,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 472
     },
     [MENU_WIN_1x2] = {
@@ -272,7 +272,7 @@ static const struct WindowTemplate sWindowTemplates_MenuActions[] =
         .tilemapTop = 15,
         .width = 7,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 472
     },
     [MENU_WIN_2x2] = {
@@ -281,7 +281,7 @@ static const struct WindowTemplate sWindowTemplates_MenuActions[] =
         .tilemapTop = 15,
         .width = 14,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 472
     },
     [MENU_WIN_2x3] = { // Unused
@@ -290,7 +290,7 @@ static const struct WindowTemplate sWindowTemplates_MenuActions[] =
         .tilemapTop = 13,
         .width = 14,
         .height = 6,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 472
     },
     [MENU_WIN_YESNO] = {
@@ -299,7 +299,7 @@ static const struct WindowTemplate sWindowTemplates_MenuActions[] =
         .tilemapTop = 15,
         .width = 5,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 472
     },
 };
@@ -578,7 +578,7 @@ static bool8 LoadPyramidBagGfx(void)
         }
         break;
     case 2:
-        LoadCompressedPalette(gBattlePyramidBagInterface_Pal, 0, 32);
+        LoadCompressedPalette(gBattlePyramidBagInterface_Pal, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
         gPyramidBagMenu->state++;
         break;
     case 3:
@@ -1439,9 +1439,9 @@ static void InitPyramidBagWindows(void)
 
     InitWindows(sWindowTemplates);
     DeactivateAllTextPrinters();
-    LoadUserWindowBorderGfx(0, 0x1, 0xE0);
-    LoadMessageBoxGfx(0, 0xA, 0xD0);
-    LoadPalette(gStandardMenuPalette, 0xF0, 0x20);
+    LoadUserWindowBorderGfx(0, 0x1, BG_PLTT_ID(0xE));
+    LoadMessageBoxGfx(0, 0xA, BG_PLTT_ID(0xD));
+    LoadPalette(gStandardMenuPalette, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
 
     for (i = 0; i < ARRAY_COUNT(sWindowTemplates); i++)
         FillWindowPixelBuffer(i, PIXEL_FILL(0));
@@ -1537,10 +1537,10 @@ static void FreeItemIconSprite(u8 spriteArrId)
 static void LoadPyramidBagPalette(void)
 {
     struct SpritePalette spritePalette;
-    u16 *palPtr = Alloc(0x40);
+    u16 *palPtr = Alloc(2 * PLTT_SIZE_4BPP);
 
     LZDecompressWram(gBattlePyramidBag_Pal, palPtr);
-    spritePalette.data = palPtr + (gSaveBlock2Ptr->frontier.lvlMode * 16);
+    spritePalette.data = palPtr + PLTT_ID(gSaveBlock2Ptr->frontier.lvlMode);
     spritePalette.tag = TAG_PYRAMID_BAG;
     LoadSpritePalette(&spritePalette);
     Free(palPtr);

--- a/src/battle_records.c
+++ b/src/battle_records.c
@@ -67,7 +67,7 @@ static const struct WindowTemplate sTrainerHillRecordsWindowTemplates[] =
         .tilemapTop = 1,
         .width = 26,
         .height = 18,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 20
     },
     DUMMY_WIN_TEMPLATE
@@ -80,7 +80,7 @@ static const struct WindowTemplate sLinkBattleRecordsWindow =
     .tilemapTop = 1,
     .width = 26,
     .height = 17,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 1
 };
 
@@ -444,7 +444,7 @@ static void LoadTrainerHillRecordsWindowGfx(u8 bgId)
 {
     LoadBgTiles(bgId, sTrainerHillWindowTileset, sizeof(sTrainerHillWindowTileset), 0);
     CopyToBgTilemapBufferRect(bgId, sTrainerHillWindowTilemap, 0, 0, 0x20, 0x20);
-    LoadPalette(sTrainerHillWindowPalette, 0, 0x20);
+    LoadPalette(sTrainerHillWindowPalette, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
 }
 
 static void VblankCB_TrainerHillRecords(void)
@@ -491,7 +491,7 @@ static void CB2_ShowTrainerHillRecords(void)
         break;
     case 3:
         LoadTrainerHillRecordsWindowGfx(3);
-        LoadPalette(GetTextWindowPalette(0), 0xF0, 0x20);
+        LoadPalette(GetTextWindowPalette(0), BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
         gMain.state++;
         break;
     case 4:

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -6013,7 +6013,7 @@ static void InitLevelUpBanner(void)
     gBattle_BG2_Y = 0;
     gBattle_BG2_X = LEVEL_UP_BANNER_START;
 
-    LoadPalette(sLevelUpBanner_Pal, 0x60, 0x20);
+    LoadPalette(sLevelUpBanner_Pal, BG_PLTT_ID(0x6), PLTT_SIZE_4BPP);
     CopyToWindowPixelBuffer(B_WIN_LEVEL_UP_BANNER, sLevelUpBanner_Gfx, 0, 0);
     PutWindowTilemap(B_WIN_LEVEL_UP_BANNER);
     CopyWindowToVram(B_WIN_LEVEL_UP_BANNER, COPYWIN_FULL);

--- a/src/battle_transition.c
+++ b/src/battle_transition.c
@@ -1406,7 +1406,7 @@ static bool8 Aqua_Init(struct Task *task)
     GetBg0TilesDst(&tilemap, &tileset);
     CpuFill16(0, tilemap, BG_SCREEN_SIZE);
     LZ77UnCompVram(sTeamAqua_Tileset, tileset);
-    LoadPalette(sEvilTeam_Palette, 0xF0, sizeof(sEvilTeam_Palette));
+    LoadPalette(sEvilTeam_Palette, BG_PLTT_ID(0xF), sizeof(sEvilTeam_Palette));
 
     task->tState++;
     return FALSE;
@@ -1421,7 +1421,7 @@ static bool8 Magma_Init(struct Task *task)
     GetBg0TilesDst(&tilemap, &tileset);
     CpuFill16(0, tilemap, BG_SCREEN_SIZE);
     LZ77UnCompVram(sTeamMagma_Tileset, tileset);
-    LoadPalette(sEvilTeam_Palette, 0xF0, sizeof(sEvilTeam_Palette));
+    LoadPalette(sEvilTeam_Palette, BG_PLTT_ID(0xF), sizeof(sEvilTeam_Palette));
 
     task->tState++;
     return FALSE;
@@ -1449,7 +1449,7 @@ static bool8 BigPokeball_Init(struct Task *task)
     GetBg0TilesDst(&tilemap, &tileset);
     CpuFill16(0, tilemap, BG_SCREEN_SIZE);
     CpuCopy16(sBigPokeball_Tileset, tileset, sizeof(sBigPokeball_Tileset));
-    LoadPalette(sFieldEffectPal_Pokeball, 0xF0, sizeof(sFieldEffectPal_Pokeball));
+    LoadPalette(sFieldEffectPal_Pokeball, BG_PLTT_ID(0xF), sizeof(sFieldEffectPal_Pokeball));
 
     task->tState++;
     return FALSE;
@@ -1504,7 +1504,7 @@ static bool8 Regice_SetGfx(struct Task *task)
     u16 *tilemap, *tileset;
 
     GetBg0TilesDst(&tilemap, &tileset);
-    LoadPalette(sRegice_Palette, 0xF0, sizeof(sRegice_Palette));
+    LoadPalette(sRegice_Palette, BG_PLTT_ID(0xF), sizeof(sRegice_Palette));
     CpuCopy16(sRegice_Tilemap, tilemap, 0x500);
     SetSinWave(gScanlineEffectRegBuffers[0], 0, task->tSinIndex, 132, task->tAmplitude, DISPLAY_HEIGHT);
 
@@ -1517,7 +1517,7 @@ static bool8 Registeel_SetGfx(struct Task *task)
     u16 *tilemap, *tileset;
 
     GetBg0TilesDst(&tilemap, &tileset);
-    LoadPalette(sRegisteel_Palette, 0xF0, sizeof(sRegisteel_Palette));
+    LoadPalette(sRegisteel_Palette, BG_PLTT_ID(0xF), sizeof(sRegisteel_Palette));
     CpuCopy16(sRegisteel_Tilemap, tilemap, 0x500);
     SetSinWave(gScanlineEffectRegBuffers[0], 0, task->tSinIndex, 132, task->tAmplitude, DISPLAY_HEIGHT);
 
@@ -1530,7 +1530,7 @@ static bool8 Regirock_SetGfx(struct Task *task)
     u16 *tilemap, *tileset;
 
     GetBg0TilesDst(&tilemap, &tileset);
-    LoadPalette(sRegirock_Palette, 0xF0, sizeof(sRegirock_Palette));
+    LoadPalette(sRegirock_Palette, BG_PLTT_ID(0xF), sizeof(sRegirock_Palette));
     CpuCopy16(sRegirock_Tilemap, tilemap, 0x500);
     SetSinWave(gScanlineEffectRegBuffers[0], 0, task->tSinIndex, 132, task->tAmplitude, DISPLAY_HEIGHT);
 
@@ -1559,7 +1559,7 @@ static bool8 Kyogre_PaletteFlash(struct Task *task)
     {
         u16 offset = task->tTimer % 30;
         offset /= 3;
-        LoadPalette(&sKyogre1_Palette[offset * 16], 0xF0, 0x20);
+        LoadPalette(&sKyogre1_Palette[offset * 16], BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
     }
     if (++task->tTimer > 58)
     {
@@ -1575,7 +1575,7 @@ static bool8 Kyogre_PaletteBrighten(struct Task *task)
     if (task->tTimer % 5 == 0)
     {
         s16 offset = task->tTimer / 5;
-        LoadPalette(&sKyogre2_Palette[offset * 16], 0xF0, 0x20);
+        LoadPalette(&sKyogre2_Palette[offset * 16], BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
     }
     if (++task->tTimer > 68)
     {
@@ -1776,7 +1776,7 @@ static bool8 PokeballsTrail_Init(struct Task *task)
     GetBg0TilesDst(&tilemap, &tileset);
     CpuSet(sPokeballTrail_Tileset, tileset, 0x20);
     CpuFill32(0, tilemap, BG_SCREEN_SIZE);
-    LoadPalette(sFieldEffectPal_Pokeball, 0xF0, sizeof(sFieldEffectPal_Pokeball));
+    LoadPalette(sFieldEffectPal_Pokeball, BG_PLTT_ID(0xF), sizeof(sFieldEffectPal_Pokeball));
 
     task->tState++;
     return FALSE;
@@ -2328,8 +2328,8 @@ static bool8 Mugshot_SetGfx(struct Task *task)
     mugshotsMap = sMugshotsTilemap;
     GetBg0TilesDst(&tilemap, &tileset);
     CpuSet(sEliteFour_Tileset, tileset, 0xF0);
-    LoadPalette(sOpponentMugshotsPals[task->tMugshotId], 0xF0, 0x20);
-    LoadPalette(sPlayerMugshotsPals[gSaveBlock2Ptr->playerGender], 0xFA, 0xC);
+    LoadPalette(sOpponentMugshotsPals[task->tMugshotId], BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
+    LoadPalette(sPlayerMugshotsPals[gSaveBlock2Ptr->playerGender], BG_PLTT_ID(0xF) + 10, PLTT_SIZEOF(6));
 
     for (i = 0; i < 20; i++)
     {
@@ -3193,7 +3193,7 @@ static bool8 RectangularSpiral_Init(struct Task *task)
     CpuCopy16(sShrinkingBoxTileset, tileset, 0x20);
     CpuCopy16(&sShrinkingBoxTileset[0x70], &tileset[0x20], 0x20);
     CpuFill16(0xF0 << 8, tilemap, BG_SCREEN_SIZE);
-    LoadPalette(sFieldEffectPal_Pokeball, 0xF0, sizeof(sFieldEffectPal_Pokeball));
+    LoadPalette(sFieldEffectPal_Pokeball, BG_PLTT_ID(0xF), sizeof(sFieldEffectPal_Pokeball));
 
     task->data[3] = 1;
     task->tState++;
@@ -3389,7 +3389,7 @@ static bool8 Groudon_PaletteFlash(struct Task *task)
     if (task->tTimer % 3 == 0)
     {
         u16 offset = (task->tTimer % 30) / 3;
-        LoadPalette(&sGroudon1_Palette[offset * 16], 0xF0, 0x20);
+        LoadPalette(&sGroudon1_Palette[offset * 16], BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
     }
     if (++task->tTimer > 58)
     {
@@ -3405,7 +3405,7 @@ static bool8 Groudon_PaletteBrighten(struct Task *task)
     if (task->tTimer % 5 == 0)
     {
         s16 offset = task->tTimer / 5;
-        LoadPalette(&sGroudon2_Palette[offset * 16], 0xF0, 0x20);
+        LoadPalette(&sGroudon2_Palette[offset * 16], BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
     }
     if (++task->tTimer > 68)
     {
@@ -3448,7 +3448,7 @@ static bool8 Rayquaza_Init(struct Task *task)
 
     sTransitionData->counter = 0;
     task->tState++;
-    LoadPalette(&sRayquaza_Palette[0x50], 0xF0, 0x20);
+    LoadPalette(&sRayquaza_Palette[0x50], BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
 
     for (i = 0; i < DISPLAY_HEIGHT; i++)
     {
@@ -3476,7 +3476,7 @@ static bool8 Rayquaza_PaletteFlash(struct Task *task)
     {
         u16 value = task->tTimer / 4;
         const u16 *palPtr = &sRayquaza_Palette[(value + 5) * 16];
-        LoadPalette(palPtr, 0xF0, 0x20);
+        LoadPalette(palPtr, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
     }
     if (++task->tTimer > 40)
     {
@@ -3524,7 +3524,7 @@ static bool8 Rayquaza_TriRing(struct Task *task)
     {
         u16 value = task->tTimer / 3;
         const u16 *palPtr = &sRayquaza_Palette[(value + 0) * 16];
-        LoadPalette(palPtr, 0xF0, 0x20);
+        LoadPalette(palPtr, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
     }
     if (++task->tTimer >= 40)
     {
@@ -3775,7 +3775,7 @@ static bool8 GridSquares_Init(struct Task *task)
     GetBg0TilesDst(&tilemap, &tileset);
     CpuSet(sShrinkingBoxTileset, tileset, 16);
     CpuFill16(0xF0 << 8, tilemap, BG_SCREEN_SIZE);
-    LoadPalette(sFieldEffectPal_Pokeball, 0xF0, sizeof(sFieldEffectPal_Pokeball));
+    LoadPalette(sFieldEffectPal_Pokeball, BG_PLTT_ID(0xF), sizeof(sFieldEffectPal_Pokeball));
 
     task->tState++;
     return FALSE;
@@ -4242,7 +4242,7 @@ static bool8 FrontierLogoWiggle_Init(struct Task *task)
     GetBg0TilesDst(&tilemap, &tileset);
     CpuFill16(0, tilemap, BG_SCREEN_SIZE);
     LZ77UnCompVram(sFrontierLogo_Tileset, tileset);
-    LoadPalette(sFrontierLogo_Palette, 0xF0, sizeof(sFrontierLogo_Palette));
+    LoadPalette(sFrontierLogo_Palette, BG_PLTT_ID(0xF), sizeof(sFrontierLogo_Palette));
 
     task->tState++;
     return FALSE;
@@ -4304,7 +4304,7 @@ static bool8 FrontierLogoWave_Init(struct Task *task)
     GetBg0TilesDst(&tilemap, &tileset);
     CpuFill16(0, tilemap, BG_SCREEN_SIZE);
     LZ77UnCompVram(sFrontierLogo_Tileset, tileset);
-    LoadPalette(sFrontierLogo_Palette, 0xF0, sizeof(sFrontierLogo_Palette));
+    LoadPalette(sFrontierLogo_Palette, BG_PLTT_ID(0xF), sizeof(sFrontierLogo_Palette));
     sTransitionData->cameraY = 0;
 
     task->tState++;
@@ -4451,10 +4451,10 @@ static bool8 FrontierSquares_Init(struct Task *task)
     LZ77UnCompVram(sFrontierSquares_FilledBg_Tileset, tileset);
 
     FillBgTilemapBufferRect_Palette0(0, 0, 0, 0, 32, 32);
-    FillBgTilemapBufferRect(0, 1, 0, 0, MARGIN_SIZE, 32, 15);
-    FillBgTilemapBufferRect(0, 1, 30 - MARGIN_SIZE, 0, MARGIN_SIZE, 32, 15);
+    FillBgTilemapBufferRect(0, 1, 0, 0, MARGIN_SIZE, 32, 0xF);
+    FillBgTilemapBufferRect(0, 1, 30 - MARGIN_SIZE, 0, MARGIN_SIZE, 32, 0xF);
     CopyBgTilemapBufferToVram(0);
-    LoadPalette(sFrontierSquares_Palette, 0xF0, sizeof(sFrontierSquares_Palette));
+    LoadPalette(sFrontierSquares_Palette, BG_PLTT_ID(0xF), sizeof(sFrontierSquares_Palette));
 
     task->tPosX = MARGIN_SIZE;
     task->tPosY = 0;
@@ -4471,7 +4471,7 @@ static bool8 FrontierSquares_Draw(struct Task *task)
                                   SQUARE_SIZE, SQUARE_SIZE,
                                   task->tPosX, task->tPosY,
                                   SQUARE_SIZE, SQUARE_SIZE,
-                                  15, 0, 0);
+                                  0xF, 0, 0);
     CopyBgTilemapBufferToVram(0);
 
     task->tPosX += SQUARE_SIZE;
@@ -4546,12 +4546,12 @@ static bool8 FrontierSquaresSpiral_Init(struct Task *task)
     LZ77UnCompVram(sFrontierSquares_FilledBg_Tileset, tileset);
 
     FillBgTilemapBufferRect_Palette0(0, 0, 0, 0, 32, 32);
-    FillBgTilemapBufferRect(0, 1, 0, 0, MARGIN_SIZE, 32, 15);
-    FillBgTilemapBufferRect(0, 1, 30 - MARGIN_SIZE, 0, MARGIN_SIZE, 32, 15);
+    FillBgTilemapBufferRect(0, 1, 0, 0, MARGIN_SIZE, 32, 0xF);
+    FillBgTilemapBufferRect(0, 1, 30 - MARGIN_SIZE, 0, MARGIN_SIZE, 32, 0xF);
     CopyBgTilemapBufferToVram(0);
-    LoadPalette(sFrontierSquares_Palette, 0xE0, sizeof(sFrontierSquares_Palette));
-    LoadPalette(sFrontierSquares_Palette, 0xF0, sizeof(sFrontierSquares_Palette));
-    BlendPalette(0xE0, 16, 8, RGB_BLACK);
+    LoadPalette(sFrontierSquares_Palette, BG_PLTT_ID(0xE), sizeof(sFrontierSquares_Palette));
+    LoadPalette(sFrontierSquares_Palette, BG_PLTT_ID(0xF), sizeof(sFrontierSquares_Palette));
+    BlendPalette(BG_PLTT_ID(0xE), 16, 8, RGB_BLACK);
 
     task->tSquareNum = NUM_SQUARES - 1;
     task->tFadeFlag = 0;
@@ -4569,7 +4569,7 @@ static bool8 FrontierSquaresSpiral_Outward(struct Task *task)
                                   SQUARE_SIZE, SQUARE_SIZE,
                                   SQUARE_SIZE * x + MARGIN_SIZE, SQUARE_SIZE * y,
                                   SQUARE_SIZE, SQUARE_SIZE,
-                                  15, 0, 0);
+                                  0xF, 0, 0);
     CopyBgTilemapBufferToVram(0);
 
     if (--task->tSquareNum < 0)
@@ -4581,7 +4581,7 @@ static bool8 FrontierSquaresSpiral_Outward(struct Task *task)
 // set it to black so it's not revealed when the squares are removed.
 static bool8 FrontierSquaresSpiral_SetBlack(struct Task *task)
 {
-    BlendPalette(0xE0, 16, 3, RGB_BLACK);
+    BlendPalette(BG_PLTT_ID(0xE), 16, 3, RGB_BLACK);
     BlendPalettes(PALETTES_ALL & ~(1 << 15 | 1 << 14), 16, RGB_BLACK);
 
     task->tSquareNum = 0;
@@ -4603,7 +4603,7 @@ static bool8 FrontierSquaresSpiral_Inward(struct Task *task)
                                       SQUARE_SIZE * (sFrontierSquaresSpiral_Positions[task->tSquareNum] % NUM_SQUARES_PER_ROW) + MARGIN_SIZE,
                                       SQUARE_SIZE * (sFrontierSquaresSpiral_Positions[task->tSquareNum] / NUM_SQUARES_PER_ROW),
                                       SQUARE_SIZE, SQUARE_SIZE,
-                                      14, 0, 0);
+                                      0xE, 0, 0);
     }
     else
     {
@@ -4614,7 +4614,7 @@ static bool8 FrontierSquaresSpiral_Inward(struct Task *task)
                                     SQUARE_SIZE * (sFrontierSquaresSpiral_Positions[task->tSquareNum - 1] % NUM_SQUARES_PER_ROW) + MARGIN_SIZE,
                                     SQUARE_SIZE * (sFrontierSquaresSpiral_Positions[task->tSquareNum - 1] / NUM_SQUARES_PER_ROW),
                                     SQUARE_SIZE, SQUARE_SIZE,
-                                    15);
+                                    0xF);
         }
         task->tSquareNum++;
     }
@@ -4664,7 +4664,7 @@ static bool8 FrontierSquaresScroll_Init(struct Task *task)
     LZ77UnCompVram(sFrontierSquares_FilledBg_Tileset, tileset);
     FillBgTilemapBufferRect_Palette0(0, 0, 0, 0, 32, 32);
     CopyBgTilemapBufferToVram(0);
-    LoadPalette(sFrontierSquares_Palette, 0xF0, sizeof(sFrontierSquares_Palette));
+    LoadPalette(sFrontierSquares_Palette, BG_PLTT_ID(0xF), sizeof(sFrontierSquares_Palette));
 
     gBattle_BG0_X = 0;
     gBattle_BG0_Y = 0;
@@ -4709,7 +4709,7 @@ static bool8 FrontierSquaresScroll_Draw(struct Task *task)
                                   SQUARE_SIZE, SQUARE_SIZE,
                                   SQUARE_SIZE * x + MARGIN_SIZE, SQUARE_SIZE * y,
                                   SQUARE_SIZE, SQUARE_SIZE,
-                                  15, 0, 0);
+                                  0xF, 0, 0);
     CopyBgTilemapBufferToVram(0);
 
     if (++task->tSquareNum >= (int)ARRAY_COUNT(sFrontierSquaresScroll_Positions))
@@ -4738,7 +4738,7 @@ static bool8 FrontierSquaresScroll_Erase(struct Task *task)
     FillBgTilemapBufferRect(0, 1,
                             SQUARE_SIZE * x + MARGIN_SIZE, SQUARE_SIZE * y,
                             SQUARE_SIZE, SQUARE_SIZE,
-                            15);
+                            0xF);
     CopyBgTilemapBufferToVram(0);
 
     if (++task->tSquareNum >= (int)ARRAY_COUNT(sFrontierSquaresScroll_Positions))

--- a/src/battle_transition_frontier.c
+++ b/src/battle_transition_frontier.c
@@ -226,7 +226,7 @@ static void LoadLogoGfx(void)
     GetBg0TilesDst(&tilemap, &tileset);
     LZ77UnCompVram(sLogoCenter_Gfx, tileset);
     LZ77UnCompVram(sLogoCenter_Tilemap, tilemap);
-    LoadPalette(sLogo_Pal, 0xF0, sizeof(sLogo_Pal));
+    LoadPalette(sLogo_Pal, BG_PLTT_ID(0xF), sizeof(sLogo_Pal));
     LoadCompressedSpriteSheet(&sSpriteSheet_LogoCircles);
     LoadSpritePalette(&sSpritePalette_LogoCircles);
 }

--- a/src/berry_blender.c
+++ b/src/berry_blender.c
@@ -338,7 +338,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 6,
         .width = 7,
         .height = 2,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x28,
     },
     {
@@ -347,7 +347,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 6,
         .width = 7,
         .height = 2,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x36,
     },
     {
@@ -356,7 +356,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 12,
         .width = 7,
         .height = 2,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x44,
     },
     {
@@ -365,7 +365,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 12,
         .width = 7,
         .height = 2,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x52,
     },
     {
@@ -374,7 +374,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 15,
         .width = 27,
         .height = 4,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x60,
     },
     {
@@ -383,7 +383,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 3,
         .width = 21,
         .height = 14,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x60,
     },
     DUMMY_WIN_TEMPLATE
@@ -396,7 +396,7 @@ static const struct WindowTemplate sYesNoWindowTemplate_ContinuePlaying =
     .tilemapTop = 9,
     .width = 5,
     .height = 4,
-    .paletteNum = 14,
+    .paletteNum = 0xE,
     .baseBlock = 0xCC
 };
 
@@ -926,7 +926,7 @@ static const struct WindowTemplate sBlenderRecordWindowTemplate =
     .tilemapTop = 4,
     .width = 18,
     .height = 11,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 8
 };
 
@@ -959,7 +959,7 @@ static bool8 LoadBerryBlenderGfx(void)
     case 1:
         CopyToBgTilemapBuffer(2, sBlenderCenter_Tilemap, 0x400, 0);
         CopyBgTilemapBufferToVram(2);
-        LoadPalette(sBlenderCenter_Pal, 0, 0x100);
+        LoadPalette(sBlenderCenter_Pal, BG_PLTT_ID(0x0), 8 * PLTT_SIZE_4BPP);
         sBerryBlender->loadGfxState++;
         break;
     case 2:
@@ -984,7 +984,7 @@ static bool8 LoadBerryBlenderGfx(void)
         sBerryBlender->loadGfxState++;
         break;
     case 7:
-        LoadPalette(sBlenderOuter_Pal, 0x80, 0x20);
+        LoadPalette(sBlenderOuter_Pal, BG_PLTT_ID(0x8), PLTT_SIZE_4BPP);
         sBerryBlender->loadGfxState++;
         break;
     case 8:
@@ -1065,8 +1065,8 @@ static void CB2_LoadBerryBlender(void)
         InitBgsFromTemplates(1, sBgTemplates, ARRAY_COUNT(sBgTemplates));
         SetBgTilemapBuffer(1, sBerryBlender->tilemapBuffers[0]);
         SetBgTilemapBuffer(2, sBerryBlender->tilemapBuffers[1]);
-        LoadUserWindowBorderGfx(0, 1, 0xD0);
-        LoadMessageBoxGfx(0, 0x14, 0xF0);
+        LoadUserWindowBorderGfx(0, 1, BG_PLTT_ID(0xD));
+        LoadMessageBoxGfx(0, 0x14, BG_PLTT_ID(0xF));
         InitBerryBlenderWindows();
 
         sBerryBlender->mainState++;
@@ -1502,8 +1502,8 @@ static void InitBlenderBgs(void)
 
     SetBgTilemapBuffer(1, sBerryBlender->tilemapBuffers[0]);
     SetBgTilemapBuffer(2, sBerryBlender->tilemapBuffers[1]);
-    LoadUserWindowBorderGfx(0, 1, 0xD0);
-    LoadMessageBoxGfx(0, 0x14, 0xF0);
+    LoadUserWindowBorderGfx(0, 1, BG_PLTT_ID(0xD));
+    LoadMessageBoxGfx(0, 0x14, BG_PLTT_ID(0xF));
     InitBerryBlenderWindows();
 
     sBerryBlender->unk0 = 0;

--- a/src/berry_crush.c
+++ b/src/berry_crush.c
@@ -473,7 +473,7 @@ static const struct WindowTemplate sWindowTemplate_Rankings =
     .tilemapTop = 4,
     .width = 24,
     .height = 13,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 1
 };
 
@@ -485,7 +485,7 @@ static const struct WindowTemplate sWindowTemplates_PlayerNames[MAX_RFU_PLAYERS 
         .tilemapTop = 0,
         .width = 9,
         .height = 2,
-        .paletteNum = 8,
+        .paletteNum = 0x8,
         .baseBlock = 1005
     },
     {
@@ -494,7 +494,7 @@ static const struct WindowTemplate sWindowTemplates_PlayerNames[MAX_RFU_PLAYERS 
         .tilemapTop = 3,
         .width = 9,
         .height = 2,
-        .paletteNum = 8,
+        .paletteNum = 0x8,
         .baseBlock = 987
     },
     {
@@ -503,7 +503,7 @@ static const struct WindowTemplate sWindowTemplates_PlayerNames[MAX_RFU_PLAYERS 
         .tilemapTop = 6,
         .width = 9,
         .height = 2,
-        .paletteNum = 8,
+        .paletteNum = 0x8,
         .baseBlock = 969
     },
     {
@@ -512,7 +512,7 @@ static const struct WindowTemplate sWindowTemplates_PlayerNames[MAX_RFU_PLAYERS 
         .tilemapTop = 3,
         .width = 9,
         .height = 2,
-        .paletteNum = 8,
+        .paletteNum = 0x8,
         .baseBlock = 951
     },
     {
@@ -521,7 +521,7 @@ static const struct WindowTemplate sWindowTemplates_PlayerNames[MAX_RFU_PLAYERS 
         .tilemapTop = 6,
         .width = 9,
         .height = 2,
-        .paletteNum = 8,
+        .paletteNum = 0x8,
         .baseBlock = 933
     },
     DUMMY_WIN_TEMPLATE,
@@ -535,7 +535,7 @@ static const struct WindowTemplate sWindowTemplates_Results[] =
         .tilemapTop = 2,
         .width = 20,
         .height = 16,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1
     },
     [STATE_RESULTS_RANDOM - RESULTS_STATE_START] = {
@@ -544,7 +544,7 @@ static const struct WindowTemplate sWindowTemplates_Results[] =
         .tilemapTop = 2,
         .width = 20,
         .height = 16,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1
     },
     [STATE_RESULTS_CRUSHING - RESULTS_STATE_START] = {
@@ -553,7 +553,7 @@ static const struct WindowTemplate sWindowTemplates_Results[] =
         .tilemapTop = 2,
         .width = 22,
         .height = 16,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1
     },
     DUMMY_WIN_TEMPLATE,
@@ -1235,7 +1235,7 @@ static s32 ShowGameDisplay(void)
         gPaletteFade.bufferTransferDisabled = TRUE;
         break;
     case 7:
-        LoadPalette(gBerryCrush_Crusher_Pal, 0, 0x180);
+        LoadPalette(gBerryCrush_Crusher_Pal, BG_PLTT_ID(0x0), 12 * PLTT_SIZE_4BPP);
         CopyToBgTilemapBuffer(1, sCrusherTop_Tilemap, 0, 0);
         CopyToBgTilemapBuffer(2, sContainerCap_Tilemap, 0, 0);
         CopyToBgTilemapBuffer(3, sBg_Tilemap, 0, 0);
@@ -1751,8 +1751,8 @@ static bool32 OpenResultsWindow(struct BerryCrushGame *game, struct BerryCrushGa
         FillWindowPixelBuffer(gfx->resultsWindowId, PIXEL_FILL(0));
         break;
     case 2:
-        LoadUserWindowBorderGfx_(gfx->resultsWindowId, 541, 208);
-        DrawStdFrameWithCustomTileAndPalette(gfx->resultsWindowId, FALSE, 541, 13);
+        LoadUserWindowBorderGfx_(gfx->resultsWindowId, 541, BG_PLTT_ID(0xD));
+        DrawStdFrameWithCustomTileAndPalette(gfx->resultsWindowId, FALSE, 541, 0xD);
         break;
     case 3:
         playerCountIdx = game->playerCount - 2;
@@ -1809,8 +1809,8 @@ static void Task_ShowRankings(u8 taskId)
         tWindowId = AddWindow(&sWindowTemplate_Rankings);
         PutWindowTilemap(tWindowId);
         FillWindowPixelBuffer(tWindowId, PIXEL_FILL(0));
-        LoadUserWindowBorderGfx_(tWindowId, 541, 208);
-        DrawStdFrameWithCustomTileAndPalette(tWindowId, FALSE, 541, 13);
+        LoadUserWindowBorderGfx_(tWindowId, 541, BG_PLTT_ID(0xD));
+        DrawStdFrameWithCustomTileAndPalette(tWindowId, FALSE, 541, 0xD);
         break;
     case 1:
         // Print header text

--- a/src/berry_fix_program.c
+++ b/src/berry_fix_program.c
@@ -77,7 +77,7 @@ static const struct WindowTemplate sBerryFixWindowTemplates[] = {
         .tilemapTop = 4,
         .width = 26,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1
     },
     {
@@ -86,7 +86,7 @@ static const struct WindowTemplate sBerryFixWindowTemplates[] = {
         .tilemapTop = 11,
         .width = 28,
         .height = 8,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 53
     },
     {
@@ -95,7 +95,7 @@ static const struct WindowTemplate sBerryFixWindowTemplates[] = {
         .tilemapTop = 8,
         .width = 30,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 277
     },
     {
@@ -104,7 +104,7 @@ static const struct WindowTemplate sBerryFixWindowTemplates[] = {
         .tilemapTop = 0,
         .width = 14,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 337
     },
     DUMMY_WIN_TEMPLATE

--- a/src/berry_powder.c
+++ b/src/berry_powder.c
@@ -4,6 +4,7 @@
 #include "event_data.h"
 #include "load_save.h"
 #include "menu.h"
+#include "palette.h"
 #include "string_util.h"
 #include "strings.h"
 #include "text.h"
@@ -67,7 +68,7 @@ static const struct WindowTemplate sBerryPowderWindowTemplates[] =
         .tilemapTop = 1,
         .width = 28,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 19
     },
     {
@@ -76,7 +77,7 @@ static const struct WindowTemplate sBerryPowderWindowTemplates[] =
         .tilemapTop = 5,
         .width = 28,
         .height = 14,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 75
     },
     {
@@ -85,7 +86,7 @@ static const struct WindowTemplate sBerryPowderWindowTemplates[] =
         .tilemapTop = 5,
         .width = 28,
         .height = 7,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 75
     },
     {
@@ -94,7 +95,7 @@ static const struct WindowTemplate sBerryPowderWindowTemplates[] =
         .tilemapTop = 8,
         .width = 19,
         .height = 3,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 19
     },
     {
@@ -103,7 +104,7 @@ static const struct WindowTemplate sBerryPowderWindowTemplates[] =
         .tilemapTop = 7,
         .width = 6,
         .height = 4,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 76
     },
     {
@@ -112,7 +113,7 @@ static const struct WindowTemplate sBerryPowderWindowTemplates[] =
         .tilemapTop = 6,
         .width = 22,
         .height = 5,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 19
     },
     {
@@ -121,7 +122,7 @@ static const struct WindowTemplate sBerryPowderWindowTemplates[] =
         .tilemapTop = 8,
         .width = 19,
         .height = 3,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 19
     },
 };
@@ -228,7 +229,7 @@ void DisplayBerryPowderVendorMenu(void)
     sBerryPowderVendorWindowId = AddWindow(&template);
     FillWindowPixelBuffer(sBerryPowderVendorWindowId, PIXEL_FILL(0));
     PutWindowTilemap(sBerryPowderVendorWindowId);
-    LoadUserWindowBorderGfx_(sBerryPowderVendorWindowId, 0x21D, 0xD0);
+    LoadUserWindowBorderGfx_(sBerryPowderVendorWindowId, 0x21D, BG_PLTT_ID(0xD));
     DrawPlayerPowderAmount(sBerryPowderVendorWindowId, 0x21D, 13, GetBerryPowder());
 }
 

--- a/src/berry_tag_screen.c
+++ b/src/berry_tag_screen.c
@@ -108,7 +108,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 4,
         .width = 8,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 69,
     },
     { // WIN_SIZE_FIRM
@@ -117,7 +117,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 7,
         .width = 18,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 85,
     },
     { // WIN_DESC
@@ -126,7 +126,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 14,
         .width = 25,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 157,
     },
     { // WIN_BERRY_TAG
@@ -135,7 +135,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 0,
         .width = 8,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 257,
     },
     DUMMY_WIN_TEMPLATE
@@ -346,7 +346,7 @@ static bool8 LoadBerryTagGfx(void)
         sBerryTag->gfxState++;
         break;
     case 4:
-        LoadCompressedPalette(gBerryCheck_Pal, 0, 0xC0);
+        LoadCompressedPalette(gBerryCheck_Pal, BG_PLTT_ID(0x0), 6 * PLTT_SIZE_4BPP);
         sBerryTag->gfxState++;
         break;
     case 5:
@@ -367,7 +367,7 @@ static void HandleInitWindows(void)
 
     InitWindows(sWindowTemplates);
     DeactivateAllTextPrinters();
-    LoadPalette(sFontPalette, 0xF0, 0x20);
+    LoadPalette(sFontPalette, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
     for (i = 0; i < ARRAY_COUNT(sWindowTemplates) - 1; i++)
         PutWindowTilemap(i);
     ScheduleBgCopyTilemapToVram(0);

--- a/src/cable_car.c
+++ b/src/cable_car.c
@@ -306,7 +306,7 @@ static void CB2_LoadCableCar(void)
     case 3:
         if (!FreeTempTileDataBuffersIfPossible())
         {
-            LoadPalette(gCableCarBg_Pal, 0, 0x80);
+            LoadPalette(gCableCarBg_Pal, BG_PLTT_ID(0x0), 4 * PLTT_SIZE_4BPP);
             gMain.state++;
         }
         break;

--- a/src/cable_club.c
+++ b/src/cable_club.c
@@ -41,7 +41,7 @@ static const struct WindowTemplate sWindowTemplate_LinkPlayerCount = {
     .tilemapTop = 11,
     .width = 11,
     .height = 2,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x0125,
 };
 

--- a/src/clear_save_data_screen.c
+++ b/src/clear_save_data_screen.c
@@ -52,7 +52,7 @@ static const struct WindowTemplate sClearSaveTextWindow[] =
         .tilemapTop = 15,
         .width = 26,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 11,
     },
     DUMMY_WIN_TEMPLATE
@@ -66,7 +66,7 @@ static const struct WindowTemplate sClearSaveYesNo[] =
         .tilemapTop = 2,
         .width = 5,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 115,
     }
 };
@@ -204,6 +204,6 @@ static void InitClearSaveDataScreenWindows(void)
     InitWindows(sClearSaveTextWindow);
     DeactivateAllTextPrinters();
     FillWindowPixelBuffer(0, PIXEL_FILL(0));
-    LoadWindowGfx(0, 0, 2, 224);
-    LoadPalette(gStandardMenuPalette, 0xF0, 0x20);
+    LoadWindowGfx(0, 0, 2, BG_PLTT_ID(0xE));
+    LoadPalette(gStandardMenuPalette, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
 }

--- a/src/contest.c
+++ b/src/contest.c
@@ -1032,13 +1032,13 @@ void LoadContestBgAfterMoveAnim(void)
     LZDecompressVram(gContestAudienceGfx, (void *)(BG_SCREEN_ADDR(4)));
     CopyToBgTilemapBuffer(3, gContestAudienceTilemap, 0, 0);
     CopyBgTilemapBufferToVram(3);
-    LoadCompressedPalette(gContestInterfaceAudiencePalette, 0, 0x200);
+    LoadCompressedPalette(gContestInterfaceAudiencePalette, BG_PLTT_OFFSET, BG_PLTT_SIZE);
     LoadContestPalettes();
     for (i = 0; i < CONTESTANT_COUNT; i++)
     {
         u32 contestantWindowId = 5 + i;
 
-        LoadPalette(eContestTempSave.cachedWindowPalettes[contestantWindowId], 16 * (5 + gContestantTurnOrder[i]), sizeof((eContestTempSave.cachedWindowPalettes[contestantWindowId])));
+        LoadPalette(eContestTempSave.cachedWindowPalettes[contestantWindowId], BG_PLTT_ID(0x5 + gContestantTurnOrder[i]), sizeof((eContestTempSave.cachedWindowPalettes[contestantWindowId])));
     }
 }
 
@@ -1073,11 +1073,11 @@ static void LoadContestPalettes(void)
 {
     s32 i;
 
-    LoadPalette(sText_Pal, 0xf0, 0x20);
-    FillPalette(RGB_BLACK, 0, 2);
+    LoadPalette(sText_Pal, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
+    SetBackdropFromColor(RGB_BLACK);
     for (i = 10; i < 14; i++)
-        LoadPalette(gPlttBufferUnfaded + 241, 240 + i, 2);
-    FillPalette(RGB(31, 17, 31), 0xF3, 2);
+        LoadPalette(gPlttBufferUnfaded + BG_PLTT_ID(0xF) + 1, BG_PLTT_ID(0xF) + i, PLTT_SIZEOF(1));
+    FillPalette(RGB(31, 17, 31), BG_PLTT_ID(0xF) + 3, PLTT_SIZEOF(1));
 }
 
 static void InitContestResources(void)
@@ -1327,11 +1327,11 @@ static bool8 SetupContestGraphics(u8 *stateVar)
         DmaCopy32Defvars(3, gContestResources->contestBgTilemaps[2], eContestTempSave.savedJunk, sizeof(eContestTempSave.savedJunk));
         break;
     case 5:
-        LoadCompressedPalette(gContestInterfaceAudiencePalette, 0, 0x200);
-        CpuCopy32(gPlttBufferUnfaded + 128, tempPalette1, 16 * sizeof(u16));
-        CpuCopy32(gPlttBufferUnfaded + (5 + gContestPlayerMonIndex) * 16, tempPalette2, 16 * sizeof(u16));
-        CpuCopy32(tempPalette2, gPlttBufferUnfaded + 128, 16 * sizeof(u16));
-        CpuCopy32(tempPalette1, gPlttBufferUnfaded + (5 + gContestPlayerMonIndex) * 16, 16 * sizeof(u16));
+        LoadCompressedPalette(gContestInterfaceAudiencePalette, BG_PLTT_OFFSET, BG_PLTT_SIZE);
+        CpuCopy32(gPlttBufferUnfaded + BG_PLTT_ID(0x8), tempPalette1, PLTT_SIZE_4BPP);
+        CpuCopy32(gPlttBufferUnfaded + BG_PLTT_ID(0x5 + gContestPlayerMonIndex), tempPalette2, 16 * sizeof(u16));
+        CpuCopy32(tempPalette2, gPlttBufferUnfaded + BG_PLTT_ID(0x8), PLTT_SIZE_4BPP);
+        CpuCopy32(tempPalette1, gPlttBufferUnfaded + BG_PLTT_ID(0x5 + gContestPlayerMonIndex), PLTT_SIZE_4BPP);
         DmaCopy32Defvars(3, gPlttBufferUnfaded, eContestTempSave.cachedWindowPalettes, sizeof(eContestTempSave.cachedWindowPalettes));
         LoadContestPalettes();
         break;
@@ -3097,7 +3097,7 @@ static u8 CreateJudgeSprite(void)
     u8 spriteId;
 
     LoadCompressedSpriteSheet(&sSpriteSheet_Judge);
-    LoadCompressedPalette(gContest2Pal, 0x110, 32);
+    LoadCompressedPalette(gContest2Pal, OBJ_PLTT_ID(0x1), PLTT_SIZE_4BPP);
     spriteId = CreateSprite(&sSpriteTemplate_Judge, 112, 36, 30);
     gSprites[spriteId].oam.paletteNum = 1;
     gSprites[spriteId].callback = SpriteCallbackDummy;
@@ -3126,7 +3126,7 @@ static u8 CreateContestantSprite(u16 species, u32 otId, u32 personality, u32 ind
     else
         HandleLoadSpecialPokePic_DontHandleDeoxys(&gMonBackPicTable[species], gMonSpritesGfxPtr->sprites.ptr[B_POSITION_PLAYER_LEFT], species, personality);
 
-    LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, otId, personality), 0x120, 0x20);
+    LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, otId, personality), OBJ_PLTT_ID(0x2), PLTT_SIZE_4BPP);
     SetMultiuseSpriteTemplateToPokemon(species, B_POSITION_PLAYER_LEFT);
 
     spriteId = CreateSprite(&gMultiuseSpriteTemplate, 0x70, GetBattlerSpriteFinal_Y(2, species, FALSE), 30);
@@ -3997,7 +3997,7 @@ static void Task_StopFlashJudgeAttentionEye(u8 taskId)
     {
         gTasks[eContest.judgeAttentionTaskId].data[contestant * 4 + 0] = 0xFF;
         gTasks[eContest.judgeAttentionTaskId].data[contestant * 4 + 1] = 0;
-        BlendPalette((eContest.prevTurnOrder[contestant] + 5) * 16 + 6, 2, 0, RGB(31, 31, 18));
+        BlendPalette(BG_PLTT_ID(0x5 + eContest.prevTurnOrder[contestant]) + 6, 2, 0, RGB(31, 31, 18));
         DestroyTask(taskId);
     }
 }
@@ -4021,7 +4021,7 @@ static void Task_FlashJudgeAttentionEye(u8 taskId)
              || gTasks[taskId].data[offset + 0] == 0)
                 gTasks[taskId].data[offset + 1] ^= 1;
 
-            BlendPalette((eContest.prevTurnOrder[i] + 5) * 16 + 6, 2, gTasks[taskId].data[offset + 0], RGB(31, 31, 18));
+            BlendPalette(BG_PLTT_ID(0x5 + eContest.prevTurnOrder[i]) + 6, 2, gTasks[taskId].data[offset + 0], RGB(31, 31, 18));
         }
     }
 }
@@ -4100,8 +4100,8 @@ static void Task_UnusedBlend(u8 taskId)
                  || gTasks[taskId].data[idx] == 0)
                     gTasks[taskId].data[idx + 1] ^= 1;
 
-                BlendPalette((i + 5) * 16 + 10,     1, gTasks[taskId].data[idx + 0], RGB(31, 31, 18));
-                BlendPalette((i + 5) * 16 + 12 + i, 1, gTasks[taskId].data[idx + 0], RGB(31, 31, 18));
+                BlendPalette(BG_PLTT_ID(0x5 + i) + 10,     1, gTasks[taskId].data[idx + 0], RGB(31, 31, 18));
+                BlendPalette(BG_PLTT_ID(0x5 + i) + 12 + i, 1, gTasks[taskId].data[idx + 0], RGB(31, 31, 18));
             }
         }
     }
@@ -4414,7 +4414,7 @@ static void DrawContestantWindows(void)
     for (i = 0; i < CONTESTANT_COUNT; i++)
     {
         s32 windowId = i + 5;
-        LoadPalette(eContestTempSave.cachedWindowPalettes[windowId], (gContestantTurnOrder[i] + 5) * 16, sizeof(eContestTempSave.cachedWindowPalettes[0]));
+        LoadPalette(eContestTempSave.cachedWindowPalettes[windowId], BG_PLTT_ID(0x5 + gContestantTurnOrder[i]), sizeof(eContestTempSave.cachedWindowPalettes[0]));
     }
     DrawContestantWindowText();
 }
@@ -4769,7 +4769,7 @@ static void Task_ApplauseOverflowAnimation(u8 taskId)
         else
             gTasks[taskId].data[4]--;
 
-        BlendPalette(264 + gTasks[taskId].data[2] * 16, 1, gTasks[taskId].data[4], RGB_WHITE);
+        BlendPalette(OBJ_PLTT_ID(gTasks[taskId].data[2]) + 8, 1, gTasks[taskId].data[4], RGB_WHITE);
 
         // At the maximum or minimum blending, switch directions.
         if (gTasks[taskId].data[4] == 0 || gTasks[taskId].data[4] == 16)
@@ -4779,7 +4779,7 @@ static void Task_ApplauseOverflowAnimation(u8 taskId)
             // Continue the animation until the applause meter is cleared.
             if (eContest.applauseLevel < 5)
             {
-                BlendPalette(264 + gTasks[taskId].data[2] * 16, 1, 0, RGB_RED);
+                BlendPalette(OBJ_PLTT_ID(gTasks[taskId].data[2]) + 8, 1, 0, RGB_RED);
                 DestroyTask(taskId);
             }
         }
@@ -4992,8 +4992,8 @@ static void Task_BlendAudienceBackground(u8 taskId)
         else
             gTasks[taskId].tBlendCoeff--;
 
-        BlendPalette(17, 1, gTasks[taskId].tBlendCoeff, gTasks[taskId].tBlendColor);
-        BlendPalette(26, 1, gTasks[taskId].tBlendCoeff, gTasks[taskId].tBlendColor);
+        BlendPalette(BG_PLTT_ID(0x1) + 1,  1, gTasks[taskId].tBlendCoeff, gTasks[taskId].tBlendColor);
+        BlendPalette(BG_PLTT_ID(0x1) + 10, 1, gTasks[taskId].tBlendCoeff, gTasks[taskId].tBlendColor);
 
         if (gTasks[taskId].tBlendCoeff == gTasks[taskId].tTargetBlendCoeff)
         {

--- a/src/contest_painting.c
+++ b/src/contest_painting.c
@@ -121,7 +121,7 @@ static const struct WindowTemplate sWindowTemplate =
     .tilemapTop = 14,
     .width = 26,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 1,
 };
 
@@ -223,7 +223,7 @@ static void ShowContestPainting(void)
         break;
     case 4:
         PrintContestPaintingCaption(gCurContestWinnerSaveIdx, gCurContestWinnerIsForArtist);
-        LoadPalette(sBgPalette, 0, 1 * 2);
+        SetBackdropFromPalette(sBgPalette);
         DmaClear32(3, PLTT, PLTT_SIZE);
         BeginFastPaletteFade(2);
         SetVBlankCallback(VBlankCB_ContestPainting);
@@ -420,7 +420,7 @@ static void LoadContestPaintingFrame(u8 contestWinnerId, bool8 isForArtist)
 {
     u8 x, y;
 
-    LoadPalette(sPictureFramePalettes, 0, 0x100);
+    LoadPalette(sPictureFramePalettes, BG_PLTT_ID(0x0), 8 * PLTT_SIZE_4BPP);
     if (isForArtist == TRUE)
     {
         // Load Artist's frame
@@ -586,7 +586,7 @@ static void DoContestPaintingImageProcessing(u8 imageEffect)
     ApplyImageProcessingEffects(&gImageProcessingContext);
     ApplyImageProcessingQuantization(&gImageProcessingContext);
     ConvertImageProcessingToGBA(&gImageProcessingContext);
-    LoadPalette(gContestPaintingMonPalette, 0x100, 0x200);
+    LoadPalette(gContestPaintingMonPalette, OBJ_PLTT_ID(0x0), 16 * PLTT_SIZE_4BPP);
 }
 
 static void CreateContestPaintingPicture(u8 contestWinnerId, bool8 isForArtist)

--- a/src/contest_util.c
+++ b/src/contest_util.c
@@ -327,7 +327,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 4,
         .width = 12,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 770
     },
     {
@@ -336,7 +336,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 7,
         .width = 12,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 794
     },
     {
@@ -345,7 +345,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 10,
         .width = 12,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 818
     },
     {
@@ -354,7 +354,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 13,
         .width = 12,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 842
     },
     DUMMY_WIN_TEMPLATE,
@@ -455,8 +455,8 @@ static void LoadContestResultsBgGfx(void)
     CopyToBgTilemapBuffer(2, gContestResults_Interface_Tilemap, 0, 0);
     CopyToBgTilemapBuffer(0, gContestResults_WinnerBanner_Tilemap, 0, 0);
     LoadContestResultsTitleBarTilemaps();
-    LoadCompressedPalette(gContestResults_Pal, 0, 0x200);
-    LoadPalette(sResultsTextWindow_Pal, 0xF0, sizeof(sResultsTextWindow_Pal));
+    LoadCompressedPalette(gContestResults_Pal, BG_PLTT_ID(0x0), 16 * PLTT_SIZE_4BPP);
+    LoadPalette(sResultsTextWindow_Pal, BG_PLTT_ID(0xF), sizeof(sResultsTextWindow_Pal));
 
     for (i = 0; i < CONTESTANT_COUNT; i++)
     {
@@ -1092,9 +1092,9 @@ static void Task_FlashStarsAndHearts(u8 taskId)
         else if (gTasks[taskId].tCoeff == 0)
             gTasks[taskId].tDecreasing = FALSE;
 
-        BlendPalette(0x6B, 1, gTasks[taskId].tCoeff, RGB(30, 22, 11));
-        BlendPalette(0x68, 1, gTasks[taskId].tCoeff, RGB_WHITE);
-        BlendPalette(0x6E, 1, gTasks[taskId].tCoeff, RGB(30, 29, 29));
+        BlendPalette(BG_PLTT_ID(0x6) + 11, 1, gTasks[taskId].tCoeff, RGB(30, 22, 11));
+        BlendPalette(BG_PLTT_ID(0x6) + 8, 1, gTasks[taskId].tCoeff, RGB_WHITE);
+        BlendPalette(BG_PLTT_ID(0x6) + 14, 1, gTasks[taskId].tCoeff, RGB(30, 29, 29));
     }
 
     if (gTasks[taskId].tCoeff == 0)
@@ -1143,7 +1143,7 @@ static void LoadAllContestMonIconPalettes(void)
     for (i = 0; i < CONTESTANT_COUNT; i++)
     {
         species = gContestMons[i].species;
-        LoadPalette(gMonIconPalettes[gMonIconPaletteIndices[GetIconSpecies(species, 0)]], i * 0x10 + 0xA0, 0x20);
+        LoadPalette(gMonIconPalettes[gMonIconPaletteIndices[GetIconSpecies(species, 0)]], BG_PLTT_ID(0xA + i), PLTT_SIZE_4BPP);
     }
 }
 
@@ -1561,7 +1561,7 @@ static void Task_HighlightWinnersBox(u8 taskId)
     if (++gTasks[taskId].data[11] == 1)
     {
         gTasks[taskId].data[11] = 0;
-        BlendPalette(0x91, 1, gTasks[taskId].data[12], RGB(13, 28, 27));
+        BlendPalette(BG_PLTT_ID(0x9) + 1, 1, gTasks[taskId].data[12], RGB(13, 28, 27));
         if (gTasks[taskId].data[13] == 0)
         {
             if (++gTasks[taskId].data[12] == 16)
@@ -2525,16 +2525,16 @@ void LoadLinkContestPlayerPalettes(void)
             if (version == VERSION_RUBY || version == VERSION_SAPPHIRE)
             {
                 if (gLinkPlayers[i].gender == MALE)
-                    LoadPalette(gObjectEventPal_RubySapphireBrendan, 0x160 + i * 0x10, 0x20);
+                    LoadPalette(gObjectEventPal_RubySapphireBrendan, OBJ_PLTT_ID(0x6 + i), PLTT_SIZE_4BPP);
                 else
-                    LoadPalette(gObjectEventPal_RubySapphireMay, 0x160 + i * 0x10, 0x20);
+                    LoadPalette(gObjectEventPal_RubySapphireMay, OBJ_PLTT_ID(0x6 + i), PLTT_SIZE_4BPP);
             }
             else
             {
                 if (gLinkPlayers[i].gender == MALE)
-                    LoadPalette(gObjectEventPal_Brendan, 0x160 + i * 0x10, 0x20);
+                    LoadPalette(gObjectEventPal_Brendan, OBJ_PLTT_ID(0x6 + i), PLTT_SIZE_4BPP);
                 else
-                    LoadPalette(gObjectEventPal_May, 0x160 + i * 0x10, 0x20);
+                    LoadPalette(gObjectEventPal_May, OBJ_PLTT_ID(0x6 + i), PLTT_SIZE_4BPP);
             }
         }
     }

--- a/src/credits.c
+++ b/src/credits.c
@@ -185,7 +185,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 9,
         .width = 30,
         .height = 12,
-        .paletteNum = 8,
+        .paletteNum = 0x8,
         .baseBlock = 1
     },
     DUMMY_WIN_TEMPLATE,
@@ -365,7 +365,7 @@ static void InitCreditsBgsAndWindows(void)
     ResetBgsAndClearDma3BusyFlags(0);
     InitBgsFromTemplates(0, sBackgroundTemplates, ARRAY_COUNT(sBackgroundTemplates));
     SetBgTilemapBuffer(0, AllocZeroed(BG_SCREEN_SIZE));
-    LoadPalette(sCredits_Pal, 0x80, 64);
+    LoadPalette(sCredits_Pal, BG_PLTT_ID(0x8), 2 * PLTT_SIZE_4BPP);
     InitWindows(sWindowTemplates);
     DeactivateAllTextPrinters();
     PutWindowTilemap(0);
@@ -549,7 +549,7 @@ static void Task_LoadShowMons(u8 taskId)
         gReservedSpritePaletteCount = 8;
         LZ77UnCompVram(gBirchHelpGfx, (void *)VRAM);
         LZ77UnCompVram(gBirchGrassTilemap, (void *)(BG_SCREEN_ADDR(7)));
-        LoadPalette(gBirchBagGrassPal[0] + 1, 1, 31 * 2);
+        LoadPalette(gBirchBagGrassPal[0] + 1, BG_PLTT_ID(0x0) + 1, PLTT_SIZEOF(2 * 16 - 1));
 
         for (i = 0; i < MON_PIC_SIZE; i++)
             gDecompressionBuffer[i] = 0x11;
@@ -624,7 +624,7 @@ static void Task_CreditsTheEnd3(u8 taskId)
 {
     ResetGpuAndVram();
     ResetPaletteFade();
-    LoadTheEndScreen(0, 0x3800, 0);
+    LoadTheEndScreen(0, 0x3800, BG_PLTT_ID(0x0));
     ResetSpriteData();
     FreeAllSpritePalettes();
     BeginNormalPaletteFade(PALETTES_ALL, 8, 16, 0, RGB_BLACK);

--- a/src/data/party_menu.h
+++ b/src/data/party_menu.h
@@ -140,7 +140,7 @@ static const struct WindowTemplate sSinglePartyMenuWindowTemplate[] =
         .tilemapTop = 3,
         .width = 10,
         .height = 7,
-        .paletteNum = 3,
+        .paletteNum = 0x3,
         .baseBlock = 0x63,
     },
     {
@@ -149,7 +149,7 @@ static const struct WindowTemplate sSinglePartyMenuWindowTemplate[] =
         .tilemapTop = 1,
         .width = 18,
         .height = 3,
-        .paletteNum = 4,
+        .paletteNum = 0x4,
         .baseBlock = 0xA9,
     },
     {
@@ -158,7 +158,7 @@ static const struct WindowTemplate sSinglePartyMenuWindowTemplate[] =
         .tilemapTop = 4,
         .width = 18,
         .height = 3,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0xDF,
     },
     {
@@ -167,7 +167,7 @@ static const struct WindowTemplate sSinglePartyMenuWindowTemplate[] =
         .tilemapTop = 7,
         .width = 18,
         .height = 3,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 0x115,
     },
     {
@@ -176,7 +176,7 @@ static const struct WindowTemplate sSinglePartyMenuWindowTemplate[] =
         .tilemapTop = 10,
         .width = 18,
         .height = 3,
-        .paletteNum = 7,
+        .paletteNum = 0x7,
         .baseBlock = 0x14B,
     },
     {
@@ -185,7 +185,7 @@ static const struct WindowTemplate sSinglePartyMenuWindowTemplate[] =
         .tilemapTop = 13,
         .width = 18,
         .height = 3,
-        .paletteNum = 8,
+        .paletteNum = 0x8,
         .baseBlock = 0x181,
     },
     {
@@ -194,7 +194,7 @@ static const struct WindowTemplate sSinglePartyMenuWindowTemplate[] =
         .tilemapTop = 15,
         .width = 28,
         .height = 4,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x1DF,
     },
     DUMMY_WIN_TEMPLATE
@@ -208,7 +208,7 @@ static const struct WindowTemplate sDoublePartyMenuWindowTemplate[] =
         .tilemapTop = 1,
         .width = 10,
         .height = 7,
-        .paletteNum = 3,
+        .paletteNum = 0x3,
         .baseBlock = 0x63,
     },
     {
@@ -217,7 +217,7 @@ static const struct WindowTemplate sDoublePartyMenuWindowTemplate[] =
         .tilemapTop = 8,
         .width = 10,
         .height = 7,
-        .paletteNum = 4,
+        .paletteNum = 0x4,
         .baseBlock = 0xA9,
     },
     {
@@ -226,7 +226,7 @@ static const struct WindowTemplate sDoublePartyMenuWindowTemplate[] =
         .tilemapTop = 1,
         .width = 18,
         .height = 3,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0xEF,
     },
     {
@@ -235,7 +235,7 @@ static const struct WindowTemplate sDoublePartyMenuWindowTemplate[] =
         .tilemapTop = 5,
         .width = 18,
         .height = 3,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 0x125,
     },
     {
@@ -244,7 +244,7 @@ static const struct WindowTemplate sDoublePartyMenuWindowTemplate[] =
         .tilemapTop = 9,
         .width = 18,
         .height = 3,
-        .paletteNum = 7,
+        .paletteNum = 0x7,
         .baseBlock = 0x15B,
     },
     {
@@ -253,7 +253,7 @@ static const struct WindowTemplate sDoublePartyMenuWindowTemplate[] =
         .tilemapTop = 13,
         .width = 18,
         .height = 3,
-        .paletteNum = 8,
+        .paletteNum = 0x8,
         .baseBlock = 0x191,
     },
     {
@@ -262,7 +262,7 @@ static const struct WindowTemplate sDoublePartyMenuWindowTemplate[] =
         .tilemapTop = 15,
         .width = 28,
         .height = 4,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x1DF,
     },
     DUMMY_WIN_TEMPLATE
@@ -276,7 +276,7 @@ static const struct WindowTemplate sMultiPartyMenuWindowTemplate[] =
         .tilemapTop = 1,
         .width = 10,
         .height = 7,
-        .paletteNum = 3,
+        .paletteNum = 0x3,
         .baseBlock = 0x63,
     },
     {
@@ -285,7 +285,7 @@ static const struct WindowTemplate sMultiPartyMenuWindowTemplate[] =
         .tilemapTop = 8,
         .width = 10,
         .height = 7,
-        .paletteNum = 4,
+        .paletteNum = 0x4,
         .baseBlock = 0xA9,
     },
     {
@@ -294,7 +294,7 @@ static const struct WindowTemplate sMultiPartyMenuWindowTemplate[] =
         .tilemapTop = 2,
         .width = 18,
         .height = 3,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0xEF,
     },
     {
@@ -303,7 +303,7 @@ static const struct WindowTemplate sMultiPartyMenuWindowTemplate[] =
         .tilemapTop = 5,
         .width = 18,
         .height = 3,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 0x125,
     },
     {
@@ -312,7 +312,7 @@ static const struct WindowTemplate sMultiPartyMenuWindowTemplate[] =
         .tilemapTop = 9,
         .width = 18,
         .height = 3,
-        .paletteNum = 7,
+        .paletteNum = 0x7,
         .baseBlock = 0x15B,
     },
     {
@@ -321,7 +321,7 @@ static const struct WindowTemplate sMultiPartyMenuWindowTemplate[] =
         .tilemapTop = 12,
         .width = 18,
         .height = 3,
-        .paletteNum = 8,
+        .paletteNum = 0x8,
         .baseBlock = 0x191,
     },
     {
@@ -330,7 +330,7 @@ static const struct WindowTemplate sMultiPartyMenuWindowTemplate[] =
         .tilemapTop = 15,
         .width = 28,
         .height = 4,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x1DF,
     },
     DUMMY_WIN_TEMPLATE
@@ -344,7 +344,7 @@ static const struct WindowTemplate sShowcaseMultiPartyMenuWindowTemplate[] =
         .tilemapTop = 2,
         .width = 10,
         .height = 7,
-        .paletteNum = 3,
+        .paletteNum = 0x3,
         .baseBlock = 0x63,
     },
     {
@@ -353,7 +353,7 @@ static const struct WindowTemplate sShowcaseMultiPartyMenuWindowTemplate[] =
         .tilemapTop = 3,
         .width = 18,
         .height = 3,
-        .paletteNum = 5,
+        .paletteNum = 0x5,
         .baseBlock = 0xA9,
     },
     {
@@ -362,7 +362,7 @@ static const struct WindowTemplate sShowcaseMultiPartyMenuWindowTemplate[] =
         .tilemapTop = 6,
         .width = 18,
         .height = 3,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 0xDF,
     },
     {
@@ -371,7 +371,7 @@ static const struct WindowTemplate sShowcaseMultiPartyMenuWindowTemplate[] =
         .tilemapTop = 11,
         .width = 10,
         .height = 7,
-        .paletteNum = 4,
+        .paletteNum = 0x4,
         .baseBlock = 0x115,
     },
     {
@@ -380,7 +380,7 @@ static const struct WindowTemplate sShowcaseMultiPartyMenuWindowTemplate[] =
         .tilemapTop = 12,
         .width = 18,
         .height = 3,
-        .paletteNum = 7,
+        .paletteNum = 0x7,
         .baseBlock = 0x16B,
     },
     {
@@ -389,7 +389,7 @@ static const struct WindowTemplate sShowcaseMultiPartyMenuWindowTemplate[] =
         .tilemapTop = 15,
         .width = 18,
         .height = 3,
-        .paletteNum = 8,
+        .paletteNum = 0x8,
         .baseBlock = 0x1A1,
     },
     DUMMY_WIN_TEMPLATE
@@ -402,7 +402,7 @@ static const struct WindowTemplate sCancelButtonWindowTemplate =
     .tilemapTop = 17,
     .width = 6,
     .height = 2,
-    .paletteNum = 3,
+    .paletteNum = 0x3,
     .baseBlock = 0x1C7,
 };
 
@@ -413,7 +413,7 @@ static const struct WindowTemplate sMultiCancelButtonWindowTemplate =
     .tilemapTop = 18,
     .width = 6,
     .height = 2,
-    .paletteNum = 3,
+    .paletteNum = 0x3,
     .baseBlock = 0x1C7,
 };
 
@@ -424,7 +424,7 @@ static const struct WindowTemplate sConfirmButtonWindowTemplate =
     .tilemapTop = 16,
     .width = 6,
     .height = 2,
-    .paletteNum = 3,
+    .paletteNum = 0x3,
     .baseBlock = 0x1D3,
 };
 
@@ -435,7 +435,7 @@ static const struct WindowTemplate sDefaultPartyMsgWindowTemplate =
     .tilemapTop = 17,
     .width = 21,
     .height = 2,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x24F,
 };
 
@@ -446,7 +446,7 @@ static const struct WindowTemplate sDoWhatWithMonMsgWindowTemplate =
     .tilemapTop = 17,
     .width = 16,
     .height = 2,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x279,
 };
 
@@ -457,7 +457,7 @@ static const struct WindowTemplate sDoWhatWithItemMsgWindowTemplate =
     .tilemapTop = 17,
     .width = 20,
     .height = 2,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x299,
 };
 
@@ -468,7 +468,7 @@ static const struct WindowTemplate sDoWhatWithMailMsgWindowTemplate =
     .tilemapTop = 17,
     .width = 18,
     .height = 2,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x299,
 };
 
@@ -479,7 +479,7 @@ static const struct WindowTemplate sWhichMoveMsgWindowTemplate =
     .tilemapTop = 17,
     .width = 16,
     .height = 2,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x299,
 };
 
@@ -490,7 +490,7 @@ static const struct WindowTemplate sAlreadyHoldingOneMsgWindowTemplate =
     .tilemapTop = 15,
     .width = 20,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x299,
 };
 
@@ -501,7 +501,7 @@ static const struct WindowTemplate sItemGiveTakeWindowTemplate =
     .tilemapTop = 13,
     .width = 6,
     .height = 6,
-    .paletteNum = 14,
+    .paletteNum = 0xE,
     .baseBlock = 0x39D,
 };
 
@@ -512,7 +512,7 @@ static const struct WindowTemplate sMailReadTakeWindowTemplate =
     .tilemapTop = 13,
     .width = 8,
     .height = 6,
-    .paletteNum = 14,
+    .paletteNum = 0xE,
     .baseBlock = 0x39D,
 };
 
@@ -523,7 +523,7 @@ static const struct WindowTemplate sMoveSelectWindowTemplate =
     .tilemapTop = 11,
     .width = 10,
     .height = 8,
-    .paletteNum = 14,
+    .paletteNum = 0xE,
     .baseBlock = 0x2E9,
 };
 
@@ -534,7 +534,7 @@ static const struct WindowTemplate sPartyMenuYesNoWindowTemplate =
     .tilemapTop = 9,
     .width = 5,
     .height = 4,
-    .paletteNum = 14,
+    .paletteNum = 0xE,
     .baseBlock = 0x2E9,
 };
 
@@ -545,7 +545,7 @@ static const struct WindowTemplate sLevelUpStatsWindowTemplate =
     .tilemapTop = 1,
     .width = 10,
     .height = 11,
-    .paletteNum = 14,
+    .paletteNum = 0xE,
     .baseBlock = 0x2E9,
 };
 
@@ -556,7 +556,7 @@ static const struct WindowTemplate sUnusedWindowTemplate1 =
     .tilemapTop = 15,
     .width = 27,
     .height = 4,
-    .paletteNum = 14,
+    .paletteNum = 0xE,
     .baseBlock = 0x1DF,
 };
 
@@ -567,7 +567,7 @@ static const struct WindowTemplate sUnusedWindowTemplate2 =
     .tilemapTop = 13,
     .width = 18,
     .height = 3,
-    .paletteNum = 12,
+    .paletteNum = 0xC,
     .baseBlock = 0x39D,
 };
 

--- a/src/data/trade.h
+++ b/src/data/trade.h
@@ -463,7 +463,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 7,
         .width = 22,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 30
     },
     {
@@ -472,7 +472,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 15,
         .width = 10,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 118
     },
     {
@@ -481,7 +481,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 5,
         .width = 8,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 158
     },
     {
@@ -490,7 +490,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 5,
         .width = 8,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 174
     },
     {
@@ -499,7 +499,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 10,
         .width = 8,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 190
     },
     {
@@ -508,7 +508,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 10,
         .width = 8,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 206
     },
     {
@@ -517,7 +517,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 15,
         .width = 8,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 222
     },
     {
@@ -526,7 +526,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 15,
         .width = 8,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 238
     },
     {
@@ -535,7 +535,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 5,
         .width = 8,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 254
     },
     {
@@ -544,7 +544,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 5,
         .width = 8,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 270
     },
     {
@@ -553,7 +553,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 10,
         .width = 8,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 286
     },
     {
@@ -562,7 +562,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 10,
         .width = 8,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 302
     },
     {
@@ -571,7 +571,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 15,
         .width = 8,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 318
     },
     {
@@ -580,7 +580,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 15,
         .width = 8,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 334
     },
     {
@@ -589,7 +589,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 5,
         .width = 14,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 350
     },
     {
@@ -598,7 +598,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 8,
         .width = 11,
         .height = 8,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 378
     },
     {
@@ -607,7 +607,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 5,
         .width = 14,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 466
     },
     {
@@ -616,7 +616,7 @@ static const struct WindowTemplate sTradeMenuWindowTemplates[] =
         .tilemapTop = 8,
         .width = 11,
         .height = 8,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 494
     },
     DUMMY_WIN_TEMPLATE,
@@ -629,7 +629,7 @@ static const struct WindowTemplate sTradeYesNoWindowTemplate =
     .tilemapTop = 13,
     .width = 5,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 582
 };
 
@@ -1112,7 +1112,7 @@ static const struct WindowTemplate sTradeSequenceWindowTemplates[] =
         .tilemapTop = 15,
         .width = 26,
         .height = 4,
-        .paletteNum = 0,
+        .paletteNum = 0x0,
         .baseBlock = 64
     },
     DUMMY_WIN_TEMPLATE
@@ -1125,7 +1125,7 @@ const struct WindowTemplate gTradeEvolutionSceneYesNoWindowTemplate =
     .tilemapTop = 9,
     .width = 5,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 188
 };
 

--- a/src/data/union_room.h
+++ b/src/data/union_room.h
@@ -627,7 +627,7 @@ static const struct WindowTemplate sWindowTemplate_BButtonCancel = {
     .tilemapTop = 0,
     .width = 30,
     .height = 2,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x0008
 };
 
@@ -669,7 +669,7 @@ static const struct WindowTemplate sWindowTemplate_PlayerList = {
     .tilemapTop = 3,
     .width = 13,
     .height = 8,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x0044
 };
 
@@ -679,7 +679,7 @@ static const struct WindowTemplate sWindowTemplate_5PlayerList = {
     .tilemapTop = 3,
     .width = 13,
     .height = 10,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x0044
 };
 
@@ -689,7 +689,7 @@ static const struct WindowTemplate sWindowTemplate_NumPlayerMode = {
     .tilemapTop = 3,
     .width = 7,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x00c6
 };
 
@@ -728,7 +728,7 @@ static const struct WindowTemplate sWindowTemplate_GroupList = {
     .tilemapTop = 3,
     .width = 17,
     .height = 10,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x0044
 };
 
@@ -738,7 +738,7 @@ static const struct WindowTemplate sWindowTemplate_PlayerNameAndId = {
     .tilemapTop = 3,
     .width = 7,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x00ee
 };
 
@@ -788,7 +788,7 @@ static const struct WindowTemplate sWindowTemplate_InviteToActivity = {
     .tilemapTop = 5,
     .width = 16,
     .height = 8,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x0001
 };
 
@@ -826,7 +826,7 @@ static const struct WindowTemplate sWindowTemplate_RegisterForTrade = {
     .tilemapTop = 7,
     .width = 16,
     .height = 6,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x0001
 };
 
@@ -863,7 +863,7 @@ static const struct WindowTemplate sWindowTemplate_TradingBoardRequestType = {
     .tilemapTop = 1,
     .width = 16,
     .height = 12,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x0001
 };
 
@@ -915,7 +915,7 @@ static const struct WindowTemplate sWindowTemplate_TradingBoardHeader = {
     .tilemapTop = 1,
     .width = 28,
     .height = 2,
-    .paletteNum = 13,
+    .paletteNum = 0xD,
     .baseBlock = 0x0001
 };
 
@@ -925,7 +925,7 @@ static const struct WindowTemplate sWindowTemplate_TradingBoardMain = {
     .tilemapTop = 5,
     .width = 28,
     .height = 12,
-    .paletteNum = 13,
+    .paletteNum = 0xD,
     .baseBlock = 0x0039
 };
 
@@ -970,7 +970,7 @@ static const struct WindowTemplate sWindowTemplate_Unused = {
     .tilemapTop = 5,
     .width = 28,
     .height = 12,
-    .paletteNum = 13,
+    .paletteNum = 0xD,
     .baseBlock = 0x0039
 };
 

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -46,7 +46,7 @@ static const struct WindowTemplate sDaycareLevelMenuWindowTemplate =
     .tilemapTop = 1,
     .width = 14,
     .height = 6,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 8
 };
 

--- a/src/decoration.c
+++ b/src/decoration.c
@@ -263,7 +263,7 @@ static const struct WindowTemplate sDecorationWindowTemplates[WINDOW_COUNT] =
         .tilemapTop = 1,
         .width = 18,
         .height = 2 * ARRAY_COUNT(sDecorationMainMenuActions),
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0001
     },
     {
@@ -272,7 +272,7 @@ static const struct WindowTemplate sDecorationWindowTemplates[WINDOW_COUNT] =
         .tilemapTop = 1,
         .width = 13,
         .height = 18,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 0x0091
     },
     {
@@ -281,7 +281,7 @@ static const struct WindowTemplate sDecorationWindowTemplates[WINDOW_COUNT] =
         .tilemapTop = 1,
         .width = 12,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x017b
     },
     {
@@ -290,7 +290,7 @@ static const struct WindowTemplate sDecorationWindowTemplates[WINDOW_COUNT] =
         .tilemapTop = 13,
         .width = 13,
         .height = 6,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0193
     }
 };
@@ -687,7 +687,7 @@ static void ReturnToDecorationActionsAfterInvalidSelection(u8 taskId)
 
 static void SecretBasePC_PrepMenuForSelectingStoredDecors(u8 taskId)
 {
-    LoadPalette(sDecorationMenuPalette, 0xd0, 0x20);
+    LoadPalette(sDecorationMenuPalette, BG_PLTT_ID(0xD), PLTT_SIZE_4BPP);
     ClearDialogWindowAndFrame(0, FALSE);
     RemoveDecorationWindow(WINDOW_MAIN_MENU);
     InitDecorationCategoriesWindow(taskId);
@@ -833,7 +833,7 @@ static void ReturnToActionsMenuFromCategories(u8 taskId)
 
 void ShowDecorationCategoriesWindow(u8 taskId)
 {
-    LoadPalette(sDecorationMenuPalette, 0xd0, 0x20);
+    LoadPalette(sDecorationMenuPalette, BG_PLTT_ID(0xD), PLTT_SIZE_4BPP);
     ClearDialogWindowAndFrame(0, FALSE);
     gTasks[taskId].tDecorationMenuCommand = DECOR_MENU_TRADE;
     sCurDecorationCategory = DECORCAT_DESK;

--- a/src/diploma.c
+++ b/src/diploma.c
@@ -72,7 +72,7 @@ void CB2_ShowDiploma(void)
     ResetSpriteData();
     ResetPaletteFade();
     FreeAllSpritePalettes();
-    LoadPalette(sDiplomaPalettes, 0, 64);
+    LoadPalette(sDiplomaPalettes, BG_PLTT_ID(0x0), 2 * PLTT_SIZE_4BPP);
     sDiplomaTilemapPtr = malloc(0x1000);
     InitDiplomaBg();
     InitDiplomaWindow();
@@ -186,7 +186,7 @@ static const struct WindowTemplate sDiplomaWinTemplates[2] =
         .tilemapTop = 2,
         .width = 20,
         .height = 16,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1,
     },
     DUMMY_WIN_TEMPLATE,
@@ -196,7 +196,7 @@ static void InitDiplomaWindow(void)
 {
     InitWindows(sDiplomaWinTemplates);
     DeactivateAllTextPrinters();
-    LoadPalette(gStandardMenuPalette, 0xF0, 0x20);
+    LoadPalette(gStandardMenuPalette, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
     FillWindowPixelBuffer(0, PIXEL_FILL(0));
     PutWindowTilemap(0);
 }

--- a/src/dodrio_berry_picking.c
+++ b/src/dodrio_berry_picking.c
@@ -2931,7 +2931,7 @@ static const struct WindowTemplate sWindowTemplates_Records =
     .tilemapTop = 1,
     .width = 20,
     .height = 11,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x1,
 };
 
@@ -3005,7 +3005,7 @@ static void PrintRecordsText(u8 windowId, s32 width)
     recordNums[1] = gSaveBlock2Ptr->berryPick.bestScore;
     recordNums[2] = gSaveBlock2Ptr->berryPick.berriesPickedInRow;
 
-    LoadUserWindowBorderGfx_(windowId, 0x21D, 0xD0);
+    LoadUserWindowBorderGfx_(windowId, 0x21D, BG_PLTT_ID(0xD));
     DrawTextBorderOuter(windowId, 0x21D, 0xD);
     FillWindowPixelBuffer(windowId, PIXEL_FILL(1));
     AddTextPrinterParameterized(windowId, FONT_NORMAL, gText_BerryPickingRecords, GetStringCenterAlignXOffset(FONT_NORMAL, gText_BerryPickingRecords, width * 8), 1, TEXT_SKIP_DRAW, NULL);
@@ -3401,7 +3401,7 @@ static const struct WindowTemplate sWindowTemplates_Results[] =
         .tilemapTop = 1,
         .width = 28,
         .height = 2,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 0x13,
     },
     {
@@ -3410,7 +3410,7 @@ static const struct WindowTemplate sWindowTemplates_Results[] =
         .tilemapTop = 5,
         .width = 28,
         .height = 14,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 0x4B,
     }
 };
@@ -3422,7 +3422,7 @@ static const struct WindowTemplate sWindowTemplate_Prize =
     .tilemapTop = 5,
     .width = 28,
     .height = 7,
-    .paletteNum = 13,
+    .paletteNum = 0xD,
     .baseBlock = 0x4B,
 };
 
@@ -3439,7 +3439,7 @@ static const struct WindowTemplate sWindowTemplates_PlayAgain[] =
         .tilemapTop = 8,
         .width = 19,
         .height = 3,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 0x13,
     },
     [WIN_YES_NO] = {
@@ -3448,7 +3448,7 @@ static const struct WindowTemplate sWindowTemplates_PlayAgain[] =
         .tilemapTop = 7,
         .width = 6,
         .height = 4,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 0x4C,
     }
 };
@@ -3460,7 +3460,7 @@ static const struct WindowTemplate sWindowTemplate_DroppedOut =
     .tilemapTop = 6,
     .width = 22,
     .height = 5,
-    .paletteNum = 13,
+    .paletteNum = 0xD,
     .baseBlock = 0x13,
 };
 
@@ -3471,7 +3471,7 @@ static const struct WindowTemplate sWindowTemplate_CommStandby =
     .tilemapTop = 8,
     .width = 19,
     .height = 3,
-    .paletteNum = 13,
+    .paletteNum = 0xD,
     .baseBlock = 0x13,
 };
 
@@ -4429,12 +4429,12 @@ static void ResetBerryAndStatusBarSprites(void)
 static void LoadWindowFrameGfx(u8 frameId)
 {
     LoadBgTiles(BG_INTERFACE, GetWindowFrameTilesPal(frameId)->tiles, 0x120, 1);
-    LoadPalette(GetWindowFrameTilesPal(frameId)->pal, 0xA0, 0x20);
+    LoadPalette(GetWindowFrameTilesPal(frameId)->pal, BG_PLTT_ID(0xA), PLTT_SIZE_4BPP);
 }
 
 static void LoadUserWindowFrameGfx(void)
 {
-    LoadUserWindowBorderGfx_(0, 0xA, 0xB0);
+    LoadUserWindowBorderGfx_(0, 0xA, BG_PLTT_ID(0xB));
 }
 
 static void ResetGfxState(void)
@@ -4448,7 +4448,7 @@ static void ResetGfxState(void)
 
 static void DrawYesNoMessageWindow(const struct WindowTemplate *template)
 {
-    u8 pal = 10;
+    u8 pal = 0xA;
 
     FillBgTilemapBufferRect(BG_INTERFACE, 1, template->tilemapLeft - 1,                template->tilemapTop - 1,                   1, 1, pal);
     FillBgTilemapBufferRect(BG_INTERFACE, 2, template->tilemapLeft,                    template->tilemapTop - 1,                   template->width, 1, pal);
@@ -4462,7 +4462,7 @@ static void DrawYesNoMessageWindow(const struct WindowTemplate *template)
 
 static void DrawMessageWindow(const struct WindowTemplate *template)
 {
-    u8 pal = 11;
+    u8 pal = 0xB;
 
     FillBgTilemapBufferRect(BG_INTERFACE, 10, template->tilemapLeft - 1,                template->tilemapTop - 1,                   1, 1, pal);
     FillBgTilemapBufferRect(BG_INTERFACE, 11, template->tilemapLeft,                    template->tilemapTop - 1,                   template->width, 1, pal);
@@ -4634,7 +4634,7 @@ static void ShowNames(void)
         window.bg = BG_INTERFACE;
         window.width = 7;
         window.height = 2;
-        window.paletteNum = 13;
+        window.paletteNum = 0xD;
         window.baseBlock = 0x13;
         for (i = 0; i < numPlayers; coords++, i++)
         {
@@ -5193,7 +5193,7 @@ static bool32 LoadBgGfx(void)
     switch (sGfx->loadState)
     {
     case 0:
-        LoadPalette(sBg_Pal, 0, sizeof(sBg_Pal));
+        LoadPalette(sBg_Pal, BG_PLTT_ID(0x0), sizeof(sBg_Pal));
         break;
     case 1:
         ResetTempTileDataBuffers();
@@ -5209,7 +5209,7 @@ static bool32 LoadBgGfx(void)
             return FALSE;
         break;
     case 5:
-        LoadPalette(GetTextWindowPalette(3), 0xD0, 0x20);
+        LoadPalette(GetTextWindowPalette(3), BG_PLTT_ID(0xD), PLTT_SIZE_4BPP);
         break;
     default:
         sGfx->loadState = 0;

--- a/src/easy_chat.c
+++ b/src/easy_chat.c
@@ -820,7 +820,7 @@ static const struct WindowTemplate sEasyChatWindowTemplates[] = {
         .tilemapTop = 0,
         .width = 18,
         .height = 2,
-        .paletteNum = 10,
+        .paletteNum = 0xA,
         .baseBlock = 0x10,
     },
     {
@@ -829,7 +829,7 @@ static const struct WindowTemplate sEasyChatWindowTemplates[] = {
         .tilemapTop = 15,
         .width = 24,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0xA,
     },
     {
@@ -838,7 +838,7 @@ static const struct WindowTemplate sEasyChatWindowTemplates[] = {
         .tilemapTop = 0,
         .width = 28,
         .height = 32,
-        .paletteNum = 3,
+        .paletteNum = 0x3,
         .baseBlock = 0,
     },
     DUMMY_WIN_TEMPLATE,
@@ -850,7 +850,7 @@ static const struct WindowTemplate sEasyChatYesNoWindowTemplate = {
     .tilemapTop = 9,
     .width = 5,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x6A,
 };
 
@@ -3911,13 +3911,13 @@ static void InitEasyChatBgs(void)
 static void LoadEasyChatPalettes(void)
 {
     ResetPaletteFade();
-    LoadPalette(gEasyChatMode_Pal, 0, 32);
-    LoadPalette(sTextInputFrameOrange_Pal, 1 * 16, 32);
-    LoadPalette(sTextInputFrameGreen_Pal, 4 * 16, 32);
-    LoadPalette(sTitleText_Pal, 10 * 16, 8);
-    LoadPalette(sText_Pal, 11 * 16, 12);
-    LoadPalette(sText_Pal, 15 * 16, 12);
-    LoadPalette(sText_Pal, 3 * 16, 12);
+    LoadPalette(gEasyChatMode_Pal, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
+    LoadPalette(sTextInputFrameOrange_Pal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
+    LoadPalette(sTextInputFrameGreen_Pal, BG_PLTT_ID(0x4), PLTT_SIZE_4BPP);
+    LoadPalette(sTitleText_Pal, BG_PLTT_ID(0xA), PLTT_SIZEOF(4));
+    LoadPalette(sText_Pal, BG_PLTT_ID(0xB), PLTT_SIZEOF(6));
+    LoadPalette(sText_Pal, BG_PLTT_ID(0xF), PLTT_SIZEOF(6));
+    LoadPalette(sText_Pal, BG_PLTT_ID(0x3), PLTT_SIZEOF(6));
 }
 
 static void PrintTitle(void)
@@ -3951,8 +3951,8 @@ static void PrintEasyChatTextWithColors(u8 windowId, u8 fontId, const u8 *str, u
 static void PrintInitialInstructions(void)
 {
     FillBgTilemapBufferRect(0, 0, 0, 0, 32, 20, 17);
-    LoadUserWindowBorderGfx(1, 1, 0xE0);
-    DrawTextBorderOuter(1, 1, 14);
+    LoadUserWindowBorderGfx(1, 1, BG_PLTT_ID(0xE));
+    DrawTextBorderOuter(1, 1, 0xE);
     PrintEasyChatStdMessage(MSG_INSTRUCTIONS);
     PutWindowTilemap(1);
     CopyBgTilemapBufferToVram(0);
@@ -4024,7 +4024,7 @@ static void AddPhraseWindow(void)
     template.tilemapTop = sPhraseFrameDimensions[frameId].top;
     template.width = sPhraseFrameDimensions[frameId].width;
     template.height = sPhraseFrameDimensions[frameId].height;
-    template.paletteNum = 11;
+    template.paletteNum = 0xB;
     template.baseBlock = 0x6C;
     sScreenControl->windowId = AddWindow(&template);
     PutWindowTilemap(sScreenControl->windowId);
@@ -5069,7 +5069,7 @@ static void AddMainScreenButtonWindow(void)
     template.tilemapTop = 11;
     template.width = 28;
     template.height = 2;
-    template.paletteNum = 11;
+    template.paletteNum = 0xB;
     template.baseBlock = 0x34;
     windowId = AddWindow(&template);
     FillWindowPixelBuffer(windowId, PIXEL_FILL(1));

--- a/src/egg_hatch.c
+++ b/src/egg_hatch.c
@@ -264,7 +264,7 @@ static const struct WindowTemplate sWinTemplates_EggHatch[] =
         .tilemapTop = 15,
         .width = 26,
         .height = 4,
-        .paletteNum = 0,
+        .paletteNum = 0x0,
         .baseBlock = 64
     },
     DUMMY_WIN_TEMPLATE
@@ -277,7 +277,7 @@ static const struct WindowTemplate sYesNoWinTemplate =
     .tilemapTop = 9,
     .width = 5,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 424
 };
 
@@ -532,7 +532,7 @@ static void CB2_LoadEggHatch(void)
     case 2:
         DecompressAndLoadBgGfxUsingHeap(0, gBattleTextboxTiles, 0, 0, 0);
         CopyToBgTilemapBuffer(0, gBattleTextboxTilemap, 0, 0);
-        LoadCompressedPalette(gBattleTextboxPalette, 0, 0x20);
+        LoadCompressedPalette(gBattleTextboxPalette, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
         gMain.state++;
         break;
     case 3:
@@ -556,7 +556,7 @@ static void CB2_LoadEggHatch(void)
         break;
     case 7:
         SetGpuReg(REG_OFFSET_DISPCNT, DISPCNT_OBJ_ON | DISPCNT_OBJ_1D_MAP);
-        LoadPalette(gTradeGba2_Pal, 0x10, 0xA0);
+        LoadPalette(gTradeGba2_Pal, BG_PLTT_ID(0x1), 5 * PLTT_SIZE_4BPP);
         LoadBgTiles(1, gTradeGba_Gfx, 0x1420, 0);
         CopyToBgTilemapBuffer(1, gTradePlatform_Tilemap, 0x1000, 0);
         CopyBgTilemapBufferToVram(1);
@@ -678,7 +678,7 @@ static void CB2_EggHatch(void)
         // Print the nickname prompt
         if (!IsTextPrinterActive(sEggHatchData->windowId))
         {
-            LoadUserWindowBorderGfx(sEggHatchData->windowId, 0x140, 0xE0);
+            LoadUserWindowBorderGfx(sEggHatchData->windowId, 0x140, BG_PLTT_ID(0xE));
             CreateYesNoMenu(&sYesNoWinTemplate, 0x140, 0xE, 0);
             sEggHatchData->state++;
         }

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2005,7 +2005,7 @@ void PatchObjectPalette(u16 paletteTag, u8 paletteSlot)
 {
     u8 paletteIndex = FindObjectEventPaletteIndexByTag(paletteTag);
 
-    LoadPalette(sObjectEventSpritePalettes[paletteIndex].data, 16 * paletteSlot + 0x100, 0x20);
+    LoadPalette(sObjectEventSpritePalettes[paletteIndex].data, OBJ_PLTT_ID(paletteSlot), PLTT_SIZE_4BPP);
 }
 
 void PatchObjectPaletteRange(const u16 *paletteTags, u8 minSlot, u8 maxSlot)

--- a/src/evolution_scene.c
+++ b/src/evolution_scene.c
@@ -263,7 +263,7 @@ void EvolutionScene(struct Pokemon *mon, u16 postEvoSpecies, bool8 canStopEvo, u
                              gMonSpritesGfxPtr->sprites.ptr[B_POSITION_OPPONENT_LEFT],
                              currSpecies);
     pokePal = GetMonSpritePalStructFromOtIdPersonality(currSpecies, trainerId, personality);
-    LoadCompressedPalette(pokePal->data, 0x110, 0x20);
+    LoadCompressedPalette(pokePal->data, OBJ_PLTT_ID(0x1), PLTT_SIZE_4BPP);
 
     SetMultiuseSpriteTemplateToPokemon(currSpecies, B_POSITION_OPPONENT_LEFT);
     gMultiuseSpriteTemplate.affineAnims = gDummySpriteAffineAnimTable;
@@ -278,7 +278,7 @@ void EvolutionScene(struct Pokemon *mon, u16 postEvoSpecies, bool8 canStopEvo, u
                              gMonSpritesGfxPtr->sprites.ptr[B_POSITION_OPPONENT_RIGHT],
                              postEvoSpecies);
     pokePal = GetMonSpritePalStructFromOtIdPersonality(postEvoSpecies, trainerId, personality);
-    LoadCompressedPalette(pokePal->data, 0x120, 0x20);
+    LoadCompressedPalette(pokePal->data, OBJ_PLTT_ID(0x2), PLTT_SIZE_4BPP);
 
     SetMultiuseSpriteTemplateToPokemon(postEvoSpecies, B_POSITION_OPPONENT_RIGHT);
     gMultiuseSpriteTemplate.affineAnims = gDummySpriteAffineAnimTable;
@@ -356,7 +356,7 @@ static void CB2_EvolutionSceneLoadGraphics(void)
                              postEvoSpecies);
     pokePal = GetMonSpritePalStructFromOtIdPersonality(postEvoSpecies, trainerId, personality);
 
-    LoadCompressedPalette(pokePal->data, 0x120, 0x20);
+    LoadCompressedPalette(pokePal->data, OBJ_PLTT_ID(0x2), PLTT_SIZE_4BPP);
 
     SetMultiuseSpriteTemplateToPokemon(postEvoSpecies, B_POSITION_OPPONENT_RIGHT);
     gMultiuseSpriteTemplate.affineAnims = gDummySpriteAffineAnimTable;
@@ -427,7 +427,7 @@ static void CB2_TradeEvolutionSceneLoadGraphics(void)
                                      gMonSpritesGfxPtr->sprites.ptr[B_POSITION_OPPONENT_RIGHT],
                                      postEvoSpecies);
             pokePal = GetMonSpritePalStructFromOtIdPersonality(postEvoSpecies, trainerId, personality);
-            LoadCompressedPalette(pokePal->data, 0x120, 0x20);
+            LoadCompressedPalette(pokePal->data, OBJ_PLTT_ID(0x2), PLTT_SIZE_4BPP);
             gMain.state++;
         }
         break;
@@ -492,7 +492,7 @@ void TradeEvolutionScene(struct Pokemon *mon, u16 postEvoSpecies, u8 preEvoSprit
                             postEvoSpecies);
 
     pokePal = GetMonSpritePalStructFromOtIdPersonality(postEvoSpecies, trainerId, personality);
-    LoadCompressedPalette(pokePal->data, 0x120, 0x20);
+    LoadCompressedPalette(pokePal->data, OBJ_PLTT_ID(0x2), PLTT_SIZE_4BPP);
 
     SetMultiuseSpriteTemplateToPokemon(postEvoSpecies, B_POSITION_OPPONENT_LEFT);
     gMultiuseSpriteTemplate.affineAnims = gDummySpriteAffineAnimTable;
@@ -1301,7 +1301,7 @@ static void Task_TradeEvolutionScene(u8 taskId)
         case T_MVSTATE_PRINT_YES_NO:
             if (!IsTextPrinterActive(0) && !IsSEPlaying())
             {
-                LoadUserWindowBorderGfx(0, 0xA8, 0xE0);
+                LoadUserWindowBorderGfx(0, 0xA8, BG_PLTT_ID(0xE));
                 CreateYesNoMenu(&gTradeEvolutionSceneYesNoWindowTemplate, 0xA8, 0xE, 0);
                 sEvoCursorPos = 0;
                 gTasks[taskId].tLearnMoveState++;
@@ -1507,7 +1507,7 @@ static void Task_UpdateBgPalette(u8 taskId)
         else
         {
             // Haven't reached final palette in current stage, load the current palette
-            LoadPalette(&sBgAnimPal[tPalStage * 16], 0xA0, 0x20);
+            LoadPalette(&sBgAnimPal[tPalStage * 16], BG_PLTT_ID(0xA), PLTT_SIZE_4BPP);
             tCycleTimer = 0;
             tPalStage++;
         }
@@ -1605,7 +1605,7 @@ static void StartBgAnimation(bool8 isLink)
     else
         innerBgId = 1, outerBgId = 3;
 
-    LoadPalette(sBgAnim_Intro_Pal, 0xA0, 0x20);
+    LoadPalette(sBgAnim_Intro_Pal, BG_PLTT_ID(0xA), PLTT_SIZE_4BPP);
 
     DecompressAndLoadBgGfxUsingHeap(1, sBgAnim_Gfx, FALSE, 0, 0);
     CopyToBgTilemapBuffer(innerBgId, sBgAnim_Inner_Tilemap, 0, 0);
@@ -1644,7 +1644,7 @@ static void PauseBgPaletteAnim(void)
     if (taskId != TASK_NONE)
         gTasks[taskId].tPaused = TRUE;
 
-    FillPalette(RGB_BLACK, 0xA0, 0x20);
+    FillPalette(RGB_BLACK, BG_PLTT_ID(0xA), PLTT_SIZE_4BPP);
 }
 
 #undef tPaused
@@ -1658,7 +1658,7 @@ static void StopBgAnimation(void)
     if ((taskId = FindTaskIdByFunc(Task_AnimateBg)) != TASK_NONE)
         DestroyTask(taskId);
 
-    FillPalette(RGB_BLACK, 0xA0, 0x20);
+    FillPalette(RGB_BLACK, BG_PLTT_ID(0xA), PLTT_SIZE_4BPP);
     RestoreBgAfterAnim();
 }
 

--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -893,7 +893,7 @@ u8 CreateTrainerSprite(u8 trainerSpriteID, s16 x, s16 y, u8 subpriority, u8 *buf
 void LoadTrainerGfx_TrainerCard(u8 gender, u16 palOffset, u8 *dest)
 {
     LZDecompressVram(gTrainerFrontPicTable[gender].data, dest);
-    LoadCompressedPalette(gTrainerFrontPicPaletteTable[gender].data, palOffset, 0x20);
+    LoadCompressedPalette(gTrainerFrontPicPaletteTable[gender].data, palOffset, PLTT_SIZE_4BPP);
 }
 
 u8 AddNewGameBirchObject(s16 x, s16 y, u8 subpriority)
@@ -2620,7 +2620,7 @@ static void FieldMoveShowMonOutdoorsEffect_LoadGfx(struct Task *task)
     u16 delta = ((REG_BG0CNT >> 8) << 11);
     CpuCopy16(sFieldMoveStreaksOutdoors_Gfx, (void *)(VRAM + offset), 0x200);
     CpuFill32(0, (void *)(VRAM + delta), 0x800);
-    LoadPalette(sFieldMoveStreaksOutdoors_Pal, 0xf0, sizeof(sFieldMoveStreaksOutdoors_Pal));
+    LoadPalette(sFieldMoveStreaksOutdoors_Pal, BG_PLTT_ID(0xF), sizeof(sFieldMoveStreaksOutdoors_Pal));
     LoadFieldMoveOutdoorStreaksTilemap(delta);
     task->tState++;
 }
@@ -2783,7 +2783,7 @@ static void FieldMoveShowMonIndoorsEffect_LoadGfx(struct Task *task)
     task->data[12] = delta;
     CpuCopy16(sFieldMoveStreaksIndoors_Gfx, (void *)(VRAM + offset), 0x80);
     CpuFill32(0, (void *)(VRAM + delta), 0x800);
-    LoadPalette(sFieldMoveStreaksIndoors_Pal, 0xf0, sizeof(sFieldMoveStreaksIndoors_Pal));
+    LoadPalette(sFieldMoveStreaksIndoors_Pal, BG_PLTT_ID(0xF), sizeof(sFieldMoveStreaksIndoors_Pal));
     task->tState++;
 }
 
@@ -3082,7 +3082,7 @@ u8 FldEff_RayquazaSpotlight(void)
     SetGpuReg(REG_OFFSET_BLDCNT, BLDCNT_TGT1_BG0 | BLDCNT_EFFECT_BLEND | BLDCNT_TGT2_BG1 | BLDCNT_TGT2_BG2 | BLDCNT_TGT2_BG3 | BLDCNT_TGT2_OBJ | BLDCNT_TGT2_BD);
     SetGpuReg(REG_OFFSET_BLDALPHA, BLDALPHA_BLEND(14, 14));
     SetGpuReg(REG_OFFSET_WININ, WININ_WIN0_BG_ALL | WININ_WIN0_OBJ | WININ_WIN0_CLR | WININ_WIN1_BG_ALL | WININ_WIN1_OBJ | WININ_WIN1_CLR);
-    LoadPalette(sSpotlight_Pal, 0xC0, sizeof(sSpotlight_Pal));
+    LoadPalette(sSpotlight_Pal, BG_PLTT_ID(0xC), sizeof(sSpotlight_Pal));
     SetGpuReg(REG_OFFSET_BG0VOFS, 120);
     for (i = 3; i < 15; i++)
     {

--- a/src/field_region_map.c
+++ b/src/field_region_map.c
@@ -72,7 +72,7 @@ static const struct WindowTemplate sFieldRegionMapWindowTemplates[] =
         .tilemapTop = 17,
         .width = 12,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1
     },
     {
@@ -81,7 +81,7 @@ static const struct WindowTemplate sFieldRegionMapWindowTemplates[] =
         .tilemapTop = 1,
         .width = 7,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 25
     },
     DUMMY_WIN_TEMPLATE
@@ -115,7 +115,7 @@ static void MCB2_InitRegionMapRegisters(void)
     InitBgsFromTemplates(1, sFieldRegionMapBgTemplates, ARRAY_COUNT(sFieldRegionMapBgTemplates));
     InitWindows(sFieldRegionMapWindowTemplates);
     DeactivateAllTextPrinters();
-    LoadUserWindowBorderGfx(0, 0x27, 0xd0);
+    LoadUserWindowBorderGfx(0, 0x27, BG_PLTT_ID(0xD));
     ClearScheduledBgCopiesToVram();
     SetMainCallback2(MCB2_FieldUpdateRegionMap);
     SetVBlankCallback(VBCB_FieldUpdateRegionMap);

--- a/src/field_screen_effect.c
+++ b/src/field_screen_effect.c
@@ -1079,9 +1079,7 @@ static void LoadOrbEffectPalette(bool8 blueOrb)
         color[0] = RGB_BLUE;
 
     for (i = 0; i < 16; i++)
-    {
-        LoadPalette(color, 0xF0 + i, 2);
-    }
+        LoadPalette(color, BG_PLTT_ID(0xF) + i, PLTT_SIZEOF(1));
 }
 
 static bool8 UpdateOrbEffectBlend(u16 shakeDir)

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -583,16 +583,16 @@ static void LoadLinkPartnerObjectEventSpritePalette(u8 graphicsId, u8 localEvent
             switch (graphicsId)
             {
             case OBJ_EVENT_GFX_LINK_RS_BRENDAN:
-                LoadPalette(gObjectEventPal_RubySapphireBrendan, 0x100 + (adjustedPaletteNum << 4), 0x20);
+                LoadPalette(gObjectEventPal_RubySapphireBrendan, OBJ_PLTT_ID(adjustedPaletteNum), PLTT_SIZE_4BPP);
                 break;
             case OBJ_EVENT_GFX_LINK_RS_MAY:
-                LoadPalette(gObjectEventPal_RubySapphireMay, 0x100 + (adjustedPaletteNum << 4), 0x20);
+                LoadPalette(gObjectEventPal_RubySapphireMay, OBJ_PLTT_ID(adjustedPaletteNum), PLTT_SIZE_4BPP);
                 break;
             case OBJ_EVENT_GFX_RIVAL_BRENDAN_NORMAL:
-                LoadPalette(gObjectEventPal_Brendan, 0x100 + (adjustedPaletteNum << 4), 0x20);
+                LoadPalette(gObjectEventPal_Brendan, OBJ_PLTT_ID(adjustedPaletteNum), PLTT_SIZE_4BPP);
                 break;
             case OBJ_EVENT_GFX_RIVAL_MAY_NORMAL:
-                LoadPalette(gObjectEventPal_May, 0x100 + (adjustedPaletteNum << 4), 0x20);
+                LoadPalette(gObjectEventPal_May, OBJ_PLTT_ID(adjustedPaletteNum), PLTT_SIZE_4BPP);
                 break;
             }
         }
@@ -1638,7 +1638,7 @@ const struct WindowTemplate gElevatorFloor_WindowTemplate =
     .tilemapTop = 1,
     .width = 8,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 8,
 };
 
@@ -2845,7 +2845,7 @@ void ShowBattlePointsWindow(void)
         .tilemapTop = 1,
         .width = 6,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 8,
     };
 
@@ -2891,7 +2891,7 @@ void ShowFrontierExchangeCornerItemIconWindow(void)
         .tilemapTop = 9,
         .width = 4,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 20,
     };
 
@@ -3031,7 +3031,7 @@ static void ShowBattleFrontierTutorWindow(u8 menu, u16 selection)
         .tilemapTop = 7,
         .width = 12,
         .height = 6,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 28,
     };
 
@@ -3266,7 +3266,7 @@ static void Task_DeoxysRockInteraction(u8 taskId)
 static void ChangeDeoxysRockLevel(u8 rockLevel)
 {
     u8 objectEventId;
-    LoadPalette(&sDeoxysRockPalettes[rockLevel], 0x1A0, 8);
+    LoadPalette(&sDeoxysRockPalettes[rockLevel], OBJ_PLTT_ID(0xA), PLTT_SIZEOF(4));
     TryGetObjectEventIdByLocalIdAndMap(LOCALID_BIRTH_ISLAND_EXTERIOR_ROCK, gSaveBlock1Ptr->location.mapNum, gSaveBlock1Ptr->location.mapGroup, &objectEventId);
 
     if (rockLevel == 0)
@@ -3314,7 +3314,7 @@ void IncrementBirthIslandRockStepCount(void)
 
 void SetDeoxysRockPalette(void)
 {
-    LoadPalette(&sDeoxysRockPalettes[(u8)VarGet(VAR_DEOXYS_ROCK_LEVEL)], 0x1A0, 8);
+    LoadPalette(&sDeoxysRockPalettes[(u8)VarGet(VAR_DEOXYS_ROCK_LEVEL)], OBJ_PLTT_ID(0xA), PLTT_SIZEOF(4));
     BlendPalettes(0x04000000, 16, 0);
 }
 

--- a/src/field_weather.c
+++ b/src/field_weather.c
@@ -545,7 +545,7 @@ static void ApplyGammaShiftWithBlend(u8 startPalIndex, u8 numPalettes, s8 gammaI
     u8 gBlend = color.g;
     u8 bBlend = color.b;
 
-    palOffset = startPalIndex * 16;
+    palOffset = BG_PLTT_ID(startPalIndex);
     numPalettes += startPalIndex;
     gammaIndex--;
     curPalIndex = startPalIndex;
@@ -556,7 +556,7 @@ static void ApplyGammaShiftWithBlend(u8 startPalIndex, u8 numPalettes, s8 gammaI
         {
             // No gamma shift. Simply blend the colors.
             BlendPalette(palOffset, 16, blendCoeff, blendColor);
-            palOffset += 16;
+            palOffset += 0x10;
         }
         else
         {
@@ -601,14 +601,14 @@ static void ApplyDroughtGammaShiftWithBlend(s8 gammaIndex, u8 blendCoeff, u16 bl
     rBlend = color.r;
     gBlend = color.g;
     bBlend = color.b;
-    palOffset = 0;
+    palOffset = 0x00;
     for (curPalIndex = 0; curPalIndex < 32; curPalIndex++)
     {
         if (sPaletteGammaTypes[curPalIndex] == GAMMA_NONE)
         {
             // No gamma shift. Simply blend the colors.
             BlendPalette(palOffset, 16, blendCoeff, blendColor);
-            palOffset += 16;
+            palOffset += 0x10;
         }
         else
         {
@@ -649,7 +649,7 @@ static void ApplyFogBlend(u8 blendCoeff, u16 blendColor)
     u8 bBlend;
     u16 curPalIndex;
 
-    BlendPalette(0, 256, blendCoeff, blendColor);
+    BlendPalette(BG_PLTT_ID(0x0), 16 * 16, blendCoeff, blendColor);
     color = *(struct RGBColor *)&blendColor;
     rBlend = color.r;
     gBlend = color.g;
@@ -683,7 +683,7 @@ static void ApplyFogBlend(u8 blendCoeff, u16 blendColor)
         }
         else
         {
-            BlendPalette(curPalIndex * 16, 16, blendCoeff, blendColor);
+            BlendPalette(PLTT_ID(curPalIndex), 16, blendCoeff, blendColor);
         }
     }
 }
@@ -823,8 +823,8 @@ void UpdateSpritePaletteWithWeather(u8 spritePaletteIndex)
         }
         break;
     case WEATHER_PAL_STATE_SCREEN_FADING_OUT:
-        paletteIndex *= 16;
-        CpuFastCopy(gPlttBufferFaded + paletteIndex, gPlttBufferUnfaded + paletteIndex, 32);
+        paletteIndex = PLTT_ID(paletteIndex);
+        CpuFastCopy(gPlttBufferFaded + paletteIndex, gPlttBufferUnfaded + paletteIndex, PLTT_SIZE_4BPP);
         BlendPalette(paletteIndex, 16, gPaletteFade.y, gPaletteFade.blendColor);
         break;
     // WEATHER_PAL_STATE_CHANGING_WEATHER
@@ -836,7 +836,7 @@ void UpdateSpritePaletteWithWeather(u8 spritePaletteIndex)
         }
         else
         {
-            paletteIndex *= 16;
+            paletteIndex = PLTT_ID(paletteIndex);
             BlendPalette(paletteIndex, 16, 12, RGB(28, 31, 28));
         }
         break;
@@ -859,7 +859,7 @@ static bool8 IsFirstFrameOfWeatherFadeIn(void)
 
 void LoadCustomWeatherSpritePalette(const u16 *palette)
 {
-    LoadPalette(palette, 0x100 + gWeatherPtr->weatherPicSpritePalIndex * 16, 32);
+    LoadPalette(palette, OBJ_PLTT_ID(gWeatherPtr->weatherPicSpritePalIndex), PLTT_SIZE_4BPP);
     UpdateSpritePaletteWithWeather(gWeatherPtr->weatherPicSpritePalIndex);
 }
 

--- a/src/fieldmap.c
+++ b/src/fieldmap.c
@@ -878,13 +878,13 @@ void LoadTilesetPalette(struct Tileset const *tileset, u16 destOffset, u16 size)
     {
         if (tileset->isSecondary == FALSE)
         {
-            LoadPalette(&black, destOffset, 2);
-            LoadPalette(((u16 *)tileset->palettes) + 1, destOffset + 1, size - 2);
-            FieldmapPaletteDummy(destOffset + 1, (size - 2) >> 1);
+            LoadPalette(&black, destOffset, PLTT_SIZEOF(1));
+            LoadPalette(((u16 *)tileset->palettes) + 1, destOffset + 1, size - PLTT_SIZEOF(1));
+            FieldmapPaletteDummy(destOffset + 1, (size - PLTT_SIZEOF(1)) >> 1);
         }
         else if (tileset->isSecondary == TRUE)
         {
-            LoadPalette(((u16 *)tileset->palettes) + (NUM_PALS_IN_PRIMARY * 16), destOffset, size);
+            LoadPalette(((u16 *)tileset->palettes) + BG_PLTT_ID(NUM_PALS_IN_PRIMARY), destOffset, size);
             FieldmapPaletteDummy(destOffset, size >> 1);
         }
         else
@@ -912,12 +912,12 @@ void CopySecondaryTilesetToVramUsingHeap(struct MapLayout const *mapLayout)
 
 static void LoadPrimaryTilesetPalette(struct MapLayout const *mapLayout)
 {
-    LoadTilesetPalette(mapLayout->primaryTileset, 0, NUM_PALS_IN_PRIMARY * 16 * 2);
+    LoadTilesetPalette(mapLayout->primaryTileset, BG_PLTT_ID(0x0), NUM_PALS_IN_PRIMARY * PLTT_SIZE_4BPP);
 }
 
 void LoadSecondaryTilesetPalette(struct MapLayout const *mapLayout)
 {
-    LoadTilesetPalette(mapLayout->secondaryTileset, NUM_PALS_IN_PRIMARY * 16, (NUM_PALS_TOTAL - NUM_PALS_IN_PRIMARY) * 16 * 2);
+    LoadTilesetPalette(mapLayout->secondaryTileset, BG_PLTT_ID(NUM_PALS_IN_PRIMARY), (NUM_PALS_TOTAL - NUM_PALS_IN_PRIMARY) * PLTT_SIZE_4BPP);
 }
 
 void CopyMapTilesetsToVram(struct MapLayout const *mapLayout)

--- a/src/fldeff_flash.c
+++ b/src/fldeff_flash.c
@@ -218,8 +218,8 @@ static void Task_ExitCaveTransition2(u8 taskId)
     SetGpuReg(REG_OFFSET_DISPCNT, 0);
     LZ77UnCompVram(sCaveTransitionTiles, (void *)(VRAM + 0xC000));
     LZ77UnCompVram(sCaveTransitionTilemap, (void *)(VRAM + 0xF800));
-    LoadPalette(sCaveTransitionPalette_White, 0xE0, 0x20);
-    LoadPalette(sCaveTransitionPalette_Exit, 0xE0, 0x10);
+    LoadPalette(sCaveTransitionPalette_White, BG_PLTT_ID(0xE), PLTT_SIZE_4BPP);
+    LoadPalette(sCaveTransitionPalette_Exit, BG_PLTT_ID(0xE), 0x10);
     SetGpuReg(REG_OFFSET_BLDCNT, BLDCNT_TGT1_BG0
                                 | BLDCNT_EFFECT_BLEND
                                 | BLDCNT_TGT2_BG1
@@ -270,11 +270,11 @@ static void Task_ExitCaveTransition4(u8 taskId)
     if (count < 8)
     {
         gTasks[taskId].data[2]++;
-        LoadPalette(&sCaveTransitionPalette_Exit[count], 0xE0, 16 - 2 * count);
+        LoadPalette(&sCaveTransitionPalette_Exit[count], BG_PLTT_ID(0xE), PLTT_SIZEOF(8) - PLTT_SIZEOF(count));
     }
     else
     {
-        LoadPalette(sCaveTransitionPalette_White, 0, 0x20);
+        LoadPalette(sCaveTransitionPalette_White, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
         gTasks[taskId].func = Task_ExitCaveTransition5;
         gTasks[taskId].data[2] = 8;
     }
@@ -315,8 +315,8 @@ static void Task_EnterCaveTransition2(u8 taskId)
                                 | DISPCNT_OBJ_1D_MAP
                                 | DISPCNT_BG0_ON
                                 | DISPCNT_OBJ_ON);
-    LoadPalette(sCaveTransitionPalette_White, 0xE0, 0x20);
-    LoadPalette(sCaveTransitionPalette_Black, 0, 0x20);
+    LoadPalette(sCaveTransitionPalette_White, BG_PLTT_ID(0xE), PLTT_SIZE_4BPP);
+    LoadPalette(sCaveTransitionPalette_Black, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
     gTasks[taskId].func = Task_EnterCaveTransition3;
     gTasks[taskId].data[0] = 16;
     gTasks[taskId].data[1] = 0;
@@ -331,7 +331,7 @@ static void Task_EnterCaveTransition3(u8 taskId)
     {
         gTasks[taskId].data[2]++;
         gTasks[taskId].data[2]++;
-        LoadPalette(&sCaveTransitionPalette_Enter[15 - count], 0xE0, 2 * (count + 1));
+        LoadPalette(&sCaveTransitionPalette_Enter[15 - count], BG_PLTT_ID(0xE), PLTT_SIZEOF(count + 1));
     }
     else
     {
@@ -359,7 +359,7 @@ static void Task_EnterCaveTransition4(u8 taskId)
     }
     else
     {
-        LoadPalette(sCaveTransitionPalette_Black, 0, 0x20);
+        LoadPalette(sCaveTransitionPalette_Black, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
         SetMainCallback2(gMain.savedCallback);
     }
 }

--- a/src/frontier_pass.c
+++ b/src/frontier_pass.c
@@ -253,7 +253,7 @@ static const struct WindowTemplate sPassWindowTemplates[WINDOW_COUNT] =
         .tilemapTop = 3,
         .width = 12,
         .height = 3,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x1,
     },
     [WINDOW_BATTLE_RECORD] = {
@@ -262,7 +262,7 @@ static const struct WindowTemplate sPassWindowTemplates[WINDOW_COUNT] =
         .tilemapTop = 10,
         .width = 12,
         .height = 3,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x26,
     },
     [WINDOW_BATTLE_POINTS] = {
@@ -271,7 +271,7 @@ static const struct WindowTemplate sPassWindowTemplates[WINDOW_COUNT] =
         .tilemapTop = 13,
         .width = 12,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x4B,
     },
     [WINDOW_DESCRIPTION] = {
@@ -280,7 +280,7 @@ static const struct WindowTemplate sPassWindowTemplates[WINDOW_COUNT] =
         .tilemapTop = 18,
         .width = 30,
         .height = 3,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x7C,
     },
     DUMMY_WIN_TEMPLATE
@@ -294,7 +294,7 @@ static const struct WindowTemplate sMapWindowTemplates[] =
         .tilemapTop = 1,
         .width = 15,
         .height = 5,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x1,
     },
     [MAP_WINDOW_NAME] = {
@@ -303,7 +303,7 @@ static const struct WindowTemplate sMapWindowTemplates[] =
         .tilemapTop = 1,
         .width = 10,
         .height = 14,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x4D,
     },
     [MAP_WINDOW_DESCRIPTION] = {
@@ -312,7 +312,7 @@ static const struct WindowTemplate sMapWindowTemplates[] =
         .tilemapTop = 16,
         .width = 26,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0xDA,
     },
     DUMMY_WIN_TEMPLATE
@@ -768,9 +768,9 @@ static bool32 InitFrontierPass(void)
         CopyBgTilemapBufferToVram(2);
         break;
     case 8:
-        LoadPalette(gFrontierPassBg_Pal[0], 0, 0x1A0);
-        LoadPalette(gFrontierPassBg_Pal[1 + sPassData->trainerStars], 0x10, 0x20);
-        LoadPalette(GetTextWindowPalette(0), 0xF0, 0x20);
+        LoadPalette(gFrontierPassBg_Pal[0], 0, 13 * PLTT_SIZE_4BPP);
+        LoadPalette(gFrontierPassBg_Pal[1 + sPassData->trainerStars], BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
+        LoadPalette(GetTextWindowPalette(0), BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
         DrawFrontierPassBg();
         UpdateAreaHighlight(sPassData->cursorArea, sPassData->previousCursorArea);
         if (sPassData->areaToShow == CURSOR_AREA_MAP || sPassData->areaToShow == CURSOR_AREA_CARD)
@@ -1412,8 +1412,8 @@ static bool32 InitFrontierMap(void)
     case 5:
         if (FreeTempTileDataBuffersIfPossible())
             return FALSE;
-        LoadPalette(gFrontierPassBg_Pal[0], 0, 0x1A0);
-        LoadPalette(GetTextWindowPalette(0), 0xF0, 0x20);
+        LoadPalette(gFrontierPassBg_Pal[0], BG_PLTT_ID(0x0), 13 * PLTT_SIZE_4BPP);
+        LoadPalette(GetTextWindowPalette(0), BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
         CopyToBgTilemapBuffer(2, sMapScreen_Tilemap, 0, 0);
         CopyBgTilemapBufferToVram(2);
         break;

--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -638,7 +638,7 @@ static const struct WindowTemplate sFrontierResultsWindowTemplate =
     .tilemapTop = 1,
     .width = 28,
     .height = 18,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 1
 };
 
@@ -649,7 +649,7 @@ static const struct WindowTemplate sLinkContestResultsWindowTemplate =
     .tilemapTop = 2,
     .width = 26,
     .height = 15,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 1
 };
 
@@ -660,7 +660,7 @@ static const struct WindowTemplate sRankingHallRecordsWindowTemplate =
     .tilemapTop = 1,
     .width = 26,
     .height = 17,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 1
 };
 

--- a/src/hall_of_fame.c
+++ b/src/hall_of_fame.c
@@ -140,7 +140,7 @@ static const struct WindowTemplate sHof_WindowTemplate = {
     .tilemapTop = 2,
     .width = 14,
     .height = 6,
-    .paletteNum = 14,
+    .paletteNum = 0xE,
     .baseBlock = 1
 };
 
@@ -702,8 +702,8 @@ static void Task_Hof_DisplayPlayer(u8 taskId)
     ShowBg(3);
     gTasks[taskId].tPlayerSpriteID = CreateTrainerPicSprite(PlayerGenderToFrontTrainerPicId_Debug(gSaveBlock2Ptr->playerGender, TRUE), TRUE, 120, 72, 6, TAG_NONE);
     AddWindow(&sHof_WindowTemplate);
-    LoadWindowGfx(1, gSaveBlock2Ptr->optionsWindowFrameType, 0x21D, 0xD0);
-    LoadPalette(GetTextWindowPalette(1), 0xE0, 0x20);
+    LoadWindowGfx(1, gSaveBlock2Ptr->optionsWindowFrameType, 0x21D, BG_PLTT_ID(0xD));
+    LoadPalette(GetTextWindowPalette(1), BG_PLTT_ID(0xE), PLTT_SIZE_4BPP);
     gTasks[taskId].tFrameCount = 120;
     gTasks[taskId].func = Task_Hof_WaitAndPrintPlayerInfo;
 }
@@ -1269,7 +1269,7 @@ static void ClearVramOamPltt_LoadHofPal(void)
     DmaFill16(3, 0, plttOffset, plttSize);
 
     ResetPaletteFade();
-    LoadPalette(sHallOfFame_Pal, 0, 0x20);
+    LoadPalette(sHallOfFame_Pal, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
 }
 
 static void LoadHofGfx(void)

--- a/src/intro.c
+++ b/src/intro.c
@@ -1051,11 +1051,11 @@ static void MainCB2_EndIntro(void)
         SetMainCallback2(CB2_InitTitleScreen);
 }
 
-static void LoadCopyrightGraphics(u16 tilesetAddress, u16 tilemapAddress, u16 paletteAddress)
+static void LoadCopyrightGraphics(u16 tilesetAddress, u16 tilemapAddress, u16 paletteOffset)
 {
     LZ77UnCompVram(gIntroCopyright_Gfx, (void *)(VRAM + tilesetAddress));
     LZ77UnCompVram(gIntroCopyright_Tilemap, (void *)(VRAM + tilemapAddress));
-    LoadPalette(gIntroCopyright_Pal, paletteAddress, 32);
+    LoadPalette(gIntroCopyright_Pal, paletteOffset, PLTT_SIZE_4BPP);
 }
 
 static void SerialCB_CopyrightScreen(void)
@@ -1080,7 +1080,7 @@ static u8 SetUpCopyrightScreen(void)
         CpuFill32(0, (void *)OAM, OAM_SIZE);
         CpuFill16(0, (void *)(PLTT + 2), PLTT_SIZE - 2);
         ResetPaletteFade();
-        LoadCopyrightGraphics(0, 0x3800, 0);
+        LoadCopyrightGraphics(0, 0x3800, BG_PLTT_ID(0x0));
         ScanlineEffect_Stop();
         ResetTasks();
         ResetSpriteData();
@@ -1178,7 +1178,7 @@ static void Task_Scene1_Load(u8 taskId)
     DmaClear16(3, BG_SCREEN_ADDR(21), BG_SCREEN_SIZE);
     LZ77UnCompVram(sIntro1Bg3_Tilemap, (void *)(BG_SCREEN_ADDR(22)));
     DmaClear16(3, BG_SCREEN_ADDR(23), BG_SCREEN_SIZE);
-    LoadPalette(sIntro1Bg_Pal, 0, sizeof(sIntro1Bg_Pal));
+    LoadPalette(sIntro1Bg_Pal, BG_PLTT_ID(0x0), sizeof(sIntro1Bg_Pal));
     SetGpuReg(REG_OFFSET_BG3CNT, BGCNT_PRIORITY(3) | BGCNT_CHARBASE(0) | BGCNT_SCREENBASE(22) | BGCNT_16COLOR | BGCNT_TXT256x512);
     SetGpuReg(REG_OFFSET_BG2CNT, BGCNT_PRIORITY(2) | BGCNT_CHARBASE(0) | BGCNT_SCREENBASE(20) | BGCNT_16COLOR | BGCNT_TXT256x512);
     SetGpuReg(REG_OFFSET_BG1CNT, BGCNT_PRIORITY(1) | BGCNT_CHARBASE(0) | BGCNT_SCREENBASE(18) | BGCNT_16COLOR | BGCNT_TXT256x512);
@@ -1717,7 +1717,7 @@ static void Task_Scene3_Load(u8 taskId)
     IntroResetGpuRegs();
     LZ77UnCompVram(sIntroPokeball_Gfx, (void *)VRAM);
     LZ77UnCompVram(sIntroPokeball_Tilemap, (void *)(BG_CHAR_ADDR(1)));
-    LoadPalette(sIntroPokeball_Pal, 0, sizeof(sIntroPokeball_Pal));
+    LoadPalette(sIntroPokeball_Pal, BG_PLTT_ID(0x0), sizeof(sIntroPokeball_Pal));
     gTasks[taskId].tAlpha = 0;
     gTasks[taskId].tZoomDiv = 0;
     gTasks[taskId].tZoomDivSpeed = 0;
@@ -2663,10 +2663,10 @@ static void Task_RayquazaAttack(u8 taskId)
         {
             if (--data[3] != 0)
             {
-                BlendPalette(0x50, 16, data[3], RGB(9, 10, 10));
-                CpuCopy16(&gIntro3Bg_Pal[0x1AC], &gPlttBufferFaded[94], 2);
-                CpuCopy16(&gIntro3Bg_Pal[0x1AC], &gPlttBufferFaded[88], 2);
-                CpuCopy16(&gIntro3Bg_Pal[0x18C], &gPlttBufferFaded[92], 2);
+                BlendPalette(BG_PLTT_ID(0x5), 16, data[3], RGB(9, 10, 10));
+                CpuCopy16(&gIntro3Bg_Pal[0x1AC], &gPlttBufferFaded[BG_PLTT_ID(0x5) + 14], PLTT_SIZEOF(1));
+                CpuCopy16(&gIntro3Bg_Pal[0x1AC], &gPlttBufferFaded[BG_PLTT_ID(0x5) + 8], PLTT_SIZEOF(1));
+                CpuCopy16(&gIntro3Bg_Pal[0x18C], &gPlttBufferFaded[BG_PLTT_ID(0x5) + 12], PLTT_SIZEOF(1));
             }
             else
             {

--- a/src/intro_credits_graphics.c
+++ b/src/intro_credits_graphics.c
@@ -730,7 +730,7 @@ void LoadIntroPart2Graphics(u8 scenery)
 {
     LZ77UnCompVram(sGrass_Gfx, (void *)(BG_CHAR_ADDR(1)));
     LZ77UnCompVram(sGrass_Tilemap, (void *)(BG_SCREEN_ADDR(15)));
-    LoadPalette(&sGrass_Pal, 240, sizeof(sGrass_Pal));
+    LoadPalette(&sGrass_Pal, BG_PLTT_ID(0xF), sizeof(sGrass_Pal));
     switch (scenery)
     {
     case 0:
@@ -739,17 +739,17 @@ void LoadIntroPart2Graphics(u8 scenery)
         // Clouds are never used in this part of the intro
         LZ77UnCompVram(sCloudsBg_Gfx, (void *)(VRAM));
         LZ77UnCompVram(sCloudsBg_Tilemap, (void *)(BG_SCREEN_ADDR(6)));
-        LoadPalette(&sCloudsBg_Pal, 0, sizeof(sCloudsBg_Pal));
+        LoadPalette(&sCloudsBg_Pal, BG_PLTT_ID(0x0), sizeof(sCloudsBg_Pal));
         LoadCompressedSpriteSheet(sSpriteSheet_Clouds);
-        LoadPalette(&sClouds_Pal, 256, sizeof(sClouds_Pal));
+        LoadPalette(&sClouds_Pal, OBJ_PLTT_ID(0x0), sizeof(sClouds_Pal));
         CreateCloudSprites();
         break;
     case 1:
         LZ77UnCompVram(sTrees_Gfx, (void *)(VRAM));
         LZ77UnCompVram(sTrees_Tilemap, (void *)(BG_SCREEN_ADDR(6)));
-        LoadPalette(&sTrees_Pal, 0, sizeof(sTrees_Pal));
+        LoadPalette(&sTrees_Pal, BG_PLTT_ID(0x0), sizeof(sTrees_Pal));
         LoadCompressedSpriteSheet(sSpriteSheet_TreesSmall);
-        LoadPalette(&sTreesSmall_Pal, 256, sizeof(sTreesSmall_Pal));
+        LoadPalette(&sTreesSmall_Pal, OBJ_PLTT_ID(0x0), sizeof(sTreesSmall_Pal));
         CreateTreeSprites();
         break;
     }
@@ -843,42 +843,42 @@ void LoadCreditsSceneGraphics(u8 scene)
     {
     case SCENE_OCEAN_MORNING:
     default:
-        LoadPalette(&sGrass_Pal, 240, sizeof(sGrass_Pal));
+        LoadPalette(&sGrass_Pal, BG_PLTT_ID(0xF), sizeof(sGrass_Pal));
         LZ77UnCompVram(sCloudsBg_Gfx, (void *)(VRAM));
         LZ77UnCompVram(sCloudsBg_Tilemap, (void *)(BG_SCREEN_ADDR(6)));
-        LoadPalette(&sCloudsBg_Pal, 0, sizeof(sCloudsBg_Pal));
+        LoadPalette(&sCloudsBg_Pal, BG_PLTT_ID(0x0), sizeof(sCloudsBg_Pal));
         LoadCompressedSpriteSheet(sSpriteSheet_Clouds);
         LZ77UnCompVram(sClouds_Gfx, (void *)(OBJ_VRAM0));
-        LoadPalette(&sClouds_Pal, 256, sizeof(sClouds_Pal));
+        LoadPalette(&sClouds_Pal, OBJ_PLTT_ID(0x0), sizeof(sClouds_Pal));
         CreateCloudSprites();
         break;
     case SCENE_OCEAN_SUNSET:
-        LoadPalette(&sGrassSunset_Pal, 240, sizeof(sGrassSunset_Pal));
+        LoadPalette(&sGrassSunset_Pal, BG_PLTT_ID(0xF), sizeof(sGrassSunset_Pal));
         LZ77UnCompVram(sCloudsBg_Gfx, (void *)(VRAM));
         LZ77UnCompVram(sCloudsBg_Tilemap, (void *)(BG_SCREEN_ADDR(6)));
-        LoadPalette(&sCloudsBgSunset_Pal, 0, sizeof(sCloudsBgSunset_Pal));
+        LoadPalette(&sCloudsBgSunset_Pal, BG_PLTT_ID(0x0), sizeof(sCloudsBgSunset_Pal));
         LoadCompressedSpriteSheet(sSpriteSheet_Clouds);
         LZ77UnCompVram(sClouds_Gfx, (void *)(OBJ_VRAM0));
-        LoadPalette(&sCloudsSunset_Pal, 256, sizeof(sCloudsSunset_Pal));
+        LoadPalette(&sCloudsSunset_Pal, OBJ_PLTT_ID(0x0), sizeof(sCloudsSunset_Pal));
         CreateCloudSprites();
         break;
     case SCENE_FOREST_RIVAL_ARRIVE:
     case SCENE_FOREST_CATCH_RIVAL:
-        LoadPalette(&sGrassSunset_Pal, 240, sizeof(sGrassSunset_Pal));
+        LoadPalette(&sGrassSunset_Pal, BG_PLTT_ID(0xF), sizeof(sGrassSunset_Pal));
         LZ77UnCompVram(sTrees_Gfx, (void *)(VRAM));
         LZ77UnCompVram(sTrees_Tilemap, (void *)(BG_SCREEN_ADDR(6)));
-        LoadPalette(&sTreesSunset_Pal, 0, sizeof(sTreesSunset_Pal));
+        LoadPalette(&sTreesSunset_Pal, BG_PLTT_ID(0x0), sizeof(sTreesSunset_Pal));
         LoadCompressedSpriteSheet(sSpriteSheet_TreesSmall);
-        LoadPalette(&sTreesSunset_Pal, 256, sizeof(sTreesSunset_Pal));
+        LoadPalette(&sTreesSunset_Pal, OBJ_PLTT_ID(0x0), sizeof(sTreesSunset_Pal));
         CreateTreeSprites();
         break;
     case SCENE_CITY_NIGHT:
-        LoadPalette(&sGrassNight_Pal, 240, sizeof(sGrassNight_Pal));
+        LoadPalette(&sGrassNight_Pal, BG_PLTT_ID(0xF), sizeof(sGrassNight_Pal));
         LZ77UnCompVram(sHouses_Gfx, (void *)(VRAM));
         LZ77UnCompVram(sHouses_Tilemap, (void *)(BG_SCREEN_ADDR(6)));
-        LoadPalette(&sHouses_Pal, 0, sizeof(sHouses_Pal));
+        LoadPalette(&sHouses_Pal, BG_PLTT_ID(0x0), sizeof(sHouses_Pal));
         LoadCompressedSpriteSheet(sSpriteSheet_HouseSilhouette);
-        LoadPalette(&sHouseSilhouette_Pal, 256, sizeof(sHouseSilhouette_Pal));
+        LoadPalette(&sHouseSilhouette_Pal, OBJ_PLTT_ID(0x0), sizeof(sHouseSilhouette_Pal));
         CreateHouseSprites();
         break;
     }
@@ -1006,8 +1006,8 @@ void CycleSceneryPalette(u8 mode)
                 x = gPlttBufferUnfaded[10];
                 y = gPlttBufferUnfaded[9];
             }
-            LoadPalette(&x, 9, sizeof(x));
-            LoadPalette(&y, 10, sizeof(y));
+            LoadPalette(&x, BG_PLTT_ID(0x0) + 9, sizeof(x));
+            LoadPalette(&y, BG_PLTT_ID(0x0) + 10, sizeof(y));
             break;
         case 2:
             if (gMain.vblankCounter1 & 3 || gPaletteFade.active)
@@ -1022,8 +1022,8 @@ void CycleSceneryPalette(u8 mode)
                 x = RGB(28, 24, 0);
                 y = RGB(7, 9, 15);
             }
-            LoadPalette(&x, 12, sizeof(x));
-            LoadPalette(&y, 13, sizeof(y));
+            LoadPalette(&x, BG_PLTT_ID(0x0) + 12, sizeof(x));
+            LoadPalette(&y, BG_PLTT_ID(0x0) + 13, sizeof(y));
             break;
         case 1:
             break;

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -399,7 +399,7 @@ static const struct WindowTemplate sDefaultBagWindows[] =
         .tilemapTop = 2,
         .width = 15,
         .height = 16,
-        .paletteNum = 1,
+        .paletteNum = 0x1,
         .baseBlock = 0x27,
     },
     [WIN_DESCRIPTION] = {
@@ -408,7 +408,7 @@ static const struct WindowTemplate sDefaultBagWindows[] =
         .tilemapTop = 13,
         .width = 14,
         .height = 6,
-        .paletteNum = 1,
+        .paletteNum = 0x1,
         .baseBlock = 0x117,
     },
     [WIN_POCKET_NAME] = {
@@ -417,7 +417,7 @@ static const struct WindowTemplate sDefaultBagWindows[] =
         .tilemapTop = 1,
         .width = 8,
         .height = 2,
-        .paletteNum = 1,
+        .paletteNum = 0x1,
         .baseBlock = 0x1A1,
     },
     [WIN_TMHM_INFO_ICONS] = {
@@ -426,7 +426,7 @@ static const struct WindowTemplate sDefaultBagWindows[] =
         .tilemapTop = 13,
         .width = 5,
         .height = 6,
-        .paletteNum = 12,
+        .paletteNum = 0xC,
         .baseBlock = 0x16B,
     },
     [WIN_TMHM_INFO] = {
@@ -435,7 +435,7 @@ static const struct WindowTemplate sDefaultBagWindows[] =
         .tilemapTop = 13,
         .width = 4,
         .height = 6,
-        .paletteNum = 12,
+        .paletteNum = 0xC,
         .baseBlock = 0x189,
     },
     [WIN_MESSAGE] = {
@@ -444,7 +444,7 @@ static const struct WindowTemplate sDefaultBagWindows[] =
         .tilemapTop = 15,
         .width = 27,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x1B1,
     },
     DUMMY_WIN_TEMPLATE,
@@ -458,7 +458,7 @@ static const struct WindowTemplate sContextMenuWindowTemplates[] =
         .tilemapTop = 17,
         .width = 7,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x21D,
     },
     [ITEMWIN_1x2] = {
@@ -467,7 +467,7 @@ static const struct WindowTemplate sContextMenuWindowTemplates[] =
         .tilemapTop = 15,
         .width = 7,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x21D,
     },
     [ITEMWIN_2x2] = {
@@ -476,7 +476,7 @@ static const struct WindowTemplate sContextMenuWindowTemplates[] =
         .tilemapTop = 15,
         .width = 14,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x21D,
     },
     [ITEMWIN_2x3] = {
@@ -485,7 +485,7 @@ static const struct WindowTemplate sContextMenuWindowTemplates[] =
         .tilemapTop = 13,
         .width = 14,
         .height = 6,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x21D,
     },
     [ITEMWIN_MESSAGE] = {
@@ -494,7 +494,7 @@ static const struct WindowTemplate sContextMenuWindowTemplates[] =
         .tilemapTop = 15,
         .width = 27,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x1B1,
     },
     [ITEMWIN_YESNO_LOW] = { // Yes/No tucked in corner, for toss confirm
@@ -503,7 +503,7 @@ static const struct WindowTemplate sContextMenuWindowTemplates[] =
         .tilemapTop = 15,
         .width = 5,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x21D,
     },
     [ITEMWIN_YESNO_HIGH] = { // Yes/No higher up, positioned above a lower message box
@@ -512,7 +512,7 @@ static const struct WindowTemplate sContextMenuWindowTemplates[] =
         .tilemapTop = 9,
         .width = 5,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x21D,
     },
     [ITEMWIN_QUANTITY] = { // Used for quantity of items to Toss/Deposit
@@ -521,7 +521,7 @@ static const struct WindowTemplate sContextMenuWindowTemplates[] =
         .tilemapTop = 17,
         .width = 5,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x21D,
     },
     [ITEMWIN_QUANTITY_WIDE] = { // Used for quantity and price of items to Sell
@@ -530,7 +530,7 @@ static const struct WindowTemplate sContextMenuWindowTemplates[] =
         .tilemapTop = 11,
         .width = 10,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x245,
     },
     [ITEMWIN_MONEY] = {
@@ -539,7 +539,7 @@ static const struct WindowTemplate sContextMenuWindowTemplates[] =
         .tilemapTop = 1,
         .width = 10,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x231,
     },
 };
@@ -818,9 +818,9 @@ static bool8 LoadBagMenu_Graphics(void)
         break;
     case 2:
         if (!IsWallysBag() && gSaveBlock2Ptr->playerGender != MALE)
-            LoadCompressedPalette(gBagScreenFemale_Pal, 0, 0x40);
+            LoadCompressedPalette(gBagScreenFemale_Pal, BG_PLTT_ID(0x0), 2 * PLTT_SIZE_4BPP);
         else
-            LoadCompressedPalette(gBagScreenMale_Pal, 0, 0x40);
+            LoadCompressedPalette(gBagScreenMale_Pal, BG_PLTT_ID(0x0), 2 * PLTT_SIZE_4BPP);
         gBagMenu->graphicsLoadState++;
         break;
     case 3:
@@ -2448,10 +2448,10 @@ static void LoadBagMenuTextWindows(void)
 
     InitWindows(sDefaultBagWindows);
     DeactivateAllTextPrinters();
-    LoadUserWindowBorderGfx(0, 1, 0xE0);
-    LoadMessageBoxGfx(0, 10, 0xD0);
-    ListMenuLoadStdPalAt(0xC0, 1);
-    LoadPalette(&gStandardMenuPalette, 0xF0, 0x20);
+    LoadUserWindowBorderGfx(0, 1, BG_PLTT_ID(0xE));
+    LoadMessageBoxGfx(0, 10, BG_PLTT_ID(0xD));
+    ListMenuLoadStdPalAt(BG_PLTT_ID(0xC), 1);
+    LoadPalette(&gStandardMenuPalette, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
     for (i = 0; i <= WIN_POCKET_NAME; i++)
     {
         FillWindowPixelBuffer(i, PIXEL_FILL(0));

--- a/src/link.c
+++ b/src/link.c
@@ -200,7 +200,7 @@ static const struct WindowTemplate sLinkErrorWindowTemplates[] = {
         .tilemapTop = 0,
         .width = 30,
         .height = 5,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x002
     }, {
         .bg = 0,
@@ -208,7 +208,7 @@ static const struct WindowTemplate sLinkErrorWindowTemplates[] = {
         .tilemapTop = 6,
         .width = 30,
         .height = 7,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x098
     }, {
         .bg = 0,
@@ -216,7 +216,7 @@ static const struct WindowTemplate sLinkErrorWindowTemplates[] = {
         .tilemapTop = 13,
         .width = 30,
         .height = 7,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x16A
     }, DUMMY_WIN_TEMPLATE
 };
@@ -247,7 +247,7 @@ void Task_DestroySelf(u8 taskId)
 
 static void InitLinkTestBG(u8 paletteNum, u8 bgNum, u8 screenBaseBlock, u8 charBaseBlock, u16 baseChar)
 {
-    LoadPalette(sLinkTestDigitsPal, paletteNum * 16, 0x20);
+    LoadPalette(sLinkTestDigitsPal, BG_PLTT_ID(paletteNum), PLTT_SIZE_4BPP);
     DmaCopy16(3, sLinkTestDigitsGfx, (u16 *)BG_CHAR_ADDR(charBaseBlock) + (16 * baseChar), sizeof sLinkTestDigitsGfx);
     gLinkTestBGInfo.screenBaseBlock = screenBaseBlock;
     gLinkTestBGInfo.paletteNum = paletteNum;
@@ -271,7 +271,7 @@ static void InitLinkTestBG(u8 paletteNum, u8 bgNum, u8 screenBaseBlock, u8 charB
 // Unused
 static void LoadLinkTestBgGfx(u8 paletteNum, u8 bgNum, u8 screenBaseBlock, u8 charBaseBlock)
 {
-    LoadPalette(sLinkTestDigitsPal, paletteNum * 16, 0x20);
+    LoadPalette(sLinkTestDigitsPal, BG_PLTT_ID(paletteNum), PLTT_SIZE_4BPP);
     DmaCopy16(3, sLinkTestDigitsGfx, (u16 *)BG_CHAR_ADDR(charBaseBlock), sizeof sLinkTestDigitsGfx);
     gLinkTestBGInfo.screenBaseBlock = screenBaseBlock;
     gLinkTestBGInfo.paletteNum = paletteNum;
@@ -1595,7 +1595,7 @@ void CB2_LinkError(void)
     ResetSpriteData();
     FreeAllSpritePalettes();
     ResetPaletteFadeControl();
-    FillPalette(RGB_BLACK, 0, 2);
+    SetBackdropFromColor(RGB_BLACK);
     ResetTasks();
     ScanlineEffect_Stop();
     if (gWirelessCommType)
@@ -1621,7 +1621,7 @@ void CB2_LinkError(void)
         SetGpuReg(REG_OFFSET_BG1HOFS, 0);
         SetGpuReg(REG_OFFSET_BG1VOFS, 0);
         ClearGpuRegBits(REG_OFFSET_DISPCNT, DISPCNT_WIN0_ON | DISPCNT_WIN1_ON | DISPCNT_OBJWIN_ON);
-        LoadPalette(gStandardMenuPalette, 0xf0, 0x20);
+        LoadPalette(gStandardMenuPalette, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
         gSoftResetDisabled = FALSE;
         CreateTask(Task_DestroySelf, 0);
         StopMapMusic();

--- a/src/list_menu.c
+++ b/src/list_menu.c
@@ -1078,7 +1078,7 @@ u8 AddScrollIndicatorArrowPair(const struct ScrollArrowsTemplate *arrowInfo, u16
 
     if (arrowInfo->palTag == TAG_NONE)
     {
-        LoadPalette(sRedArrowPal, (16 * arrowInfo->palNum) + 0x100, 0x20);
+        LoadPalette(sRedArrowPal, OBJ_PLTT_ID(arrowInfo->palNum), PLTT_SIZE_4BPP);
     }
     else
     {
@@ -1324,7 +1324,7 @@ static u8 ListMenuAddRedOutlineCursorObject(struct CursorStruct *cursor)
 
     if (cursor->palTag == TAG_NONE)
     {
-        LoadPalette(sRedArrowPal, (16 * cursor->palNum) + 0x100, 0x20);
+        LoadPalette(sRedArrowPal, OBJ_PLTT_ID(cursor->palNum), PLTT_SIZE_4BPP);
     }
     else
     {
@@ -1409,7 +1409,7 @@ static u8 ListMenuAddRedArrowCursorObject(struct CursorStruct *cursor)
 
     if (cursor->palTag == TAG_NONE)
     {
-        LoadPalette(sRedArrowPal, (16 * cursor->palNum) + 0x100, 0x20);
+        LoadPalette(sRedArrowPal, OBJ_PLTT_ID(cursor->palNum), PLTT_SIZE_4BPP);
     }
     else
     {

--- a/src/mail.c
+++ b/src/mail.c
@@ -113,7 +113,7 @@ static const struct WindowTemplate sWindowTemplates[] = {
         .tilemapTop = 3,
         .width = 26,
         .height = 15,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1
     },
     DUMMY_WIN_TEMPLATE
@@ -566,13 +566,13 @@ static bool8 MailReadBuildGraphics(void)
             CopyBgTilemapBufferToVram(2);
             break;
         case 12:
-            LoadPalette(GetOverworldTextboxPalettePtr(), 240, 32);
+            LoadPalette(GetOverworldTextboxPalettePtr(), BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
 
             gPlttBufferUnfaded[250] = sMailGraphics[sMailRead->mailType].textColor;
             gPlttBufferFaded[250] = sMailGraphics[sMailRead->mailType].textColor;
             gPlttBufferUnfaded[251] = sMailGraphics[sMailRead->mailType].textShadow;
             gPlttBufferFaded[251] = sMailGraphics[sMailRead->mailType].textShadow;
-            LoadPalette(sMailGraphics[sMailRead->mailType].palette, 0, 32);
+            LoadPalette(sMailGraphics[sMailRead->mailType].palette, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
 
             gPlttBufferUnfaded[10] = sBgColors[gSaveBlock2Ptr->playerGender][0];
             gPlttBufferFaded[10] = sBgColors[gSaveBlock2Ptr->playerGender][0];

--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -294,7 +294,7 @@ static const struct WindowTemplate sWindowTemplates_MainMenu[] =
         .tilemapTop = MENU_TOP_WIN0,
         .width = MENU_WIDTH,
         .height = MENU_HEIGHT_WIN0,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1
     },
     // OPTIONS
@@ -304,7 +304,7 @@ static const struct WindowTemplate sWindowTemplates_MainMenu[] =
         .tilemapTop = MENU_TOP_WIN1,
         .width = MENU_WIDTH,
         .height = MENU_HEIGHT_WIN1,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x35
     },
     // Has saved game
@@ -315,7 +315,7 @@ static const struct WindowTemplate sWindowTemplates_MainMenu[] =
         .tilemapTop = MENU_TOP_WIN2,
         .width = MENU_WIDTH,
         .height = MENU_HEIGHT_WIN2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1
     },
     // NEW GAME
@@ -325,7 +325,7 @@ static const struct WindowTemplate sWindowTemplates_MainMenu[] =
         .tilemapTop = MENU_TOP_WIN3,
         .width = MENU_WIDTH,
         .height = MENU_HEIGHT_WIN3,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x9D
     },
     // OPTION / MYSTERY GIFT
@@ -335,7 +335,7 @@ static const struct WindowTemplate sWindowTemplates_MainMenu[] =
         .tilemapTop = MENU_TOP_WIN4,
         .width = MENU_WIDTH,
         .height = MENU_HEIGHT_WIN4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0xD1
     },
     // OPTION / MYSTERY EVENTS
@@ -345,7 +345,7 @@ static const struct WindowTemplate sWindowTemplates_MainMenu[] =
         .tilemapTop = MENU_TOP_WIN5,
         .width = MENU_WIDTH,
         .height = MENU_HEIGHT_WIN5,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x105
     },
     // OPTION
@@ -355,7 +355,7 @@ static const struct WindowTemplate sWindowTemplates_MainMenu[] =
         .tilemapTop = MENU_TOP_WIN6,
         .width = MENU_WIDTH,
         .height = MENU_HEIGHT_WIN6,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x139
     },
     // Error message window
@@ -365,7 +365,7 @@ static const struct WindowTemplate sWindowTemplates_MainMenu[] =
         .tilemapTop = MENU_TOP_ERROR,
         .width = MENU_WIDTH_ERROR,
         .height = MENU_HEIGHT_ERROR,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x16D
     },
     DUMMY_WIN_TEMPLATE
@@ -379,7 +379,7 @@ static const struct WindowTemplate sNewGameBirchSpeechTextWindows[] =
         .tilemapTop = 15,
         .width = 27,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1
     },
     {
@@ -388,7 +388,7 @@ static const struct WindowTemplate sNewGameBirchSpeechTextWindows[] =
         .tilemapTop = 5,
         .width = 6,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x6D
     },
     {
@@ -397,7 +397,7 @@ static const struct WindowTemplate sNewGameBirchSpeechTextWindows[] =
         .tilemapTop = 2,
         .width = 9,
         .height = 10,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x85
     },
     DUMMY_WIN_TEMPLATE
@@ -571,8 +571,8 @@ static u32 InitMainMenu(bool8 returningFromOptionsMenu)
     DmaFill16(3, 0, (void *)(PLTT + 2), PLTT_SIZE - 2);
 
     ResetPaletteFade();
-    LoadPalette(sMainMenuBgPal, 0, 32);
-    LoadPalette(sMainMenuTextPal, 0xF0, 32);
+    LoadPalette(sMainMenuBgPal, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
+    LoadPalette(sMainMenuTextPal, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
     ScanlineEffect_Stop();
     ResetTasks();
     ResetSpriteData();
@@ -750,28 +750,28 @@ static void Task_DisplayMainMenu(u8 taskId)
         SetGpuReg(REG_OFFSET_BLDY, 7);
 
         palette = RGB_BLACK;
-        LoadPalette(&palette, 254, 2);
+        LoadPalette(&palette, BG_PLTT_ID(0xF) + 14, PLTT_SIZEOF(1));
 
         palette = RGB_WHITE;
-        LoadPalette(&palette, 250, 2);
+        LoadPalette(&palette, BG_PLTT_ID(0xF) + 10, PLTT_SIZEOF(1));
 
         palette = RGB(12, 12, 12);
-        LoadPalette(&palette, 251, 2);
+        LoadPalette(&palette, BG_PLTT_ID(0xF) + 11, PLTT_SIZEOF(1));
 
         palette = RGB(26, 26, 25);
-        LoadPalette(&palette, 252, 2);
+        LoadPalette(&palette, BG_PLTT_ID(0xF) + 12, PLTT_SIZEOF(1));
 
         // Note: If there is no save file, the save block is zeroed out,
         // so the default gender is MALE.
         if (gSaveBlock2Ptr->playerGender == MALE)
         {
             palette = RGB(4, 16, 31);
-            LoadPalette(&palette, 241, 2);
+            LoadPalette(&palette, BG_PLTT_ID(0xF) + 1, PLTT_SIZEOF(1));
         }
         else
         {
             palette = RGB(31, 3, 21);
-            LoadPalette(&palette, 241, 2);
+            LoadPalette(&palette, BG_PLTT_ID(0xF) + 1, PLTT_SIZEOF(1));
         }
 
         switch (gTasks[taskId].tMenuType)
@@ -1274,8 +1274,8 @@ static void Task_NewGameBirchSpeech_Init(u8 taskId)
 
     LZ77UnCompVram(sBirchSpeechShadowGfx, (void *)VRAM);
     LZ77UnCompVram(sBirchSpeechBgMap, (void *)(BG_SCREEN_ADDR(7)));
-    LoadPalette(sBirchSpeechBgPals, 0, 64);
-    LoadPalette(sBirchSpeechPlatformBlackPal, 1, 16);
+    LoadPalette(sBirchSpeechBgPals, BG_PLTT_ID(0x0), 2 * PLTT_SIZE_4BPP);
+    LoadPalette(sBirchSpeechPlatformBlackPal, BG_PLTT_ID(0x0) + 1, PLTT_SIZEOF(8));
     ScanlineEffect_Stop();
     ResetSpriteData();
     FreeAllSpritePalettes();
@@ -1327,7 +1327,7 @@ static void Task_NewGameBirchSpeech_WaitForSpriteFadeInWelcome(u8 taskId)
         {
             InitWindows(sNewGameBirchSpeechTextWindows);
             LoadMainMenuWindowFrameTiles(0, 0xF3);
-            LoadMessageBoxGfx(0, 0xFC, 0xF0);
+            LoadMessageBoxGfx(0, 0xFC, BG_PLTT_ID(0xF));
             NewGameBirchSpeech_ShowDialogueWindow(0, 1);
             PutWindowTilemap(0);
             CopyWindowToVram(0, COPYWIN_GFX);
@@ -1809,8 +1809,8 @@ static void CB2_NewGameBirchSpeech_ReturnFromNamingScreen(void)
     ResetPaletteFade();
     LZ77UnCompVram(sBirchSpeechShadowGfx, (u8 *)VRAM);
     LZ77UnCompVram(sBirchSpeechBgMap, (u8 *)(BG_SCREEN_ADDR(7)));
-    LoadPalette(sBirchSpeechBgPals, 0, 64);
-    LoadPalette(&sBirchSpeechBgGradientPal[1], 1, 16);
+    LoadPalette(sBirchSpeechBgPals, BG_PLTT_ID(0x0), 2 * PLTT_SIZE_4BPP);
+    LoadPalette(&sBirchSpeechBgGradientPal[1], BG_PLTT_ID(0x0) + 1, PLTT_SIZEOF(8));
     ResetTasks();
     taskId = CreateTask(Task_NewGameBirchSpeech_ReturnFromNamingScreenShowTextbox, 0);
     gTasks[taskId].tTimer = 5;
@@ -1853,7 +1853,7 @@ static void CB2_NewGameBirchSpeech_ReturnFromNamingScreen(void)
     SetMainCallback2(CB2_MainMenu);
     InitWindows(sNewGameBirchSpeechTextWindows);
     LoadMainMenuWindowFrameTiles(0, 0xF3);
-    LoadMessageBoxGfx(0, 0xFC, 0xF0);
+    LoadMessageBoxGfx(0, 0xFC, BG_PLTT_ID(0xF));
     PutWindowTilemap(0);
     CopyWindowToVram(0, COPYWIN_FULL);
 }
@@ -2029,7 +2029,7 @@ static void Task_NewGameBirchSpeech_FadePlatformIn(u8 taskId)
     {
         gTasks[taskId].tDelayTimer = gTasks[taskId].tDelay;
         gTasks[taskId].tPalIndex++;
-        LoadPalette(&sBirchSpeechBgGradientPal[gTasks[taskId].tPalIndex], 1, 16);
+        LoadPalette(&sBirchSpeechBgGradientPal[gTasks[taskId].tPalIndex], BG_PLTT_ID(0x0) + 1, PLTT_SIZEOF(8));
     }
 }
 
@@ -2063,7 +2063,7 @@ static void Task_NewGameBirchSpeech_FadePlatformOut(u8 taskId)
     {
         gTasks[taskId].tDelayTimer = gTasks[taskId].tDelay;
         gTasks[taskId].tPalIndex--;
-        LoadPalette(&sBirchSpeechBgGradientPal[gTasks[taskId].tPalIndex], 1, 16);
+        LoadPalette(&sBirchSpeechBgGradientPal[gTasks[taskId].tPalIndex], BG_PLTT_ID(0x0) + 1, PLTT_SIZEOF(8));
     }
 }
 
@@ -2191,7 +2191,7 @@ static void MainMenu_FormatSavegameBadges(void)
 static void LoadMainMenuWindowFrameTiles(u8 bgId, u16 tileOffset)
 {
     LoadBgTiles(bgId, GetWindowFrameTilesPal(gSaveBlock2Ptr->optionsWindowFrameType)->tiles, 0x120, tileOffset);
-    LoadPalette(GetWindowFrameTilesPal(gSaveBlock2Ptr->optionsWindowFrameType)->pal, 32, 32);
+    LoadPalette(GetWindowFrameTilesPal(gSaveBlock2Ptr->optionsWindowFrameType)->pal, BG_PLTT_ID(0x2), PLTT_SIZE_4BPP);
 }
 
 static void DrawMainMenuWindowBorder(const struct WindowTemplate *template, u16 baseTileNum)
@@ -2204,26 +2204,26 @@ static void DrawMainMenuWindowBorder(const struct WindowTemplate *template, u16 
     u16 sp14 = 7 + baseTileNum;
     u16 r6 = 8 + baseTileNum;
 
-    FillBgTilemapBufferRect(template->bg, baseTileNum, template->tilemapLeft - 1, template->tilemapTop - 1, 1, 1, 2);
-    FillBgTilemapBufferRect(template->bg, r9, template->tilemapLeft, template->tilemapTop - 1, template->width, 1, 2);
-    FillBgTilemapBufferRect(template->bg, r10, template->tilemapLeft + template->width, template->tilemapTop - 1, 1, 1, 2);
-    FillBgTilemapBufferRect(template->bg, sp18, template->tilemapLeft - 1, template->tilemapTop, 1, template->height, 2);
-    FillBgTilemapBufferRect(template->bg, spC, template->tilemapLeft + template->width, template->tilemapTop, 1, template->height, 2);
-    FillBgTilemapBufferRect(template->bg, sp10, template->tilemapLeft - 1, template->tilemapTop + template->height, 1, 1, 2);
-    FillBgTilemapBufferRect(template->bg, sp14, template->tilemapLeft, template->tilemapTop + template->height, template->width, 1, 2);
-    FillBgTilemapBufferRect(template->bg, r6, template->tilemapLeft + template->width, template->tilemapTop + template->height, 1, 1, 2);
+    FillBgTilemapBufferRect(template->bg, baseTileNum, template->tilemapLeft - 1, template->tilemapTop - 1, 1, 1, 0x2);
+    FillBgTilemapBufferRect(template->bg, r9, template->tilemapLeft, template->tilemapTop - 1, template->width, 1, 0x2);
+    FillBgTilemapBufferRect(template->bg, r10, template->tilemapLeft + template->width, template->tilemapTop - 1, 1, 1, 0x2);
+    FillBgTilemapBufferRect(template->bg, sp18, template->tilemapLeft - 1, template->tilemapTop, 1, template->height, 0x2);
+    FillBgTilemapBufferRect(template->bg, spC, template->tilemapLeft + template->width, template->tilemapTop, 1, template->height, 0x2);
+    FillBgTilemapBufferRect(template->bg, sp10, template->tilemapLeft - 1, template->tilemapTop + template->height, 1, 1, 0x2);
+    FillBgTilemapBufferRect(template->bg, sp14, template->tilemapLeft, template->tilemapTop + template->height, template->width, 1, 0x2);
+    FillBgTilemapBufferRect(template->bg, r6, template->tilemapLeft + template->width, template->tilemapTop + template->height, 1, 1, 0x2);
     CopyBgTilemapBufferToVram(template->bg);
 }
 
 static void ClearMainMenuWindowTilemap(const struct WindowTemplate *template)
 {
-    FillBgTilemapBufferRect(template->bg, 0, template->tilemapLeft - 1, template->tilemapTop - 1, template->tilemapLeft + template->width + 1, template->tilemapTop + template->height + 1, 2);
+    FillBgTilemapBufferRect(template->bg, 0, template->tilemapLeft - 1, template->tilemapTop - 1, template->tilemapLeft + template->width + 1, template->tilemapTop + template->height + 1, 0x2);
     CopyBgTilemapBufferToVram(template->bg);
 }
 
 static void NewGameBirchSpeech_ClearGenderWindowTilemap(u8 bg, u8 x, u8 y, u8 width, u8 height, u8 unused)
 {
-    FillBgTilemapBufferRect(bg, 0, x + 255, y + 255, width + 2, height + 2, 2);
+    FillBgTilemapBufferRect(bg, 0, x + 255, y + 255, width + 2, height + 2, 0x2);
 }
 
 static void NewGameBirchSpeech_ClearGenderWindow(u8 windowId, bool8 copyToVram)

--- a/src/map_name_popup.c
+++ b/src/map_name_popup.c
@@ -351,19 +351,19 @@ static void DrawMapNamePopUpFrame(u8 bg, u8 x, u8 y, u8 deltaX, u8 deltaY, u8 un
 
     // Draw top edge
     for (i = 0; i < 1 + TILE_TOP_EDGE_END - TILE_TOP_EDGE_START; i++)
-        FillBgTilemapBufferRect(bg, TILE_TOP_EDGE_START + i, i - 1 + x, y - 1, 1, 1, 14);
+        FillBgTilemapBufferRect(bg, TILE_TOP_EDGE_START + i, i - 1 + x, y - 1, 1, 1, 0xE);
 
     // Draw sides
-    FillBgTilemapBufferRect(bg, TILE_LEFT_EDGE_TOP,       x - 1,     y, 1, 1, 14);
-    FillBgTilemapBufferRect(bg, TILE_RIGHT_EDGE_TOP, deltaX + x,     y, 1, 1, 14);
-    FillBgTilemapBufferRect(bg, TILE_LEFT_EDGE_MID,       x - 1, y + 1, 1, 1, 14);
-    FillBgTilemapBufferRect(bg, TILE_RIGHT_EDGE_MID, deltaX + x, y + 1, 1, 1, 14);
-    FillBgTilemapBufferRect(bg, TILE_LEFT_EDGE_BOT,       x - 1, y + 2, 1, 1, 14);
-    FillBgTilemapBufferRect(bg, TILE_RIGHT_EDGE_BOT, deltaX + x, y + 2, 1, 1, 14);
+    FillBgTilemapBufferRect(bg, TILE_LEFT_EDGE_TOP,       x - 1,     y, 1, 1, 0xE);
+    FillBgTilemapBufferRect(bg, TILE_RIGHT_EDGE_TOP, deltaX + x,     y, 1, 1, 0xE);
+    FillBgTilemapBufferRect(bg, TILE_LEFT_EDGE_MID,       x - 1, y + 1, 1, 1, 0xE);
+    FillBgTilemapBufferRect(bg, TILE_RIGHT_EDGE_MID, deltaX + x, y + 1, 1, 1, 0xE);
+    FillBgTilemapBufferRect(bg, TILE_LEFT_EDGE_BOT,       x - 1, y + 2, 1, 1, 0xE);
+    FillBgTilemapBufferRect(bg, TILE_RIGHT_EDGE_BOT, deltaX + x, y + 2, 1, 1, 0xE);
 
     // Draw bottom edge
     for (i = 0; i < 1 + TILE_BOT_EDGE_END - TILE_BOT_EDGE_START; i++)
-        FillBgTilemapBufferRect(bg, TILE_BOT_EDGE_START + i, i - 1 + x, y + deltaY, 1, 1, 14);
+        FillBgTilemapBufferRect(bg, TILE_BOT_EDGE_START + i, i - 1 + x, y + deltaY, 1, 1, 0xE);
 }
 
 static void LoadMapNamePopUpWindowBg(void)
@@ -385,8 +385,8 @@ static void LoadMapNamePopUpWindowBg(void)
     CallWindowFunction(popupWindowId, DrawMapNamePopUpFrame);
     PutWindowTilemap(popupWindowId);
     if (gMapHeader.weather == WEATHER_UNDERWATER_BUBBLES)
-        LoadPalette(&sMapPopUp_Palette_Underwater, 0xE0, sizeof(sMapPopUp_Palette_Underwater));
+        LoadPalette(&sMapPopUp_Palette_Underwater, BG_PLTT_ID(0xE), sizeof(sMapPopUp_Palette_Underwater));
     else
-        LoadPalette(sMapPopUp_PaletteTable[popUpThemeId], 0xE0, sizeof(sMapPopUp_PaletteTable[0]));
+        LoadPalette(sMapPopUp_PaletteTable[popUpThemeId], BG_PLTT_ID(0xE), sizeof(sMapPopUp_PaletteTable[0]));
     BlitBitmapToWindow(popupWindowId, sMapPopUp_Table[popUpThemeId], 0, 0, 80, 24);
 }

--- a/src/match_call.c
+++ b/src/match_call.c
@@ -1235,7 +1235,7 @@ static const struct WindowTemplate sMatchCallTextWindow =
     .tilemapTop = 15,
     .width = 28,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x200
 };
 
@@ -1267,8 +1267,8 @@ static bool32 MatchCall_LoadGfx(u8 taskId)
     }
 
     FillWindowPixelBuffer(tWindowId, PIXEL_FILL(8));
-    LoadPalette(sMatchCallWindow_Pal, 0xE0, sizeof(sMatchCallWindow_Pal));
-    LoadPalette(sPokenavIcon_Pal, 0xF0, sizeof(sPokenavIcon_Pal));
+    LoadPalette(sMatchCallWindow_Pal, BG_PLTT_ID(0xE), sizeof(sMatchCallWindow_Pal));
+    LoadPalette(sPokenavIcon_Pal, BG_PLTT_ID(0xF), sizeof(sPokenavIcon_Pal));
     ChangeBgY(0, -0x2000, BG_COORD_SET);
     return TRUE;
 }
@@ -2102,7 +2102,7 @@ void LoadMatchCallWindowGfx(u32 windowId, u32 destOffset, u32 paletteId)
 {
     u8 bg = GetWindowAttribute(windowId, WINDOW_BG);
     LoadBgTiles(bg, sMatchCallWindow_Gfx, 0x100, destOffset);
-    LoadPalette(sMatchCallWindow_Pal, paletteId << 4, sizeof(sMatchCallWindow_Pal));
+    LoadPalette(sMatchCallWindow_Pal, BG_PLTT_ID(paletteId), sizeof(sMatchCallWindow_Pal));
 }
 
 void DrawMatchCallTextBoxBorder(u32 windowId, u32 tileOffset, u32 paletteId)

--- a/src/menu.c
+++ b/src/menu.c
@@ -20,9 +20,10 @@
 #include "window.h"
 #include "constants/songs.h"
 
-#define DLG_WINDOW_PALETTE_NUM 15
+#define DLG_WINDOW_PALETTE_NUM 0xF
 #define DLG_WINDOW_BASE_TILE_NUM 0x200
-#define STD_WINDOW_PALETTE_NUM 14
+#define STD_WINDOW_PALETTE_NUM 0xE
+#define STD_WINDOW_PALETTE_SIZE PLTT_SIZEOF(10)
 #define STD_WINDOW_BASE_TILE_NUM 0x214
 
 struct MenuInfoIcon
@@ -88,7 +89,7 @@ static const struct WindowTemplate sStandardTextBox_WindowTemplates[] =
         .tilemapTop = 15,
         .width = 27,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x194
     },
     DUMMY_WIN_TEMPLATE
@@ -101,7 +102,7 @@ static const struct WindowTemplate sYesNo_WindowTemplates =
     .tilemapTop = 9,
     .width = 5,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x125
 };
 
@@ -208,8 +209,8 @@ void AddTextPrinterWithCustomSpeedForMessage(bool8 allowSkippingDelayWithButtonP
 
 void LoadMessageBoxAndBorderGfx(void)
 {
-    LoadMessageBoxGfx(0, DLG_WINDOW_BASE_TILE_NUM, DLG_WINDOW_PALETTE_NUM * 0x10);
-    LoadUserWindowBorderGfx(0, STD_WINDOW_BASE_TILE_NUM, STD_WINDOW_PALETTE_NUM * 0x10);
+    LoadMessageBoxGfx(0, DLG_WINDOW_BASE_TILE_NUM, BG_PLTT_ID(DLG_WINDOW_PALETTE_NUM));
+    LoadUserWindowBorderGfx(0, STD_WINDOW_BASE_TILE_NUM, BG_PLTT_ID(STD_WINDOW_PALETTE_NUM));
 }
 
 void DrawDialogueFrame(u8 windowId, bool8 copyToVram)
@@ -427,18 +428,18 @@ void SetStandardWindowBorderStyle(u8 windowId, bool8 copyToVram)
 
 void LoadMessageBoxAndFrameGfx(u8 windowId, bool8 copyToVram)
 {
-    LoadMessageBoxGfx(windowId, DLG_WINDOW_BASE_TILE_NUM, DLG_WINDOW_PALETTE_NUM * 0x10);
+    LoadMessageBoxGfx(windowId, DLG_WINDOW_BASE_TILE_NUM, BG_PLTT_ID(DLG_WINDOW_PALETTE_NUM));
     DrawDialogFrameWithCustomTileAndPalette(windowId, copyToVram, DLG_WINDOW_BASE_TILE_NUM, 0xF);
 }
 
 void Menu_LoadStdPal(void)
 {
-    LoadPalette(gStandardMenuPalette, STD_WINDOW_PALETTE_NUM * 0x10, 0x14);
+    LoadPalette(gStandardMenuPalette, BG_PLTT_ID(STD_WINDOW_PALETTE_NUM), STD_WINDOW_PALETTE_SIZE);
 }
 
 void Menu_LoadStdPalAt(u16 offset)
 {
-    LoadPalette(gStandardMenuPalette, offset, 0x14);
+    LoadPalette(gStandardMenuPalette, offset, STD_WINDOW_PALETTE_SIZE);
 }
 
 // Unused
@@ -550,7 +551,7 @@ void AddTextPrinterWithCallbackForMessage(bool8 canSpeedUp, void (*callback)(str
 
 void EraseFieldMessageBox(bool8 copyToVram)
 {
-    FillBgTilemapBufferRect(0, 0, 0, 0, 32, 32, 0x11);
+    FillBgTilemapBufferRect(0, 0, 0, 0, 32, 32, 17);
     if (copyToVram == TRUE)
         CopyBgTilemapBufferToVram(0);
 }
@@ -685,7 +686,7 @@ void ClearDialogWindowAndFrameToTransparent(u8 windowId, bool8 copyToVram)
 
 static void WindowFunc_ClearDialogWindowAndFrameNullPalette(u8 bg, u8 tilemapLeft, u8 tilemapTop, u8 width, u8 height, u8 paletteNum)
 {
-    FillBgTilemapBufferRect(bg, 0, tilemapLeft - 3, tilemapTop - 1, width + 6, height + 2, 0);
+    FillBgTilemapBufferRect(bg, 0, tilemapLeft - 3, tilemapTop - 1, width + 6, height + 2, 0x0);
 }
 
 void DrawStdFrameWithCustomTileAndPalette(u8 windowId, bool8 copyToVram, u16 baseTileNum, u8 paletteNum)
@@ -782,7 +783,7 @@ void ClearStdWindowAndFrameToTransparent(u8 windowId, bool8 copyToVram)
 
 static void WindowFunc_ClearStdWindowAndFrameToTransparent(u8 bg, u8 tilemapLeft, u8 tilemapTop, u8 width, u8 height, u8 paletteNum)
 {
-    FillBgTilemapBufferRect(bg, 0, tilemapLeft - 1, tilemapTop - 1, width + 2, height + 2, 0);
+    FillBgTilemapBufferRect(bg, 0, tilemapLeft - 1, tilemapTop - 1, width + 2, height + 2, 0x0);
 }
 
 // Creates the window used to display the info bar at the top of the HOF PC that shows the controls and team number.
@@ -805,10 +806,10 @@ u8 HofPCTopBar_AddWindow(u8 bg, u8 xPos, u8 yPos, u8 palette, u16 baseTile)
 
     sHofPCTopBarWindowId = AddWindow(&window);
 
-    if (palette > 15)
-        palette = 15 * 16;
+    if (palette > 0xF)
+        palette = BG_PLTT_ID(0xF);
     else
-        palette *= 16;
+        palette = BG_PLTT_ID(palette);
 
     LoadPalette(sHofPC_TopBar_Pal, palette, sizeof(sHofPC_TopBar_Pal));
     return sHofPCTopBarWindowId;
@@ -2084,7 +2085,7 @@ static void UnusedBlitBitmapRect(const struct Bitmap *src, struct Bitmap *dst, u
 // Unused
 static void LoadMonIconPalAtOffset(u8 palOffset, u16 speciesId)
 {
-    LoadPalette(GetValidMonIconPalettePtr(speciesId), palOffset, 0x20);
+    LoadPalette(GetValidMonIconPalettePtr(speciesId), palOffset, PLTT_SIZE_4BPP);
 }
 
 // Unused
@@ -2111,7 +2112,7 @@ void ListMenuLoadStdPalAt(u8 palOffset, u8 palId)
             break;
     }
 
-    LoadPalette(palette, palOffset, 0x20);
+    LoadPalette(palette, palOffset, PLTT_SIZE_4BPP);
 }
 
 void BlitMenuInfoIcon(u8 windowId, u8 iconId, u16 x, u16 y)

--- a/src/menu_specialized.c
+++ b/src/menu_specialized.c
@@ -48,7 +48,7 @@ static const struct WindowTemplate sWindowTemplates_MailboxMenu[MAILBOXWIN_COUNT
         .tilemapTop = 1,
         .width = 8,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x8
     },
     [MAILBOXWIN_LIST] = {
@@ -57,7 +57,7 @@ static const struct WindowTemplate sWindowTemplates_MailboxMenu[MAILBOXWIN_COUNT
         .tilemapTop = 1,
         .width = 8,
         .height = 18,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x18
     },
     [MAILBOXWIN_OPTIONS] = {
@@ -66,7 +66,7 @@ static const struct WindowTemplate sWindowTemplates_MailboxMenu[MAILBOXWIN_COUNT
         .tilemapTop = 1,
         .width = 11,
         .height = 8,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x18
     }
 };
@@ -707,8 +707,8 @@ void InitMoveRelearnerWindows(bool8 useContextWindow)
 
     InitWindows(sMoveRelearnerWindowTemplates);
     DeactivateAllTextPrinters();
-    LoadUserWindowBorderGfx(0, 1, 0xE0);
-    LoadPalette(gStandardMenuPalette, 0xF0, 0x20);
+    LoadUserWindowBorderGfx(0, 1, BG_PLTT_ID(0xE));
+    LoadPalette(gStandardMenuPalette, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
 
     for (i = 0; i < ARRAY_COUNT(sMoveRelearnerWindowTemplates) - 1; i++)
         FillWindowPixelBuffer(i, PIXEL_FILL(1));

--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -405,7 +405,7 @@ static void CB2_InitLearnMove(void)
     CreateUISprites();
 
     sMoveRelearnerStruct->moveListMenuTask = ListMenuInit(&gMultiuseListMenuTemplate, sMoveRelearnerMenuSate.listOffset, sMoveRelearnerMenuSate.listRow);
-    FillPalette(RGB_BLACK, 0, 2);
+    SetBackdropFromColor(RGB_BLACK);
     SetMainCallback2(CB2_MoveRelearnerMain);
 }
 
@@ -430,7 +430,7 @@ static void CB2_InitLearnMoveReturnFromSelectMove(void)
     CreateUISprites();
 
     sMoveRelearnerStruct->moveListMenuTask = ListMenuInit(&gMultiuseListMenuTemplate, sMoveRelearnerMenuSate.listOffset, sMoveRelearnerMenuSate.listRow);
-    FillPalette(RGB_BLACK, 0, 2);
+    SetBackdropFromColor(RGB_BLACK);
     SetMainCallback2(CB2_MoveRelearnerMain);
 }
 

--- a/src/mystery_event_menu.c
+++ b/src/mystery_event_menu.c
@@ -46,7 +46,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 15,
         .width = 22,
         .height = 4,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 20
     },
     {
@@ -55,7 +55,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 6,
         .width = 16,
         .height = 4,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x6C
     },
     DUMMY_WIN_TEMPLATE
@@ -91,8 +91,8 @@ void CB2_InitMysteryEventMenu(void)
             FillWindowPixelBuffer(i, PIXEL_FILL(0));
 
         FillBgTilemapBufferRect_Palette0(0, 0, 0, 0, 0x1E, 0x14);
-        LoadUserWindowBorderGfx(0, 1u, 0xD0u);
-        Menu_LoadStdPalAt(0xE0);
+        LoadUserWindowBorderGfx(0, 1, BG_PLTT_ID(0xD));
+        Menu_LoadStdPalAt(BG_PLTT_ID(0xE));
         SetGpuReg(REG_OFFSET_DISPCNT, DISPCNT_MODE_0 | DISPCNT_OBJ_1D_MAP | DISPCNT_BG0_ON);
         SetGpuReg(REG_OFFSET_BLDCNT, 0);
         CreateTask(Task_DestroySelf, 0);
@@ -102,7 +102,7 @@ void CB2_InitMysteryEventMenu(void)
         BuildOamBuffer();
         RunTextPrinters();
         UpdatePaletteFade();
-        FillPalette(RGB_BLACK, 0, 2);
+        SetBackdropFromColor(RGB_BLACK);
         SetMainCallback2(CB2_MysteryEventMenu);
     }
 }

--- a/src/mystery_gift_menu.c
+++ b/src/mystery_gift_menu.c
@@ -33,7 +33,7 @@
 #include "constants/cable_club.h"
 
 #define LIST_MENU_TILE_NUM 10
-#define LIST_MENU_PAL_NUM 224
+#define LIST_MENU_PAL_NUM BG_PLTT_ID(0xE)
 
 static void LoadMysteryGiftTextboxBorder(u8 bgId);
 static void CreateMysteryGiftTask(void);
@@ -104,7 +104,7 @@ static const struct WindowTemplate sMainWindows[] = {
         .tilemapTop = 0,
         .width = 30,
         .height = 2,
-        .paletteNum = 12,
+        .paletteNum = 0xC,
         .baseBlock = 0x0013
     }, {
         .bg = 0,
@@ -112,7 +112,7 @@ static const struct WindowTemplate sMainWindows[] = {
         .tilemapTop = 15,
         .width = 28,
         .height = 4,
-        .paletteNum = 12,
+        .paletteNum = 0xC,
         .baseBlock = 0x004f
     }, {
         .bg = 0,
@@ -120,7 +120,7 @@ static const struct WindowTemplate sMainWindows[] = {
         .tilemapTop = 15,
         .width = 30,
         .height = 5,
-        .paletteNum = 13,
+        .paletteNum = 0xD,
         .baseBlock = 0x004f
     },
     DUMMY_WIN_TEMPLATE
@@ -132,7 +132,7 @@ static const struct WindowTemplate sWindowTemplate_YesNoMsg_Wide = {
     .tilemapTop = 15,
     .width = 28,
     .height = 4,
-    .paletteNum = 12,
+    .paletteNum = 0xC,
     .baseBlock = 0x00e5
 };
 
@@ -142,7 +142,7 @@ static const struct WindowTemplate sWindowTemplate_YesNoMsg = {
     .tilemapTop = 15,
     .width = 20,
     .height = 4,
-    .paletteNum = 12,
+    .paletteNum = 0xC,
     .baseBlock = 0x00e5
 };
 
@@ -152,7 +152,7 @@ static const struct WindowTemplate sWindowTemplate_GiftSelect = {
     .tilemapTop = 15,
     .width = 19,
     .height = 4,
-    .paletteNum = 12,
+    .paletteNum = 0xC,
     .baseBlock = 0x00e5
 };
 
@@ -162,7 +162,7 @@ static const struct WindowTemplate sWindowTemplate_ThreeOptions = {
     .tilemapTop = 6,
     .width = 14,
     .height = 6,
-    .paletteNum = 12,
+    .paletteNum = 0xC,
     .baseBlock = 0x0155
 };
 
@@ -172,7 +172,7 @@ static const struct WindowTemplate sWindowTemplate_YesNoBox = {
     .tilemapTop = 15,
     .width = 6,
     .height = 4,
-    .paletteNum = 12,
+    .paletteNum = 0xC,
     .baseBlock = 0x0155
 };
 
@@ -182,7 +182,7 @@ static const struct WindowTemplate sWindowTemplate_GiftSelect_3Options = {
     .tilemapTop = 11,
     .width = 7,
     .height = 8,
-    .paletteNum = 12,
+    .paletteNum = 0xC,
     .baseBlock = 0x0155
 };
 
@@ -192,7 +192,7 @@ static const struct WindowTemplate sWindowTemplate_GiftSelect_2Options = {
     .tilemapTop = 13,
     .width = 7,
     .height = 6,
-    .paletteNum = 12,
+    .paletteNum = 0xC,
     .baseBlock = 0x0155
 };
 
@@ -202,7 +202,7 @@ static const struct WindowTemplate sWindowTemplate_GiftSelect_1Option = {
     .tilemapTop = 15,
     .width = 7,
     .height = 4,
-    .paletteNum = 12,
+    .paletteNum = 0xC,
     .baseBlock = 0x0155
 };
 
@@ -411,14 +411,14 @@ static bool32 HandleMysteryGiftOrEReaderSetup(s32 isEReader)
         gMain.state++;
         break;
     case 1:
-        LoadPalette(sTextboxBorder_Pal, 0, 0x20);
-        LoadPalette(GetTextWindowPalette(2), 0xd0, 0x20);
-        Menu_LoadStdPalAt(0xC0);
-        LoadUserWindowBorderGfx(0, 0xA, 0xE0);
-        LoadUserWindowBorderGfx_(0, 0x1, 0xF0);
-        FillBgTilemapBufferRect(0, 0x000, 0, 0, 32, 32, 0x11);
-        FillBgTilemapBufferRect(1, 0x000, 0, 0, 32, 32, 0x11);
-        FillBgTilemapBufferRect(2, 0x000, 0, 0, 32, 32, 0x11);
+        LoadPalette(sTextboxBorder_Pal, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
+        LoadPalette(GetTextWindowPalette(2), BG_PLTT_ID(0xD), PLTT_SIZE_4BPP);
+        Menu_LoadStdPalAt(BG_PLTT_ID(0xC));
+        LoadUserWindowBorderGfx(0, 0xA, BG_PLTT_ID(0xE));
+        LoadUserWindowBorderGfx_(0, 0x1, BG_PLTT_ID(0xF));
+        FillBgTilemapBufferRect(0, 0x000, 0, 0, 32, 32, 17);
+        FillBgTilemapBufferRect(1, 0x000, 0, 0, 32, 32, 17);
+        FillBgTilemapBufferRect(2, 0x000, 0, 0, 32, 32, 17);
         MG_DrawCheckerboardPattern(3);
         PrintMysteryGiftOrEReaderTopMenu(isEReader, FALSE);
         gMain.state++;
@@ -505,16 +505,16 @@ void MG_DrawCheckerboardPattern(u32 bg)
 {
     s32 i = 0, j;
 
-    FillBgTilemapBufferRect(bg, 0x003, 0, 0, 32, 2, 0x11);
+    FillBgTilemapBufferRect(bg, 0x003, 0, 0, 32, 2, 17);
 
     for (i = 0; i < 18; i++)
     {
         for (j = 0; j < 32; j++)
         {
             if ((i & 1) != (j & 1))
-                FillBgTilemapBufferRect(bg, 1, j, i + 2, 1, 1, 0x11);
+                FillBgTilemapBufferRect(bg, 1, j, i + 2, 1, 1, 17);
             else
-                FillBgTilemapBufferRect(bg, 2, j, i + 2, 1, 1, 0x11);
+                FillBgTilemapBufferRect(bg, 2, j, i + 2, 1, 1, 17);
         }
     }
 }
@@ -524,10 +524,10 @@ static void ClearScreenInBg0(bool32 ignoreTopTwoRows)
     switch (ignoreTopTwoRows)
     {
     case 0:
-        FillBgTilemapBufferRect(0, 0, 0, 0, 32, 32, 0x11);
+        FillBgTilemapBufferRect(0, 0, 0, 0, 32, 32, 17);
         break;
     case 1:
-        FillBgTilemapBufferRect(0, 0, 0, 2, 32, 30, 0x11);
+        FillBgTilemapBufferRect(0, 0, 0, 2, 32, 30, 17);
         break;
     }
     CopyBgTilemapBufferToVram(0);

--- a/src/mystery_gift_view.c
+++ b/src/mystery_gift_view.c
@@ -96,7 +96,7 @@ static const struct WindowTemplate sCard_WindowTemplates[] = {
         .tilemapTop = 1,
         .width = 25,
         .height = 4,
-        .paletteNum = 2,
+        .paletteNum = 0x2,
         .baseBlock = 0x029c
     },
     [CARD_WIN_BODY] = {
@@ -105,7 +105,7 @@ static const struct WindowTemplate sCard_WindowTemplates[] = {
         .tilemapTop = 6,
         .width = 28,
         .height = 8,
-        .paletteNum = 2,
+        .paletteNum = 0x2,
         .baseBlock = 0x01bc
     },
     [CARD_WIN_FOOTER] = {
@@ -114,7 +114,7 @@ static const struct WindowTemplate sCard_WindowTemplates[] = {
         .tilemapTop = 14,
         .width = 28,
         .height = 5,
-        .paletteNum = 2,
+        .paletteNum = 0x2,
         .baseBlock = 0x0130
     }
 };
@@ -239,11 +239,11 @@ s32 WonderCard_Enter(void)
     case 3:
         if (FreeTempTileDataBuffersIfPossible())
             return 0;
-        LoadPalette(GetTextWindowPalette(1), 0x20, 0x20);
+        LoadPalette(GetTextWindowPalette(1), BG_PLTT_ID(0x2), PLTT_SIZE_4BPP);
         gPaletteFade.bufferTransferDisabled = TRUE;
-        LoadPalette(sWonderCardData->gfx->pal, 0x10, 0x20);
+        LoadPalette(sWonderCardData->gfx->pal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
         LZ77UnCompWram(sWonderCardData->gfx->map, sWonderCardData->bgTilemapBuffer);
-        CopyRectToBgTilemapBufferRect(2, sWonderCardData->bgTilemapBuffer, 0, 0, 30, 20, 0, 0, 30, 20, 1, 0x008, 0);
+        CopyRectToBgTilemapBufferRect(2, sWonderCardData->bgTilemapBuffer, 0, 0, 30, 20, 0, 0, 30, 20, 0x1, 0x008, 0);
         CopyBgTilemapBufferToVram(2);
         break;
     case 4:
@@ -586,7 +586,7 @@ static const struct WindowTemplate sNews_WindowTemplates[] = {
         .tilemapTop = 0,
         .width = 28,
         .height = 3,
-        .paletteNum = 2,
+        .paletteNum = 0x2,
         .baseBlock = 0x2AC
     },
     [NEWS_WIN_BODY] = {
@@ -595,7 +595,7 @@ static const struct WindowTemplate sNews_WindowTemplates[] = {
         .tilemapTop = 3,
         .width = 28,
         .height = 20,
-        .paletteNum = 2,
+        .paletteNum = 0x2,
         .baseBlock = 0x07C
     }
 };
@@ -702,12 +702,12 @@ s32 WonderNews_Enter(void)
     case 3:
         if (FreeTempTileDataBuffersIfPossible())
             return 0;
-        LoadPalette(GetTextWindowPalette(1), 0x20, 0x20);
+        LoadPalette(GetTextWindowPalette(1), BG_PLTT_ID(0x2), PLTT_SIZE_4BPP);
         gPaletteFade.bufferTransferDisabled = TRUE;
-        LoadPalette(sWonderNewsData->gfx->pal, 0x10, 0x20);
+        LoadPalette(sWonderNewsData->gfx->pal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
         LZ77UnCompWram(sWonderNewsData->gfx->map, sWonderNewsData->bgTilemapBuffer);
-        CopyRectToBgTilemapBufferRect(1, sWonderNewsData->bgTilemapBuffer, 0, 0, 30, 3, 0, 0, 30, 3, 1, 8, 0);
-        CopyRectToBgTilemapBufferRect(3, sWonderNewsData->bgTilemapBuffer, 0, 3, 30, 23, 0, 3, 30, 23, 1, 8, 0);
+        CopyRectToBgTilemapBufferRect(1, sWonderNewsData->bgTilemapBuffer, 0, 0, 30, 3, 0, 0, 30, 3, 0x1, 8, 0);
+        CopyRectToBgTilemapBufferRect(3, sWonderNewsData->bgTilemapBuffer, 0, 3, 30, 23, 0, 3, 30, 23, 0x1, 8, 0);
         CopyBgTilemapBufferToVram(1);
         CopyBgTilemapBufferToVram(3);
         break;

--- a/src/naming_screen.c
+++ b/src/naming_screen.c
@@ -233,7 +233,7 @@ static const struct WindowTemplate sWindowTemplates[WIN_COUNT + 1] =
         .tilemapTop = 10,
         .width = 19,
         .height = 8,
-        .paletteNum = 10,
+        .paletteNum = 0xA,
         .baseBlock = 0x030
     },
     [WIN_KB_PAGE_2] = {
@@ -242,7 +242,7 @@ static const struct WindowTemplate sWindowTemplates[WIN_COUNT + 1] =
         .tilemapTop = 10,
         .width = 19,
         .height = 8,
-        .paletteNum = 10,
+        .paletteNum = 0xA,
         .baseBlock = 0x0C8
     },
     [WIN_TEXT_ENTRY] = {
@@ -251,7 +251,7 @@ static const struct WindowTemplate sWindowTemplates[WIN_COUNT + 1] =
         .tilemapTop = 6,
         .width = 17,
         .height = 2,
-        .paletteNum = 10,
+        .paletteNum = 0xA,
         .baseBlock = 0x030
     },
     [WIN_TEXT_ENTRY_BOX] = {
@@ -260,7 +260,7 @@ static const struct WindowTemplate sWindowTemplates[WIN_COUNT + 1] =
         .tilemapTop = 4,
         .width = 17,
         .height = 2,
-        .paletteNum = 10,
+        .paletteNum = 0xA,
         .baseBlock = 0x052
     },
     [WIN_BANNER] = {
@@ -269,7 +269,7 @@ static const struct WindowTemplate sWindowTemplates[WIN_COUNT + 1] =
         .tilemapTop = 0,
         .width = 30,
         .height = 2,
-        .paletteNum = 11,
+        .paletteNum = 0xB,
         .baseBlock = 0x074
     },
     DUMMY_WIN_TEMPLATE
@@ -1880,9 +1880,9 @@ static void CreateHelperTasks(void)
 
 static void LoadPalettes(void)
 {
-    LoadPalette(gNamingScreenMenu_Pal, 0, sizeof(gNamingScreenMenu_Pal));
-    LoadPalette(sKeyboard_Pal, 0xA0, sizeof(sKeyboard_Pal));
-    LoadPalette(GetTextWindowPalette(2), 0xB0, 0x20);
+    LoadPalette(gNamingScreenMenu_Pal, BG_PLTT_ID(0x0), sizeof(gNamingScreenMenu_Pal));
+    LoadPalette(sKeyboard_Pal, BG_PLTT_ID(0xA), sizeof(sKeyboard_Pal));
+    LoadPalette(GetTextWindowPalette(2), BG_PLTT_ID(0xB), PLTT_SIZE_4BPP);
 }
 
 static void DrawBgTilemap(u8 bg, const void *src)

--- a/src/option_menu.c
+++ b/src/option_menu.c
@@ -102,7 +102,7 @@ static const struct WindowTemplate sOptionMenuWinTemplates[] =
         .tilemapTop = 1,
         .width = 26,
         .height = 2,
-        .paletteNum = 1,
+        .paletteNum = 0x1,
         .baseBlock = 2
     },
     {
@@ -111,7 +111,7 @@ static const struct WindowTemplate sOptionMenuWinTemplates[] =
         .tilemapTop = 5,
         .width = 26,
         .height = 14,
-        .paletteNum = 1,
+        .paletteNum = 0x1,
         .baseBlock = 0x36
     },
     DUMMY_WIN_TEMPLATE
@@ -207,12 +207,12 @@ void CB2_InitOptionMenu(void)
         gMain.state++;
         break;
     case 4:
-        LoadPalette(sOptionMenuBg_Pal, 0, sizeof(sOptionMenuBg_Pal));
-        LoadPalette(GetWindowFrameTilesPal(gSaveBlock2Ptr->optionsWindowFrameType)->pal, 0x70, 0x20);
+        LoadPalette(sOptionMenuBg_Pal, BG_PLTT_ID(0x0), sizeof(sOptionMenuBg_Pal));
+        LoadPalette(GetWindowFrameTilesPal(gSaveBlock2Ptr->optionsWindowFrameType)->pal, BG_PLTT_ID(0x7), PLTT_SIZE_4BPP);
         gMain.state++;
         break;
     case 5:
-        LoadPalette(sOptionMenuText_Pal, 16, sizeof(sOptionMenuText_Pal));
+        LoadPalette(sOptionMenuText_Pal, BG_PLTT_ID(0x1), sizeof(sOptionMenuText_Pal));
         gMain.state++;
         break;
     case 6:
@@ -529,7 +529,7 @@ static u8 FrameType_ProcessInput(u8 selection)
             selection = 0;
 
         LoadBgTiles(1, GetWindowFrameTilesPal(selection)->tiles, 0x120, 0x1A2);
-        LoadPalette(GetWindowFrameTilesPal(selection)->pal, 0x70, 0x20);
+        LoadPalette(GetWindowFrameTilesPal(selection)->pal, BG_PLTT_ID(0x7), PLTT_SIZE_4BPP);
         sArrowPressed = TRUE;
     }
     if (JOY_NEW(DPAD_LEFT))
@@ -540,7 +540,7 @@ static u8 FrameType_ProcessInput(u8 selection)
             selection = WINDOW_FRAMES_COUNT - 1;
 
         LoadBgTiles(1, GetWindowFrameTilesPal(selection)->tiles, 0x120, 0x1A2);
-        LoadPalette(GetWindowFrameTilesPal(selection)->pal, 0x70, 0x20);
+        LoadPalette(GetWindowFrameTilesPal(selection)->pal, BG_PLTT_ID(0x7), PLTT_SIZE_4BPP);
         sArrowPressed = TRUE;
     }
     return selection;
@@ -653,24 +653,24 @@ static void DrawBgWindowFrames(void)
 {
     //                     bg, tile,              x, y, width, height, palNum
     // Draw title window frame
-    FillBgTilemapBufferRect(1, TILE_TOP_CORNER_L,  1,  0,  1,  1,  7);
-    FillBgTilemapBufferRect(1, TILE_TOP_EDGE,      2,  0, 27,  1,  7);
-    FillBgTilemapBufferRect(1, TILE_TOP_CORNER_R, 28,  0,  1,  1,  7);
-    FillBgTilemapBufferRect(1, TILE_LEFT_EDGE,     1,  1,  1,  2,  7);
-    FillBgTilemapBufferRect(1, TILE_RIGHT_EDGE,   28,  1,  1,  2,  7);
-    FillBgTilemapBufferRect(1, TILE_BOT_CORNER_L,  1,  3,  1,  1,  7);
-    FillBgTilemapBufferRect(1, TILE_BOT_EDGE,      2,  3, 27,  1,  7);
-    FillBgTilemapBufferRect(1, TILE_BOT_CORNER_R, 28,  3,  1,  1,  7);
+    FillBgTilemapBufferRect(1, TILE_TOP_CORNER_L,  1,  0,  1,  1,  0x7);
+    FillBgTilemapBufferRect(1, TILE_TOP_EDGE,      2,  0, 27,  1,  0x7);
+    FillBgTilemapBufferRect(1, TILE_TOP_CORNER_R, 28,  0,  1,  1,  0x7);
+    FillBgTilemapBufferRect(1, TILE_LEFT_EDGE,     1,  1,  1,  2,  0x7);
+    FillBgTilemapBufferRect(1, TILE_RIGHT_EDGE,   28,  1,  1,  2,  0x7);
+    FillBgTilemapBufferRect(1, TILE_BOT_CORNER_L,  1,  3,  1,  1,  0x7);
+    FillBgTilemapBufferRect(1, TILE_BOT_EDGE,      2,  3, 27,  1,  0x7);
+    FillBgTilemapBufferRect(1, TILE_BOT_CORNER_R, 28,  3,  1,  1,  0x7);
 
     // Draw options list window frame
-    FillBgTilemapBufferRect(1, TILE_TOP_CORNER_L,  1,  4,  1,  1,  7);
-    FillBgTilemapBufferRect(1, TILE_TOP_EDGE,      2,  4, 26,  1,  7);
-    FillBgTilemapBufferRect(1, TILE_TOP_CORNER_R, 28,  4,  1,  1,  7);
-    FillBgTilemapBufferRect(1, TILE_LEFT_EDGE,     1,  5,  1, 18,  7);
-    FillBgTilemapBufferRect(1, TILE_RIGHT_EDGE,   28,  5,  1, 18,  7);
-    FillBgTilemapBufferRect(1, TILE_BOT_CORNER_L,  1, 19,  1,  1,  7);
-    FillBgTilemapBufferRect(1, TILE_BOT_EDGE,      2, 19, 26,  1,  7);
-    FillBgTilemapBufferRect(1, TILE_BOT_CORNER_R, 28, 19,  1,  1,  7);
+    FillBgTilemapBufferRect(1, TILE_TOP_CORNER_L,  1,  4,  1,  1,  0x7);
+    FillBgTilemapBufferRect(1, TILE_TOP_EDGE,      2,  4, 26,  1,  0x7);
+    FillBgTilemapBufferRect(1, TILE_TOP_CORNER_R, 28,  4,  1,  1,  0x7);
+    FillBgTilemapBufferRect(1, TILE_LEFT_EDGE,     1,  5,  1, 18,  0x7);
+    FillBgTilemapBufferRect(1, TILE_RIGHT_EDGE,   28,  5,  1, 18,  0x7);
+    FillBgTilemapBufferRect(1, TILE_BOT_CORNER_L,  1, 19,  1,  1,  0x7);
+    FillBgTilemapBufferRect(1, TILE_BOT_EDGE,      2, 19, 26,  1,  0x7);
+    FillBgTilemapBufferRect(1, TILE_BOT_CORNER_R, 28, 19,  1,  1,  0x7);
 
     CopyBgTilemapBufferToVram(1);
 }

--- a/src/palette.c
+++ b/src/palette.c
@@ -431,7 +431,7 @@ static u8 UpdateNormalPaletteFade(void)
             gPaletteFade.delayCounter = 0;
         }
 
-        paletteOffset = 0;
+        paletteOffset = 0x00;
 
         if (!gPaletteFade.objPaletteToggle)
         {
@@ -452,7 +452,7 @@ static u8 UpdateNormalPaletteFade(void)
                     gPaletteFade.y,
                     gPaletteFade.blendColor);
             selectedPalettes >>= 1;
-            paletteOffset += 16;
+            paletteOffset += 0x10;
         }
 
         gPaletteFade.objPaletteToggle ^= 1;
@@ -495,7 +495,7 @@ static u8 UpdateNormalPaletteFade(void)
 
 void InvertPlttBuffer(u32 selectedPalettes)
 {
-    u16 paletteOffset = 0;
+    u16 paletteOffset = 0x00;
 
     while (selectedPalettes)
     {
@@ -506,13 +506,13 @@ void InvertPlttBuffer(u32 selectedPalettes)
                 gPlttBufferFaded[paletteOffset + i] = ~gPlttBufferFaded[paletteOffset + i];
         }
         selectedPalettes >>= 1;
-        paletteOffset += 16;
+        paletteOffset += 0x10;
     }
 }
 
 void TintPlttBuffer(u32 selectedPalettes, s8 r, s8 g, s8 b)
 {
-    u16 paletteOffset = 0;
+    u16 paletteOffset = 0x00;
 
     while (selectedPalettes)
     {
@@ -528,13 +528,13 @@ void TintPlttBuffer(u32 selectedPalettes, s8 r, s8 g, s8 b)
             }
         }
         selectedPalettes >>= 1;
-        paletteOffset += 16;
+        paletteOffset += 0x10;
     }
 }
 
 void UnfadePlttBuffer(u32 selectedPalettes)
 {
-    u16 paletteOffset = 0;
+    u16 paletteOffset = 0x00;
 
     while (selectedPalettes)
     {
@@ -545,7 +545,7 @@ void UnfadePlttBuffer(u32 selectedPalettes)
                 gPlttBufferFaded[paletteOffset + i] = gPlttBufferUnfaded[paletteOffset + i];
         }
         selectedPalettes >>= 1;
-        paletteOffset += 16;
+        paletteOffset += 0x10;
     }
 }
 
@@ -835,7 +835,7 @@ void BlendPalettes(u32 selectedPalettes, u8 coeff, u16 color)
 {
     u16 paletteOffset;
 
-    for (paletteOffset = 0; selectedPalettes; paletteOffset += 16)
+    for (paletteOffset = 0x00; selectedPalettes; paletteOffset += 0x10)
     {
         if (selectedPalettes & 1)
             BlendPalette(paletteOffset, 16, coeff, color);

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -668,8 +668,8 @@ static bool8 AllocPartyMenuBgGfx(void)
         }
         break;
     case 2:
-        LoadCompressedPalette(gPartyMenuBg_Pal, 0, 0x160);
-        CpuCopy16(gPlttBufferUnfaded, sPartyMenuInternal->palBuffer, 0x160);
+        LoadCompressedPalette(gPartyMenuBg_Pal, BG_PLTT_ID(0x0), 11 * PLTT_SIZE_4BPP);
+        CpuCopy16(gPlttBufferUnfaded, sPartyMenuInternal->palBuffer, 11 * PLTT_SIZE_4BPP);
         sPartyMenuInternal->data[0]++;
         break;
     case 3:
@@ -1021,7 +1021,7 @@ static void CreateCancelConfirmPokeballSprites(void)
     if (gPartyMenu.menuType == PARTY_MENU_TYPE_MULTI_SHOWCASE)
     {
         // The showcase has no Cancel/Confirm buttons
-        FillBgTilemapBufferRect(1, 14, 23, 17, 7, 2, 1);
+        FillBgTilemapBufferRect(1, 14, 23, 17, 7, 2, 0x1);
     }
     else
     {
@@ -2015,9 +2015,9 @@ static void InitPartyMenuWindows(u8 layout)
     DeactivateAllTextPrinters();
     for (i = 0; i < PARTY_SIZE; i++)
         FillWindowPixelBuffer(i, PIXEL_FILL(0));
-    LoadUserWindowBorderGfx(0, 0x4F, 0xD0);
-    LoadPalette(GetOverworldTextboxPalettePtr(), 0xE0, 0x20);
-    LoadPalette(gStandardMenuPalette, 0xF0, 0x20);
+    LoadUserWindowBorderGfx(0, 0x4F, BG_PLTT_ID(0xD));
+    LoadPalette(GetOverworldTextboxPalettePtr(), BG_PLTT_ID(0xE), PLTT_SIZE_4BPP);
+    LoadPalette(gStandardMenuPalette, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
 }
 
 static void CreateCancelConfirmWindows(bool8 chooseHalf)
@@ -2119,9 +2119,9 @@ static void DrawEmptySlot(u8 windowId)
 
 #define LOAD_PARTY_BOX_PAL(paletteIds, paletteOffsets)                                    \
 {                                                                                         \
-    LoadPalette(GetPartyMenuPalBufferPtr(paletteIds[0]), paletteOffsets[0] + palNum, 2);  \
-    LoadPalette(GetPartyMenuPalBufferPtr(paletteIds[1]), paletteOffsets[1] + palNum, 2);  \
-    LoadPalette(GetPartyMenuPalBufferPtr(paletteIds[2]), paletteOffsets[2] + palNum, 2);  \
+    LoadPalette(GetPartyMenuPalBufferPtr(paletteIds[0]), paletteOffsets[0] + palNum, PLTT_SIZEOF(1));  \
+    LoadPalette(GetPartyMenuPalBufferPtr(paletteIds[1]), paletteOffsets[1] + palNum, PLTT_SIZEOF(1));  \
+    LoadPalette(GetPartyMenuPalBufferPtr(paletteIds[2]), paletteOffsets[2] + palNum, PLTT_SIZEOF(1));  \
 }
 
 static void LoadPartyBoxPalette(struct PartyMenuBox *menuBox, u8 palFlags)
@@ -2263,13 +2263,13 @@ static void DisplayPartyPokemonGender(u8 gender, u16 species, u8 *nickname, stru
     switch (gender)
     {
     case MON_MALE:
-        LoadPalette(GetPartyMenuPalBufferPtr(sGenderMalePalIds[0]), sGenderPalOffsets[0] + palNum, 2);
-        LoadPalette(GetPartyMenuPalBufferPtr(sGenderMalePalIds[1]), sGenderPalOffsets[1] + palNum, 2);
+        LoadPalette(GetPartyMenuPalBufferPtr(sGenderMalePalIds[0]), sGenderPalOffsets[0] + palNum, PLTT_SIZEOF(1));
+        LoadPalette(GetPartyMenuPalBufferPtr(sGenderMalePalIds[1]), sGenderPalOffsets[1] + palNum, PLTT_SIZEOF(1));
         DisplayPartyPokemonBarDetail(menuBox->windowId, gText_MaleSymbol, 2, &menuBox->infoRects->dimensions[8]);
         break;
     case MON_FEMALE:
-        LoadPalette(GetPartyMenuPalBufferPtr(sGenderFemalePalIds[0]), sGenderPalOffsets[0] + palNum, 2);
-        LoadPalette(GetPartyMenuPalBufferPtr(sGenderFemalePalIds[1]), sGenderPalOffsets[1] + palNum, 2);
+        LoadPalette(GetPartyMenuPalBufferPtr(sGenderFemalePalIds[0]), sGenderPalOffsets[0] + palNum, PLTT_SIZEOF(1));
+        LoadPalette(GetPartyMenuPalBufferPtr(sGenderFemalePalIds[1]), sGenderPalOffsets[1] + palNum, PLTT_SIZEOF(1));
         DisplayPartyPokemonBarDetail(menuBox->windowId, gText_FemaleSymbol, 2, &menuBox->infoRects->dimensions[8]);
         break;
     }
@@ -2330,16 +2330,16 @@ static void DisplayPartyPokemonHPBar(u16 hp, u16 maxhp, struct PartyMenuBox *men
     {
     case HP_BAR_GREEN:
     case HP_BAR_FULL:
-        LoadPalette(GetPartyMenuPalBufferPtr(sHPBarGreenPalIds[0]), sHPBarPalOffsets[0] + palNum, 2);
-        LoadPalette(GetPartyMenuPalBufferPtr(sHPBarGreenPalIds[1]), sHPBarPalOffsets[1] + palNum, 2);
+        LoadPalette(GetPartyMenuPalBufferPtr(sHPBarGreenPalIds[0]), sHPBarPalOffsets[0] + palNum, PLTT_SIZEOF(1));
+        LoadPalette(GetPartyMenuPalBufferPtr(sHPBarGreenPalIds[1]), sHPBarPalOffsets[1] + palNum, PLTT_SIZEOF(1));
         break;
     case HP_BAR_YELLOW:
-        LoadPalette(GetPartyMenuPalBufferPtr(sHPBarYellowPalIds[0]), sHPBarPalOffsets[0] + palNum, 2);
-        LoadPalette(GetPartyMenuPalBufferPtr(sHPBarYellowPalIds[1]), sHPBarPalOffsets[1] + palNum, 2);
+        LoadPalette(GetPartyMenuPalBufferPtr(sHPBarYellowPalIds[0]), sHPBarPalOffsets[0] + palNum, PLTT_SIZEOF(1));
+        LoadPalette(GetPartyMenuPalBufferPtr(sHPBarYellowPalIds[1]), sHPBarPalOffsets[1] + palNum, PLTT_SIZEOF(1));
         break;
     default:
-        LoadPalette(GetPartyMenuPalBufferPtr(sHPBarRedPalIds[0]), sHPBarPalOffsets[0] + palNum, 2);
-        LoadPalette(GetPartyMenuPalBufferPtr(sHPBarRedPalIds[1]), sHPBarPalOffsets[1] + palNum, 2);
+        LoadPalette(GetPartyMenuPalBufferPtr(sHPBarRedPalIds[0]), sHPBarPalOffsets[0] + palNum, PLTT_SIZEOF(1));
+        LoadPalette(GetPartyMenuPalBufferPtr(sHPBarRedPalIds[1]), sHPBarPalOffsets[1] + palNum, PLTT_SIZEOF(1));
         break;
     }
 
@@ -2822,7 +2822,7 @@ static void MoveAndBufferPartySlot(const void *rectSrc, s16 x, s16 y, s16 width,
     {
         FillBgTilemapBufferRect_Palette0(0, 0, newX, y, newWidth, height);
         if (TryMovePartySlot(x + dir, width, &srcX, &newX, &newWidth))
-            CopyRectToBgTilemapBufferRect(0, rectSrc, srcX, 0, width, height, newX, y, newWidth, height, 17, 0, 0);
+            CopyRectToBgTilemapBufferRect(0, rectSrc, srcX, 0, width, height, newX, y, newWidth, height, 17, 0, 0x0);
     }
 }
 

--- a/src/player_pc.c
+++ b/src/player_pc.c
@@ -244,7 +244,7 @@ static const struct WindowTemplate sWindowTemplates_MainMenus[] =
         .tilemapTop = 1,
         .width = 9,
         .height = 6,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1
     },
     [WIN_MAIN_MENU_BEDROOM] = {
@@ -253,7 +253,7 @@ static const struct WindowTemplate sWindowTemplates_MainMenus[] =
         .tilemapTop = 1,
         .width = 9,
         .height = 8,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1
     },
     [WIN_ITEM_STORAGE_MENU] = {
@@ -262,7 +262,7 @@ static const struct WindowTemplate sWindowTemplates_MainMenus[] =
         .tilemapTop = 1,
         .width = 10,
         .height = 8,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1
     }
 };
@@ -302,7 +302,7 @@ static const struct WindowTemplate sWindowTemplates_ItemStorage[ITEMPC_WIN_COUNT
         .tilemapTop = 1,
         .width = 13,
         .height = 18,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0001
     },
     [ITEMPC_WIN_MESSAGE] = {
@@ -311,7 +311,7 @@ static const struct WindowTemplate sWindowTemplates_ItemStorage[ITEMPC_WIN_COUNT
         .tilemapTop = 13,
         .width = 13,
         .height = 6,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x00EB
     },
     [ITEMPC_WIN_ICON] = {
@@ -320,7 +320,7 @@ static const struct WindowTemplate sWindowTemplates_ItemStorage[ITEMPC_WIN_COUNT
         .tilemapTop = 8,
         .width = 3,
         .height = 3,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0153
     },
     [ITEMPC_WIN_TITLE] = {
@@ -329,7 +329,7 @@ static const struct WindowTemplate sWindowTemplates_ItemStorage[ITEMPC_WIN_COUNT
         .tilemapTop = 1,
         .width = 13,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0139
     },
     [ITEMPC_WIN_QUANTITY] = {
@@ -338,7 +338,7 @@ static const struct WindowTemplate sWindowTemplates_ItemStorage[ITEMPC_WIN_COUNT
         .tilemapTop = 9,
         .width = 6,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x015C
     },
     [ITEMPC_WIN_YESNO] = {
@@ -347,7 +347,7 @@ static const struct WindowTemplate sWindowTemplates_ItemStorage[ITEMPC_WIN_COUNT
         .tilemapTop = 7,
         .width = 5,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0168
     }
 };

--- a/src/pokeblock.c
+++ b/src/pokeblock.c
@@ -314,7 +314,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 1,
         .width = 9,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x1E
     },
     [WIN_LIST] = {
@@ -323,7 +323,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 1,
         .width = 14,
         .height = 18,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x30
     },
     [WIN_SPICY] = {
@@ -332,7 +332,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 13,
         .width = 5,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x12C
     },
     [WIN_DRY] = {
@@ -341,7 +341,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 15,
         .width = 5,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x136
     },
     [WIN_SWEET] = {
@@ -350,7 +350,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 17,
         .width = 5,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x140
     },
     [WIN_BITTER] = {
@@ -359,7 +359,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 13,
         .width = 5,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x14A
     },
     [WIN_SOUR] = {
@@ -368,7 +368,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 15,
         .width = 5,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x154
     },
     [WIN_FEEL] = {
@@ -377,7 +377,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 17,
         .width = 2,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x15E
     },
     [WIN_ACTIONS_TALL] = {
@@ -386,7 +386,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 5,
         .width = 6,
         .height = 6,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x162
     },
     [WIN_ACTIONS] = {
@@ -395,7 +395,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 7,
         .width = 6,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x186
     },
     [WIN_TOSS_MSG] = {
@@ -404,7 +404,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 15,
         .width = 27,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x19E
     },
     DUMMY_WIN_TEMPLATE
@@ -417,7 +417,7 @@ static const struct WindowTemplate sTossPkblockWindowTemplate =
     .tilemapTop = 9,
     .width = 5,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x20A
 };
 
@@ -653,7 +653,7 @@ static bool8 LoadPokeblockMenuGfx(void)
         }
         break;
     case 2:
-        LoadCompressedPalette(gMenuPokeblock_Pal, 0, 0xC0);
+        LoadCompressedPalette(gMenuPokeblock_Pal, BG_PLTT_ID(0x0), 6 * PLTT_SIZE_4BPP);
         sPokeblockMenu->gfxState++;
         break;
     case 3:
@@ -679,9 +679,9 @@ static void HandleInitWindows(void)
 
     InitWindows(sWindowTemplates);
     DeactivateAllTextPrinters();
-    LoadUserWindowBorderGfx(0, 1, 0xE0);
-    LoadMessageBoxGfx(0, 0xA, 0xD0);
-    LoadPalette(gStandardMenuPalette, 0xF0, 0x20);
+    LoadUserWindowBorderGfx(0, 1, BG_PLTT_ID(0xE));
+    LoadMessageBoxGfx(0, 0xA, BG_PLTT_ID(0xD));
+    LoadPalette(gStandardMenuPalette, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
 
     for (i = 0; i < ARRAY_COUNT(sWindowTemplates) - 1; i++)
         FillWindowPixelBuffer(i, PIXEL_FILL(0));

--- a/src/pokeblock_feed.c
+++ b/src/pokeblock_feed.c
@@ -459,7 +459,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 15,
         .width = 28,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0xA
     },
     DUMMY_WIN_TEMPLATE
@@ -771,7 +771,7 @@ static bool8 LoadMonAndSceneGfx(struct Pokemon *mon)
         }
         break;
     case 8:
-        LoadCompressedPalette(gBattleTerrainPalette_Frontier, 0x20, 0x60);
+        LoadCompressedPalette(gBattleTerrainPalette_Frontier, BG_PLTT_ID(0x2), 3 * PLTT_SIZE_4BPP);
         sPokeblockFeed->loadGfxState = 0;
         return TRUE;
     }
@@ -783,8 +783,8 @@ static void HandleInitWindows(void)
 {
     InitWindows(sWindowTemplates);
     DeactivateAllTextPrinters();
-    LoadUserWindowBorderGfx(0, 1, 0xE0);
-    LoadPalette(gStandardMenuPalette, 0xF0, 0x20);
+    LoadUserWindowBorderGfx(0, 1, BG_PLTT_ID(0xE));
+    LoadPalette(gStandardMenuPalette, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
     FillWindowPixelBuffer(0, PIXEL_FILL(0));
     PutWindowTilemap(0);
     ScheduleBgCopyTilemapToVram(0);

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -831,7 +831,7 @@ static const struct WindowTemplate sPokemonList_WindowTemplate[] =
         .tilemapTop = 0,
         .width = 32,
         .height = 32,
-        .paletteNum = 0,
+        .paletteNum = 0x0,
         .baseBlock = 1,
     },
     DUMMY_WIN_TEMPLATE
@@ -902,7 +902,7 @@ static const struct WindowTemplate sInfoScreen_WindowTemplates[] =
         .tilemapTop = 0,
         .width = 32,
         .height = 20,
-        .paletteNum = 0,
+        .paletteNum = 0x0,
         .baseBlock = 1,
     },
     [WIN_FOOTPRINT] =
@@ -912,7 +912,7 @@ static const struct WindowTemplate sInfoScreen_WindowTemplates[] =
         .tilemapTop = 8,
         .width = 2,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 641,
     },
     [WIN_CRY_WAVE] =
@@ -922,7 +922,7 @@ static const struct WindowTemplate sInfoScreen_WindowTemplates[] =
         .tilemapTop = 12,
         .width = 32,
         .height = 7,
-        .paletteNum = 8,
+        .paletteNum = 0x8,
         .baseBlock = 645,
     },
     [WIN_VU_METER] =
@@ -932,7 +932,7 @@ static const struct WindowTemplate sInfoScreen_WindowTemplates[] =
         .tilemapTop = 3,
         .width = 10,
         .height = 8,
-        .paletteNum = 9,
+        .paletteNum = 0x9,
         .baseBlock = 869,
     },
     DUMMY_WIN_TEMPLATE
@@ -969,7 +969,7 @@ static const struct WindowTemplate sNewEntryInfoScreen_WindowTemplates[] =
         .tilemapTop = 0,
         .width = 32,
         .height = 20,
-        .paletteNum = 0,
+        .paletteNum = 0x0,
         .baseBlock = 1,
     },
     [WIN_FOOTPRINT] =
@@ -979,7 +979,7 @@ static const struct WindowTemplate sNewEntryInfoScreen_WindowTemplates[] =
         .tilemapTop = 8,
         .width = 2,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 641,
     },
     DUMMY_WIN_TEMPLATE
@@ -1490,7 +1490,7 @@ static const struct WindowTemplate sSearchMenu_WindowTemplate[] =
         .tilemapTop = 0,
         .width = 32,
         .height = 20,
-        .paletteNum = 0,
+        .paletteNum = 0x0,
         .baseBlock = 0x0001,
     },
     DUMMY_WIN_TEMPLATE
@@ -2145,12 +2145,12 @@ static bool8 LoadPokedexListPage(u8 page)
 static void LoadPokedexBgPalette(bool8 isSearchResults)
 {
     if (isSearchResults == TRUE)
-        LoadPalette(gPokedexSearchResults_Pal + 1, 1, 0xBE);
+        LoadPalette(gPokedexSearchResults_Pal + 1, BG_PLTT_ID(0x0) + 1, PLTT_SIZEOF(6 * 16 - 1));
     else if (!IsNationalPokedexEnabled())
-        LoadPalette(gPokedexBgHoenn_Pal + 1, 1, 0xBE);
+        LoadPalette(gPokedexBgHoenn_Pal + 1, BG_PLTT_ID(0x0) + 1, PLTT_SIZEOF(6 * 16 - 1));
     else
-        LoadPalette(gPokedexBgNational_Pal + 1, 1, 0xBE);
-    LoadPalette(GetOverworldTextboxPalettePtr(), 0xF0, 32);
+        LoadPalette(gPokedexBgNational_Pal + 1, BG_PLTT_ID(0x0) + 1, PLTT_SIZEOF(6 * 16 - 1));
+    LoadPalette(GetOverworldTextboxPalettePtr(), BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
 }
 
 static void FreeWindowAndBgBuffers(void)
@@ -3264,7 +3264,7 @@ static void Task_LoadInfoScreen(u8 taskId)
     case 4:
         PrintMonInfo(sPokedexListItem->dexNum, sPokedexView->dexMode == DEX_MODE_HOENN ? FALSE : TRUE, sPokedexListItem->owned, 0);
         if (!sPokedexListItem->owned)
-            LoadPalette(gPlttBufferUnfaded + 1, 0x31, 0x1E);
+            LoadPalette(gPlttBufferUnfaded + 1, BG_PLTT_ID(0x3) + 1, PLTT_SIZEOF(16 - 1));
         CopyWindowToVram(WIN_INFO, COPYWIN_FULL);
         CopyBgTilemapBufferToVram(1);
         CopyBgTilemapBufferToVram(2);
@@ -3713,7 +3713,7 @@ static void LoadPlayArrowPalette(bool8 cryPlaying)
         color = RGB(18, 28, 0);
     else
         color = RGB(15, 21, 0);
-    LoadPalette(&color, 0x5D, 2);
+    LoadPalette(&color, BG_PLTT_ID(0x5) + 13, PLTT_SIZEOF(1));
 }
 
 static void Task_LoadSizeScreen(u8 taskId)
@@ -3768,7 +3768,7 @@ static void Task_LoadSizeScreen(u8 taskId)
         gSprites[spriteId].oam.priority = 0;
         gSprites[spriteId].y2 = gPokedexEntries[sPokedexListItem->dexNum].trainerOffset;
         SetOamMatrix(1, gPokedexEntries[sPokedexListItem->dexNum].trainerScale, 0, 0, gPokedexEntries[sPokedexListItem->dexNum].trainerScale);
-        LoadPalette(sSizeScreenSilhouette_Pal, (gSprites[spriteId].oam.paletteNum + 16) * 16, 0x20);
+        LoadPalette(sSizeScreenSilhouette_Pal, OBJ_PLTT_ID2(gSprites[spriteId].oam.paletteNum), PLTT_SIZE_4BPP);
         gTasks[taskId].tTrainerSpriteId = spriteId;
         gMain.state++;
         break;
@@ -3779,7 +3779,7 @@ static void Task_LoadSizeScreen(u8 taskId)
         gSprites[spriteId].oam.priority = 0;
         gSprites[spriteId].y2 = gPokedexEntries[sPokedexListItem->dexNum].pokemonOffset;
         SetOamMatrix(2, gPokedexEntries[sPokedexListItem->dexNum].pokemonScale, 0, 0, gPokedexEntries[sPokedexListItem->dexNum].pokemonScale);
-        LoadPalette(sSizeScreenSilhouette_Pal, (gSprites[spriteId].oam.paletteNum + 16) * 16, 0x20);
+        LoadPalette(sSizeScreenSilhouette_Pal, OBJ_PLTT_ID2(gSprites[spriteId].oam.paletteNum), PLTT_SIZE_4BPP);
         gTasks[taskId].tMonSpriteId = spriteId;
         CopyWindowToVram(WIN_INFO, COPYWIN_FULL);
         CopyBgTilemapBufferToVram(1);
@@ -4030,11 +4030,11 @@ static void Task_HandleCaughtMonPageInput(u8 taskId)
     // Flicker caught screen color
     else if (++gTasks[taskId].tPalTimer & 16)
     {
-        LoadPalette(gPokedexBgHoenn_Pal + 1, 0x31, 14);
+        LoadPalette(gPokedexBgHoenn_Pal + 1, BG_PLTT_ID(0x3) + 1, PLTT_SIZEOF(7));
     }
     else
     {
-        LoadPalette(gPokedexCaughtScreen_Pal + 1, 0x31, 14);
+        LoadPalette(gPokedexCaughtScreen_Pal + 1, BG_PLTT_ID(0x3) + 1, PLTT_SIZEOF(7));
     }
 }
 
@@ -4063,7 +4063,7 @@ static void Task_ExitCaughtMonPage(u8 taskId)
         personality = ((u16)gTasks[taskId].tPersonalityHi << 16) | (u16)gTasks[taskId].tPersonalityLo;
         paletteNum = gSprites[gTasks[taskId].tMonSpriteId].oam.paletteNum;
         lzPaletteData = GetMonSpritePalFromSpeciesAndPersonality(species, otId, personality);
-        LoadCompressedPalette(lzPaletteData, 0x100 | paletteNum * 16, 32);
+        LoadCompressedPalette(lzPaletteData, OBJ_PLTT_ID(paletteNum), PLTT_SIZE_4BPP);
         DestroyTask(taskId);
     }
 }
@@ -4836,7 +4836,7 @@ static void Task_LoadSearchMenu(u8 taskId)
                 CopyToBgTilemapBuffer(3, gPokedexSearchMenuHoenn_Tilemap, 0, 0);
             else
                 CopyToBgTilemapBuffer(3, gPokedexSearchMenuNational_Tilemap, 0, 0);
-            LoadPalette(gPokedexSearchMenu_Pal + 1, 1, 0x7E);
+            LoadPalette(gPokedexSearchMenu_Pal + 1, BG_PLTT_ID(0x0) + 1, PLTT_SIZEOF(4 * 16 - 1));
             gMain.state = 1;
         }
         break;

--- a/src/pokedex_cry_screen.c
+++ b/src/pokedex_cry_screen.c
@@ -258,7 +258,7 @@ bool8 LoadCryWaveformWindow(struct CryScreenWindow *window, u8 windowId)
         break;
     case 2:
         DrawWaveformWindow(windowId);
-        LoadPalette(sCryScreenBg_Pal, window->paletteNo * 16, 32);
+        LoadPalette(sCryScreenBg_Pal, BG_PLTT_ID(window->paletteNo), PLTT_SIZE_4BPP);
         finished = TRUE;
         break;
     }
@@ -458,7 +458,7 @@ bool8 LoadCryMeter(struct CryScreenWindow *window, u8 windowId)
             sCryMeterNeedle = AllocZeroed(sizeof(*sCryMeterNeedle));
 
         CopyToWindowPixelBuffer(windowId, sCryMeter_Gfx, 0, 0);
-        LoadPalette(sCryMeter_Pal, window->paletteNo * 16, 32);
+        LoadPalette(sCryMeter_Pal, BG_PLTT_ID(window->paletteNo), PLTT_SIZE_4BPP);
         gDexCryScreenState++;
         break;
     case 1:

--- a/src/pokemon_animation.c
+++ b/src/pokemon_animation.c
@@ -1,5 +1,6 @@
 #include "global.h"
 #include "battle.h"
+#include "palette.h"
 #include "pokemon.h"
 #include "pokemon_animation.h"
 #include "sprite.h"
@@ -1538,7 +1539,7 @@ static void Anim_CircleCounterclockwise(struct Sprite *sprite)
 #define GlowColor(color, colorIncrement, speed)                         \
 {                                                                       \
     if (sprite->data[2] == 0)                                           \
-        sprite->data[7] = (sprite->oam.paletteNum * 16) + 256;          \
+        sprite->data[7] = OBJ_PLTT_ID(sprite->oam.paletteNum);          \
                                                                         \
     if (sprite->data[2] > 128)                                          \
     {                                                                   \
@@ -2473,7 +2474,7 @@ static void Anim_FlashYellow(struct Sprite *sprite)
 {
     if (++sprite->data[2] == 1)
     {
-        sprite->data[7] = (sprite->oam.paletteNum * 16) + 256;
+        sprite->data[7] = OBJ_PLTT_ID(sprite->oam.paletteNum);
         sprite->data[6] = 0;
         sprite->data[5] = 0;
         sprite->data[4] = 0;
@@ -5262,7 +5263,7 @@ static void Anim_ShakeFlashYellow_Fast(struct Sprite *sprite)
 {
     if (++sprite->data[2] == 1)
     {
-        sprite->data[7] = (sprite->oam.paletteNum * 16) + 256;
+        sprite->data[7] = OBJ_PLTT_ID(sprite->oam.paletteNum);
         sprite->data[6] = 0;
         sprite->data[5] = 0;
         sprite->data[4] = 0;
@@ -5276,7 +5277,7 @@ static void Anim_ShakeFlashYellow(struct Sprite *sprite)
 {
     if (++sprite->data[2] == 1)
     {
-        sprite->data[7] = (sprite->oam.paletteNum * 16) + 256;
+        sprite->data[7] = OBJ_PLTT_ID(sprite->oam.paletteNum);
         sprite->data[6] = 0;
         sprite->data[5] = 0;
         sprite->data[4] = 0;
@@ -5290,7 +5291,7 @@ static void Anim_ShakeFlashYellow_Slow(struct Sprite *sprite)
 {
     if (++sprite->data[2] == 1)
     {
-        sprite->data[7] = (sprite->oam.paletteNum * 16) + 256;
+        sprite->data[7] = OBJ_PLTT_ID(sprite->oam.paletteNum);
         sprite->data[6] = 0;
         sprite->data[5] = 0;
         sprite->data[4] = 0;
@@ -5356,7 +5357,7 @@ static void Anim_ShakeGlowRed_Fast(struct Sprite *sprite)
 {
     if (sprite->data[2] == 0)
     {
-        sprite->data[7] = (sprite->oam.paletteNum * 16) + 256;
+        sprite->data[7] = OBJ_PLTT_ID(sprite->oam.paletteNum);
         sprite->data[0] = 10;
         sprite->data[5] = 0;
         sprite->data[4] = 2;
@@ -5377,7 +5378,7 @@ static void Anim_ShakeGlowRed(struct Sprite *sprite)
 {
     if (sprite->data[2] == 0)
     {
-        sprite->data[7] = (sprite->oam.paletteNum * 16) + 256;
+        sprite->data[7] = OBJ_PLTT_ID(sprite->oam.paletteNum);
         sprite->data[0] = 20;
         sprite->data[5] = 0;
         sprite->data[4] = 1;
@@ -5398,7 +5399,7 @@ static void Anim_ShakeGlowRed_Slow(struct Sprite *sprite)
 {
     if (sprite->data[2] == 0)
     {
-        sprite->data[7] = (sprite->oam.paletteNum * 16) + 256;
+        sprite->data[7] = OBJ_PLTT_ID(sprite->oam.paletteNum);
         sprite->data[0] = 80;
         sprite->data[5] = 0;
         sprite->data[4] = 1;
@@ -5419,7 +5420,7 @@ static void Anim_ShakeGlowGreen_Fast(struct Sprite *sprite)
 {
     if (sprite->data[2] == 0)
     {
-        sprite->data[7] = (sprite->oam.paletteNum * 16) + 256;
+        sprite->data[7] = OBJ_PLTT_ID(sprite->oam.paletteNum);
         sprite->data[0] = 10;
         sprite->data[5] = 0;
         sprite->data[4] = 2;
@@ -5440,7 +5441,7 @@ static void Anim_ShakeGlowGreen(struct Sprite *sprite)
 {
     if (sprite->data[2] == 0)
     {
-        sprite->data[7] = (sprite->oam.paletteNum * 16) + 256;
+        sprite->data[7] = OBJ_PLTT_ID(sprite->oam.paletteNum);
         sprite->data[0] = 20;
         sprite->data[5] = 0;
         sprite->data[4] = 1;
@@ -5461,7 +5462,7 @@ static void Anim_ShakeGlowGreen_Slow(struct Sprite *sprite)
 {
     if (sprite->data[2] == 0)
     {
-        sprite->data[7] = (sprite->oam.paletteNum * 16) + 256;
+        sprite->data[7] = OBJ_PLTT_ID(sprite->oam.paletteNum);
         sprite->data[0] = 80;
         sprite->data[5] = 0;
         sprite->data[4] = 1;
@@ -5482,7 +5483,7 @@ static void Anim_ShakeGlowBlue_Fast(struct Sprite *sprite)
 {
     if (sprite->data[2] == 0)
     {
-        sprite->data[7] = (sprite->oam.paletteNum * 16) + 256;
+        sprite->data[7] = OBJ_PLTT_ID(sprite->oam.paletteNum);
         sprite->data[0] = 10;
         sprite->data[5] = 0;
         sprite->data[4] = 2;
@@ -5503,7 +5504,7 @@ static void Anim_ShakeGlowBlue(struct Sprite *sprite)
 {
     if (sprite->data[2] == 0)
     {
-        sprite->data[7] = (sprite->oam.paletteNum * 16) + 256;
+        sprite->data[7] = OBJ_PLTT_ID(sprite->oam.paletteNum);
         sprite->data[0] = 20;
         sprite->data[5] = 0;
         sprite->data[4] = 1;
@@ -5524,7 +5525,7 @@ static void Anim_ShakeGlowBlue_Slow(struct Sprite *sprite)
 {
     if (sprite->data[2] == 0)
     {
-        sprite->data[7] = (sprite->oam.paletteNum * 16) + 256;
+        sprite->data[7] = OBJ_PLTT_ID(sprite->oam.paletteNum);
         sprite->data[0] = 80;
         sprite->data[5] = 0;
         sprite->data[4] = 1;

--- a/src/pokemon_icon.c
+++ b/src/pokemon_icon.c
@@ -1201,12 +1201,12 @@ void TryLoadAllMonIconPalettesAtOffset(u16 offset)
     s32 i;
     const struct SpritePalette* monIconPalettePtr;
 
-    if (offset <= 0xA0)
+    if (offset <= BG_PLTT_ID(0xA))
     {
         monIconPalettePtr = gMonIconPaletteTable;
-        for(i = ARRAY_COUNT(gMonIconPaletteTable) - 1; i >= 0; i--)
+        for (i = ARRAY_COUNT(gMonIconPaletteTable) - 1; i >= 0; i--)
         {
-            LoadPalette(monIconPalettePtr->data, offset, 0x20);
+            LoadPalette(monIconPalettePtr->data, offset, PLTT_SIZE_4BPP);
             offset += 0x10;
             monIconPalettePtr++;
         }

--- a/src/pokemon_jump.c
+++ b/src/pokemon_jump.c
@@ -3105,7 +3105,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 0,
         .width = 6,
         .height = 2,
-        .paletteNum = 2,
+        .paletteNum = 0x2,
         .baseBlock = 0x13,
     },
     [WIN_TIMES] = {
@@ -3114,7 +3114,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 0,
         .width = 6,
         .height = 2,
-        .paletteNum = 2,
+        .paletteNum = 0x2,
         .baseBlock = 0x1F,
     },
     DUMMY_WIN_TEMPLATE,
@@ -3183,21 +3183,21 @@ static void LoadPokeJumpGfx(void)
         ResetTempTileDataBuffers();
         LoadSpriteSheetsAndPalettes(sPokemonJumpGfx);
         InitDigitPrinters();
-        LoadPalette(sBg_Pal, 0, 0x20);
+        LoadPalette(sBg_Pal, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
         DecompressAndCopyTileDataToVram(BG_SCENERY, sBg_Gfx, 0, 0, 0);
         DecompressAndCopyTileDataToVram(BG_SCENERY, sBg_Tilemap, 0, 0, 1);
-        LoadPalette(sVenusaur_Pal, 0x30, 0x20);
+        LoadPalette(sVenusaur_Pal, BG_PLTT_ID(0x3), PLTT_SIZE_4BPP);
         DecompressAndCopyTileDataToVram(BG_VENUSAUR, sVenusaur_Gfx, 0, 0, 0);
         DecompressAndCopyTileDataToVram(BG_VENUSAUR, sVenusaur_Tilemap, 0, 0, 1);
-        LoadPalette(sBonuses_Pal, 0x10, 0x20);
+        LoadPalette(sBonuses_Pal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
         DecompressAndCopyTileDataToVram(BG_BONUSES, sBonuses_Gfx, 0, 0, 0);
         DecompressAndCopyTileDataToVram(BG_BONUSES, sBonuses_Tilemap, 0, 0, 1);
-        LoadPalette(sInterface_Pal, 0x20, 0x20);
+        LoadPalette(sInterface_Pal, BG_PLTT_ID(0x2), PLTT_SIZE_4BPP);
         SetBgTilemapBuffer(BG_INTERFACE, sPokemonJumpGfx->tilemapBuffer);
         FillBgTilemapBufferRect_Palette0(BG_INTERFACE, 0, 0, 0, 0x20, 0x20);
         PrintScoreSuffixes();
         PrintScore(0);
-        LoadUserWindowBorderGfxOnBg(0, 1, 0xE0);
+        LoadUserWindowBorderGfxOnBg(0, 1, BG_PLTT_ID(0xE));
         CopyBgTilemapBufferToVram(BG_INTERFACE);
         CopyBgTilemapBufferToVram(BG_VENUSAUR);
         CopyBgTilemapBufferToVram(BG_BONUSES);
@@ -3321,7 +3321,7 @@ static void Msg_WantToPlayAgain(void)
         if (!IsDma3ManagerBusyWithBgCopy())
         {
             PutWindowTilemap(sPokemonJumpGfx->msgWindowId);
-            DrawTextBorderOuter(sPokemonJumpGfx->msgWindowId, 1, 14);
+            DrawTextBorderOuter(sPokemonJumpGfx->msgWindowId, 1, 0xE);
             CreatePokeJumpYesNoMenu(23, 7, 0);
             CopyBgTilemapBufferToVram(BG_INTERFACE);
             sPokemonJumpGfx->mainState++;
@@ -3348,7 +3348,7 @@ static void Msg_SavingDontTurnOff(void)
         if (!IsDma3ManagerBusyWithBgCopy())
         {
             PutWindowTilemap(sPokemonJumpGfx->msgWindowId);
-            DrawTextBorderOuter(sPokemonJumpGfx->msgWindowId, 1, 14);
+            DrawTextBorderOuter(sPokemonJumpGfx->msgWindowId, 1, 0xE);
             CopyBgTilemapBufferToVram(BG_INTERFACE);
             sPokemonJumpGfx->mainState++;
         }
@@ -3391,7 +3391,7 @@ static void Msg_SomeoneDroppedOut(void)
         if (!IsDma3ManagerBusyWithBgCopy())
         {
             PutWindowTilemap(sPokemonJumpGfx->msgWindowId);
-            DrawTextBorderOuter(sPokemonJumpGfx->msgWindowId, 1, 14);
+            DrawTextBorderOuter(sPokemonJumpGfx->msgWindowId, 1, 0xE);
             CopyBgTilemapBufferToVram(BG_INTERFACE);
             sPokemonJumpGfx->mainState++;
         }
@@ -3417,7 +3417,7 @@ static void Msg_CommunicationStandby(void)
         if (!IsDma3ManagerBusyWithBgCopy())
         {
             PutWindowTilemap(sPokemonJumpGfx->msgWindowId);
-            DrawTextBorderOuter(sPokemonJumpGfx->msgWindowId, 1, 14);
+            DrawTextBorderOuter(sPokemonJumpGfx->msgWindowId, 1, 0xE);
             CopyBgTilemapBufferToVram(BG_INTERFACE);
             sPokemonJumpGfx->mainState++;
         }
@@ -3527,7 +3527,7 @@ static bool32 DoPrizeMessageAndFanfare(void)
         if (!IsDma3ManagerBusyWithBgCopy())
         {
             PutWindowTilemap(sPokemonJumpGfx->msgWindowId);
-            DrawTextBorderOuter(sPokemonJumpGfx->msgWindowId, 1, 14);
+            DrawTextBorderOuter(sPokemonJumpGfx->msgWindowId, 1, 0xE);
             CopyBgTilemapBufferToVram(BG_INTERFACE);
             sPokemonJumpGfx->msgWindowState++;
         }
@@ -3618,7 +3618,7 @@ static void CreatePokeJumpYesNoMenu(u16 left, u16 top, u8 cursorPos)
     window.tilemapTop = top;
     window.width = 6;
     window.height = 4;
-    window.paletteNum = 2;
+    window.paletteNum = 0x2;
     window.baseBlock = 0x2B;
 
     CreateYesNoMenu(&window, 1, 0xD, cursorPos);
@@ -3832,7 +3832,7 @@ static void AddPlayerNameWindows(void)
     window.bg = BG_INTERFACE;
     window.width = 8;
     window.height = 2;
-    window.paletteNum = 2;
+    window.paletteNum = 0x2;
     window.baseBlock = 0x2B;
 
     for (i = 0; i < playersCount; i++)
@@ -4142,7 +4142,7 @@ static const struct WindowTemplate sWindowTemplate_Records =
     .tilemapTop = 1,
     .width = 28,
     .height = 9,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x1,
 };
 
@@ -4213,7 +4213,7 @@ static void PrintRecordsText(u16 windowId, int width)
     recordNums[1] = records->bestJumpScore;
     recordNums[2] = records->excellentsInRow;
 
-    LoadUserWindowBorderGfx_(windowId, 0x21D, 0xD0);
+    LoadUserWindowBorderGfx_(windowId, 0x21D, BG_PLTT_ID(0xD));
     DrawTextBorderOuter(windowId, 0x21D, 0xD);
     FillWindowPixelBuffer(windowId, PIXEL_FILL(1));
     AddTextPrinterParameterized(windowId, FONT_NORMAL, gText_PkmnJumpRecords, GetStringCenterAlignXOffset(FONT_NORMAL, gText_PkmnJumpRecords, width * 8), 1, TEXT_SKIP_DRAW, NULL);

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -895,7 +895,7 @@ static const struct WindowTemplate sWindowTemplate_MainMenu =
     .tilemapTop = 1,
     .width = 17,
     .height = 10,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x1,
 };
 
@@ -976,7 +976,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 11,
         .width = 9,
         .height = 7,
-        .paletteNum = 3,
+        .paletteNum = 0x3,
         .baseBlock = 0xC0,
     },
     [WIN_MESSAGE] = {
@@ -985,7 +985,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 17,
         .width = 18,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x14,
     },
     [WIN_ITEM_DESC] = {
@@ -994,7 +994,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 13,
         .width = 21,
         .height = 7,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x14,
     },
     DUMMY_WIN_TEMPLATE
@@ -1104,7 +1104,7 @@ static const struct WindowTemplate sYesNoWindowTemplate =
     .tilemapTop = 11,
     .width = 5,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x5C,
 };
 
@@ -2128,7 +2128,7 @@ static void Task_InitPokeStorage(u8 taskId)
         PutWindowTilemap(WIN_DISPLAY_INFO);
         ClearWindowTilemap(WIN_MESSAGE);
         CpuFill32(0, (void *)VRAM, 0x200);
-        LoadUserWindowBorderGfx(WIN_MESSAGE, 0xB, 0xE0);
+        LoadUserWindowBorderGfx(WIN_MESSAGE, 0xB, BG_PLTT_ID(0xE));
         break;
     case 3:
         ResetAllBgCoords();
@@ -3849,13 +3849,13 @@ static void LoadWaveformSpritePalette(void)
 
 static void InitPalettesAndSprites(void)
 {
-    LoadPalette(sInterface_Pal, 0, sizeof(sInterface_Pal));
-    LoadPalette(sPkmnDataGray_Pal, 0x20, sizeof(sPkmnDataGray_Pal));
-    LoadPalette(sTextWindows_Pal, 0xF0, sizeof(sTextWindows_Pal));
+    LoadPalette(sInterface_Pal, BG_PLTT_ID(0x0), sizeof(sInterface_Pal));
+    LoadPalette(sPkmnDataGray_Pal, BG_PLTT_ID(0x2), sizeof(sPkmnDataGray_Pal));
+    LoadPalette(sTextWindows_Pal, BG_PLTT_ID(0xF), sizeof(sTextWindows_Pal));
     if (sStorage->boxOption != OPTION_MOVE_ITEMS)
-        LoadPalette(sBg_Pal, 0x30, sizeof(sBg_Pal));
+        LoadPalette(sBg_Pal, BG_PLTT_ID(0x3), sizeof(sBg_Pal));
     else
-        LoadPalette(sBgMoveItems_Pal, 0x30, sizeof(sBgMoveItems_Pal));
+        LoadPalette(sBgMoveItems_Pal, BG_PLTT_ID(0x3), sizeof(sBgMoveItems_Pal));
 
     SetGpuReg(REG_OFFSET_BG1CNT, BGCNT_PRIORITY(1) | BGCNT_CHARBASE(1) | BGCNT_16COLOR | BGCNT_SCREENBASE(30));
     CreateDisplayMonSprite();
@@ -3958,7 +3958,7 @@ static void CreateDisplayMonSprite(void)
             break;
 
         sStorage->displayMonSprite = &gSprites[spriteId];
-        sStorage->displayMonPalOffset = palSlot * 16 + 0x100;
+        sStorage->displayMonPalOffset = OBJ_PLTT_ID(palSlot);
         sStorage->displayMonTilePtr = (void *) OBJ_VRAM0 + tileStart * TILE_SIZE_4BPP;
     } while (0);
 
@@ -3979,7 +3979,7 @@ static void LoadDisplayMonGfx(u16 species, u32 pid)
         LoadSpecialPokePic(&gMonFrontPicTable[species], sStorage->tileBuffer, species, pid, TRUE);
         LZ77UnCompWram(sStorage->displayMonPalette, sStorage->displayMonPalBuffer);
         CpuCopy32(sStorage->tileBuffer, sStorage->displayMonTilePtr, MON_PIC_SIZE);
-        LoadPalette(sStorage->displayMonPalBuffer, sStorage->displayMonPalOffset, 0x20);
+        LoadPalette(sStorage->displayMonPalBuffer, sStorage->displayMonPalOffset, PLTT_SIZE_4BPP);
         sStorage->displayMonSprite->invisible = FALSE;
     }
     else
@@ -4045,7 +4045,7 @@ static void UpdateWaveformAnimation(void)
 static void InitSupplementalTilemaps(void)
 {
     LZ77UnCompWram(gStorageSystemPartyMenu_Tilemap, sStorage->partyMenuTilemapBuffer);
-    LoadPalette(gStorageSystemPartyMenu_Pal, 0x10, 0x20);
+    LoadPalette(gStorageSystemPartyMenu_Pal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
     TilemapUtil_SetMap(TILEMAPID_PARTY_MENU, 1, sStorage->partyMenuTilemapBuffer, 12, 22);
     TilemapUtil_SetMap(TILEMAPID_CLOSE_BUTTON, 1, sCloseBoxButton_Tilemap, 9, 4);
     TilemapUtil_SetPos(TILEMAPID_PARTY_MENU, 10, 0);
@@ -4267,7 +4267,7 @@ static void UpdateBoxToSendMons(void)
 static void InitPokeStorageBg0(void)
 {
     SetGpuReg(REG_OFFSET_BG0CNT, BGCNT_PRIORITY(0) | BGCNT_CHARBASE(0) | BGCNT_SCREENBASE(29));
-    LoadUserWindowBorderGfx(WIN_MESSAGE, 2, 208);
+    LoadUserWindowBorderGfx(WIN_MESSAGE, 2, BG_PLTT_ID(0xD));
     FillBgTilemapBufferRect(0, 0, 0, 0, 32, 20, 17);
     CopyBgTilemapBufferToVram(0);
 }
@@ -4308,7 +4308,7 @@ static void PrintMessage(u8 id)
     DynamicPlaceholderTextUtil_ExpandPlaceholders(sStorage->messageText, sMessages[id].text);
     FillWindowPixelBuffer(WIN_MESSAGE, PIXEL_FILL(1));
     AddTextPrinterParameterized(WIN_MESSAGE, FONT_NORMAL, sStorage->messageText, 0, 1, TEXT_SKIP_DRAW, NULL);
-    DrawTextBorderOuter(WIN_MESSAGE, 2, 14);
+    DrawTextBorderOuter(WIN_MESSAGE, 2, 0xE);
     PutWindowTilemap(WIN_MESSAGE);
     CopyWindowToVram(WIN_MESSAGE, COPYWIN_GFX);
     ScheduleBgCopyTilemapToVram(0);
@@ -5380,9 +5380,9 @@ static void LoadWallpaperGfx(u8 boxId, s8 direction)
         DrawWallpaper(sStorage->wallpaperTilemap, sStorage->wallpaperLoadDir, sStorage->wallpaperOffset);
 
         if (sStorage->wallpaperLoadDir != 0)
-            LoadPalette(wallpaper->palettes, (sStorage->wallpaperOffset * 32) + 0x40, 0x40);
+            LoadPalette(wallpaper->palettes, 0x40 + BG_PLTT_ID(sStorage->wallpaperOffset * 2), 2 * PLTT_SIZE_4BPP);
         else
-            CpuCopy16(wallpaper->palettes, &gPlttBufferUnfaded[(sStorage->wallpaperOffset * 32) + 0x40], 0x40);
+            CpuCopy16(wallpaper->palettes, &gPlttBufferUnfaded[0x40 + BG_PLTT_ID(sStorage->wallpaperOffset * 2)], 2 * PLTT_SIZE_4BPP);
 
         sStorage->wallpaperTiles = malloc_and_decompress(wallpaper->tiles, &tilesSize);
         LoadBgTiles(2, sStorage->wallpaperTiles, tilesSize, sStorage->wallpaperOffset << 8);
@@ -5398,9 +5398,9 @@ static void LoadWallpaperGfx(u8 boxId, s8 direction)
         CpuCopy16(GetWaldaWallpaperColorsPtr(), &sStorage->wallpaperTilemap[17], 4);
 
         if (sStorage->wallpaperLoadDir != 0)
-            LoadPalette(sStorage->wallpaperTilemap, (sStorage->wallpaperOffset * 32) + 0x40, 0x40);
+            LoadPalette(sStorage->wallpaperTilemap, 0x40 + BG_PLTT_ID(sStorage->wallpaperOffset * 2), 2 * PLTT_SIZE_4BPP);
         else
-            CpuCopy16(sStorage->wallpaperTilemap, &gPlttBufferUnfaded[(sStorage->wallpaperOffset * 32) + 0x40], 0x40);
+            CpuCopy16(sStorage->wallpaperTilemap, &gPlttBufferUnfaded[0x40 + BG_PLTT_ID(sStorage->wallpaperOffset * 2)], 2 * PLTT_SIZE_4BPP);
 
         sStorage->wallpaperTiles = malloc_and_decompress(wallpaper->tiles, &tilesSize);
         iconGfx = malloc_and_decompress(sWaldaWallpaperIcons[GetWaldaWallpaperIconId()], &iconSize);
@@ -5437,7 +5437,7 @@ static void DrawWallpaper(const void *tilemap, s8 direction, u8 offset)
     else
         x -= 4;
 
-    FillBgTilemapBufferRect(2, 0, x, 2, 4, 0x12, 0x11);
+    FillBgTilemapBufferRect(2, 0, x, 2, 4, 0x12, 17);
 }
 
 static void TrimOldWallpaper(void *tilemap)
@@ -5488,7 +5488,7 @@ static void InitBoxTitle(u8 boxId)
     sStorage->wallpaperPalBits = 0x3f0;
 
     tagIndex = IndexOfSpritePaletteTag(PALTAG_BOX_TITLE);
-    sStorage->boxTitlePalOffset = 0x10e + 16 * tagIndex;
+    sStorage->boxTitlePalOffset = OBJ_PLTT_ID(tagIndex) + 14;
     sStorage->wallpaperPalBits |= 0x10000 << tagIndex;
 
     // The below seems intended to have separately tracked
@@ -5496,7 +5496,7 @@ static void InitBoxTitle(u8 boxId)
     // share a palette tag, all colors (and fields in some cases)
     // this is redundant along with the use of boxTitleAltPalOffset
     tagIndex = IndexOfSpritePaletteTag(PALTAG_BOX_TITLE);
-    sStorage->boxTitleAltPalOffset = 0x10e + 16 * tagIndex;
+    sStorage->boxTitleAltPalOffset = OBJ_PLTT_ID(tagIndex) + 14;
     sStorage->wallpaperPalBits |= 0x10000 << tagIndex;
 
     StringCopyPadded(sStorage->boxTitleText, GetBoxNamePtr(boxId), 0, BOX_NAME_LENGTH);
@@ -7929,7 +7929,7 @@ static void InitMenu(void)
     sStorage->menuItemsCount = 0;
     sStorage->menuWidth = 0;
     sStorage->menuWindow.bg = 0;
-    sStorage->menuWindow.paletteNum = 15;
+    sStorage->menuWindow.paletteNum = 0xF;
     sStorage->menuWindow.baseBlock = 92;
 }
 
@@ -8085,7 +8085,7 @@ static const struct WindowTemplate sWindowTemplate_MultiMove =
     .tilemapTop = 3,
     .width = 20,
     .height = 18,
-    .paletteNum = 9,
+    .paletteNum = 0x9,
     .baseBlock = 0xA,
 };
 
@@ -8164,7 +8164,7 @@ static bool8 MultiMove_Start(void)
     {
     case 0:
         HideBg(0);
-        TryLoadAllMonIconPalettesAtOffset(0x80);
+        TryLoadAllMonIconPalettesAtOffset(BG_PLTT_ID(0x8));
         sMultiMove->state++;
         break;
     case 1:
@@ -8213,7 +8213,7 @@ static bool8 MultiMove_Cancel(void)
         if (!IsDma3ManagerBusyWithBgCopy())
         {
             SetCursorPriorityTo1();
-            LoadPalette(GetTextWindowPalette(3), 0xD0, 0x20);
+            LoadPalette(GetTextWindowPalette(3), BG_PLTT_ID(0xD), PLTT_SIZE_4BPP);
             ShowBg(0);
             return FALSE;
         }
@@ -8319,7 +8319,7 @@ static bool8 MultiMove_PlaceMons(void)
     case 3:
         if (!IsDma3ManagerBusyWithBgCopy())
         {
-            LoadPalette(GetTextWindowPalette(3), 0xD0, 0x20);
+            LoadPalette(GetTextWindowPalette(3), BG_PLTT_ID(0xD), PLTT_SIZE_4BPP);
             SetCursorPriorityTo1();
             ShowBg(0);
             return FALSE;
@@ -9103,7 +9103,7 @@ static void LoadItemIconGfx(u8 id, const u32 *itemTiles, const u32 *itemPal)
 
     CpuFastCopy(sStorage->itemIconBuffer, sStorage->itemIcons[id].tiles, 0x200);
     LZ77UnCompWram(itemPal, sStorage->itemIconBuffer);
-    LoadPalette(sStorage->itemIconBuffer, sStorage->itemIcons[id].palIndex, 0x20);
+    LoadPalette(sStorage->itemIconBuffer, sStorage->itemIcons[id].palIndex, PLTT_SIZE_4BPP);
 }
 
 static void SetItemIconAffineAnim(u8 id, u8 animNum)
@@ -9236,7 +9236,7 @@ static bool8 UpdateItemInfoWindowSlideOut(void)
     if (pos >= 0)
         DrawItemInfoWindow(pos);
 
-    FillBgTilemapBufferRect(0, 0, pos + 1, 12, 1, 9, 0x11);
+    FillBgTilemapBufferRect(0, 0, pos + 1, 12, 1, 9, 17);
     ScheduleBgCopyTilemapToVram(0);
     return TRUE;
 }
@@ -9245,12 +9245,12 @@ static void DrawItemInfoWindow(u32 x)
 {
     if (x != 0)
     {
-        FillBgTilemapBufferRect(0, 0x13A, 0, 0xC, x, 1, 0xFu);
-        FillBgTilemapBufferRect(0, 0x93A, 0, 0x14, x, 1, 0xFu);
+        FillBgTilemapBufferRect(0, 0x13A, 0, 0xC, x, 1, 0xF);
+        FillBgTilemapBufferRect(0, 0x93A, 0, 0x14, x, 1, 0xF);
     }
-    FillBgTilemapBufferRect(0, 0x13B, x, 0xD, 1, 7, 0xFu);
-    FillBgTilemapBufferRect(0, 0x13C, x, 0xC, 1, 1, 0xFu);
-    FillBgTilemapBufferRect(0, 0x13D, x, 0x14, 1, 1, 0xFu);
+    FillBgTilemapBufferRect(0, 0x13B, x, 0xD, 1, 7, 0xF);
+    FillBgTilemapBufferRect(0, 0x13C, x, 0xC, 1, 1, 0xF);
+    FillBgTilemapBufferRect(0, 0x13D, x, 0x14, 1, 1, 0xF);
     ScheduleBgCopyTilemapToVram(0);
 }
 

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -391,7 +391,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 0,
         .width = 11,
         .height = 2,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 1,
     },
     [PSS_LABEL_WINDOW_POKEMON_SKILLS_TITLE] = {
@@ -400,7 +400,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 0,
         .width = 11,
         .height = 2,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 23,
     },
     [PSS_LABEL_WINDOW_BATTLE_MOVES_TITLE] = {
@@ -409,7 +409,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 0,
         .width = 11,
         .height = 2,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 45,
     },
     [PSS_LABEL_WINDOW_CONTEST_MOVES_TITLE] = {
@@ -418,7 +418,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 0,
         .width = 11,
         .height = 2,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 67,
     },
     [PSS_LABEL_WINDOW_PROMPT_CANCEL] = {
@@ -427,7 +427,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 0,
         .width = 8,
         .height = 2,
-        .paletteNum = 7,
+        .paletteNum = 0x7,
         .baseBlock = 89,
     },
     [PSS_LABEL_WINDOW_PROMPT_INFO] = {
@@ -436,7 +436,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 0,
         .width = 8,
         .height = 2,
-        .paletteNum = 7,
+        .paletteNum = 0x7,
         .baseBlock = 105,
     },
     [PSS_LABEL_WINDOW_PROMPT_SWITCH] = {
@@ -445,7 +445,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 0,
         .width = 8,
         .height = 2,
-        .paletteNum = 7,
+        .paletteNum = 0x7,
         .baseBlock = 121,
     },
     [PSS_LABEL_WINDOW_UNUSED1] = {
@@ -454,7 +454,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 4,
         .width = 0,
         .height = 2,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 137,
     },
     [PSS_LABEL_WINDOW_POKEMON_INFO_RENTAL] = {
@@ -463,7 +463,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 4,
         .width = 18,
         .height = 2,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 137,
     },
     [PSS_LABEL_WINDOW_POKEMON_INFO_TYPE] = {
@@ -472,7 +472,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 6,
         .width = 18,
         .height = 2,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 173,
     },
     [PSS_LABEL_WINDOW_POKEMON_SKILLS_STATS_LEFT] = {
@@ -481,7 +481,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 7,
         .width = 6,
         .height = 6,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 209,
     },
     [PSS_LABEL_WINDOW_POKEMON_SKILLS_STATS_RIGHT] = {
@@ -490,7 +490,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 7,
         .width = 5,
         .height = 6,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 245,
     },
     [PSS_LABEL_WINDOW_POKEMON_SKILLS_EXP] = {
@@ -499,7 +499,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 14,
         .width = 11,
         .height = 4,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 275,
     },
     [PSS_LABEL_WINDOW_POKEMON_SKILLS_STATUS] = {
@@ -508,7 +508,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 18,
         .width = 6,
         .height = 2,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 319,
     },
     [PSS_LABEL_WINDOW_MOVES_POWER_ACC] = {
@@ -517,7 +517,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 15,
         .width = 9,
         .height = 4,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 331,
     },
     [PSS_LABEL_WINDOW_MOVES_APPEAL_JAM] = {
@@ -526,7 +526,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 15,
         .width = 5,
         .height = 4,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 367,
     },
     [PSS_LABEL_WINDOW_UNUSED2] = {
@@ -535,7 +535,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 4,
         .width = 0,
         .height = 2,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 387,
     },
     [PSS_LABEL_WINDOW_PORTRAIT_DEX_NUMBER] = {
@@ -544,7 +544,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 2,
         .width = 4,
         .height = 2,
-        .paletteNum = 7,
+        .paletteNum = 0x7,
         .baseBlock = 387,
     },
     [PSS_LABEL_WINDOW_PORTRAIT_NICKNAME] = {
@@ -553,7 +553,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 12,
         .width = 9,
         .height = 2,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 395,
     },
     [PSS_LABEL_WINDOW_PORTRAIT_SPECIES] = {
@@ -562,7 +562,7 @@ static const struct WindowTemplate sSummaryTemplate[] =
         .tilemapTop = 14,
         .width = 9,
         .height = 4,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 413,
     },
     [PSS_LABEL_WINDOW_END] = DUMMY_WIN_TEMPLATE
@@ -575,7 +575,7 @@ static const struct WindowTemplate sPageInfoTemplate[] =
         .tilemapTop = 4,
         .width = 11,
         .height = 2,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 449,
     },
     [PSS_DATA_WINDOW_INFO_ID] = {
@@ -584,7 +584,7 @@ static const struct WindowTemplate sPageInfoTemplate[] =
         .tilemapTop = 4,
         .width = 7,
         .height = 2,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 471,
     },
     [PSS_DATA_WINDOW_INFO_ABILITY] = {
@@ -593,7 +593,7 @@ static const struct WindowTemplate sPageInfoTemplate[] =
         .tilemapTop = 9,
         .width = 18,
         .height = 4,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 485,
     },
     [PSS_DATA_WINDOW_INFO_MEMO] = {
@@ -602,7 +602,7 @@ static const struct WindowTemplate sPageInfoTemplate[] =
         .tilemapTop = 14,
         .width = 18,
         .height = 6,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 557,
     },
 };
@@ -614,7 +614,7 @@ static const struct WindowTemplate sPageSkillsTemplate[] =
         .tilemapTop = 4,
         .width = 10,
         .height = 2,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 449,
     },
     [PSS_DATA_WINDOW_SKILLS_RIBBON_COUNT] = {
@@ -623,7 +623,7 @@ static const struct WindowTemplate sPageSkillsTemplate[] =
         .tilemapTop = 4,
         .width = 10,
         .height = 2,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 469,
     },
     [PSS_DATA_WINDOW_SKILLS_STATS_LEFT] = {
@@ -632,7 +632,7 @@ static const struct WindowTemplate sPageSkillsTemplate[] =
         .tilemapTop = 7,
         .width = 6,
         .height = 6,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 489,
     },
     [PSS_DATA_WINDOW_SKILLS_STATS_RIGHT] = {
@@ -641,7 +641,7 @@ static const struct WindowTemplate sPageSkillsTemplate[] =
         .tilemapTop = 7,
         .width = 3,
         .height = 6,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 525,
     },
     [PSS_DATA_WINDOW_EXP] = {
@@ -650,7 +650,7 @@ static const struct WindowTemplate sPageSkillsTemplate[] =
         .tilemapTop = 14,
         .width = 6,
         .height = 4,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 543,
     },
 };
@@ -662,7 +662,7 @@ static const struct WindowTemplate sPageMovesTemplate[] = // This is used for bo
         .tilemapTop = 4,
         .width = 9,
         .height = 10,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 449,
     },
     [PSS_DATA_WINDOW_MOVE_PP] = {
@@ -671,7 +671,7 @@ static const struct WindowTemplate sPageMovesTemplate[] = // This is used for bo
         .tilemapTop = 4,
         .width = 6,
         .height = 10,
-        .paletteNum = 8,
+        .paletteNum = 0x8,
         .baseBlock = 539,
     },
     [PSS_DATA_WINDOW_MOVE_DESCRIPTION] = {
@@ -680,7 +680,7 @@ static const struct WindowTemplate sPageMovesTemplate[] = // This is used for bo
         .tilemapTop = 15,
         .width = 20,
         .height = 4,
-        .paletteNum = 6,
+        .paletteNum = 0x6,
         .baseBlock = 599,
     },
 };
@@ -1328,8 +1328,8 @@ static bool8 DecompressGraphics(void)
         sMonSummaryScreen->switchCounter++;
         break;
     case 6:
-        LoadCompressedPalette(gSummaryScreen_Pal, 0, 0x100);
-        LoadPalette(&gPPTextPalette, 0x81, 0x1E);
+        LoadCompressedPalette(gSummaryScreen_Pal, BG_PLTT_ID(0x0), 8 * PLTT_SIZE_4BPP);
+        LoadPalette(&gPPTextPalette, BG_PLTT_ID(0x8) + 1, PLTT_SIZEOF(16 - 1));
         sMonSummaryScreen->switchCounter++;
         break;
     case 7:
@@ -1353,7 +1353,7 @@ static bool8 DecompressGraphics(void)
         sMonSummaryScreen->switchCounter++;
         break;
     case 12:
-        LoadCompressedPalette(gMoveTypes_Pal, 0x1D0, 0x60);
+        LoadCompressedPalette(gMoveTypes_Pal, OBJ_PLTT_ID(0xD), 3 * PLTT_SIZE_4BPP);
         sMonSummaryScreen->switchCounter = 0;
         return TRUE;
     }
@@ -4001,7 +4001,7 @@ static void StopPokemonAnimations(void)  // A subtle effect, this function stops
     gSprites[sMonSummaryScreen->spriteIds[SPRITE_ARR_ID_MON]].callback = SpriteCallbackDummy;
     StopPokemonAnimationDelayTask();
 
-    paletteIndex = (gSprites[sMonSummaryScreen->spriteIds[SPRITE_ARR_ID_MON]].oam.paletteNum * 16) | 0x100;
+    paletteIndex = OBJ_PLTT_ID(gSprites[sMonSummaryScreen->spriteIds[SPRITE_ARR_ID_MON]].oam.paletteNum);
 
     for (i = 0; i < 16; i++)
     {

--- a/src/pokenav_conditions_gfx.c
+++ b/src/pokenav_conditions_gfx.c
@@ -68,7 +68,7 @@ static const struct WindowTemplate sMonNameGenderWindowTemplate =
     .tilemapTop = 1,
     .width = 13,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 2
 };
 
@@ -79,7 +79,7 @@ static const struct WindowTemplate sListIndexWindowTemplate =
     .tilemapTop = 6,
     .width = 7,
     .height = 2,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x36
 };
 
@@ -90,7 +90,7 @@ static const struct WindowTemplate sUnusedWindowTemplate1 =
     .tilemapTop = 0x1C,
     .width = 5,
     .height = 2,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x44
 };
 
@@ -101,7 +101,7 @@ static const struct WindowTemplate sUnusedWindowTemplate2 =
     .tilemapTop = 0x1C,
     .width = 3,
     .height = 2,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x44
 };
 
@@ -224,8 +224,8 @@ static u32 LoopedTask_OpenConditionGraphMenu(s32 state)
             CopyToBgTilemapBufferRect(3, gPokenavOptions_Tilemap, 0, 5, 9, 4);
 
         CopyBgTilemapBufferToVram(3);
-        CopyPaletteIntoBufferUnfaded(gPokenavCondition_Pal, 0x10, 0x20);
-        CopyPaletteIntoBufferUnfaded(gConditionText_Pal, 0xF0, 0x20);
+        CopyPaletteIntoBufferUnfaded(gPokenavCondition_Pal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
+        CopyPaletteIntoBufferUnfaded(gConditionText_Pal, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
         menu->monTransitionX = -80;
         return LT_INC_AND_PAUSE;
     case 4:
@@ -235,7 +235,7 @@ static u32 LoopedTask_OpenConditionGraphMenu(s32 state)
         LZ77UnCompVram(sConditionGraphData_Tilemap, menu->tilemapBuffers[2]);
         SetBgTilemapBuffer(2, menu->tilemapBuffers[2]);
         CopyBgTilemapBufferToVram(2);
-        CopyPaletteIntoBufferUnfaded(gConditionGraphData_Pal, 0x30, 0x20);
+        CopyPaletteIntoBufferUnfaded(gConditionGraphData_Pal, BG_PLTT_ID(0x3), PLTT_SIZE_4BPP);
         ConditionGraph_InitWindow(2);
         return LT_INC_AND_PAUSE;
     case 5:
@@ -827,13 +827,13 @@ static void CreateConditionMonPic(u8 id)
             menu->monPicSpriteId = spriteId;
             gSprites[menu->monPicSpriteId].callback = MonPicGfxSpriteCallback;
             menu->monGfxPtr = (void *)VRAM + BG_VRAM_SIZE + (menu->monGfxTileStart * 32);
-            menu->monPalIndex = (menu->monPalIndex * 16) + 0x100;
+            menu->monPalIndex = OBJ_PLTT_ID(menu->monPalIndex);
         }
     }
     else
     {
         DmaCopy16Defvars(3, GetConditionMonPicGfx(id), menu->monGfxPtr, MON_PIC_SIZE);
-        LoadPalette(GetConditionMonPal(id), menu->monPalIndex, 0x20);
+        LoadPalette(GetConditionMonPal(id), menu->monPalIndex, PLTT_SIZE_4BPP);
     }
 }
 

--- a/src/pokenav_conditions_search_results.c
+++ b/src/pokenav_conditions_search_results.c
@@ -2,6 +2,7 @@
 #include "pokenav.h"
 #include "bg.h"
 #include "menu.h"
+#include "palette.h"
 #include "window.h"
 #include "sound.h"
 #include "dynamic_placeholder_text_util.h"
@@ -120,7 +121,7 @@ static const struct WindowTemplate sSearchResultListMenuWindowTemplate =
     .tilemapTop = 6,
     .width = 7,
     .height = 2,
-    .paletteNum = 1,
+    .paletteNum = 0x1,
     .baseBlock = 20
 };
 
@@ -431,7 +432,7 @@ static u32 LoopedTask_OpenConditionSearchResults(s32 state)
         SetBgTilemapBuffer(1, gfx->buff);
         CopyToBgTilemapBuffer(1, sConditionSearchResultTilemap, 0, 0);
         CopyBgTilemapBufferToVram(1);
-        CopyPaletteIntoBufferUnfaded(sConditionSearchResultFramePal, 0x10, 0x20);
+        CopyPaletteIntoBufferUnfaded(sConditionSearchResultFramePal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
         CopyBgTilemapBufferToVram(1);
         return LT_INC_AND_PAUSE;
     case 1:
@@ -443,7 +444,7 @@ static u32 LoopedTask_OpenConditionSearchResults(s32 state)
     case 2:
         if (FreeTempTileDataBuffersIfPossible())
             return LT_PAUSE;
-        CopyPaletteIntoBufferUnfaded(sListBg_Pal, 0x20, 32);
+        CopyPaletteIntoBufferUnfaded(sListBg_Pal, BG_PLTT_ID(0x2), PLTT_SIZE_4BPP);
         CreateSearchResultsList();
         return LT_INC_AND_PAUSE;
     case 3:

--- a/src/pokenav_main_menu.c
+++ b/src/pokenav_main_menu.c
@@ -78,7 +78,7 @@ static const struct WindowTemplate sHelpBarWindowTemplate[] =
         .tilemapTop = 22,
         .width = 16,
         .height = 2,
-        .paletteNum = 0,
+        .paletteNum = 0x0,
         .baseBlock = 0x36,
     },
     DUMMY_WIN_TEMPLATE
@@ -349,7 +349,7 @@ static u32 LoopedTask_InitPokenavMenu(s32 state)
         DecompressAndCopyTileDataToVram(0, &gPokenavHeader_Gfx, 0, 0, 0);
         SetBgTilemapBuffer(0, menu->tilemapBuffer);
         CopyToBgTilemapBuffer(0, &gPokenavHeader_Tilemap, 0, 0);
-        CopyPaletteIntoBufferUnfaded(gPokenavHeader_Pal, 0, 0x20);
+        CopyPaletteIntoBufferUnfaded(gPokenavHeader_Pal, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
         CopyBgTilemapBufferToVram(0);
         return LT_INC_AND_PAUSE;
     case 2:
@@ -460,8 +460,8 @@ void Pokenav_AllocAndLoadPalettes(const struct SpritePalette *palettes)
         }
         else
         {
-            index = (index * 16) + 0x100;
-            CopyPaletteIntoBufferUnfaded(current->data, index, 0x20);
+            index = OBJ_PLTT_ID(index);
+            CopyPaletteIntoBufferUnfaded(current->data, index, PLTT_SIZE_4BPP);
         }
     }
 }
@@ -683,7 +683,7 @@ static void LoadLeftHeaderGfxForMenu(u32 menuGfxId)
     menu = GetSubstructPtr(POKENAV_SUBSTRUCT_MAIN_MENU);
     tag = sMenuLeftHeaderSpriteSheets[menuGfxId].tag;
     size = GetDecompressedDataSize(sMenuLeftHeaderSpriteSheets[menuGfxId].data);
-    LoadPalette(&gPokenavLeftHeader_Pal[tag * 16], (IndexOfSpritePaletteTag(1) * 16) + 0x100, 0x20);
+    LoadPalette(&gPokenavLeftHeader_Pal[tag * 16], OBJ_PLTT_ID(IndexOfSpritePaletteTag(1)), PLTT_SIZE_4BPP);
     LZ77UnCompWram(sMenuLeftHeaderSpriteSheets[menuGfxId].data, gDecompressionBuffer);
     RequestDma3Copy(gDecompressionBuffer, (void *)OBJ_VRAM0 + (GetSpriteTileStartByTag(2) * 32), size, 1);
     menu->leftHeaderSprites[1]->oam.tileNum = GetSpriteTileStartByTag(2) + sMenuLeftHeaderSpriteSheets[menuGfxId].size;
@@ -703,7 +703,7 @@ static void LoadLeftHeaderGfxForSubMenu(u32 menuGfxId)
 
     tag = sPokenavSubMenuLeftHeaderSpriteSheets[menuGfxId].tag;
     size = GetDecompressedDataSize(sPokenavSubMenuLeftHeaderSpriteSheets[menuGfxId].data);
-    LoadPalette(&gPokenavLeftHeader_Pal[tag * 16], (IndexOfSpritePaletteTag(2) * 16) + 0x100, 0x20);
+    LoadPalette(&gPokenavLeftHeader_Pal[tag * 16], OBJ_PLTT_ID(IndexOfSpritePaletteTag(2)), PLTT_SIZE_4BPP);
     LZ77UnCompWram(sPokenavSubMenuLeftHeaderSpriteSheets[menuGfxId].data, &gDecompressionBuffer[0x1000]);
     RequestDma3Copy(&gDecompressionBuffer[0x1000], (void *)OBJ_VRAM0 + 0x800 + (GetSpriteTileStartByTag(2) * 32), size, 1);
 }

--- a/src/pokenav_match_call_gfx.c
+++ b/src/pokenav_match_call_gfx.c
@@ -182,7 +182,7 @@ static const struct WindowTemplate sMatchCallLocationWindowTemplate =
     .tilemapTop = 5,
     .width = 11,
     .height = 2,
-    .paletteNum = 2,
+    .paletteNum = 0x2,
     .baseBlock = 16
 };
 
@@ -193,7 +193,7 @@ static const struct WindowTemplate sMatchCallInfoBoxWindowTemplate =
     .tilemapTop = 9,
     .width = 11,
     .height = 8,
-    .paletteNum = 2,
+    .paletteNum = 0x2,
     .baseBlock = 38
 };
 
@@ -214,7 +214,7 @@ static const struct WindowTemplate sCallMsgBoxWindowTemplate =
     .tilemapTop = 12,
     .width = 28,
     .height = 4,
-    .paletteNum = 1,
+    .paletteNum = 0x1,
     .baseBlock = 10
 };
 
@@ -333,7 +333,7 @@ static u32 LoopedTask_OpenMatchCall(s32 state)
         SetBgTilemapBuffer(2, gfx->bgTilemapBuffer2);
         CopyToBgTilemapBuffer(2, sMatchCallUI_Tilemap, 0, 0);
         CopyBgTilemapBufferToVram(2);
-        CopyPaletteIntoBufferUnfaded(sMatchCallUI_Pal, 0x20, 0x20);
+        CopyPaletteIntoBufferUnfaded(sMatchCallUI_Pal, BG_PLTT_ID(0x2), PLTT_SIZE_4BPP);
         CopyBgTilemapBufferToVram(2);
         return LT_INC_AND_PAUSE;
     case 1:
@@ -343,7 +343,7 @@ static u32 LoopedTask_OpenMatchCall(s32 state)
         BgDmaFill(1, 0, 0, 1);
         SetBgTilemapBuffer(1, gfx->bgTilemapBuffer1);
         FillBgTilemapBufferRect_Palette0(1, 0x1000, 0, 0, 32, 20);
-        CopyPaletteIntoBufferUnfaded(sCallWindow_Pal, 0x10, 0x20);
+        CopyPaletteIntoBufferUnfaded(sCallWindow_Pal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
         CopyBgTilemapBufferToVram(1);
         return LT_INC_AND_PAUSE;
     case 2:
@@ -352,8 +352,8 @@ static u32 LoopedTask_OpenMatchCall(s32 state)
 
         LoadCallWindowAndFade(gfx);
         DecompressAndCopyTileDataToVram(3, sPokeball_Gfx, 0, 0, 0);
-        CopyPaletteIntoBufferUnfaded(sListWindow_Pal, 0x30, 0x20);
-        CopyPaletteIntoBufferUnfaded(sPokeball_Pal, 0x50, 0x20);
+        CopyPaletteIntoBufferUnfaded(sListWindow_Pal, BG_PLTT_ID(0x3), PLTT_SIZE_4BPP);
+        CopyPaletteIntoBufferUnfaded(sPokeball_Pal, BG_PLTT_ID(0x5), PLTT_SIZE_4BPP);
         return LT_INC_AND_PAUSE;
     case 3:
         if (FreeTempTileDataBuffersIfPossible() || !IsMatchCallListInitFinished())
@@ -1082,15 +1082,15 @@ static void UpdateWindowsToShowCheckPage(struct Pokenav_MatchCallGfx *gfx)
 static void LoadCallWindowAndFade(struct Pokenav_MatchCallGfx *gfx)
 {
     gfx->msgBoxWindowId = AddWindow(&sCallMsgBoxWindowTemplate);
-    LoadMatchCallWindowGfx(gfx->msgBoxWindowId, 1, 4);
+    LoadMatchCallWindowGfx(gfx->msgBoxWindowId, 1, 0x4);
     FadeToBlackExceptPrimary();
 }
 
 static void DrawMsgBoxForMatchCallMsg(struct Pokenav_MatchCallGfx *gfx)
 {
     struct Sprite *sprite;
-    LoadMatchCallWindowGfx(gfx->msgBoxWindowId, 1, 4);
-    DrawMatchCallTextBoxBorder(gfx->msgBoxWindowId, 1, 4);
+    LoadMatchCallWindowGfx(gfx->msgBoxWindowId, 1, 0x4);
+    DrawMatchCallTextBoxBorder(gfx->msgBoxWindowId, 1, 0x4);
     FillWindowPixelBuffer(gfx->msgBoxWindowId, PIXEL_FILL(1));
     PutWindowTilemap(gfx->msgBoxWindowId);
     CopyWindowToVram(gfx->msgBoxWindowId, COPYWIN_FULL);
@@ -1102,8 +1102,8 @@ static void DrawMsgBoxForMatchCallMsg(struct Pokenav_MatchCallGfx *gfx)
 
 static void DrawMsgBoxForCloseByMsg(struct Pokenav_MatchCallGfx *gfx)
 {
-    LoadUserWindowBorderGfx(gfx->msgBoxWindowId, 1, 0x40);
-    DrawTextBorderOuter(gfx->msgBoxWindowId, 1, 4);
+    LoadUserWindowBorderGfx(gfx->msgBoxWindowId, 1, BG_PLTT_ID(0x4));
+    DrawTextBorderOuter(gfx->msgBoxWindowId, 1, 0x4);
     FillWindowPixelBuffer(gfx->msgBoxWindowId, PIXEL_FILL(1));
     PutWindowTilemap(gfx->msgBoxWindowId);
     CopyWindowToVram(gfx->msgBoxWindowId, COPYWIN_FULL);
@@ -1186,7 +1186,7 @@ static void AllocMatchCallSprites(void)
     spriteSheet.tag = GFXTAG_TRAINER_PIC;
     gfx->trainerPicGfxPtr = (u8 *)OBJ_VRAM0 + LoadSpriteSheet(&spriteSheet) * 0x20;
     paletteNum = AllocSpritePalette(PALTAG_TRAINER_PIC);
-    gfx->trainerPicPalOffset = 0x100 + paletteNum * 0x10;
+    gfx->trainerPicPalOffset = OBJ_PLTT_ID(paletteNum);
     gfx->trainerPicSprite = CreateTrainerPicSprite();
     gfx->trainerPicSprite->invisible = TRUE;
 }

--- a/src/pokenav_menu_handler_gfx.c
+++ b/src/pokenav_menu_handler_gfx.c
@@ -261,7 +261,7 @@ static const struct WindowTemplate sOptionDescWindowTemplate =
     .tilemapTop = 17,
     .width = 24,
     .height = 2,
-    .paletteNum = 1,
+    .paletteNum = 0x1,
     .baseBlock = 8
 };
 
@@ -457,7 +457,7 @@ static u32 LoopedTask_OpenMenu(s32 state)
         SetBgTilemapBuffer(1, gfx->bg1TilemapBuffer);
         CopyToBgTilemapBuffer(1, gPokenavMessageBox_Tilemap, 0, 0);
         CopyBgTilemapBufferToVram(1);
-        CopyPaletteIntoBufferUnfaded(gPokenavMessageBox_Pal, 0x10, 0x20);
+        CopyPaletteIntoBufferUnfaded(gPokenavMessageBox_Pal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
         ChangeBgX(1, 0, BG_COORD_SET);
         ChangeBgY(1, 0, BG_COORD_SET);
         ChangeBgX(2, 0, BG_COORD_SET);
@@ -470,14 +470,14 @@ static u32 LoopedTask_OpenMenu(s32 state)
             return LT_PAUSE;
         DecompressAndCopyTileDataToVram(2, sPokenavDeviceBgTiles, 0, 0, 0);
         DecompressAndCopyTileDataToVram(2, sPokenavDeviceBgTilemap, 0, 0, 1);
-        CopyPaletteIntoBufferUnfaded(sPokenavDeviceBgPal, 0x20, 0x20);
+        CopyPaletteIntoBufferUnfaded(sPokenavDeviceBgPal, BG_PLTT_ID(0x2), PLTT_SIZE_4BPP);
         return LT_INC_AND_PAUSE;
     case 2:
         if (FreeTempTileDataBuffersIfPossible())
             return LT_PAUSE;
         DecompressAndCopyTileDataToVram(3, sPokenavBgDotsTiles, 0, 0, 0);
         DecompressAndCopyTileDataToVram(3, sPokenavBgDotsTilemap, 0, 0, 1);
-        CopyPaletteIntoBufferUnfaded(sPokenavBgDotsPal, 0x30, 0x20);
+        CopyPaletteIntoBufferUnfaded(sPokenavBgDotsPal, BG_PLTT_ID(0x3), PLTT_SIZE_4BPP);
         if (GetPokenavMenuType() == POKENAV_MENU_TYPE_CONDITION || GetPokenavMenuType() == POKENAV_MENU_TYPE_CONDITION_SEARCH)
             ChangeBgDotsColorToPurple();
         return LT_INC_AND_PAUSE;
@@ -1270,7 +1270,7 @@ static void CreateBgDotPurplePalTask(void)
 
 static void ChangeBgDotsColorToPurple(void)
 {
-    CopyPaletteIntoBufferUnfaded(sPokenavBgDotsPal + 7, 0x31, 4);
+    CopyPaletteIntoBufferUnfaded(sPokenavBgDotsPal + 7, BG_PLTT_ID(0x3) + 1, PLTT_SIZEOF(2));
 }
 
 static void CreateBgDotLightBluePalTask(void)
@@ -1293,7 +1293,7 @@ static void Task_UpdateBgDotsPalette(u8 taskId)
     const u16 * pal2 = (const u16 *)GetWordTaskArg(taskId, 3);
 
     PokenavCopyPalette(pal1, pal2, 2, 12, ++data[0], sp8);
-    LoadPalette(sp8, 0x31, 4);
+    LoadPalette(sp8, BG_PLTT_ID(0x3) + 1, PLTT_SIZEOF(2));
     if (data[0] == 12)
         DestroyTask(taskId);
 }

--- a/src/pokenav_region_map.c
+++ b/src/pokenav_region_map.c
@@ -140,7 +140,7 @@ static const struct WindowTemplate sMapSecInfoWindowTemplate =
     .tilemapTop = 4,
     .width = 12,
     .height = 13,
-    .paletteNum = 1,
+    .paletteNum = 0x1,
     .baseBlock = 0x4C
 };
 
@@ -509,14 +509,14 @@ static void LoadPokenavRegionMapGfx(struct Pokenav_RegionMapGfx *state)
     CpuFill16(0x1040, state->tilemapBuffer, 0x800);
     SetBgTilemapBuffer(1, state->tilemapBuffer);
     state->infoWindowId = AddWindow(&sMapSecInfoWindowTemplate);
-    LoadUserWindowBorderGfx_(state->infoWindowId, 0x42, 0x40);
-    DrawTextBorderOuter(state->infoWindowId, 0x42, 4);
+    LoadUserWindowBorderGfx_(state->infoWindowId, 0x42, BG_PLTT_ID(0x4));
+    DrawTextBorderOuter(state->infoWindowId, 0x42, 0x4);
     DecompressAndCopyTileDataToVram(1, sRegionMapCityZoomTiles_Gfx, 0, 0, 0);
     FillWindowPixelBuffer(state->infoWindowId, PIXEL_FILL(1));
     PutWindowTilemap(state->infoWindowId);
     CopyWindowToVram(state->infoWindowId, COPYWIN_FULL);
-    CopyPaletteIntoBufferUnfaded(sMapSecInfoWindow_Pal, 0x10, 0x20);
-    CopyPaletteIntoBufferUnfaded(gRegionMapCityZoomTiles_Pal, 0x30, 0x20);
+    CopyPaletteIntoBufferUnfaded(sMapSecInfoWindow_Pal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
+    CopyPaletteIntoBufferUnfaded(gRegionMapCityZoomTiles_Pal, BG_PLTT_ID(0x3), PLTT_SIZE_4BPP);
     if (!IsRegionMapZoomed())
         ChangeBgY(1, -0x6000, BG_COORD_SET);
     else

--- a/src/pokenav_ribbons_list.c
+++ b/src/pokenav_ribbons_list.c
@@ -2,6 +2,7 @@
 #include "pokenav.h"
 #include "bg.h"
 #include "menu.h"
+#include "palette.h"
 #include "window.h"
 #include "sound.h"
 #include "string_util.h"
@@ -431,7 +432,7 @@ static u32 LoopedTask_OpenRibbonsMonList(s32 state)
         DecompressAndCopyTileDataToVram(1, sMonRibbonListFrameTiles, 0, 0, 0);
         SetBgTilemapBuffer(1, menu->buff);
         CopyToBgTilemapBuffer(1, sMonRibbonListFrameTilemap, 0, 0);
-        CopyPaletteIntoBufferUnfaded(sMonRibbonListFramePal, 0x10, 0x20);
+        CopyPaletteIntoBufferUnfaded(sMonRibbonListFramePal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
         CopyBgTilemapBufferToVram(1);
         return LT_INC_AND_PAUSE;
     case 1:
@@ -446,7 +447,7 @@ static u32 LoopedTask_OpenRibbonsMonList(s32 state)
     case 2:
         if (FreeTempTileDataBuffersIfPossible())
             return LT_PAUSE;
-        CopyPaletteIntoBufferUnfaded(sMonRibbonListUi_Pal, 0x20, 0x20);
+        CopyPaletteIntoBufferUnfaded(sMonRibbonListUi_Pal, BG_PLTT_ID(0x2), PLTT_SIZE_4BPP);
         CreateRibbonMonsList();
         return LT_INC_AND_PAUSE;
     case 3:

--- a/src/pokenav_ribbons_summary.c
+++ b/src/pokenav_ribbons_summary.c
@@ -3,6 +3,7 @@
 #include "dynamic_placeholder_text_util.h"
 #include "graphics.h"
 #include "international_string_util.h"
+#include "palette.h"
 #include "pokenav.h"
 #include "sound.h"
 #include "sprite.h"
@@ -572,7 +573,7 @@ static u32 LoopedTask_OpenRibbonsSummaryMenu(s32 state)
         DecompressAndCopyTileDataToVram(2, gPokenavRibbonsSummaryBg_Gfx, 0, 0, 0);
         SetBgTilemapBuffer(2, menu->tilemapBuffers[0]);
         CopyToBgTilemapBuffer(2, gPokenavRibbonsSummaryBg_Tilemap, 0, 0);
-        CopyPaletteIntoBufferUnfaded(gPokenavRibbonsSummaryBg_Pal, 0x10, 0x20);
+        CopyPaletteIntoBufferUnfaded(gPokenavRibbonsSummaryBg_Pal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
         CopyBgTilemapBufferToVram(2);
         return LT_INC_AND_PAUSE;
     case 1:
@@ -582,8 +583,8 @@ static u32 LoopedTask_OpenRibbonsSummaryMenu(s32 state)
             DecompressAndCopyTileDataToVram(1, sRibbonIconsSmall_Gfx, 0, 1, 0);
             SetBgTilemapBuffer(1, menu->tilemapBuffers[1]);
             FillBgTilemapBufferRect_Palette0(1, 0, 0, 0, 32, 20);
-            CopyPaletteIntoBufferUnfaded(sRibbonIcons1_Pal, 0x20, 0xA0);
-            CopyPaletteIntoBufferUnfaded(sMonInfo_Pal, 0xA0, 0x20);
+            CopyPaletteIntoBufferUnfaded(sRibbonIcons1_Pal, BG_PLTT_ID(0x2), 5 * PLTT_SIZE_4BPP);
+            CopyPaletteIntoBufferUnfaded(sMonInfo_Pal, BG_PLTT_ID(0xA), PLTT_SIZE_4BPP);
             CopyBgTilemapBufferToVram(1);
             return LT_INC_AND_PAUSE;
         }
@@ -789,7 +790,7 @@ static const struct WindowTemplate sRibbonCountWindowTemplate =
     .tilemapTop = 13,
     .width = 16,
     .height = 4,
-    .paletteNum = 1,
+    .paletteNum = 0x1,
     .baseBlock = 0x14,
 };
 
@@ -853,7 +854,7 @@ static const struct WindowTemplate sRibbonSummaryMonNameWindowTemplate =
     .tilemapTop = 1,
     .width = 13,
     .height = 2,
-    .paletteNum = 10,
+    .paletteNum = 0xA,
     .baseBlock = 0x54,
 };
 
@@ -908,7 +909,7 @@ static const struct WindowTemplate sRibbonMonListIndexWindowTemplate[] =
         .tilemapTop = 5,
         .width = 7,
         .height = 2,
-        .paletteNum = 1,
+        .paletteNum = 0x1,
         .baseBlock = 0x6E,
     },
     {},

--- a/src/rayquaza_scene.c
+++ b/src/rayquaza_scene.c
@@ -1301,7 +1301,7 @@ static void CB2_InitRayquazaScene(void)
     ResetPaletteFade();
     ResetSpriteData();
     ResetTasks();
-    FillPalette(RGB_BLACK, 0xF0, 32);
+    FillPalette(RGB_BLACK, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
     CreateTask(sTasksForAnimations[sRayScene->animId], 0);
     SetMainCallback2(CB2_RayquazaScene);
 }
@@ -1592,7 +1592,7 @@ static void LoadDuoFightSceneGfx(void)
     LZDecompressWram(gRaySceneDuoFight_Clouds2_Tilemap, sRayScene->tilemapBuffers[0]);
     LZDecompressWram(gRaySceneDuoFight_Clouds1_Tilemap, sRayScene->tilemapBuffers[1]);
     LZDecompressWram(gRaySceneDuoFight_Clouds3_Tilemap, sRayScene->tilemapBuffers[2]);
-    LoadCompressedPalette(gRaySceneDuoFight_Clouds_Pal, 0, 0x40);
+    LoadCompressedPalette(gRaySceneDuoFight_Clouds_Pal, BG_PLTT_ID(0x0), 2 * PLTT_SIZE_4BPP);
     LoadCompressedSpriteSheet(&sSpriteSheet_DuoFight_Groudon);
     LoadCompressedSpriteSheet(&sSpriteSheet_DuoFight_GroudonShoulder);
     LoadCompressedSpriteSheet(&sSpriteSheet_DuoFight_GroudonClaw);
@@ -2032,7 +2032,7 @@ static void LoadTakesFlightSceneGfx(void)
     LZDecompressWram(gRaySceneDuoFight_Clouds2_Tilemap, sRayScene->tilemapBuffers[0]);
     LZDecompressWram(gRaySceneTakesFlight_Bg_Tilemap, sRayScene->tilemapBuffers[1]);
     LZDecompressWram(gRaySceneTakesFlight_Rayquaza_Tilemap, sRayScene->tilemapBuffers[2]);
-    LoadCompressedPalette(gRaySceneTakesFlight_Rayquaza_Pal, 0, 64);
+    LoadCompressedPalette(gRaySceneTakesFlight_Rayquaza_Pal, BG_PLTT_ID(0x0), 2 * PLTT_SIZE_4BPP);
     LoadCompressedSpriteSheet(&sSpriteSheet_TakesFlight_Smoke);
     LoadCompressedSpritePalette(&sSpritePal_TakesFlight_Smoke);
 }
@@ -2238,7 +2238,7 @@ static void LoadDescendsSceneGfx(void)
     CpuFastCopy(sRayScene->tilemapBuffers[3], sRayScene->tilemapBuffers[1], BG_SCREEN_SIZE);
     CpuFastFill16(0, &sRayScene->tilemapBuffers[1][0x100], 0x340);
 
-    LoadCompressedPalette(gRaySceneDescends_Bg_Pal, 0, 0x40);
+    LoadCompressedPalette(gRaySceneDescends_Bg_Pal, BG_PLTT_ID(0x0), 2 * PLTT_SIZE_4BPP);
     gPlttBufferUnfaded[0] = RGB_WHITE;
     gPlttBufferFaded[0] = RGB_WHITE;
     LoadCompressedSpriteSheet(&sSpriteSheet_Descends_Rayquaza);
@@ -2487,7 +2487,7 @@ static void LoadChargesSceneGfx(void)
     LZDecompressWram(gRaySceneCharges_Rayquaza_Tilemap, sRayScene->tilemapBuffers[1]);
     LZDecompressWram(gRaySceneCharges_Streaks_Tilemap, sRayScene->tilemapBuffers[2]);
     LZDecompressWram(gRaySceneCharges_Bg_Tilemap, sRayScene->tilemapBuffers[3]);
-    LoadCompressedPalette(gRaySceneCharges_Bg_Pal, 0, 0x80);
+    LoadCompressedPalette(gRaySceneCharges_Bg_Pal, BG_PLTT_ID(0x0), 4 * PLTT_SIZE_4BPP);
 }
 
 #define tState          data[0]
@@ -2671,7 +2671,7 @@ static void LoadChasesAwaySceneGfx(void)
     LZDecompressWram(gRaySceneChasesAway_Bg_Tilemap, sRayScene->tilemapBuffers[1]);
     LZDecompressWram(gRaySceneChasesAway_Light_Tilemap, sRayScene->tilemapBuffers[0]);
     LZDecompressWram(gRaySceneChasesAway_Ring_Tilemap, sRayScene->tilemapBuffers[2]);
-    LoadCompressedPalette(gRaySceneChasesAway_Bg_Pal, 0, 0x60);
+    LoadCompressedPalette(gRaySceneChasesAway_Bg_Pal, BG_PLTT_ID(0x0), 3 * PLTT_SIZE_4BPP);
     LoadCompressedSpriteSheet(&sSpriteSheet_ChasesAway_Groudon);
     LoadCompressedSpriteSheet(&sSpriteSheet_ChasesAway_GroudonTail);
     LoadCompressedSpriteSheet(&sSpriteSheet_ChasesAway_Kyogre);

--- a/src/region_map.c
+++ b/src/region_map.c
@@ -392,7 +392,7 @@ static const struct WindowTemplate sFlyMapWindowTemplates[] =
         .tilemapTop = 17,
         .width = 12,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x01
     },
     {
@@ -401,7 +401,7 @@ static const struct WindowTemplate sFlyMapWindowTemplates[] =
         .tilemapTop = 15,
         .width = 12,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x19
     },
     {
@@ -410,7 +410,7 @@ static const struct WindowTemplate sFlyMapWindowTemplates[] =
         .tilemapTop = 18,
         .width = 14,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x49
     },
     DUMMY_WIN_TEMPLATE
@@ -567,7 +567,7 @@ bool8 LoadRegionMapGfx(void)
         break;
     case 2:
         if (!FreeTempTileDataBuffersIfPossible())
-            LoadPalette(sRegionMapBg_Pal, 0x70, 0x60);
+            LoadPalette(sRegionMapBg_Pal, BG_PLTT_ID(0x7), 3 * PLTT_SIZE_4BPP);
         break;
     case 3:
         LZ77UnCompWram(sRegionMapCursorSmallGfxLZ, sRegionMap->cursorSmallImage);
@@ -1689,7 +1689,7 @@ void CB2_OpenFlyMap(void)
         gMain.state++;
         break;
     case 3:
-        LoadUserWindowBorderGfx(0, 0x65, 0xd0);
+        LoadUserWindowBorderGfx(0, 0x65, BG_PLTT_ID(0xD));
         ClearScheduledBgCopiesToVram();
         gMain.state++;
         break;
@@ -1712,7 +1712,7 @@ void CB2_OpenFlyMap(void)
         gMain.state++;
         break;
     case 7:
-        LoadPalette(sRegionMapFramePal, 0x10, sizeof(sRegionMapFramePal));
+        LoadPalette(sRegionMapFramePal, BG_PLTT_ID(0x1), sizeof(sRegionMapFramePal));
         PutWindowTilemap(2);
         FillWindowPixelBuffer(2, PIXEL_FILL(0));
         AddTextPrinterParameterized(2, FONT_NORMAL, gText_FlyToWhere, 0, 1, 0, NULL);

--- a/src/reset_rtc_screen.c
+++ b/src/reset_rtc_screen.c
@@ -85,7 +85,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 1,
         .width = 19,
         .height = 9,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x155
     },
     {
@@ -94,7 +94,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 15,
         .width = 27,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0xE9
     },
     DUMMY_WIN_TEMPLATE
@@ -106,7 +106,7 @@ static const struct WindowTemplate sInputTimeWindow = {
     .tilemapTop = 9,
     .width = 21,
     .height = 2,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0xBF
 };
 

--- a/src/roulette.c
+++ b/src/roulette.c
@@ -460,7 +460,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 15,
         .width = 24,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0xC5
     },
     #ifdef UBFIX
@@ -1195,7 +1195,7 @@ static void CB2_LoadRoulette(void)
         ResetTempTileDataBuffers();
         break;
     case 3:
-        LoadPalette(&sWheel_Pal, 0, 0x1C0);
+        LoadPalette(&sWheel_Pal, BG_PLTT_ID(0x0), 14 * PLTT_SIZE_4BPP);
         DecompressAndCopyTileDataToVram(1, gRouletteMenu_Gfx, 0, 0, 0);
         DecompressAndCopyTileDataToVram(2, gRouletteWheel_Gfx, 0, 0, 0);
         break;
@@ -2167,16 +2167,16 @@ static void FlashSelectionOnWheel(u8 selectionId)
         // The specific color of the poke it references doesn't matter, because the icons of a poke share a palette
         // So it just uses the first sprite ID of each
         case COL_WYNAUT:
-            palOffset = gSprites[sRoulette->spriteIds[SPR_WHEEL_ICON_ORANGE_WYNAUT]].oam.paletteNum * 16;
+            palOffset = PLTT_ID(gSprites[sRoulette->spriteIds[SPR_WHEEL_ICON_ORANGE_WYNAUT]].oam.paletteNum);
             break;
         case COL_AZURILL:
-            palOffset = gSprites[sRoulette->spriteIds[SPR_WHEEL_ICON_GREEN_AZURILL]].oam.paletteNum * 16;
+            palOffset = PLTT_ID(gSprites[sRoulette->spriteIds[SPR_WHEEL_ICON_GREEN_AZURILL]].oam.paletteNum);
             break;
         case COL_SKITTY:
-            palOffset = gSprites[sRoulette->spriteIds[SPR_WHEEL_ICON_PURPLE_SKITTY]].oam.paletteNum * 16;
+            palOffset = PLTT_ID(gSprites[sRoulette->spriteIds[SPR_WHEEL_ICON_PURPLE_SKITTY]].oam.paletteNum);
             break;
         case COL_MAKUHITA:
-            palOffset = gSprites[sRoulette->spriteIds[SPR_WHEEL_ICON_ORANGE_MAKUHITA]].oam.paletteNum * 16;
+            palOffset = PLTT_ID(gSprites[sRoulette->spriteIds[SPR_WHEEL_ICON_ORANGE_MAKUHITA]].oam.paletteNum);
             break;
         }
         if (numSelected == 1)

--- a/src/save_failed_screen.c
+++ b/src/save_failed_screen.c
@@ -103,7 +103,7 @@ static const struct WindowTemplate sWindowTemplate_Text[] =
         .tilemapTop = 13,
         .width = 28,
         .height = 6,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1,
     }
 };
@@ -116,7 +116,7 @@ static const struct WindowTemplate sWindowTemplate_Clock[] =
         .tilemapTop = 9,
         .width = 2,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 169,
     }
 };
@@ -214,10 +214,10 @@ static void CB2_SaveFailedScreen(void)
         ResetSpriteData();
         ResetTasks();
         ResetPaletteFade();
-        LoadPalette(gBirchBagGrassPal, 0, 0x40);
-        LoadPalette(sSaveFailedClockPal, 0x100, 0x20);
-        LoadPalette(gTextWindowFrame1_Pal, 0xE0, 0x20);
-        LoadPalette(gStandardMenuPalette, 0xF0, 0x20);
+        LoadPalette(gBirchBagGrassPal, BG_PLTT_ID(0x0), 2 * PLTT_SIZE_4BPP);
+        LoadPalette(sSaveFailedClockPal, OBJ_PLTT_ID(0x0), PLTT_SIZE_4BPP);
+        LoadPalette(gTextWindowFrame1_Pal, BG_PLTT_ID(0xE), PLTT_SIZE_4BPP);
+        LoadPalette(gStandardMenuPalette, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
         DrawStdFrameWithCustomTileAndPalette(sWindowIds[TEXT_WIN_ID], FALSE, 0x214, 0xE);
         DrawStdFrameWithCustomTileAndPalette(sWindowIds[CLOCK_WIN_ID], FALSE, 0x214, 0xE);
         FillWindowPixelBuffer(sWindowIds[CLOCK_WIN_ID], PIXEL_FILL(1)); // backwards?

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -1526,7 +1526,7 @@ bool8 ScrCmd_braillemessage(struct ScriptContext *ctx)
 
     winTemplate = CreateWindowTemplate(0, xWindow, yWindow + 1, width, height, 0xF, 0x1);
     sBrailleWindowId = AddWindow(&winTemplate);
-    LoadUserWindowBorderGfx(sBrailleWindowId, 0x214, 0xE0);
+    LoadUserWindowBorderGfx(sBrailleWindowId, 0x214, BG_PLTT_ID(0xE));
     DrawStdWindowFrame(sBrailleWindowId, FALSE);
     PutWindowTilemap(sBrailleWindowId);
     FillWindowPixelBuffer(sBrailleWindowId, PIXEL_FILL(1));

--- a/src/secret_base.c
+++ b/src/secret_base.c
@@ -181,7 +181,7 @@ static const struct WindowTemplate sRegistryWindowTemplates[] =
         .tilemapTop = 1,
         .width = 11,
         .height = 18,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x01,
     },
     {
@@ -190,7 +190,7 @@ static const struct WindowTemplate sRegistryWindowTemplates[] =
         .tilemapTop = 1,
         .width = 28,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0xc7,
     }
 };

--- a/src/shop.c
+++ b/src/shop.c
@@ -120,7 +120,7 @@ static const struct WindowTemplate sShopMenuWindowTemplates[] =
         .tilemapTop = 1,
         .width = 9,
         .height = 6,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0008,
     },
     {
@@ -129,7 +129,7 @@ static const struct WindowTemplate sShopMenuWindowTemplates[] =
         .tilemapTop = 1,
         .width = 9,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0008,
     }
 };
@@ -204,7 +204,7 @@ static const struct WindowTemplate sShopBuyMenuWindowTemplates[] =
         .tilemapTop = 1,
         .width = 10,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x001E,
     },
     {
@@ -213,7 +213,7 @@ static const struct WindowTemplate sShopBuyMenuWindowTemplates[] =
         .tilemapTop = 2,
         .width = 15,
         .height = 16,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0032,
     },
     {
@@ -222,7 +222,7 @@ static const struct WindowTemplate sShopBuyMenuWindowTemplates[] =
         .tilemapTop = 13,
         .width = 14,
         .height = 6,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0122,
     },
     {
@@ -231,7 +231,7 @@ static const struct WindowTemplate sShopBuyMenuWindowTemplates[] =
         .tilemapTop = 11,
         .width = 12,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0176,
     },
     {
@@ -240,7 +240,7 @@ static const struct WindowTemplate sShopBuyMenuWindowTemplates[] =
         .tilemapTop = 11,
         .width = 10,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x018E,
     },
     {
@@ -249,7 +249,7 @@ static const struct WindowTemplate sShopBuyMenuWindowTemplates[] =
         .tilemapTop = 15,
         .width = 27,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x01A2,
     },
     DUMMY_WIN_TEMPLATE
@@ -262,7 +262,7 @@ static const struct WindowTemplate sShopBuyMenuYesNoWindowTemplates =
     .tilemapTop = 9,
     .width = 5,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x020E,
 };
 
@@ -676,15 +676,15 @@ static void BuyMenuDecompressBgGraphics(void)
 {
     DecompressAndCopyTileDataToVram(1, gShopMenu_Gfx, 0x3A0, 0x3E3, 0);
     LZDecompressWram(gShopMenu_Tilemap, sShopData->tilemapBuffers[0]);
-    LoadCompressedPalette(gShopMenu_Pal, 0xC0, 0x20);
+    LoadCompressedPalette(gShopMenu_Pal, BG_PLTT_ID(0xC), PLTT_SIZE_4BPP);
 }
 
 static void BuyMenuInitWindows(void)
 {
     InitWindows(sShopBuyMenuWindowTemplates);
     DeactivateAllTextPrinters();
-    LoadUserWindowBorderGfx(0, 1, 0xD0);
-    LoadMessageBoxGfx(0, 0xA, 0xE0);
+    LoadUserWindowBorderGfx(0, 1, BG_PLTT_ID(0xD));
+    LoadMessageBoxGfx(0, 0xA, BG_PLTT_ID(0xE));
     PutWindowTilemap(0);
     PutWindowTilemap(1);
     PutWindowTilemap(2);

--- a/src/slot_machine.c
+++ b/src/slot_machine.c
@@ -789,7 +789,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 15,
         .width = 27,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x194
     },
     DUMMY_WIN_TEMPLATE
@@ -802,7 +802,7 @@ static const struct WindowTemplate sWindowTemplate_InfoBox =
     .tilemapTop = 3,
     .width = 20,
     .height = 13,
-    .paletteNum = 13,
+    .paletteNum = 0xD,
     .baseBlock = 1
 };
 
@@ -1247,8 +1247,8 @@ static void SlotMachineSetup_LoadGfxAndTilemaps(void)
     LoadMenuGfx();
     LoadMenuAndReelOverlayTilemaps();
     LoadSlotMachineGfx();
-    LoadMessageBoxGfx(0, 0x200, 0xF0);
-    LoadUserWindowBorderGfx(0, 0x214, 0xE0);
+    LoadMessageBoxGfx(0, 0x200, BG_PLTT_ID(0xF));
+    LoadUserWindowBorderGfx(0, 0x214, BG_PLTT_ID(0xE));
     PutWindowTilemap(0);
 }
 
@@ -3211,12 +3211,12 @@ static void StopReelButton_Unpress(struct Task *task, u8 taskId)
 
 static void LightenMatchLine(u8 matchLineId)
 {
-    LoadPalette(sLitMatchLinePalTable[matchLineId], sMatchLinePalOffsets[matchLineId], 2);
+    LoadPalette(sLitMatchLinePalTable[matchLineId], sMatchLinePalOffsets[matchLineId], PLTT_SIZEOF(1));
 }
 
 static void DarkenMatchLine(u8 matchLineId)
 {
-    LoadPalette(sDarkMatchLinePalTable[matchLineId], sMatchLinePalOffsets[matchLineId], 2);
+    LoadPalette(sDarkMatchLinePalTable[matchLineId], sMatchLinePalOffsets[matchLineId], PLTT_SIZEOF(1));
 }
 
 // light up the match line for each bet by the player
@@ -3360,7 +3360,7 @@ static bool8 TryStopSlotMachineLights(void)
     if (gTasks[taskId].sFlashState == 0)
     {
         DestroyTask(taskId);
-        LoadPalette(sSlotMachineMenu_Pal, 0x10, 0x20);
+        LoadPalette(sSlotMachineMenu_Pal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
         return TRUE;
     }
     return FALSE;
@@ -3376,7 +3376,7 @@ static void Task_FlashSlotMachineLights(u8 taskId)
         if (task->sFlashState == 0 || task->sFlashState == 2)
             task->sFlashDir = -task->sFlashDir;
     }
-    LoadPalette(sFlashingLightsPalTable[task->sFlashState], 0x10, 0x20);
+    LoadPalette(sFlashingLightsPalTable[task->sFlashState], BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
 }
 
 #undef sDelayTimer
@@ -4857,7 +4857,7 @@ static void SpriteCB_DigitalDisplay_PokeballShining(struct Sprite *sprite)
 {
     if (sprite->sCounter < 3)
     {
-        LoadPalette(sPokeballShiningPalTable[sprite->sCounter], (IndexOfSpritePaletteTag(PALTAG_DIG_DISPLAY) << 4) + 0x100, 32);
+        LoadPalette(sPokeballShiningPalTable[sprite->sCounter], OBJ_PLTT_ID(IndexOfSpritePaletteTag(PALTAG_DIG_DISPLAY)), PLTT_SIZE_4BPP);
         if (++sprite->data[2] >= 4)
         {
             sprite->data[1]++;
@@ -4866,7 +4866,7 @@ static void SpriteCB_DigitalDisplay_PokeballShining(struct Sprite *sprite)
     }
     else
     {
-        LoadPalette(sPokeballShiningPalTable[sprite->sCounter], (IndexOfSpritePaletteTag(PALTAG_DIG_DISPLAY) << 4) + 0x100, 32);
+        LoadPalette(sPokeballShiningPalTable[sprite->sCounter], OBJ_PLTT_ID(IndexOfSpritePaletteTag(PALTAG_DIG_DISPLAY)), PLTT_SIZE_4BPP);
         if (++sprite->data[2] >= 25)
         {
             sprite->sCounter = 0;
@@ -4995,7 +4995,7 @@ static void EndDigitalDisplayScene_StopReel(void)
 
 static void EndDigitalDisplayScene_Win(void)
 {
-    LoadPalette(sDigitalDisplay_Pal, (IndexOfSpritePaletteTag(PALTAG_DIG_DISPLAY) << 4) + 0x100, 0x20);
+    LoadPalette(sDigitalDisplay_Pal, OBJ_PLTT_ID(IndexOfSpritePaletteTag(PALTAG_DIG_DISPLAY)), PLTT_SIZE_4BPP);
 }
 
 static void EndDigitalDisplayScene_InsertBet(void)
@@ -5054,8 +5054,8 @@ static void LoadMenuGfx(void)
     sMenuGfx = Alloc(0x2200);
     LZDecompressWram(gSlotMachineMenu_Gfx, sMenuGfx);
     LoadBgTiles(2, sMenuGfx, 0x2200, 0);
-    LoadPalette(gSlotMachineMenu_Pal, 0, 160);
-    LoadPalette(sUnkPalette, 208, 32);
+    LoadPalette(gSlotMachineMenu_Pal, BG_PLTT_ID(0x0), 5 * PLTT_SIZE_4BPP);
+    LoadPalette(sUnkPalette, BG_PLTT_ID(0xD), PLTT_SIZE_4BPP);
 }
 
 static void LoadMenuAndReelOverlayTilemaps(void)
@@ -7728,19 +7728,19 @@ static const u16 *const sLitMatchLinePalTable[NUM_MATCH_LINES] =
 
 static const u16 *const sDarkMatchLinePalTable[NUM_MATCH_LINES] =
 {
-    [MATCH_MIDDLE_ROW] = &gSlotMachineMenu_Pal[74],
-    [MATCH_TOP_ROW]    = &gSlotMachineMenu_Pal[75],
-    [MATCH_BOTTOM_ROW] = &gSlotMachineMenu_Pal[76],
-    [MATCH_NWSE_DIAG]  = &gSlotMachineMenu_Pal[77],
-    [MATCH_NESW_DIAG]  = &gSlotMachineMenu_Pal[78],
+    [MATCH_MIDDLE_ROW] = &gSlotMachineMenu_Pal[BG_PLTT_ID(0x4) + 10],
+    [MATCH_TOP_ROW]    = &gSlotMachineMenu_Pal[BG_PLTT_ID(0x4) + 11],
+    [MATCH_BOTTOM_ROW] = &gSlotMachineMenu_Pal[BG_PLTT_ID(0x4) + 12],
+    [MATCH_NWSE_DIAG]  = &gSlotMachineMenu_Pal[BG_PLTT_ID(0x4) + 13],
+    [MATCH_NESW_DIAG]  = &gSlotMachineMenu_Pal[BG_PLTT_ID(0x4) + 14],
 };
 
 static const u8 sMatchLinePalOffsets[NUM_MATCH_LINES] = {
-    [MATCH_MIDDLE_ROW] = 74,
-    [MATCH_TOP_ROW]    = 75,
-    [MATCH_BOTTOM_ROW] = 76,
-    [MATCH_NWSE_DIAG]  = 78, // Diag colors flipped for some reason
-    [MATCH_NESW_DIAG]  = 77  // Doesn't matter as both are identical
+    [MATCH_MIDDLE_ROW] = BG_PLTT_ID(0x4) + 10,
+    [MATCH_TOP_ROW]    = BG_PLTT_ID(0x4) + 11,
+    [MATCH_BOTTOM_ROW] = BG_PLTT_ID(0x4) + 12,
+    [MATCH_NWSE_DIAG]  = BG_PLTT_ID(0x4) + 14, // Diag colors flipped for some reason
+    [MATCH_NESW_DIAG]  = BG_PLTT_ID(0x4) + 13  // Doesn't matter as both are identical
 };
 
 static const u8 sBetToMatchLineIds[MAX_BET][2] =

--- a/src/start_menu.c
+++ b/src/start_menu.c
@@ -192,7 +192,7 @@ static const struct WindowTemplate sWindowTemplates_LinkBattleSave[] =
         .tilemapTop = 15,
         .width = 26,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x194
     },
     DUMMY_WIN_TEMPLATE
@@ -204,7 +204,7 @@ static const struct WindowTemplate sSaveInfoWindowTemplate = {
     .tilemapTop = 1,
     .width = 14,
     .height = 10,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 8
 };
 
@@ -1196,8 +1196,8 @@ static bool32 InitSaveWindowAfterLinkBattle(u8 *state)
         ResetBgsAndClearDma3BusyFlags(0);
         InitBgsFromTemplates(0, sBgTemplates_LinkBattleSave, ARRAY_COUNT(sBgTemplates_LinkBattleSave));
         InitWindows(sWindowTemplates_LinkBattleSave);
-        LoadUserWindowBorderGfx_(0, 8, 224);
-        Menu_LoadStdPalAt(240);
+        LoadUserWindowBorderGfx_(0, 8, BG_PLTT_ID(0xE));
+        Menu_LoadStdPalAt(BG_PLTT_ID(0xF));
         break;
     case 3:
         ShowBg(0);
@@ -1246,7 +1246,7 @@ static void Task_SaveAfterLinkBattle(u8 taskId)
                                         TEXT_COLOR_DARK_GRAY,
                                         TEXT_COLOR_WHITE,
                                         TEXT_COLOR_LIGHT_GRAY);
-            DrawTextBorderOuter(0, 8, 14);
+            DrawTextBorderOuter(0, 8, 0xE);
             PutWindowTilemap(0);
             CopyWindowToVram(0, COPYWIN_FULL);
             BeginNormalPaletteFade(PALETTES_ALL, 0, 16, 0, RGB_BLACK);

--- a/src/starter_choose.c
+++ b/src/starter_choose.c
@@ -73,7 +73,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 15,
         .width = 24,
         .height = 4,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x0200
     },
     DUMMY_WIN_TEMPLATE,
@@ -86,7 +86,7 @@ static const struct WindowTemplate sWindowTemplate_ConfirmStarter =
     .tilemapTop = 9,
     .width = 5,
     .height = 4,
-    .paletteNum = 14,
+    .paletteNum = 0xE,
     .baseBlock = 0x0260
 };
 
@@ -97,7 +97,7 @@ static const struct WindowTemplate sWindowTemplate_StarterLabel =
     .tilemapTop = 0,
     .width = 13,
     .height = 4,
-    .paletteNum = 14,
+    .paletteNum = 0xE,
     .baseBlock = 0x0274
 };
 
@@ -411,7 +411,7 @@ void CB2_ChooseStarter(void)
     InitWindows(sWindowTemplates);
 
     DeactivateAllTextPrinters();
-    LoadUserWindowBorderGfx(0, 0x2A8, 0xD0);
+    LoadUserWindowBorderGfx(0, 0x2A8, BG_PLTT_ID(0xD));
     ClearScheduledBgCopiesToVram();
     ScanlineEffect_Stop();
     ResetTasks();
@@ -420,8 +420,8 @@ void CB2_ChooseStarter(void)
     FreeAllSpritePalettes();
     ResetAllPicSprites();
 
-    LoadPalette(GetOverworldTextboxPalettePtr(), 0xE0, 0x20);
-    LoadPalette(gBirchBagGrassPal, 0, 0x40);
+    LoadPalette(GetOverworldTextboxPalettePtr(), BG_PLTT_ID(0xE), PLTT_SIZE_4BPP);
+    LoadPalette(gBirchBagGrassPal, BG_PLTT_ID(0x0), 2 * PLTT_SIZE_4BPP);
     LoadCompressedSpriteSheet(&sSpriteSheet_PokeballSelect[0]);
     LoadCompressedSpriteSheet(&sSpriteSheet_StarterCircle[0]);
     LoadSpritePalettes(sSpritePalettes_StarterChoose);

--- a/src/text_window.c
+++ b/src/text_window.c
@@ -93,7 +93,7 @@ const struct TilesPal *GetWindowFrameTilesPal(u8 id)
 void LoadMessageBoxGfx(u8 windowId, u16 destOffset, u8 palOffset)
 {
     LoadBgTiles(GetWindowAttribute(windowId, WINDOW_BG), gMessageBox_Gfx, 0x1C0, destOffset);
-    LoadPalette(GetOverworldTextboxPalettePtr(), palOffset, 0x20);
+    LoadPalette(GetOverworldTextboxPalettePtr(), palOffset, PLTT_SIZE_4BPP);
 }
 
 void LoadUserWindowBorderGfx_(u8 windowId, u16 destOffset, u8 palOffset)
@@ -104,7 +104,7 @@ void LoadUserWindowBorderGfx_(u8 windowId, u16 destOffset, u8 palOffset)
 void LoadWindowGfx(u8 windowId, u8 frameId, u16 destOffset, u8 palOffset)
 {
     LoadBgTiles(GetWindowAttribute(windowId, WINDOW_BG), sWindowFrames[frameId].tiles, 0x120, destOffset);
-    LoadPalette(sWindowFrames[frameId].pal, palOffset, 0x20);
+    LoadPalette(sWindowFrames[frameId].pal, palOffset, PLTT_SIZE_4BPP);
 }
 
 void LoadUserWindowBorderGfx(u8 windowId, u16 destOffset, u8 palOffset)
@@ -164,7 +164,7 @@ const u16 *GetTextWindowPalette(u8 id)
     switch (id)
     {
     case 0:
-        id = 0;
+        id = 0x00;
         break;
     case 1:
         id = 0x10;
@@ -193,5 +193,5 @@ const u16 *GetOverworldTextboxPalettePtr(void)
 void LoadUserWindowBorderGfxOnBg(u8 bg, u16 destOffset, u8 palOffset)
 {
     LoadBgTiles(bg, sWindowFrames[gSaveBlock2Ptr->optionsWindowFrameType].tiles, 0x120, destOffset);
-    LoadPalette(GetWindowFrameTilesPal(gSaveBlock2Ptr->optionsWindowFrameType)->pal, palOffset, 0x20);
+    LoadPalette(GetWindowFrameTilesPal(gSaveBlock2Ptr->optionsWindowFrameType)->pal, palOffset, PLTT_SIZE_4BPP);
 }

--- a/src/tileset_anims.c
+++ b/src/tileset_anims.c
@@ -1168,7 +1168,7 @@ static void QueueAnimTiles_BattlePyramid_StatueShadow(u16 timer)
 static void BlendAnimPalette_BattleDome_FloorLights(u16 timer)
 {
     CpuCopy16(sTilesetAnims_BattleDomeFloorLightPals[timer % ARRAY_COUNT(sTilesetAnims_BattleDomeFloorLightPals)], &gPlttBufferUnfaded[0x80], 32);
-    BlendPalette(0x80, 16, gPaletteFade.y, gPaletteFade.blendColor & 0x7FFF);
+    BlendPalette(BG_PLTT_ID(0x8), 16, gPaletteFade.y, gPaletteFade.blendColor & 0x7FFF);
     if ((u8)FindTaskIdByFunc(Task_BattleTransition_Intro) != TASK_NONE)
     {
         sSecondaryTilesetAnimCallback = TilesetAnim_BattleDome2;
@@ -1181,7 +1181,7 @@ static void BlendAnimPalette_BattleDome_FloorLightsNoBlend(u16 timer)
     CpuCopy16(sTilesetAnims_BattleDomeFloorLightPals[timer % ARRAY_COUNT(sTilesetAnims_BattleDomeFloorLightPals)], &gPlttBufferUnfaded[0x80], 32);
     if ((u8)FindTaskIdByFunc(Task_BattleTransition_Intro) == TASK_NONE)
     {
-        BlendPalette(0x80, 16, gPaletteFade.y, gPaletteFade.blendColor & 0x7FFF);
+        BlendPalette(BG_PLTT_ID(0x8), 16, gPaletteFade.y, gPaletteFade.blendColor & 0x7FFF);
         if (!--sSecondaryTilesetAnimCounterMax)
             sSecondaryTilesetAnimCallback = NULL;
     }

--- a/src/title_screen.c
+++ b/src/title_screen.c
@@ -548,7 +548,7 @@ void CB2_InitTitleScreen(void)
         // bg2
         LZ77UnCompVram(gTitleScreenPokemonLogoGfx, (void *)(BG_CHAR_ADDR(0)));
         LZ77UnCompVram(gTitleScreenPokemonLogoTilemap, (void *)(BG_SCREEN_ADDR(9)));
-        LoadPalette(gTitleScreenBgPalettes, 0, 0x1E0);
+        LoadPalette(gTitleScreenBgPalettes, BG_PLTT_ID(0x0), 15 * PLTT_SIZE_4BPP);
         // bg3
         LZ77UnCompVram(sTitleScreenRayquazaGfx, (void *)(BG_CHAR_ADDR(2)));
         LZ77UnCompVram(sTitleScreenRayquazaTilemap, (void *)(BG_SCREEN_ADDR(26)));
@@ -563,7 +563,7 @@ void CB2_InitTitleScreen(void)
         LoadCompressedSpriteSheet(&sSpriteSheet_EmeraldVersion[0]);
         LoadCompressedSpriteSheet(&sSpriteSheet_PressStart[0]);
         LoadCompressedSpriteSheet(&sPokemonLogoShineSpriteSheet[0]);
-        LoadPalette(gTitleScreenEmeraldVersionPal, 0x100, 0x20);
+        LoadPalette(gTitleScreenEmeraldVersionPal, OBJ_PLTT_ID(0x0), PLTT_SIZE_4BPP);
         LoadSpritePalette(&sSpritePalette_PressStart[0]);
         gMain.state = 2;
         break;
@@ -812,6 +812,6 @@ static void UpdateLegendaryMarkingColor(u8 frameNum)
         s32 b = 12;
 
         u16 color = RGB(r, g, b);
-        LoadPalette(&color, 0xEF, sizeof(color));
+        LoadPalette(&color, BG_PLTT_ID(0xE) + 15, sizeof(color));
    }
 }

--- a/src/trade.c
+++ b/src/trade.c
@@ -333,8 +333,8 @@ static void InitTradeMenu(void)
     gPaletteFade.bufferTransferDisabled = TRUE;
 
     SetVBlankCallback(VBlankCB_TradeMenu);
-    LoadPalette(gStandardMenuPalette, 0xF0, 20);
-    LoadPalette(gStandardMenuPalette, 0xD0, 20);
+    LoadPalette(gStandardMenuPalette, BG_PLTT_ID(0xF), PLTT_SIZEOF(10));
+    LoadPalette(gStandardMenuPalette, BG_PLTT_ID(0xD), PLTT_SIZEOF(10));
     ResetBgsAndClearDma3BusyFlags(0);
     InitBgsFromTemplates(0, sTradeMenuBgTemplates, ARRAY_COUNT(sTradeMenuBgTemplates));
     SetBgTilemapBuffer(1, sTradeMenuData->tilemapBuffer);
@@ -351,9 +351,9 @@ static void InitTradeMenu(void)
             FillWindowPixelBuffer(i, PIXEL_FILL(0));
         }
 
-        FillBgTilemapBufferRect(0, 0, 0, 0, 30, 20, 15);
-        LoadUserWindowBorderGfx_(0, 20, 0xC0);
-        LoadUserWindowBorderGfx(2, 1, 0xE0);
+        FillBgTilemapBufferRect(0, 0, 0, 0, 30, 20, 0xF);
+        LoadUserWindowBorderGfx_(0, 20, BG_PLTT_ID(0xC));
+        LoadUserWindowBorderGfx(2, 1, BG_PLTT_ID(0xE));
         LoadMonIconPalettes();
         sTradeMenuData->bufferPartyState = 0;
         sTradeMenuData->tradeMenuFunc = 0;
@@ -910,7 +910,7 @@ static void LoadTradeBgGfx(u8 state)
     switch (state)
     {
     case 0:
-        LoadPalette(gTradeMenu_Pal, 0, 0x60);
+        LoadPalette(gTradeMenu_Pal, BG_PLTT_ID(0x0), 3 * PLTT_SIZE_4BPP);
         LoadBgTiles(1, gTradeMenu_Gfx, 0x1280, 0);
         CopyToBgTilemapBufferRect_ChangePalette(1, gTradeMenu_Tilemap, 0, 0, 32, 20, 0);
         LoadBgTilemap(2, sTradeStripesBG2Tilemap, 0x800, 0);
@@ -1391,7 +1391,7 @@ static void TradeMenuProcessInput(void)
         // Cursor is in player's party
         if (sTradeMenuData->cursorPosition < PARTY_SIZE)
         {
-            DrawTextBorderOuter(1, 1, 14);
+            DrawTextBorderOuter(1, 1, 0xE);
             FillWindowPixelBuffer(1, PIXEL_FILL(1));
             PrintMenuTable(1, ARRAY_COUNT(sSelectTradeMonActions), sSelectTradeMonActions);
             InitMenuInUpperLeftCornerNormal(1, ARRAY_COUNT(sSelectTradeMonActions), 0);
@@ -2153,7 +2153,7 @@ static void PrintTradeMessage(u8 messageId)
 {
     FillWindowPixelBuffer(0, PIXEL_FILL(1));
     AddTextPrinterParameterized(0, FONT_NORMAL, sTradeMessages[messageId], 0, 1, TEXT_SKIP_DRAW, NULL);
-    DrawTextBorderOuter(0, 20, 12);
+    DrawTextBorderOuter(0, 20, 0xC);
     PutWindowTilemap(0);
     CopyWindowToVram(0, COPYWIN_FULL);
 }
@@ -2605,7 +2605,7 @@ static void SpriteCB_LinkMonShadow(struct Sprite *sprite)
         if (++sprite->data[0] == 12)
             sprite->data[0] = 0;
 
-        LoadPalette(&sLinkMonShadow_Pal[sprite->data[0]], (sprite->oam.paletteNum + 16) * 16 + 4, 2);
+        LoadPalette(&sLinkMonShadow_Pal[sprite->data[0]], OBJ_PLTT_ID2(sprite->oam.paletteNum) + 4, PLTT_SIZEOF(1));
     }
 }
 
@@ -2915,12 +2915,12 @@ static void InitTradeBgInternal(void)
     DecompressAndLoadBgGfxUsingHeap(0, gBattleTextboxTiles, 0, 0, 0);
     LZDecompressWram(gBattleTextboxTilemap, gDecompressionBuffer);
     CopyToBgTilemapBuffer(0, gDecompressionBuffer, 0x800, 0);
-    LoadCompressedPalette(gBattleTextboxPalette, 0, 0x20);
+    LoadCompressedPalette(gBattleTextboxPalette, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
     InitWindows(sTradeSequenceWindowTemplates);
     DecompressAndLoadBgGfxUsingHeap(0, gBattleTextboxTiles, 0, 0, 0);
     LZDecompressWram(gBattleTextboxTilemap, gDecompressionBuffer);
     CopyToBgTilemapBuffer(0, gDecompressionBuffer, 0x800, 0);
-    LoadCompressedPalette(gBattleTextboxPalette, 0, 0x20);
+    LoadCompressedPalette(gBattleTextboxPalette, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
 }
 
 static void CB2_InGameTrade(void)
@@ -3100,7 +3100,7 @@ static void SetTradeSequenceBgGpuRegs(u8 state)
                                      BGCNT_16COLOR |
                                      BGCNT_SCREENBASE(18) |
                                      BGCNT_TXT512x256);
-        LoadPalette(gTradeGba2_Pal, 16, 0x60);
+        LoadPalette(gTradeGba2_Pal, BG_PLTT_ID(0x1), 3 * PLTT_SIZE_4BPP);
         DmaCopyLarge16(3, gTradeGba_Gfx, (void *) BG_CHAR_ADDR(1), 0x1420, 0x1000);
         DmaCopy16Defvars(3, gTradePlatform_Tilemap, (void *) BG_SCREEN_ADDR(18), 0x1000);
         break;
@@ -3157,7 +3157,7 @@ static void SetTradeSequenceBgGpuRegs(u8 state)
         }
         break;
     case 3:
-        LoadPalette(sWirelessSignalNone_Pal, 48, 0x20);
+        LoadPalette(sWirelessSignalNone_Pal, BG_PLTT_ID(0x3), PLTT_SIZE_4BPP);
         LZ77UnCompVram(sWirelessSignal_Gfx, (void *) BG_CHAR_ADDR(1));
         LZ77UnCompVram(sWirelessSignal_Tilemap, (void *) BG_SCREEN_ADDR(18));
         sTradeData->bg2vofs = 80;
@@ -3236,7 +3236,7 @@ static void SetTradeSequenceBgGpuRegs(u8 state)
                                      BGCNT_16COLOR |
                                      BGCNT_SCREENBASE(18) |
                                      BGCNT_TXT512x256);
-        LoadPalette(gTradeGba2_Pal, 16, 0x60);
+        LoadPalette(gTradeGba2_Pal, BG_PLTT_ID(0x1), 3 * PLTT_SIZE_4BPP);
         DmaCopyLarge16(3, gTradeGba_Gfx, (void *) BG_CHAR_ADDR(1), 0x1420, 0x1000);
         DmaCopy16Defvars(3, gTradePlatform_Tilemap, (void *) BG_SCREEN_ADDR(18), 0x1000);
         break;
@@ -4849,16 +4849,16 @@ static void Task_AnimateWirelessSignal(u8 taskId)
     if (!signalComingBack)
     {
         if (paletteIdx == 256)
-            LoadPalette(sWirelessSignalNone_Pal, 0x30, 32);
+            LoadPalette(sWirelessSignalNone_Pal, BG_PLTT_ID(0x3), PLTT_SIZE_4BPP);
         else
-            LoadPalette(&sWirelessSignalSend_Pal[paletteIdx], 0x30, 32);
+            LoadPalette(&sWirelessSignalSend_Pal[paletteIdx], BG_PLTT_ID(0x3), PLTT_SIZE_4BPP);
     }
     else
     {
         if (paletteIdx == 256)
-            LoadPalette(sWirelessSignalNone_Pal, 0x30, 32);
+            LoadPalette(sWirelessSignalNone_Pal, BG_PLTT_ID(0x3), PLTT_SIZE_4BPP);
         else
-            LoadPalette(&sWirelessSignalRecv_Pal[paletteIdx], 0x30, 32);
+            LoadPalette(&sWirelessSignalRecv_Pal[paletteIdx], BG_PLTT_ID(0x3), PLTT_SIZE_4BPP);
     }
 
     if (sWirelessSignalTiming[idx][0] == 0 && counter == 0)

--- a/src/trader.c
+++ b/src/trader.c
@@ -66,7 +66,7 @@ void CreateAvailableDecorationsMenu(u8 taskId)
         .tilemapTop = 1,
         .width = 10,
         .height = 10,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1
     };
     s32 windowWidth = GetStringWidth(FONT_NORMAL, gText_Exit, 0);

--- a/src/trainer_card.c
+++ b/src/trainer_card.c
@@ -231,7 +231,7 @@ static const struct WindowTemplate sTrainerCardWindowTemplates[] =
         .tilemapTop = 15,
         .width = 27,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x253,
     },
     {
@@ -240,7 +240,7 @@ static const struct WindowTemplate sTrainerCardWindowTemplates[] =
         .tilemapTop = 1,
         .width = 28,
         .height = 18,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x1,
     },
     {
@@ -249,7 +249,7 @@ static const struct WindowTemplate sTrainerCardWindowTemplates[] =
         .tilemapTop = 5,
         .width = 9,
         .height = 10,
-        .paletteNum = 8,
+        .paletteNum = 0x8,
         .baseBlock = 0x150,
     },
     DUMMY_WIN_TEMPLATE
@@ -1371,7 +1371,7 @@ static void LoadMonIconGfx(void)
         TintPalette_SepiaTone(sData->monIconPal, 96);
         break;
     }
-    LoadPalette(sData->monIconPal, 80, 192);
+    LoadPalette(sData->monIconPal, BG_PLTT_ID(0x5), 6 * PLTT_SIZE_4BPP);
 
     for (i = 0; i < PARTY_SIZE; i++)
     {
@@ -1398,10 +1398,10 @@ static void PrintStickersOnCard(void)
 
 static void LoadStickerGfx(void)
 {
-    LoadPalette(sTrainerCardSticker1_Pal, 176, 32);
-    LoadPalette(sTrainerCardSticker2_Pal, 192, 32);
-    LoadPalette(sTrainerCardSticker3_Pal, 208, 32);
-    LoadPalette(sTrainerCardSticker4_Pal, 224, 32);
+    LoadPalette(sTrainerCardSticker1_Pal, BG_PLTT_ID(0xB), PLTT_SIZE_4BPP);
+    LoadPalette(sTrainerCardSticker2_Pal, BG_PLTT_ID(0xC), PLTT_SIZE_4BPP);
+    LoadPalette(sTrainerCardSticker3_Pal, BG_PLTT_ID(0xD), PLTT_SIZE_4BPP);
+    LoadPalette(sTrainerCardSticker4_Pal, BG_PLTT_ID(0xE), PLTT_SIZE_4BPP);
     LoadBgTiles(3, sData->stickerTiles, 1024, 128);
 }
 
@@ -1424,19 +1424,19 @@ static u8 SetCardBgsAndPals(void)
     case 2:
         if (sData->cardType != CARD_TYPE_FRLG)
         {
-            LoadPalette(sHoennTrainerCardStarPals[sData->trainerCard.stars], 0, 96);
-            LoadPalette(sHoennTrainerCardBadges_Pal, 48, 32);
+            LoadPalette(sHoennTrainerCardStarPals[sData->trainerCard.stars], BG_PLTT_ID(0x0), 3 * PLTT_SIZE_4BPP);
+            LoadPalette(sHoennTrainerCardBadges_Pal, BG_PLTT_ID(0x3), PLTT_SIZE_4BPP);
             if (sData->trainerCard.gender != MALE)
-                LoadPalette(sHoennTrainerCardFemaleBg_Pal, 16, 32);
+                LoadPalette(sHoennTrainerCardFemaleBg_Pal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
         }
         else
         {
-            LoadPalette(sKantoTrainerCardStarPals[sData->trainerCard.stars], 0, 96);
-            LoadPalette(sKantoTrainerCardBadges_Pal, 48, 32);
+            LoadPalette(sKantoTrainerCardStarPals[sData->trainerCard.stars], BG_PLTT_ID(0x0), 3 * PLTT_SIZE_4BPP);
+            LoadPalette(sKantoTrainerCardBadges_Pal, BG_PLTT_ID(0x3), PLTT_SIZE_4BPP);
             if (sData->trainerCard.gender != MALE)
-                LoadPalette(sKantoTrainerCardFemaleBg_Pal, 16, 32);
+                LoadPalette(sKantoTrainerCardFemaleBg_Pal, BG_PLTT_ID(0x1), PLTT_SIZE_4BPP);
         }
-        LoadPalette(sTrainerCardGold_Pal, 64, 32);
+        LoadPalette(sTrainerCardGold_Pal, BG_PLTT_ID(0x4), PLTT_SIZE_4BPP);
         break;
     case 3:
         SetBgTilemapBuffer(0, sData->cardTilemapBuffer);
@@ -1495,9 +1495,9 @@ static void DrawStarsAndBadgesOnCard(void)
 
     s16 i, x;
     u16 tileNum = 192;
-    u8 palNum = 3;
+    u8 palNum = 0x3;
 
-    FillBgTilemapBufferRect(3, 143, 15, yOffsets[sData->isHoenn], sData->trainerCard.stars, 1, 4);
+    FillBgTilemapBufferRect(3, 143, 15, yOffsets[sData->isHoenn], sData->trainerCard.stars, 1, 0x4);
     if (!sData->isLink)
     {
         x = 4;
@@ -1521,38 +1521,38 @@ static void DrawCardBackStats(void)
     {
         if (sData->hasTrades)
         {
-            FillBgTilemapBufferRect(3, 141, 27, 9, 1, 1, 1);
-            FillBgTilemapBufferRect(3, 157, 27, 10, 1, 1, 1);
+            FillBgTilemapBufferRect(3, 141, 27, 9, 1, 1, 0x1);
+            FillBgTilemapBufferRect(3, 157, 27, 10, 1, 1, 0x1);
         }
         if (sData->trainerCard.linkPoints.berryCrush)
         {
-            FillBgTilemapBufferRect(3, 141, 21, 13, 1, 1, 1);
-            FillBgTilemapBufferRect(3, 157, 21, 14, 1, 1, 1);
+            FillBgTilemapBufferRect(3, 141, 21, 13, 1, 1, 0x1);
+            FillBgTilemapBufferRect(3, 157, 21, 14, 1, 1, 0x1);
         }
         if (sData->trainerCard.unionRoomNum)
         {
-            FillBgTilemapBufferRect(3, 141, 27, 11, 1, 1, 1);
-            FillBgTilemapBufferRect(3, 157, 27, 12, 1, 1, 1);
+            FillBgTilemapBufferRect(3, 141, 27, 11, 1, 1, 0x1);
+            FillBgTilemapBufferRect(3, 157, 27, 12, 1, 1, 0x1);
         }
     }
     else
     {
         if (sData->hasTrades)
         {
-            FillBgTilemapBufferRect(3, 141, 27, 9, 1, 1, 0);
-            FillBgTilemapBufferRect(3, 157, 27, 10, 1, 1, 0);
+            FillBgTilemapBufferRect(3, 141, 27, 9, 1, 1, 0x0);
+            FillBgTilemapBufferRect(3, 157, 27, 10, 1, 1, 0x0);
         }
         if (sData->trainerCard.contestsWithFriends)
         {
-            FillBgTilemapBufferRect(3, 141, 27, 13, 1, 1, 0);
-            FillBgTilemapBufferRect(3, 157, 27, 14, 1, 1, 0);
+            FillBgTilemapBufferRect(3, 141, 27, 13, 1, 1, 0x0);
+            FillBgTilemapBufferRect(3, 157, 27, 14, 1, 1, 0x0);
         }
         if (sData->hasBattleTowerWins)
         {
-            FillBgTilemapBufferRect(3, 141, 17, 15, 1, 1, 0);
-            FillBgTilemapBufferRect(3, 157, 17, 16, 1, 1, 0);
-            FillBgTilemapBufferRect(3, 140, 27, 15, 1, 1, 0);
-            FillBgTilemapBufferRect(3, 156, 27, 16, 1, 1, 0);
+            FillBgTilemapBufferRect(3, 141, 17, 15, 1, 1, 0x0);
+            FillBgTilemapBufferRect(3, 157, 17, 16, 1, 1, 0x0);
+            FillBgTilemapBufferRect(3, 140, 27, 15, 1, 1, 0x0);
+            FillBgTilemapBufferRect(3, 156, 27, 16, 1, 1, 0x0);
         }
     }
     CopyBgTilemapBufferToVram(3);

--- a/src/trainer_hill.c
+++ b/src/trainer_hill.c
@@ -951,7 +951,7 @@ static void SetAllTrainerFlags(void)
 void TryLoadTrainerHillEReaderPalette(void)
 {
     if (OnTrainerHillEReaderChallengeFloor() == TRUE)
-        LoadPalette(sEReader_Pal, 0x70, 0x20);
+        LoadPalette(sEReader_Pal, BG_PLTT_ID(0x7), PLTT_SIZE_4BPP);
 }
 
 static void GetGameSaved(void)

--- a/src/trainer_pokemon_sprites.c
+++ b/src/trainer_pokemon_sprites.c
@@ -94,7 +94,7 @@ static void LoadPicPaletteByTagOrSlot(u16 species, u32 otId, u32 personality, u8
         if (paletteTag == TAG_NONE)
         {
             sCreatingSpriteTemplate.paletteTag = TAG_NONE;
-            LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, otId, personality), 0x100 + paletteSlot * 0x10, 0x20);
+            LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, otId, personality), OBJ_PLTT_ID(paletteSlot), PLTT_SIZE_4BPP);
         }
         else
         {
@@ -107,7 +107,7 @@ static void LoadPicPaletteByTagOrSlot(u16 species, u32 otId, u32 personality, u8
         if (paletteTag == TAG_NONE)
         {
             sCreatingSpriteTemplate.paletteTag = TAG_NONE;
-            LoadCompressedPalette(gTrainerFrontPicPaletteTable[species].data, 0x100 + paletteSlot * 0x10, 0x20);
+            LoadCompressedPalette(gTrainerFrontPicPaletteTable[species].data, OBJ_PLTT_ID(paletteSlot), PLTT_SIZE_4BPP);
         }
         else
         {
@@ -120,9 +120,9 @@ static void LoadPicPaletteByTagOrSlot(u16 species, u32 otId, u32 personality, u8
 static void LoadPicPaletteBySlot(u16 species, u32 otId, u32 personality, u8 paletteSlot, bool8 isTrainer)
 {
     if (!isTrainer)
-        LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, otId, personality), paletteSlot * 0x10, 0x20);
+        LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, otId, personality), PLTT_ID(paletteSlot), PLTT_SIZE_4BPP);
     else
-        LoadCompressedPalette(gTrainerFrontPicPaletteTable[species].data, paletteSlot * 0x10, 0x20);
+        LoadCompressedPalette(gTrainerFrontPicPaletteTable[species].data, PLTT_ID(paletteSlot), PLTT_SIZE_4BPP);
 }
 
 static void AssignSpriteAnimsTable(bool8 isTrainer)

--- a/src/union_room.c
+++ b/src/union_room.c
@@ -1910,7 +1910,7 @@ static void Task_SendMysteryGift(u8 taskId)
 
         winTemplate = sWindowTemplate_PlayerList;
         winTemplate.baseBlock = GetMysteryGiftBaseBlock();
-        winTemplate.paletteNum = 12;
+        winTemplate.paletteNum = 0xC;
         data->listWindowId = AddWindow(&winTemplate);
         MG_DrawTextBorder(data->listWindowId);
         gMultiuseListMenuTemplate = sListMenuTemplate_PossibleGroupMembers;
@@ -2114,11 +2114,11 @@ static void Task_CardOrNewsWithFriend(u8 taskId)
 
         listWinTemplate = sWindowTemplate_GroupList;
         listWinTemplate.baseBlock = GetMysteryGiftBaseBlock();
-        listWinTemplate.paletteNum = 12;
+        listWinTemplate.paletteNum = 0xC;
         data->listWindowId = AddWindow(&listWinTemplate);
 
         playerNameWinTemplate = sWindowTemplate_PlayerNameAndId;
-        playerNameWinTemplate.paletteNum = 12;
+        playerNameWinTemplate.paletteNum = 0xC;
         data->playerNameAndIdWindowId = AddWindow(&playerNameWinTemplate);
 
         MG_DrawTextBorder(data->listWindowId);
@@ -2439,7 +2439,7 @@ void RunUnionRoom(void)
     uroom->unreadPlayerId = 0;
 
     gSpecialVar_Result = 0;
-    ListMenuLoadStdPalAt(0xD0, 1);
+    ListMenuLoadStdPalAt(BG_PLTT_ID(0xD), 1);
 }
 
 static u16 ReadAsU16(const u8 *ptr)
@@ -3775,7 +3775,7 @@ static s32 TradeBoardMenuHandler(u8 *state, u8 *mainWindowId, u8 *listMenuId, u8
 
 static void UR_ClearBg0(void)
 {
-    FillBgTilemapBufferRect(0, 0, 0, 0, 32, 32, 0);
+    FillBgTilemapBufferRect(0, 0, 0, 0, 32, 32, 0x0);
     CopyBgTilemapBufferToVram(0);
 }
 

--- a/src/union_room_battle.c
+++ b/src/union_room_battle.c
@@ -130,8 +130,8 @@ void CB2_UnionRoomBattle(void)
         FillWindowPixelBuffer(0, PIXEL_FILL(0));
         FillWindowPixelBuffer(0, PIXEL_FILL(1));
         FillBgTilemapBufferRect(0, 0, 0, 0, 30, 20, 0xF);
-        LoadUserWindowBorderGfx(0, 1, 0xD0);
-        LoadUserWindowBorderGfx_(0, 1, 0xD0);
+        LoadUserWindowBorderGfx(0, 1, BG_PLTT_ID(0xD));
+        LoadUserWindowBorderGfx_(0, 1, BG_PLTT_ID(0xD));
         Menu_LoadStdPal();
         SetVBlankCallback(VBlankCB_UnionRoomBattle);
         gMain.state++;

--- a/src/union_room_chat.c
+++ b/src/union_room_chat.c
@@ -566,7 +566,7 @@ static const struct WindowTemplate sWinTemplates[] = {
         .tilemapTop = 1,
         .width = 21,
         .height = 19,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0001,
     }, {
         .bg = 1,
@@ -574,7 +574,7 @@ static const struct WindowTemplate sWinTemplates[] = {
         .tilemapTop = 18,
         .width = 15,
         .height = 2,
-        .paletteNum = 12,
+        .paletteNum = 0xC,
         .baseBlock = 0x007a,
     }, {
         .bg = 1,
@@ -582,7 +582,7 @@ static const struct WindowTemplate sWinTemplates[] = {
         .tilemapTop = 2,
         .width = 6,
         .height = 15,
-        .paletteNum = 7,
+        .paletteNum = 0x7,
         .baseBlock = 0x0020,
     }, {
         .bg = 0,
@@ -590,7 +590,7 @@ static const struct WindowTemplate sWinTemplates[] = {
         .tilemapTop = 2,
         .width = 7,
         .height = 9,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 0x0013,
     }, DUMMY_WIN_TEMPLATE
 };
@@ -2732,7 +2732,7 @@ static void AddYesNoMenuAt(u8 left, u8 top, u8 initialCursorPos)
     template.tilemapTop = top;
     template.width = 6;
     template.height = 4;
-    template.paletteNum = 14;
+    template.paletteNum = 0xE;
     template.baseBlock = 0x52;
     sDisplay->yesNoMenuWindowId = AddWindow(&template);
     if (sDisplay->yesNoMenuWindowId != WINDOW_NONE)
@@ -2741,7 +2741,7 @@ static void AddYesNoMenuAt(u8 left, u8 top, u8 initialCursorPos)
         PutWindowTilemap(sDisplay->yesNoMenuWindowId);
         AddTextPrinterParameterized(sDisplay->yesNoMenuWindowId, FONT_NORMAL, gText_Yes, 8, 1, TEXT_SKIP_DRAW, NULL);
         AddTextPrinterParameterized(sDisplay->yesNoMenuWindowId, FONT_NORMAL, gText_No, 8, 17, TEXT_SKIP_DRAW, NULL);
-        DrawTextBorderOuter(sDisplay->yesNoMenuWindowId, 1, 13);
+        DrawTextBorderOuter(sDisplay->yesNoMenuWindowId, 1, 0xD);
         InitMenuInUpperLeftCornerNormal(sDisplay->yesNoMenuWindowId, 2, initialCursorPos);
     }
 }
@@ -2779,7 +2779,7 @@ static void AddStdMessageWindow(int msgId, u16 bg0vofs)
     template.tilemapTop = 16;
     template.width = 21;
     template.height = 4;
-    template.paletteNum = 14;
+    template.paletteNum = 0xE;
     template.baseBlock = 0x6A;
     if (sDisplayStdMessages[msgId].useWiderBox)
     {
@@ -3050,8 +3050,8 @@ static void ClearBg0(void)
 
 static void LoadChatWindowBorderGfx(void)
 {
-    LoadPalette(gUnionRoomChat_Window_Pal2, 0x70, 0x20);
-    LoadPalette(gUnionRoomChat_Window_Pal1, 0xC0, 0x20);
+    LoadPalette(gUnionRoomChat_Window_Pal2, BG_PLTT_ID(0x7), PLTT_SIZE_4BPP);
+    LoadPalette(gUnionRoomChat_Window_Pal1, BG_PLTT_ID(0xC), PLTT_SIZE_4BPP);
     DecompressAndCopyTileDataToVram(1, gUnionRoomChat_Border_Gfx, 0, 0, 0);
     CopyToBgTilemapBuffer(1, gUnionRoomChat_Border_Tilemap, 0, 0);
     CopyBgTilemapBufferToVram(1);
@@ -3061,7 +3061,7 @@ static void LoadChatWindowGfx(void)
 {
     u8 *ptr;
 
-    LoadPalette(gUnionRoomChat_Background_Pal, 0, 0x20);
+    LoadPalette(gUnionRoomChat_Background_Pal, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
     ptr = DecompressAndCopyTileDataToVram(2, gUnionRoomChat_Background_Gfx, 0, 0, 0);
     if (ptr)
     {
@@ -3075,13 +3075,13 @@ static void LoadChatWindowGfx(void)
 
 static void LoadChatUnkPalette(void)
 {
-    LoadPalette(sUnk_Palette1, 0x80, sizeof(sUnk_Palette1));
+    LoadPalette(sUnk_Palette1, BG_PLTT_ID(0x8), sizeof(sUnk_Palette1));
     RequestDma3Fill(0, (void *)BG_CHAR_ADDR(1) + 0x20, 0x20, 1);
 }
 
 static void LoadChatMessagesWindow(void)
 {
-    LoadPalette(sUnk_Palette2, 0xF0, sizeof(sUnk_Palette2));
+    LoadPalette(sUnk_Palette2, BG_PLTT_ID(0xF), sizeof(sUnk_Palette2));
     PutWindowTilemap(0);
     FillWindowPixelBuffer(0, PIXEL_FILL(1));
     CopyWindowToVram(0, COPYWIN_FULL);
@@ -3112,9 +3112,9 @@ static void LoadTextEntryWindow(void)
 static void LoadKeyboardSwapWindow(void)
 {
     FillWindowPixelBuffer(3, PIXEL_FILL(1));
-    LoadUserWindowBorderGfx(3, 1, 0xD0);
-    LoadUserWindowBorderGfx_(3, 0xA, 0x20);
-    LoadPalette(gStandardMenuPalette, 0xE0,  0x20);
+    LoadUserWindowBorderGfx(3, 1, BG_PLTT_ID(0xD));
+    LoadUserWindowBorderGfx_(3, 0xA, BG_PLTT_ID(0x2));
+    LoadPalette(gStandardMenuPalette, BG_PLTT_ID(0xE),  PLTT_SIZE_4BPP);
 }
 
 static void InitScanlineEffect(void)
@@ -3197,7 +3197,7 @@ static void SetRegisteredTextPalette(bool32 registering)
 {
     const u16 *palette = &sUnionRoomChatInterfacePal[registering * 2 + 1];
     u8 index = IndexOfSpritePaletteTag(PALTAG_INTERFACE);
-    LoadPalette(palette, index * 16 + 0x101, 4);
+    LoadPalette(palette, OBJ_PLTT_ID(index) + 1, PLTT_SIZEOF(2));
 }
 
 static void StartKeyboardCursorAnim(void)

--- a/src/use_pokeblock.c
+++ b/src/use_pokeblock.c
@@ -251,7 +251,7 @@ static const struct WindowTemplate sWindowTemplates[WIN_COUNT + 1] =
         .tilemapTop = 1,
         .width = 13,
         .height = 4,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 1
     },
     [WIN_NATURE] = {
@@ -260,7 +260,7 @@ static const struct WindowTemplate sWindowTemplates[WIN_COUNT + 1] =
         .tilemapTop = 14,
         .width = 11,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x35
     },
     [WIN_TEXT] = {
@@ -269,7 +269,7 @@ static const struct WindowTemplate sWindowTemplates[WIN_COUNT + 1] =
         .tilemapTop = 17,
         .width = 28,
         .height = 2,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x4B
     },
     DUMMY_WIN_TEMPLATE
@@ -282,7 +282,7 @@ static const struct WindowTemplate sUsePokeblockYesNoWinTemplate =
     .tilemapTop = 11,
     .width = 5,
     .height = 4,
-    .paletteNum = 15,
+    .paletteNum = 0xF,
     .baseBlock = 0x83
 };
 
@@ -505,7 +505,7 @@ static void LoadUsePokeblockMenu(void)
         InitBgsFromTemplates(0, sBgTemplates, ARRAY_COUNT(sBgTemplates));
         InitWindows(sWindowTemplates);
         DeactivateAllTextPrinters();
-        LoadUserWindowBorderGfx(0, 0x97, 0xE0);
+        LoadUserWindowBorderGfx(0, 0x97, BG_PLTT_ID(0xE));
         sInfo->mainState++;
         break;
     case 4:
@@ -1233,13 +1233,13 @@ static void UpdateMonPic(u8 loadId)
             gSprites[sMenu->curMonSpriteId].callback = SpriteCB_MonPic;
             gSprites[sMenu->curMonSpriteId].y2 -= 34;
             sMenu->curMonTileStart = (void *)(OBJ_VRAM0 + (sMenu->curMonSheet * 32));
-            sMenu->curMonPalette = (sMenu->curMonPalette * 16) + 0x100;
+            sMenu->curMonPalette = OBJ_PLTT_ID(sMenu->curMonPalette);
         }
     }
     else
     {
         Dma3CopyLarge16_(sMenu->partySheets[loadId], sMenu->curMonTileStart, MON_PIC_SIZE);
-        LoadPalette(sMenu->partyPalettes[loadId], sMenu->curMonPalette, 32);
+        LoadPalette(sMenu->partyPalettes[loadId], sMenu->curMonPalette, PLTT_SIZE_4BPP);
     }
 }
 
@@ -1340,7 +1340,7 @@ static bool8 LoadUsePokeblockMenuGfx(void)
          LoadBgTilemap(3, sMonFrame_TilemapPtr, 1280, 0);
         break;
     case 5:
-        LoadPalette(sMonFrame_Pal, 208, 32);
+        LoadPalette(sMonFrame_Pal, BG_PLTT_ID(0xD), PLTT_SIZE_4BPP);
         sMenu->curMonXOffset = -80;
         break;
     case 6:
@@ -1348,7 +1348,7 @@ static bool8 LoadUsePokeblockMenuGfx(void)
         break;
     case 7:
         LZ77UnCompVram(gUsePokeblockGraph_Tilemap, sGraph_Tilemap);
-        LoadPalette(gUsePokeblockGraph_Pal, 32, 32);
+        LoadPalette(gUsePokeblockGraph_Pal, BG_PLTT_ID(0x2), PLTT_SIZE_4BPP);
         break;
     case 8:
         LoadBgTiles(1, sGraph_Gfx, 6656, 160 << 2);
@@ -1363,8 +1363,8 @@ static bool8 LoadUsePokeblockMenuGfx(void)
         break;
     case 11:
         LoadBgTilemap(2, sMenu->tilemapBuffer, 1280, 0);
-        LoadPalette(gConditionGraphData_Pal, 48, 32);
-        LoadPalette(gConditionText_Pal, 240, 32);
+        LoadPalette(gConditionGraphData_Pal, BG_PLTT_ID(0x3), PLTT_SIZE_4BPP);
+        LoadPalette(gConditionText_Pal, BG_PLTT_ID(0xF), PLTT_SIZE_4BPP);
         ConditionGraph_InitWindow(2);
         break;
     default:

--- a/src/wallclock.c
+++ b/src/wallclock.c
@@ -79,7 +79,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 17,
         .width = 24,
         .height = 2,
-        .paletteNum = 14,
+        .paletteNum = 0xE,
         .baseBlock = 512
     },
     {
@@ -88,7 +88,7 @@ static const struct WindowTemplate sWindowTemplates[] =
         .tilemapTop = 16,
         .width = 6,
         .height = 2,
-        .paletteNum = 12,
+        .paletteNum = 0xC,
         .baseBlock = 560
     },
     DUMMY_WIN_TEMPLATE
@@ -101,7 +101,7 @@ static const struct WindowTemplate sWindowTemplate_ConfirmYesNo =
     .tilemapTop = 9,
     .width = 5,
     .height = 4,
-    .paletteNum = 14,
+    .paletteNum = 0xE,
     .baseBlock = 572
 };
 
@@ -644,17 +644,17 @@ static void LoadWallClockGraphics(void)
     LZ77UnCompVram(gWallClock_Gfx, (void *)VRAM);
 
     if (gSpecialVar_0x8004 == MALE)
-        LoadPalette(gWallClockMale_Pal, 0, 32);
+        LoadPalette(gWallClockMale_Pal, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
     else
-        LoadPalette(gWallClockFemale_Pal, 0, 32);
+        LoadPalette(gWallClockFemale_Pal, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
 
-    LoadPalette(GetOverworldTextboxPalettePtr(), 0xe0, 32);
-    LoadPalette(sTextPrompt_Pal, 0xc0, 8);
+    LoadPalette(GetOverworldTextboxPalettePtr(), BG_PLTT_ID(0xE), PLTT_SIZE_4BPP);
+    LoadPalette(sTextPrompt_Pal, BG_PLTT_ID(0xC), PLTT_SIZEOF(4));
     ResetBgsAndClearDma3BusyFlags(0);
     InitBgsFromTemplates(0, sBgTemplates, ARRAY_COUNT(sBgTemplates));
     InitWindows(sWindowTemplates);
     DeactivateAllTextPrinters();
-    LoadUserWindowBorderGfx(0, 0x250, 0xd0);
+    LoadUserWindowBorderGfx(0, 0x250, BG_PLTT_ID(0xD));
     ClearScheduledBgCopiesToVram();
     ScanlineEffect_Stop();
     ResetTasks();

--- a/src/wireless_communication_status_screen.c
+++ b/src/wireless_communication_status_screen.c
@@ -76,7 +76,7 @@ static const struct WindowTemplate sWindowTemplates[] = {
         .tilemapTop = 0,
         .width = 24,
         .height = 3,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0001
     }, {
         .bg = 0,
@@ -84,7 +84,7 @@ static const struct WindowTemplate sWindowTemplates[] = {
         .tilemapTop = 4,
         .width = 21,
         .height = 15,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0049
     }, {
         .bg = 0,
@@ -92,7 +92,7 @@ static const struct WindowTemplate sWindowTemplates[] = {
         .tilemapTop = 4,
         .width = 3,
         .height = 15,
-        .paletteNum = 15,
+        .paletteNum = 0xF,
         .baseBlock = 0x0184
     }, DUMMY_WIN_TEMPLATE
 };
@@ -193,10 +193,10 @@ static void CB2_InitWirelessCommunicationScreen(void)
     ChangeBgY(0, 0, BG_COORD_SET);
     ChangeBgX(1, 0, BG_COORD_SET);
     ChangeBgY(1, 0, BG_COORD_SET);
-    LoadPalette(sBgTiles_Pal, 0x00, 0x20);
+    LoadPalette(sBgTiles_Pal, BG_PLTT_ID(0x0), PLTT_SIZE_4BPP);
     Menu_LoadStdPalAt(0xF0);
     DynamicPlaceholderTextUtil_Reset();
-    FillBgTilemapBufferRect(0, 0, 0, 0, 32, 32, 0x0F);
+    FillBgTilemapBufferRect(0, 0, 0, 0, 32, 32, 0xF);
     CopyBgTilemapBufferToVram(1);
     SetMainCallback2(CB2_RunWirelessCommunicationScreen);
     RunTasks();
@@ -227,7 +227,7 @@ static void WCSS_CyclePalette(s16 * counter, s16 * palIdx)
 
         *counter = 0;
     }
-    LoadPalette(sBgTiles_Pal + 16 * (*palIdx + 2), 0, 0x10);
+    LoadPalette(sBgTiles_Pal + 16 * (*palIdx + 2), BG_PLTT_ID(0x0), PLTT_SIZEOF(8));
 }
 
 static void PrintHeaderTexts(void)


### PR DESCRIPTION
Hopefully these changes make it easier to understand what the UI code is doing at a glance. It's largely in preparation for the idea of compile-time checking for the base blocks and palette numbers.
When referencing inside a a palette I think of it as being an ID plus an offset, e.g. `0xF0 + 3` which is represented as `BG_PLLT_ID(0xF) + 3`.

1. Write palette IDs in hex.
2. Introduce a `PLTT_SIZE_4BPP` constant loads of multiples of 16 colors, and `PLTT_SIZEOF(n)` for other sizes of loads.
3. Introduce `BG_PLLT_ID` to turn, e.g. `0xF` into `0x0F0`, and `OBJ_PLTT_ID` to turn, e.g. `0xF` into `0x1F0`. There is also `OBJ_PLTT_ID2` for matching reasons.

TODO:
1. Write oam `paletteNum`s in hex. And identify which ones should be omitted because the sprite uses a palette tag.
2. Give names to the various palette IDs, ala `BLG_WINDOW_PALETTE_NUM`.
3. Create a constant for `16`/`0x10` when steping through palettes (e.g. in `src/palette.c`), and for passing to things like `BlendPalette`.
4. Write all base blocks in hex.
5. Write explicit sizes on the various palettes in `include/graphics.h` so that we can use `sizeof` where possible.