### PR TITLE
Rename special map constants, treat warp ids as strings

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -469,7 +469,7 @@
 	formatwarp \map, \a, \b, \c
 	.endm
 
-	@ Sets the dynamic warp destination. Warps with a destination map of MAP_NONE will target this destination.
+	@ Sets the dynamic warp destination. Warps with a destination map of MAP_DYNAMIC will target this destination.
 	@ Warp commands can be given either the id of which warp location to go to on the destination map
 	@ or a pair of x/y coordinates to go to directly on the destination map.
 	.macro setdynamicwarp map:req, a, b, c

--- a/data/maps/AbandonedShip_CaptainsOffice/map.json
+++ b/data/maps/AbandonedShip_CaptainsOffice/map.json
@@ -47,14 +47,14 @@
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_DECK",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 8,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_DECK",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/AbandonedShip_Corridors_1F/map.json
+++ b/data/maps/AbandonedShip_Corridors_1F/map.json
@@ -47,84 +47,84 @@
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_DECK",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 8,
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_DECK",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 0,
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_DECK",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 1,
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_DECK",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 11,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_ROOMS_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 14,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_ROOMS_1F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 11,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_ROOMS_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 14,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_ROOMS_1F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 3,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_ROOMS2_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 16,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_B1F",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 5,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_B1F",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 3,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_ROOMS2_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/AbandonedShip_Corridors_B1F/map.json
+++ b/data/maps/AbandonedShip_Corridors_B1F/map.json
@@ -47,56 +47,56 @@
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_ROOMS2_B1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 3,
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_ROOMS2_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 5,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_ROOMS_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 8,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_ROOMS_B1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 11,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_ROOMS_B1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 11,
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_ROOM_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 0,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_1F",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     },
     {
       "x": 8,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_1F",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     }
   ],
   "coord_events": [],

--- a/data/maps/AbandonedShip_Deck/map.json
+++ b/data/maps/AbandonedShip_Deck/map.json
@@ -20,35 +20,35 @@
       "y": 15,
       "elevation": 3,
       "dest_map": "MAP_ROUTE108",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 14,
       "y": 15,
       "elevation": 3,
       "dest_map": "MAP_ROUTE108",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 13,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 8,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 12,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CAPTAINS_OFFICE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/AbandonedShip_HiddenFloorCorridors/map.json
+++ b/data/maps/AbandonedShip_HiddenFloorCorridors/map.json
@@ -20,42 +20,42 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_ROOMS",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_ROOMS",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 9,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_ROOMS",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 3,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_ROOMS",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 6,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_ROOMS",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 9,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_ROOMS",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     }
   ],
   "coord_events": [],

--- a/data/maps/AbandonedShip_HiddenFloorRooms/map.json
+++ b/data/maps/AbandonedShip_HiddenFloorRooms/map.json
@@ -73,63 +73,63 @@
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_CORRIDORS",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 7,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_CORRIDORS",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 21,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_CORRIDORS",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 22,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_CORRIDORS",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 36,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_CORRIDORS",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 37,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_CORRIDORS",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 6,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_CORRIDORS",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 21,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_CORRIDORS",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 36,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_HIDDEN_FLOOR_CORRIDORS",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/AbandonedShip_Room_B1F/map.json
+++ b/data/maps/AbandonedShip_Room_B1F/map.json
@@ -34,14 +34,14 @@
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_B1F",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 5,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_B1F",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/AbandonedShip_Rooms2_1F/map.json
+++ b/data/maps/AbandonedShip_Rooms2_1F/map.json
@@ -86,21 +86,21 @@
       "y": 16,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_1F",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 5,
       "y": 16,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_1F",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 4,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_1F",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     }
   ],
   "coord_events": [],

--- a/data/maps/AbandonedShip_Rooms2_B1F/map.json
+++ b/data/maps/AbandonedShip_Rooms2_B1F/map.json
@@ -47,28 +47,28 @@
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_B1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_B1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 13,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 14,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/AbandonedShip_Rooms_1F/map.json
+++ b/data/maps/AbandonedShip_Rooms_1F/map.json
@@ -73,42 +73,42 @@
       "y": 16,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_1F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 5,
       "y": 16,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_1F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 4,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_1F",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 13,
       "y": 16,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_1F",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 13,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_1F",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 14,
       "y": 16,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_1F",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/AbandonedShip_Rooms_B1F/map.json
+++ b/data/maps/AbandonedShip_Rooms_B1F/map.json
@@ -47,21 +47,21 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_B1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 13,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_B1F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 22,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_CORRIDORS_B1F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/AbandonedShip_Underwater1/map.json
+++ b/data/maps/AbandonedShip_Underwater1/map.json
@@ -20,14 +20,14 @@
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_UNDERWATER2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_UNDERWATER2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/AbandonedShip_Underwater2/map.json
+++ b/data/maps/AbandonedShip_Underwater2/map.json
@@ -20,7 +20,7 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_UNDERWATER1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/AlteringCave/map.json
+++ b/data/maps/AlteringCave/map.json
@@ -20,7 +20,7 @@
       "y": 22,
       "elevation": 0,
       "dest_map": "MAP_ROUTE103",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/AncientTomb/map.json
+++ b/data/maps/AncientTomb/map.json
@@ -34,21 +34,21 @@
       "y": 29,
       "elevation": 3,
       "dest_map": "MAP_ROUTE120",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 8,
       "y": 20,
       "elevation": 0,
       "dest_map": "MAP_ANCIENT_TOMB",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 8,
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_ANCIENT_TOMB",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/AquaHideout_1F/map.json
+++ b/data/maps/AquaHideout_1F/map.json
@@ -60,21 +60,21 @@
       "y": 27,
       "elevation": 1,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 14,
       "y": 27,
       "elevation": 1,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 22,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/AquaHideout_B1F/map.json
+++ b/data/maps/AquaHideout_B1F/map.json
@@ -138,175 +138,175 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 18,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 12,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B2F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 3,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B2F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 31,
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 27,
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 20,
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     },
     {
       "x": 27,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 3,
       "y": 15,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 3,
       "y": 20,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 12
+      "dest_warp_id": "12"
     },
     {
       "x": 32,
       "y": 19,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 23,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 22
+      "dest_warp_id": "22"
     },
     {
       "x": 45,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     },
     {
       "x": 42,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 18
+      "dest_warp_id": "18"
     },
     {
       "x": 45,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 12
+      "dest_warp_id": "12"
     },
     {
       "x": 48,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 16
+      "dest_warp_id": "16"
     },
     {
       "x": 42,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 15
+      "dest_warp_id": "15"
     },
     {
       "x": 45,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 20
+      "dest_warp_id": "20"
     },
     {
       "x": 48,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 13
+      "dest_warp_id": "13"
     },
     {
       "x": 42,
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 24
+      "dest_warp_id": "24"
     },
     {
       "x": 45,
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 17
+      "dest_warp_id": "17"
     },
     {
       "x": 48,
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 12
+      "dest_warp_id": "12"
     },
     {
       "x": 42,
       "y": 17,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     },
     {
       "x": 45,
       "y": 17,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 17
+      "dest_warp_id": "17"
     },
     {
       "x": 48,
       "y": 17,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 19
+      "dest_warp_id": "19"
     }
   ],
   "coord_events": [],

--- a/data/maps/AquaHideout_B2F/map.json
+++ b/data/maps/AquaHideout_B2F/map.json
@@ -99,70 +99,70 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 12,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 3,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 31,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B2F",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 8,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B2F",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 5,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B2F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 18,
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B2F",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 12,
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B2F",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 31,
       "y": 17,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B2F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 32,
       "y": 20,
       "elevation": 3,
       "dest_map": "MAP_AQUA_HIDEOUT_B1F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [

--- a/data/maps/ArtisanCave_1F/map.json
+++ b/data/maps/ArtisanCave_1F/map.json
@@ -34,14 +34,14 @@
       "y": 17,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 13
+      "dest_warp_id": "13"
     },
     {
       "x": 6,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ARTISAN_CAVE_B1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/ArtisanCave_B1F/map.json
+++ b/data/maps/ArtisanCave_B1F/map.json
@@ -34,14 +34,14 @@
       "y": 48,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     },
     {
       "x": 38,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ARTISAN_CAVE_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleColosseum_2P/map.json
+++ b/data/maps/BattleColosseum_2P/map.json
@@ -34,14 +34,14 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     },
     {
       "x": 7,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     }
   ],
   "coord_events": [

--- a/data/maps/BattleColosseum_2P/map.json
+++ b/data/maps/BattleColosseum_2P/map.json
@@ -33,14 +33,14 @@
       "x": 6,
       "y": 8,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     },
     {
       "x": 7,
       "y": 8,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     }
   ],

--- a/data/maps/BattleColosseum_4P/map.json
+++ b/data/maps/BattleColosseum_4P/map.json
@@ -19,28 +19,28 @@
       "x": 5,
       "y": 8,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     },
     {
       "x": 7,
       "y": 8,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     },
     {
       "x": 8,
       "y": 8,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     }
   ],

--- a/data/maps/BattleColosseum_4P/map.json
+++ b/data/maps/BattleColosseum_4P/map.json
@@ -20,28 +20,28 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     },
     {
       "x": 7,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     },
     {
       "x": 8,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     }
   ],
   "coord_events": [

--- a/data/maps/BattleFrontier_BattleArenaLobby/map.json
+++ b/data/maps/BattleFrontier_BattleArenaLobby/map.json
@@ -86,7 +86,7 @@
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_BattleDomeCorridor/map.json
+++ b/data/maps/BattleFrontier_BattleDomeCorridor/map.json
@@ -34,14 +34,14 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 7,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_BattleDomeLobby/map.json
+++ b/data/maps/BattleFrontier_BattleDomeLobby/map.json
@@ -99,14 +99,14 @@
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 12,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_BattleDomePreBattleRoom/map.json
+++ b/data/maps/BattleFrontier_BattleDomePreBattleRoom/map.json
@@ -34,14 +34,14 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 7,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_BattleFactoryLobby/map.json
+++ b/data/maps/BattleFrontier_BattleFactoryLobby/map.json
@@ -99,14 +99,14 @@
       "y": 11,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 10,
       "y": 11,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_BattlePalaceBattleRoom/map.json
+++ b/data/maps/BattleFrontier_BattlePalaceBattleRoom/map.json
@@ -86,14 +86,14 @@
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_PALACE_CORRIDOR",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_PALACE_CORRIDOR",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_BattlePalaceCorridor/map.json
+++ b/data/maps/BattleFrontier_BattlePalaceCorridor/map.json
@@ -112,28 +112,28 @@
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_PALACE_LOBBY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 9,
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_PALACE_LOBBY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 6,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_PALACE_BATTLE_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_PALACE_BATTLE_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_BattlePalaceLobby/map.json
+++ b/data/maps/BattleFrontier_BattlePalaceLobby/map.json
@@ -99,21 +99,21 @@
       "y": 11,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 13,
       "y": 11,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_PALACE_CORRIDOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_BattlePikeLobby/map.json
+++ b/data/maps/BattleFrontier_BattlePikeLobby/map.json
@@ -73,21 +73,21 @@
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_BattlePyramidLobby/map.json
+++ b/data/maps/BattleFrontier_BattlePyramidLobby/map.json
@@ -73,7 +73,7 @@
       "y": 17,
       "elevation": 4,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_BattleTowerBattleRoom/map.json
+++ b/data/maps/BattleFrontier_BattleTowerBattleRoom/map.json
@@ -60,14 +60,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_TOWER_LOBBY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_TOWER_LOBBY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_BattleTowerLobby/map.json
+++ b/data/maps/BattleFrontier_BattleTowerLobby/map.json
@@ -138,21 +138,21 @@
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 13,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_TOWER_BATTLE_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_ExchangeServiceCorner/map.json
+++ b/data/maps/BattleFrontier_ExchangeServiceCorner/map.json
@@ -138,21 +138,21 @@
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 6,
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 8,
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_Lounge1/map.json
+++ b/data/maps/BattleFrontier_Lounge1/map.json
@@ -60,7 +60,7 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_Lounge2/map.json
+++ b/data/maps/BattleFrontier_Lounge2/map.json
@@ -86,14 +86,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 2,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_Lounge3/map.json
+++ b/data/maps/BattleFrontier_Lounge3/map.json
@@ -86,7 +86,7 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_Lounge4/map.json
+++ b/data/maps/BattleFrontier_Lounge4/map.json
@@ -60,7 +60,7 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_Lounge5/map.json
+++ b/data/maps/BattleFrontier_Lounge5/map.json
@@ -73,14 +73,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 2,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_Lounge6/map.json
+++ b/data/maps/BattleFrontier_Lounge6/map.json
@@ -34,7 +34,7 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_Lounge7/map.json
+++ b/data/maps/BattleFrontier_Lounge7/map.json
@@ -73,7 +73,7 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_Lounge8/map.json
+++ b/data/maps/BattleFrontier_Lounge8/map.json
@@ -60,7 +60,7 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_Lounge9/map.json
+++ b/data/maps/BattleFrontier_Lounge9/map.json
@@ -34,14 +34,14 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     },
     {
       "x": 2,
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_Mart/map.json
+++ b/data/maps/BattleFrontier_Mart/map.json
@@ -73,14 +73,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_OutsideEast/map.json
+++ b/data/maps/BattleFrontier_OutsideEast/map.json
@@ -365,98 +365,98 @@
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_TOWER_LOBBY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 39,
       "y": 29,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_ARENA_LOBBY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 45,
       "y": 56,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_PALACE_LOBBY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 58,
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_PYRAMID_LOBBY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 35,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_RANKING_HALL",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 44,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_LOUNGE1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 28,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_EXCHANGE_SERVICE_CORNER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 22,
       "y": 51,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_LOUNGE5",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 5,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_LOUNGE6",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 65,
       "y": 31,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_LOUNGE3",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 14,
       "y": 51,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_LOUNGE8",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 21,
       "y": 45,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_LOUNGE9",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 3,
       "y": 51,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 28,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_ARTISAN_CAVE_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_OutsideWest/map.json
+++ b/data/maps/BattleFrontier_OutsideWest/map.json
@@ -339,77 +339,77 @@
       "y": 27,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_PIKE_LOBBY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 19,
       "y": 17,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_DOME_LOBBY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 11,
       "y": 38,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_BATTLE_FACTORY_LOBBY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 45,
       "y": 44,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_LOUNGE2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 51,
       "y": 51,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_MART",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 44,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_SCOTTS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 53,
       "y": 44,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_LOUNGE4",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 5,
       "y": 20,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_LOUNGE7",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 26,
       "y": 65,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_RECEPTION_GATE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 26,
       "y": 61,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_RECEPTION_GATE",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 39,
       "y": 55,
       "elevation": 0,
       "dest_map": "MAP_ARTISAN_CAVE_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_PokemonCenter_1F/map.json
+++ b/data/maps/BattleFrontier_PokemonCenter_1F/map.json
@@ -86,21 +86,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 12
+      "dest_warp_id": "12"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 12
+      "dest_warp_id": "12"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_BATTLE_FRONTIER_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_PokemonCenter_2F/map.json
+++ b/data/maps/BattleFrontier_PokemonCenter_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_BATTLE_FRONTIER_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_RankingHall/map.json
+++ b/data/maps/BattleFrontier_RankingHall/map.json
@@ -60,14 +60,14 @@
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 27,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_EAST",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_ReceptionGate/map.json
+++ b/data/maps/BattleFrontier_ReceptionGate/map.json
@@ -86,14 +86,14 @@
       "y": 13,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 4,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     }
   ],
   "coord_events": [],

--- a/data/maps/BattleFrontier_ScottsHouse/map.json
+++ b/data/maps/BattleFrontier_ScottsHouse/map.json
@@ -34,14 +34,14 @@
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 3,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_BATTLE_FRONTIER_OUTSIDE_WEST",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/BirthIsland_Exterior/map.json
+++ b/data/maps/BirthIsland_Exterior/map.json
@@ -47,7 +47,7 @@
       "y": 24,
       "elevation": 0,
       "dest_map": "MAP_BIRTH_ISLAND_HARBOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/BirthIsland_Harbor/map.json
+++ b/data/maps/BirthIsland_Harbor/map.json
@@ -47,7 +47,7 @@
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_BIRTH_ISLAND_EXTERIOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/CaveOfOrigin_1F/map.json
+++ b/data/maps/CaveOfOrigin_1F/map.json
@@ -20,14 +20,14 @@
       "y": 17,
       "elevation": 3,
       "dest_map": "MAP_CAVE_OF_ORIGIN_ENTRANCE",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 14,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_CAVE_OF_ORIGIN_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/CaveOfOrigin_B1F/map.json
+++ b/data/maps/CaveOfOrigin_B1F/map.json
@@ -34,7 +34,7 @@
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_CAVE_OF_ORIGIN_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/CaveOfOrigin_Entrance/map.json
+++ b/data/maps/CaveOfOrigin_Entrance/map.json
@@ -20,14 +20,14 @@
       "y": 20,
       "elevation": 3,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 9,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_CAVE_OF_ORIGIN_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/CaveOfOrigin_UnusedRubySapphireMap1/map.json
+++ b/data/maps/CaveOfOrigin_UnusedRubySapphireMap1/map.json
@@ -20,14 +20,14 @@
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_CAVE_OF_ORIGIN_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_CAVE_OF_ORIGIN_UNUSED_RUBY_SAPPHIRE_MAP2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/CaveOfOrigin_UnusedRubySapphireMap2/map.json
+++ b/data/maps/CaveOfOrigin_UnusedRubySapphireMap2/map.json
@@ -20,14 +20,14 @@
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_CAVE_OF_ORIGIN_UNUSED_RUBY_SAPPHIRE_MAP1",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 8,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_CAVE_OF_ORIGIN_UNUSED_RUBY_SAPPHIRE_MAP3",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/CaveOfOrigin_UnusedRubySapphireMap3/map.json
+++ b/data/maps/CaveOfOrigin_UnusedRubySapphireMap3/map.json
@@ -20,14 +20,14 @@
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_CAVE_OF_ORIGIN_UNUSED_RUBY_SAPPHIRE_MAP2",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 12,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_CAVE_OF_ORIGIN_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/DesertRuins/map.json
+++ b/data/maps/DesertRuins/map.json
@@ -34,21 +34,21 @@
       "y": 29,
       "elevation": 3,
       "dest_map": "MAP_ROUTE111",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 8,
       "y": 20,
       "elevation": 0,
       "dest_map": "MAP_DESERT_RUINS",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 8,
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_DESERT_RUINS",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/DesertUnderpass/map.json
+++ b/data/maps/DesertUnderpass/map.json
@@ -34,7 +34,7 @@
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_ROUTE114_FOSSIL_MANIACS_TUNNEL",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/DewfordTown/map.json
+++ b/data/maps/DewfordTown/map.json
@@ -97,35 +97,35 @@
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_DEWFORD_TOWN_HALL",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 2,
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_DEWFORD_TOWN_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 8,
       "y": 17,
       "elevation": 0,
       "dest_map": "MAP_DEWFORD_TOWN_GYM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 17,
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_DEWFORD_TOWN_HOUSE1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 8,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_DEWFORD_TOWN_HOUSE2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/DewfordTown_Gym/map.json
+++ b/data/maps/DewfordTown_Gym/map.json
@@ -125,14 +125,14 @@
       "y": 27,
       "elevation": 0,
       "dest_map": "MAP_DEWFORD_TOWN",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 6,
       "y": 27,
       "elevation": 0,
       "dest_map": "MAP_DEWFORD_TOWN",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/DewfordTown_Hall/map.json
+++ b/data/maps/DewfordTown_Hall/map.json
@@ -138,14 +138,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_DEWFORD_TOWN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_DEWFORD_TOWN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/DewfordTown_House1/map.json
+++ b/data/maps/DewfordTown_House1/map.json
@@ -60,14 +60,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_DEWFORD_TOWN",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_DEWFORD_TOWN",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/DewfordTown_House2/map.json
+++ b/data/maps/DewfordTown_House2/map.json
@@ -47,14 +47,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_DEWFORD_TOWN",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 4,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_DEWFORD_TOWN",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/DewfordTown_PokemonCenter_1F/map.json
+++ b/data/maps/DewfordTown_PokemonCenter_1F/map.json
@@ -60,21 +60,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_DEWFORD_TOWN",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_DEWFORD_TOWN",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_DEWFORD_TOWN_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/DewfordTown_PokemonCenter_2F/map.json
+++ b/data/maps/DewfordTown_PokemonCenter_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_DEWFORD_TOWN_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity/map.json
+++ b/data/maps/EverGrandeCity/map.json
@@ -26,28 +26,28 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_EVER_GRANDE_CITY_POKEMON_LEAGUE_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 27,
       "y": 48,
       "elevation": 0,
       "dest_map": "MAP_EVER_GRANDE_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 18,
       "y": 41,
       "elevation": 0,
       "dest_map": "MAP_VICTORY_ROAD_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 18,
       "y": 27,
       "elevation": 0,
       "dest_map": "MAP_VICTORY_ROAD_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [

--- a/data/maps/EverGrandeCity_ChampionsRoom/map.json
+++ b/data/maps/EverGrandeCity_ChampionsRoom/map.json
@@ -60,14 +60,14 @@
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_HALL4",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 6,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_EVER_GRANDE_CITY_HALL_OF_FAME",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity_DrakesRoom/map.json
+++ b/data/maps/EverGrandeCity_DrakesRoom/map.json
@@ -34,14 +34,14 @@
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_HALL3",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 6,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_EVER_GRANDE_CITY_HALL4",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity_GlaciasRoom/map.json
+++ b/data/maps/EverGrandeCity_GlaciasRoom/map.json
@@ -34,14 +34,14 @@
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_HALL2",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 6,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_EVER_GRANDE_CITY_HALL3",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity_Hall1/map.json
+++ b/data/maps/EverGrandeCity_Hall1/map.json
@@ -20,28 +20,28 @@
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_SIDNEYS_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_EVER_GRANDE_CITY_PHOEBES_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_SIDNEYS_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 6,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_SIDNEYS_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity_Hall2/map.json
+++ b/data/maps/EverGrandeCity_Hall2/map.json
@@ -20,28 +20,28 @@
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_PHOEBES_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_EVER_GRANDE_CITY_GLACIAS_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_PHOEBES_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 6,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_PHOEBES_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity_Hall3/map.json
+++ b/data/maps/EverGrandeCity_Hall3/map.json
@@ -20,28 +20,28 @@
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_GLACIAS_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_EVER_GRANDE_CITY_DRAKES_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_GLACIAS_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 6,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_GLACIAS_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity_Hall4/map.json
+++ b/data/maps/EverGrandeCity_Hall4/map.json
@@ -20,14 +20,14 @@
       "y": 33,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_DRAKES_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_EVER_GRANDE_CITY_CHAMPIONS_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity_Hall5/map.json
+++ b/data/maps/EverGrandeCity_Hall5/map.json
@@ -20,28 +20,28 @@
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_POKEMON_LEAGUE_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_EVER_GRANDE_CITY_SIDNEYS_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_POKEMON_LEAGUE_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 6,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_POKEMON_LEAGUE_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity_HallOfFame/map.json
+++ b/data/maps/EverGrandeCity_HallOfFame/map.json
@@ -34,7 +34,7 @@
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_CHAMPIONS_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity_PhoebesRoom/map.json
+++ b/data/maps/EverGrandeCity_PhoebesRoom/map.json
@@ -34,14 +34,14 @@
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_HALL1",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 6,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_EVER_GRANDE_CITY_HALL2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity_PokemonCenter_1F/map.json
+++ b/data/maps/EverGrandeCity_PokemonCenter_1F/map.json
@@ -73,21 +73,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_EVER_GRANDE_CITY_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity_PokemonCenter_2F/map.json
+++ b/data/maps/EverGrandeCity_PokemonCenter_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_EVER_GRANDE_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity_PokemonLeague_1F/map.json
+++ b/data/maps/EverGrandeCity_PokemonLeague_1F/map.json
@@ -73,35 +73,35 @@
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_HALL5",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_HALL5",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 1,
       "y": 7,
       "elevation": 4,
       "dest_map": "MAP_EVER_GRANDE_CITY_POKEMON_LEAGUE_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity_PokemonLeague_2F/map.json
+++ b/data/maps/EverGrandeCity_PokemonLeague_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_EVER_GRANDE_CITY_POKEMON_LEAGUE_1F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/EverGrandeCity_SidneysRoom/map.json
+++ b/data/maps/EverGrandeCity_SidneysRoom/map.json
@@ -34,14 +34,14 @@
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY_HALL5",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 6,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_EVER_GRANDE_CITY_HALL1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/FallarborTown/map.json
+++ b/data/maps/FallarborTown/map.json
@@ -84,35 +84,35 @@
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_FALLARBOR_TOWN_MART",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 8,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_FALLARBOR_TOWN_BATTLE_TENT_LOBBY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 14,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_FALLARBOR_TOWN_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 17,
       "elevation": 0,
       "dest_map": "MAP_FALLARBOR_TOWN_COZMOS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_FALLARBOR_TOWN_MOVE_RELEARNERS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/FallarborTown_BattleTentLobby/map.json
+++ b/data/maps/FallarborTown_BattleTentLobby/map.json
@@ -86,14 +86,14 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_FALLARBOR_TOWN",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 7,
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_FALLARBOR_TOWN",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/FallarborTown_CozmosHouse/map.json
+++ b/data/maps/FallarborTown_CozmosHouse/map.json
@@ -47,14 +47,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_FALLARBOR_TOWN",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 4,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_FALLARBOR_TOWN",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/FallarborTown_Mart/map.json
+++ b/data/maps/FallarborTown_Mart/map.json
@@ -86,14 +86,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_FALLARBOR_TOWN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_FALLARBOR_TOWN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/FallarborTown_MoveRelearnersHouse/map.json
+++ b/data/maps/FallarborTown_MoveRelearnersHouse/map.json
@@ -34,14 +34,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_FALLARBOR_TOWN",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_FALLARBOR_TOWN",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/FallarborTown_PokemonCenter_1F/map.json
+++ b/data/maps/FallarborTown_PokemonCenter_1F/map.json
@@ -73,21 +73,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_FALLARBOR_TOWN",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_FALLARBOR_TOWN",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_FALLARBOR_TOWN_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/FallarborTown_PokemonCenter_2F/map.json
+++ b/data/maps/FallarborTown_PokemonCenter_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_FALLARBOR_TOWN_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/FarawayIsland_Entrance/map.json
+++ b/data/maps/FarawayIsland_Entrance/map.json
@@ -47,14 +47,14 @@
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_FARAWAY_ISLAND_INTERIOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 23,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_FARAWAY_ISLAND_INTERIOR",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [

--- a/data/maps/FarawayIsland_Interior/map.json
+++ b/data/maps/FarawayIsland_Interior/map.json
@@ -34,14 +34,14 @@
       "y": 19,
       "elevation": 0,
       "dest_map": "MAP_FARAWAY_ISLAND_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 13,
       "y": 19,
       "elevation": 0,
       "dest_map": "MAP_FARAWAY_ISLAND_ENTRANCE",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/FieryPath/map.json
+++ b/data/maps/FieryPath/map.json
@@ -125,14 +125,14 @@
       "y": 36,
       "elevation": 3,
       "dest_map": "MAP_ROUTE112",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 26,
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_ROUTE112",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/FortreeCity/map.json
+++ b/data/maps/FortreeCity/map.json
@@ -123,63 +123,63 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY_HOUSE1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 22,
       "y": 11,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY_GYM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY_MART",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 17,
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY_HOUSE2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 25,
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY_HOUSE3",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 32,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY_HOUSE4",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 12,
       "y": 13,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY_HOUSE5",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 37,
       "y": 13,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY_DECORATION_SHOP",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/FortreeCity_DecorationShop/map.json
+++ b/data/maps/FortreeCity_DecorationShop/map.json
@@ -73,14 +73,14 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 4,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     }
   ],
   "coord_events": [],

--- a/data/maps/FortreeCity_Gym/map.json
+++ b/data/maps/FortreeCity_Gym/map.json
@@ -125,14 +125,14 @@
       "y": 24,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 16,
       "y": 24,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/FortreeCity_House1/map.json
+++ b/data/maps/FortreeCity_House1/map.json
@@ -60,14 +60,14 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 4,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/FortreeCity_House2/map.json
+++ b/data/maps/FortreeCity_House2/map.json
@@ -47,14 +47,14 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 4,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/FortreeCity_House3/map.json
+++ b/data/maps/FortreeCity_House3/map.json
@@ -47,14 +47,14 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 4,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/FortreeCity_House4/map.json
+++ b/data/maps/FortreeCity_House4/map.json
@@ -60,14 +60,14 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 4,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     }
   ],
   "coord_events": [],

--- a/data/maps/FortreeCity_House5/map.json
+++ b/data/maps/FortreeCity_House5/map.json
@@ -60,14 +60,14 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 4,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     }
   ],
   "coord_events": [],

--- a/data/maps/FortreeCity_Mart/map.json
+++ b/data/maps/FortreeCity_Mart/map.json
@@ -73,14 +73,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/FortreeCity_PokemonCenter_1F/map.json
+++ b/data/maps/FortreeCity_PokemonCenter_1F/map.json
@@ -73,21 +73,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_FORTREE_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_FORTREE_CITY_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/FortreeCity_PokemonCenter_2F/map.json
+++ b/data/maps/FortreeCity_PokemonCenter_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_FORTREE_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/GraniteCave_1F/map.json
+++ b/data/maps/GraniteCave_1F/map.json
@@ -47,28 +47,28 @@
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_ROUTE106",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 35,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 17,
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_B1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_STEVENS_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/GraniteCave_B1F/map.json
+++ b/data/maps/GraniteCave_B1F/map.json
@@ -34,49 +34,49 @@
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 4,
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 29,
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_B2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 28,
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_B2F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 8,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_B2F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 12,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_B2F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 29,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_B2F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/GraniteCave_B2F/map.json
+++ b/data/maps/GraniteCave_B2F/map.json
@@ -138,35 +138,35 @@
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_B1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 28,
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_B1F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 8,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_B1F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 12,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_B1F",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 29,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_B1F",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     }
   ],
   "coord_events": [],

--- a/data/maps/GraniteCave_StevensRoom/map.json
+++ b/data/maps/GraniteCave_StevensRoom/map.json
@@ -34,7 +34,7 @@
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_GRANITE_CAVE_1F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/InsideOfTruck/map.json
+++ b/data/maps/InsideOfTruck/map.json
@@ -59,21 +59,21 @@
       "x": 4,
       "y": 1,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     },
     {
       "x": 4,
       "y": 2,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     },
     {
       "x": 4,
       "y": 3,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     }
   ],

--- a/data/maps/InsideOfTruck/map.json
+++ b/data/maps/InsideOfTruck/map.json
@@ -60,21 +60,21 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     },
     {
       "x": 4,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     },
     {
       "x": 4,
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     }
   ],
   "coord_events": [

--- a/data/maps/IslandCave/map.json
+++ b/data/maps/IslandCave/map.json
@@ -34,21 +34,21 @@
       "y": 29,
       "elevation": 3,
       "dest_map": "MAP_ROUTE105",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 8,
       "y": 20,
       "elevation": 0,
       "dest_map": "MAP_ISLAND_CAVE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 8,
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_ISLAND_CAVE",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/JaggedPass/map.json
+++ b/data/maps/JaggedPass/map.json
@@ -112,35 +112,35 @@
       "y": 40,
       "elevation": 3,
       "dest_map": "MAP_ROUTE112",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 15,
       "y": 40,
       "elevation": 3,
       "dest_map": "MAP_ROUTE112",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 13,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_MT_CHIMNEY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 14,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_MT_CHIMNEY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 16,
       "y": 18,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/LavaridgeTown/map.json
+++ b/data/maps/LavaridgeTown/map.json
@@ -144,42 +144,42 @@
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_LAVARIDGE_TOWN_HERB_SHOP",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 5,
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 15,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_LAVARIDGE_TOWN_MART",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_LAVARIDGE_TOWN_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 16,
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_LAVARIDGE_TOWN_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_POKEMON_CENTER_1F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [

--- a/data/maps/LavaridgeTown_Gym_1F/map.json
+++ b/data/maps/LavaridgeTown_Gym_1F/map.json
@@ -99,182 +99,182 @@
       "y": 18,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 14,
       "y": 18,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 10,
       "y": 18,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 8,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 4,
       "y": 18,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 5,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 0,
       "y": 17,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 2,
       "y": 15,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 3,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 1,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 0,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     },
     {
       "x": 3,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     },
     {
       "x": 0,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     },
     {
       "x": 3,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 12
+      "dest_warp_id": "12"
     },
     {
       "x": 5,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 13
+      "dest_warp_id": "13"
     },
     {
       "x": 2,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 14
+      "dest_warp_id": "14"
     },
     {
       "x": 5,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 15
+      "dest_warp_id": "15"
     },
     {
       "x": 7,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 16
+      "dest_warp_id": "16"
     },
     {
       "x": 8,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 17
+      "dest_warp_id": "17"
     },
     {
       "x": 10,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 18
+      "dest_warp_id": "18"
     },
     {
       "x": 4,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 20
+      "dest_warp_id": "20"
     },
     {
       "x": 12,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 19
+      "dest_warp_id": "19"
     },
     {
       "x": 14,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 21
+      "dest_warp_id": "21"
     },
     {
       "x": 13,
       "y": 17,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 22
+      "dest_warp_id": "22"
     },
     {
       "x": 12,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_B1F",
-      "dest_warp_id": 23
+      "dest_warp_id": "23"
     }
   ],
   "coord_events": [],

--- a/data/maps/LavaridgeTown_Gym_B1F/map.json
+++ b/data/maps/LavaridgeTown_Gym_B1F/map.json
@@ -73,168 +73,168 @@
       "y": 18,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 0,
       "y": 17,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 8,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 5,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 4,
       "y": 18,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 5,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 2,
       "y": 15,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 3,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     },
     {
       "x": 1,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     },
     {
       "x": 0,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     },
     {
       "x": 3,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 12
+      "dest_warp_id": "12"
     },
     {
       "x": 0,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 13
+      "dest_warp_id": "13"
     },
     {
       "x": 3,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 14
+      "dest_warp_id": "14"
     },
     {
       "x": 5,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 15
+      "dest_warp_id": "15"
     },
     {
       "x": 2,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 16
+      "dest_warp_id": "16"
     },
     {
       "x": 5,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 17
+      "dest_warp_id": "17"
     },
     {
       "x": 7,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 18
+      "dest_warp_id": "18"
     },
     {
       "x": 8,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 19
+      "dest_warp_id": "19"
     },
     {
       "x": 10,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 20
+      "dest_warp_id": "20"
     },
     {
       "x": 12,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 22
+      "dest_warp_id": "22"
     },
     {
       "x": 4,
       "y": 16,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 21
+      "dest_warp_id": "21"
     },
     {
       "x": 14,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 23
+      "dest_warp_id": "23"
     },
     {
       "x": 13,
       "y": 17,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 24
+      "dest_warp_id": "24"
     },
     {
       "x": 12,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN_GYM_1F",
-      "dest_warp_id": 25
+      "dest_warp_id": "25"
     }
   ],
   "coord_events": [],

--- a/data/maps/LavaridgeTown_HerbShop/map.json
+++ b/data/maps/LavaridgeTown_HerbShop/map.json
@@ -60,14 +60,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LAVARIDGE_TOWN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LAVARIDGE_TOWN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/LavaridgeTown_House/map.json
+++ b/data/maps/LavaridgeTown_House/map.json
@@ -60,14 +60,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LAVARIDGE_TOWN",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LAVARIDGE_TOWN",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/LavaridgeTown_Mart/map.json
+++ b/data/maps/LavaridgeTown_Mart/map.json
@@ -60,14 +60,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LAVARIDGE_TOWN",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LAVARIDGE_TOWN",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/LavaridgeTown_PokemonCenter_1F/map.json
+++ b/data/maps/LavaridgeTown_PokemonCenter_1F/map.json
@@ -73,28 +73,28 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_LAVARIDGE_TOWN",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_LAVARIDGE_TOWN_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 2,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LAVARIDGE_TOWN",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/LavaridgeTown_PokemonCenter_2F/map.json
+++ b/data/maps/LavaridgeTown_PokemonCenter_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_LAVARIDGE_TOWN_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity/map.json
+++ b/data/maps/LilycoveCity/map.json
@@ -318,98 +318,98 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 37,
       "y": 24,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_COVE_LILY_MOTEL_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 24,
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 11,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_LILYCOVE_MUSEUM_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 23,
       "y": 24,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_CONTEST_LOBBY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 39,
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_POKEMON_TRAINER_FAN_CLUB",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 70,
       "y": 5,
       "elevation": 1,
       "dest_map": "MAP_AQUA_HIDEOUT_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 36,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_MOVE_DELETERS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 42,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_HOUSE1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 55,
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_HOUSE2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 11,
       "y": 22,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_HOUSE3",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 12,
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_HOUSE4",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 12,
       "y": 32,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_HARBOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 12,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_LILYCOVE_MUSEUM_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_ContestHall/map.json
+++ b/data/maps/LilycoveCity_ContestHall/map.json
@@ -437,28 +437,28 @@
       "y": 32,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_CONTEST_LOBBY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 30,
       "y": 32,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_CONTEST_LOBBY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 20,
       "y": 32,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_CONTEST_LOBBY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 31,
       "y": 32,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_CONTEST_LOBBY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_ContestLobby/map.json
+++ b/data/maps/LilycoveCity_ContestLobby/map.json
@@ -346,28 +346,28 @@
       "y": 11,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 15,
       "y": 11,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_CONTEST_HALL",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 21,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_CONTEST_HALL",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_CoveLilyMotel_1F/map.json
+++ b/data/maps/LilycoveCity_CoveLilyMotel_1F/map.json
@@ -34,21 +34,21 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 2,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_COVE_LILY_MOTEL_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/LilycoveCity_CoveLilyMotel_2F/map.json
+++ b/data/maps/LilycoveCity_CoveLilyMotel_2F/map.json
@@ -112,7 +112,7 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_COVE_LILY_MOTEL_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_DepartmentStoreElevator/map.json
+++ b/data/maps/LilycoveCity_DepartmentStoreElevator/map.json
@@ -33,14 +33,14 @@
       "x": 1,
       "y": 5,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     },
     {
       "x": 2,
       "y": 5,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     }
   ],

--- a/data/maps/LilycoveCity_DepartmentStoreElevator/map.json
+++ b/data/maps/LilycoveCity_DepartmentStoreElevator/map.json
@@ -34,14 +34,14 @@
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     },
     {
       "x": 2,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_DepartmentStoreRooftop/map.json
+++ b/data/maps/LilycoveCity_DepartmentStoreRooftop/map.json
@@ -73,7 +73,7 @@
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_5F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_DepartmentStore_1F/map.json
+++ b/data/maps/LilycoveCity_DepartmentStore_1F/map.json
@@ -99,28 +99,28 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 16,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 2,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_ELEVATOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_DepartmentStore_2F/map.json
+++ b/data/maps/LilycoveCity_DepartmentStore_2F/map.json
@@ -86,21 +86,21 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 13,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_3F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 2,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_ELEVATOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_DepartmentStore_3F/map.json
+++ b/data/maps/LilycoveCity_DepartmentStore_3F/map.json
@@ -86,21 +86,21 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_2F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 16,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_4F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 2,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_ELEVATOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_DepartmentStore_4F/map.json
+++ b/data/maps/LilycoveCity_DepartmentStore_4F/map.json
@@ -86,21 +86,21 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_3F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 13,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_5F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 2,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_ELEVATOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_DepartmentStore_5F/map.json
+++ b/data/maps/LilycoveCity_DepartmentStore_5F/map.json
@@ -112,21 +112,21 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_4F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 2,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_ELEVATOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 16,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_DEPARTMENT_STORE_ROOFTOP",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_Harbor/map.json
+++ b/data/maps/LilycoveCity_Harbor/map.json
@@ -86,14 +86,14 @@
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 12
+      "dest_warp_id": "12"
     },
     {
       "x": 12,
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 12
+      "dest_warp_id": "12"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_House1/map.json
+++ b/data/maps/LilycoveCity_House1/map.json
@@ -47,14 +47,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 4,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_House2/map.json
+++ b/data/maps/LilycoveCity_House2/map.json
@@ -34,14 +34,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     },
     {
       "x": 3,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_House3/map.json
+++ b/data/maps/LilycoveCity_House3/map.json
@@ -99,14 +99,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_House4/map.json
+++ b/data/maps/LilycoveCity_House4/map.json
@@ -47,14 +47,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     },
     {
       "x": 4,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_LilycoveMuseum_1F/map.json
+++ b/data/maps/LilycoveCity_LilycoveMuseum_1F/map.json
@@ -151,21 +151,21 @@
       "y": 13,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 10,
       "y": 13,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 13
+      "dest_warp_id": "13"
     },
     {
       "x": 16,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_LILYCOVE_MUSEUM_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_LilycoveMuseum_2F/map.json
+++ b/data/maps/LilycoveCity_LilycoveMuseum_2F/map.json
@@ -73,7 +73,7 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY_LILYCOVE_MUSEUM_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_MoveDeletersHouse/map.json
+++ b/data/maps/LilycoveCity_MoveDeletersHouse/map.json
@@ -34,14 +34,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_PokemonCenter_1F/map.json
+++ b/data/maps/LilycoveCity_PokemonCenter_1F/map.json
@@ -86,21 +86,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_LILYCOVE_CITY_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_PokemonCenter_2F/map.json
+++ b/data/maps/LilycoveCity_PokemonCenter_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_LILYCOVE_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_PokemonTrainerFanClub/map.json
+++ b/data/maps/LilycoveCity_PokemonTrainerFanClub/map.json
@@ -138,14 +138,14 @@
       "y": 13,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 5,
       "y": 13,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/LilycoveCity_UnusedMart/map.json
+++ b/data/maps/LilycoveCity_UnusedMart/map.json
@@ -20,14 +20,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_LILYCOVE_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/LittlerootTown/map.json
+++ b/data/maps/LittlerootTown/map.json
@@ -131,21 +131,21 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_LITTLEROOT_TOWN_MAYS_HOUSE_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_LITTLEROOT_TOWN_BRENDANS_HOUSE_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 7,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_LITTLEROOT_TOWN_PROFESSOR_BIRCHS_LAB",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/LittlerootTown_BrendansHouse_1F/map.json
+++ b/data/maps/LittlerootTown_BrendansHouse_1F/map.json
@@ -112,21 +112,21 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_LITTLEROOT_TOWN",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 8,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_LITTLEROOT_TOWN",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 8,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_LITTLEROOT_TOWN_BRENDANS_HOUSE_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/LittlerootTown_BrendansHouse_2F/map.json
+++ b/data/maps/LittlerootTown_BrendansHouse_2F/map.json
@@ -229,7 +229,7 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LITTLEROOT_TOWN_BRENDANS_HOUSE_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/LittlerootTown_MaysHouse_1F/map.json
+++ b/data/maps/LittlerootTown_MaysHouse_1F/map.json
@@ -112,21 +112,21 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_LITTLEROOT_TOWN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 2,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_LITTLEROOT_TOWN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 2,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_LITTLEROOT_TOWN_MAYS_HOUSE_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/LittlerootTown_MaysHouse_2F/map.json
+++ b/data/maps/LittlerootTown_MaysHouse_2F/map.json
@@ -229,7 +229,7 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_LITTLEROOT_TOWN_MAYS_HOUSE_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/LittlerootTown_ProfessorBirchsLab/map.json
+++ b/data/maps/LittlerootTown_ProfessorBirchsLab/map.json
@@ -99,14 +99,14 @@
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_LITTLEROOT_TOWN",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 7,
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_LITTLEROOT_TOWN",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/MagmaHideout_1F/map.json
+++ b/data/maps/MagmaHideout_1F/map.json
@@ -99,28 +99,28 @@
       "y": 34,
       "elevation": 3,
       "dest_map": "MAP_JAGGED_PASS",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 25,
       "y": 34,
       "elevation": 3,
       "dest_map": "MAP_MAGMA_HIDEOUT_2F_1R",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 31,
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_2F_2R",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 20,
       "y": 22,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_2F_3R",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/MagmaHideout_2F_1R/map.json
+++ b/data/maps/MagmaHideout_2F_1R/map.json
@@ -73,21 +73,21 @@
       "y": 23,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_2F_2R",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 8,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 17,
       "y": 33,
       "elevation": 3,
       "dest_map": "MAP_MAGMA_HIDEOUT_3F_1R",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/MagmaHideout_2F_2R/map.json
+++ b/data/maps/MagmaHideout_2F_2R/map.json
@@ -99,14 +99,14 @@
       "y": 22,
       "elevation": 3,
       "dest_map": "MAP_MAGMA_HIDEOUT_2F_1R",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 36,
       "y": 4,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/MagmaHideout_2F_3R/map.json
+++ b/data/maps/MagmaHideout_2F_3R/map.json
@@ -20,14 +20,14 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_1F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 16,
       "y": 13,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_3F_3R",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/MagmaHideout_3F_1R/map.json
+++ b/data/maps/MagmaHideout_3F_1R/map.json
@@ -60,21 +60,21 @@
       "y": 21,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_4F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 21,
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_3F_2R",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 23,
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_2F_1R",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/MagmaHideout_3F_2R/map.json
+++ b/data/maps/MagmaHideout_3F_2R/map.json
@@ -47,7 +47,7 @@
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_3F_1R",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/MagmaHideout_3F_3R/map.json
+++ b/data/maps/MagmaHideout_3F_3R/map.json
@@ -34,14 +34,14 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_2F_3R",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 16,
       "y": 21,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_4F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/MagmaHideout_4F/map.json
+++ b/data/maps/MagmaHideout_4F/map.json
@@ -125,14 +125,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_3F_1R",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 20,
       "y": 21,
       "elevation": 0,
       "dest_map": "MAP_MAGMA_HIDEOUT_3F_3R",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/MarineCave_End/map.json
+++ b/data/maps/MarineCave_End/map.json
@@ -34,7 +34,7 @@
       "y": 4,
       "elevation": 0,
       "dest_map": "MAP_MARINE_CAVE_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/MarineCave_Entrance/map.json
+++ b/data/maps/MarineCave_Entrance/map.json
@@ -20,7 +20,7 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_MARINE_CAVE_END",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/MauvilleCity/map.json
+++ b/data/maps/MauvilleCity/map.json
@@ -185,49 +185,49 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY_GYM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 22,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 35,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY_BIKE_SHOP",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 23,
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY_MART",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 32,
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY_HOUSE1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 8,
       "y": 13,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY_GAME_CORNER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 19,
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY_HOUSE2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/MauvilleCity_BikeShop/map.json
+++ b/data/maps/MauvilleCity_BikeShop/map.json
@@ -47,14 +47,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 4,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/MauvilleCity_GameCorner/map.json
+++ b/data/maps/MauvilleCity_GameCorner/map.json
@@ -177,14 +177,14 @@
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_MAUVILLE_CITY",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 12,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_MAUVILLE_CITY",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/MauvilleCity_Gym/map.json
+++ b/data/maps/MauvilleCity_Gym/map.json
@@ -112,14 +112,14 @@
       "y": 20,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 5,
       "y": 20,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/MauvilleCity_House1/map.json
+++ b/data/maps/MauvilleCity_House1/map.json
@@ -34,14 +34,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/MauvilleCity_House2/map.json
+++ b/data/maps/MauvilleCity_House2/map.json
@@ -34,14 +34,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 4,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     }
   ],
   "coord_events": [],

--- a/data/maps/MauvilleCity_Mart/map.json
+++ b/data/maps/MauvilleCity_Mart/map.json
@@ -60,14 +60,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MAUVILLE_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/MauvilleCity_PokemonCenter_1F/map.json
+++ b/data/maps/MauvilleCity_PokemonCenter_1F/map.json
@@ -86,21 +86,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_MAUVILLE_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_MAUVILLE_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_MAUVILLE_CITY_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/MauvilleCity_PokemonCenter_2F/map.json
+++ b/data/maps/MauvilleCity_PokemonCenter_2F/map.json
@@ -86,21 +86,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_MAUVILLE_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/MeteorFalls_1F_1R/map.json
+++ b/data/maps/MeteorFalls_1F_1R/map.json
@@ -151,42 +151,42 @@
       "y": 18,
       "elevation": 4,
       "dest_map": "MAP_ROUTE114",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 39,
       "elevation": 3,
       "dest_map": "MAP_ROUTE115",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_METEOR_FALLS_1F_2R",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 5,
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_METEOR_FALLS_B1F_1R",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 26,
       "y": 28,
       "elevation": 3,
       "dest_map": "MAP_METEOR_FALLS_B1F_1R",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 4,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_METEOR_FALLS_STEVENS_CAVE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/MeteorFalls_1F_2R/map.json
+++ b/data/maps/MeteorFalls_1F_2R/map.json
@@ -60,28 +60,28 @@
       "y": 29,
       "elevation": 3,
       "dest_map": "MAP_METEOR_FALLS_1F_1R",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 4,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_METEOR_FALLS_B1F_1R",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 7,
       "y": 20,
       "elevation": 3,
       "dest_map": "MAP_METEOR_FALLS_B1F_1R",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 21,
       "y": 23,
       "elevation": 3,
       "dest_map": "MAP_METEOR_FALLS_B1F_1R",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/MeteorFalls_B1F_1R/map.json
+++ b/data/maps/MeteorFalls_B1F_1R/map.json
@@ -20,42 +20,42 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_METEOR_FALLS_1F_2R",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 7,
       "y": 11,
       "elevation": 5,
       "dest_map": "MAP_METEOR_FALLS_1F_2R",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 18,
       "y": 15,
       "elevation": 4,
       "dest_map": "MAP_METEOR_FALLS_1F_2R",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 17,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_METEOR_FALLS_B1F_2R",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 3,
       "y": 23,
       "elevation": 5,
       "dest_map": "MAP_METEOR_FALLS_1F_1R",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 20,
       "y": 36,
       "elevation": 3,
       "dest_map": "MAP_METEOR_FALLS_1F_1R",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/MeteorFalls_B1F_2R/map.json
+++ b/data/maps/MeteorFalls_B1F_2R/map.json
@@ -34,7 +34,7 @@
       "y": 15,
       "elevation": 3,
       "dest_map": "MAP_METEOR_FALLS_B1F_1R",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/MeteorFalls_StevensCave/map.json
+++ b/data/maps/MeteorFalls_StevensCave/map.json
@@ -34,7 +34,7 @@
       "y": 29,
       "elevation": 3,
       "dest_map": "MAP_METEOR_FALLS_1F_1R",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/MirageTower_1F/map.json
+++ b/data/maps/MirageTower_1F/map.json
@@ -20,14 +20,14 @@
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_ROUTE111",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 15,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_MIRAGE_TOWER_2F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/MirageTower_2F/map.json
+++ b/data/maps/MirageTower_2F/map.json
@@ -20,14 +20,14 @@
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_MIRAGE_TOWER_3F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 15,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_MIRAGE_TOWER_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/MirageTower_3F/map.json
+++ b/data/maps/MirageTower_3F/map.json
@@ -47,14 +47,14 @@
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_MIRAGE_TOWER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 2,
       "y": 4,
       "elevation": 0,
       "dest_map": "MAP_MIRAGE_TOWER_4F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/MirageTower_4F/map.json
+++ b/data/maps/MirageTower_4F/map.json
@@ -60,7 +60,7 @@
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_MIRAGE_TOWER_3F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/MossdeepCity/map.json
+++ b/data/maps/MossdeepCity/map.json
@@ -258,70 +258,70 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_HOUSE1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 38,
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_GYM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 28,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 67,
       "y": 25,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_HOUSE2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 37,
       "y": 18,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_MART",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 49,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_HOUSE3",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 19,
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_STEVENS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 18,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_HOUSE4",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 64,
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_SPACE_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 36,
       "y": 24,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_GAME_CORNER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/MossdeepCity_GameCorner_1F/map.json
+++ b/data/maps/MossdeepCity_GameCorner_1F/map.json
@@ -47,21 +47,21 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     },
     {
       "x": 6,
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     },
     {
       "x": 2,
       "y": 0,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_GAME_CORNER_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/MossdeepCity_GameCorner_B1F/map.json
+++ b/data/maps/MossdeepCity_GameCorner_B1F/map.json
@@ -34,7 +34,7 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_GAME_CORNER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/MossdeepCity_Gym/map.json
+++ b/data/maps/MossdeepCity_Gym/map.json
@@ -489,98 +489,98 @@
       "y": 35,
       "elevation": 3,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 7,
       "y": 35,
       "elevation": 3,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 3,
       "y": 28,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_GYM",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 1,
       "y": 23,
       "elevation": 3,
       "dest_map": "MAP_MOSSDEEP_CITY_GYM",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 7,
       "y": 18,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_GYM",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 8,
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_GYM",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 9,
       "y": 18,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_GYM",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 23,
       "y": 20,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_GYM",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 1,
       "y": 33,
       "elevation": 3,
       "dest_map": "MAP_MOSSDEEP_CITY_GYM",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     },
     {
       "x": 20,
       "y": 24,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_GYM",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 11,
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_GYM",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     },
     {
       "x": 11,
       "y": 35,
       "elevation": 3,
       "dest_map": "MAP_MOSSDEEP_CITY_GYM",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     },
     {
       "x": 13,
       "y": 32,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_GYM",
-      "dest_warp_id": 13
+      "dest_warp_id": "13"
     },
     {
       "x": 21,
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_GYM",
-      "dest_warp_id": 12
+      "dest_warp_id": "12"
     }
   ],
   "coord_events": [

--- a/data/maps/MossdeepCity_House1/map.json
+++ b/data/maps/MossdeepCity_House1/map.json
@@ -47,14 +47,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/MossdeepCity_House2/map.json
+++ b/data/maps/MossdeepCity_House2/map.json
@@ -60,14 +60,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 4,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/MossdeepCity_House3/map.json
+++ b/data/maps/MossdeepCity_House3/map.json
@@ -34,14 +34,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/MossdeepCity_House4/map.json
+++ b/data/maps/MossdeepCity_House4/map.json
@@ -60,14 +60,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 3,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     }
   ],
   "coord_events": [],

--- a/data/maps/MossdeepCity_Mart/map.json
+++ b/data/maps/MossdeepCity_Mart/map.json
@@ -73,14 +73,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/MossdeepCity_PokemonCenter_1F/map.json
+++ b/data/maps/MossdeepCity_PokemonCenter_1F/map.json
@@ -60,21 +60,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_MOSSDEEP_CITY_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/MossdeepCity_PokemonCenter_2F/map.json
+++ b/data/maps/MossdeepCity_PokemonCenter_2F/map.json
@@ -86,21 +86,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_MOSSDEEP_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/MossdeepCity_SpaceCenter_1F/map.json
+++ b/data/maps/MossdeepCity_SpaceCenter_1F/map.json
@@ -164,21 +164,21 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 8,
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 13,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_SPACE_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/MossdeepCity_SpaceCenter_2F/map.json
+++ b/data/maps/MossdeepCity_SpaceCenter_2F/map.json
@@ -138,7 +138,7 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY_SPACE_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/MossdeepCity_StevensHouse/map.json
+++ b/data/maps/MossdeepCity_StevensHouse/map.json
@@ -60,14 +60,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_MOSSDEEP_CITY",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     }
   ],
   "coord_events": [],

--- a/data/maps/MtChimney/map.json
+++ b/data/maps/MtChimney/map.json
@@ -411,28 +411,28 @@
       "y": 36,
       "elevation": 0,
       "dest_map": "MAP_MT_CHIMNEY_CABLE_CAR_STATION",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 18,
       "y": 36,
       "elevation": 0,
       "dest_map": "MAP_MT_CHIMNEY_CABLE_CAR_STATION",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 20,
       "y": 41,
       "elevation": 3,
       "dest_map": "MAP_JAGGED_PASS",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 21,
       "y": 41,
       "elevation": 3,
       "dest_map": "MAP_JAGGED_PASS",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/MtChimney_CableCarStation/map.json
+++ b/data/maps/MtChimney_CableCarStation/map.json
@@ -47,14 +47,14 @@
       "y": 11,
       "elevation": 0,
       "dest_map": "MAP_MT_CHIMNEY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 7,
       "y": 11,
       "elevation": 0,
       "dest_map": "MAP_MT_CHIMNEY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/MtPyre_1F/map.json
+++ b/data/maps/MtPyre_1F/map.json
@@ -60,42 +60,42 @@
       "y": 18,
       "elevation": 3,
       "dest_map": "MAP_ROUTE122",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 3,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_EXTERIOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 18,
       "y": 18,
       "elevation": 3,
       "dest_map": "MAP_ROUTE122",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_EXTERIOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 11,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 20,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_2F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/MtPyre_2F/map.json
+++ b/data/maps/MtPyre_2F/map.json
@@ -125,35 +125,35 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_1F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 10,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_3F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_3F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 6,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_3F",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 11,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_1F",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/MtPyre_3F/map.json
+++ b/data/maps/MtPyre_3F/map.json
@@ -73,42 +73,42 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_2F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 2,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_4F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 9,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_4F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 1,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_4F",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 10,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_2F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 6,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_2F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/MtPyre_4F/map.json
+++ b/data/maps/MtPyre_4F/map.json
@@ -47,42 +47,42 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_5F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 2,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_3F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 12,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_5F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 12,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_5F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 9,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_3F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 2,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_3F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/MtPyre_5F/map.json
+++ b/data/maps/MtPyre_5F/map.json
@@ -47,35 +47,35 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_6F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_4F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 1,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_6F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 12,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_4F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 12,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_4F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/MtPyre_6F/map.json
+++ b/data/maps/MtPyre_6F/map.json
@@ -60,14 +60,14 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_5F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 1,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_5F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/MtPyre_Exterior/map.json
+++ b/data/maps/MtPyre_Exterior/map.json
@@ -47,21 +47,21 @@
       "y": 42,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 19,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_SUMMIT",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 20,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_SUMMIT",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [

--- a/data/maps/MtPyre_Summit/map.json
+++ b/data/maps/MtPyre_Summit/map.json
@@ -125,21 +125,21 @@
       "y": 31,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_EXTERIOR",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 23,
       "y": 31,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_EXTERIOR",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 24,
       "y": 31,
       "elevation": 3,
       "dest_map": "MAP_MT_PYRE_EXTERIOR",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [

--- a/data/maps/NavelRock_B1F/map.json
+++ b/data/maps/NavelRock_B1F/map.json
@@ -20,14 +20,14 @@
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 18,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_FORK",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Bottom/map.json
+++ b/data/maps/NavelRock_Bottom/map.json
@@ -34,7 +34,7 @@
       "y": 19,
       "elevation": 0,
       "dest_map": "MAP_NAVEL_ROCK_DOWN11",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Down01/map.json
+++ b/data/maps/NavelRock_Down01/map.json
@@ -20,14 +20,14 @@
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_FORK",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN02",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Down02/map.json
+++ b/data/maps/NavelRock_Down02/map.json
@@ -20,14 +20,14 @@
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN01",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 3,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN03",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Down03/map.json
+++ b/data/maps/NavelRock_Down03/map.json
@@ -20,14 +20,14 @@
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN02",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN04",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Down04/map.json
+++ b/data/maps/NavelRock_Down04/map.json
@@ -20,14 +20,14 @@
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN03",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 3,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN05",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Down05/map.json
+++ b/data/maps/NavelRock_Down05/map.json
@@ -20,14 +20,14 @@
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN04",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN06",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Down06/map.json
+++ b/data/maps/NavelRock_Down06/map.json
@@ -20,14 +20,14 @@
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN05",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 3,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN07",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Down07/map.json
+++ b/data/maps/NavelRock_Down07/map.json
@@ -20,14 +20,14 @@
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN06",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN08",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Down08/map.json
+++ b/data/maps/NavelRock_Down08/map.json
@@ -20,14 +20,14 @@
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN07",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 3,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN09",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Down09/map.json
+++ b/data/maps/NavelRock_Down09/map.json
@@ -20,14 +20,14 @@
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN08",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN10",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Down10/map.json
+++ b/data/maps/NavelRock_Down10/map.json
@@ -20,14 +20,14 @@
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN09",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 3,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN11",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Down11/map.json
+++ b/data/maps/NavelRock_Down11/map.json
@@ -20,14 +20,14 @@
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_BOTTOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 3,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN10",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Entrance/map.json
+++ b/data/maps/NavelRock_Entrance/map.json
@@ -20,14 +20,14 @@
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 26,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_EXTERIOR",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Exterior/map.json
+++ b/data/maps/NavelRock_Exterior/map.json
@@ -20,14 +20,14 @@
       "y": 18,
       "elevation": 0,
       "dest_map": "MAP_NAVEL_ROCK_HARBOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_NAVEL_ROCK_ENTRANCE",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Fork/map.json
+++ b/data/maps/NavelRock_Fork/map.json
@@ -20,21 +20,21 @@
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_UP1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 11,
       "y": 79,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_B1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 22,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_DOWN01",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Harbor/map.json
+++ b/data/maps/NavelRock_Harbor/map.json
@@ -47,7 +47,7 @@
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_NAVEL_ROCK_EXTERIOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Top/map.json
+++ b/data/maps/NavelRock_Top/map.json
@@ -34,7 +34,7 @@
       "y": 20,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_UP4",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [

--- a/data/maps/NavelRock_Up1/map.json
+++ b/data/maps/NavelRock_Up1/map.json
@@ -20,14 +20,14 @@
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_FORK",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 3,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_UP2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Up2/map.json
+++ b/data/maps/NavelRock_Up2/map.json
@@ -20,14 +20,14 @@
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_UP1",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_UP3",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Up3/map.json
+++ b/data/maps/NavelRock_Up3/map.json
@@ -20,14 +20,14 @@
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_UP2",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 3,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_UP4",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NavelRock_Up4/map.json
+++ b/data/maps/NavelRock_Up4/map.json
@@ -20,14 +20,14 @@
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_UP3",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_NAVEL_ROCK_TOP",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/NewMauville_Entrance/map.json
+++ b/data/maps/NewMauville_Entrance/map.json
@@ -20,14 +20,14 @@
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_NEW_MAUVILLE_INSIDE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/NewMauville_Inside/map.json
+++ b/data/maps/NewMauville_Inside/map.json
@@ -125,7 +125,7 @@
       "y": 33,
       "elevation": 3,
       "dest_map": "MAP_NEW_MAUVILLE_ENTRANCE",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [

--- a/data/maps/OldaleTown/map.json
+++ b/data/maps/OldaleTown/map.json
@@ -89,28 +89,28 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_OLDALE_TOWN_HOUSE1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 15,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_OLDALE_TOWN_HOUSE2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_OLDALE_TOWN_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 14,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_OLDALE_TOWN_MART",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/OldaleTown_House1/map.json
+++ b/data/maps/OldaleTown_House1/map.json
@@ -34,14 +34,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_OLDALE_TOWN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_OLDALE_TOWN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/OldaleTown_House2/map.json
+++ b/data/maps/OldaleTown_House2/map.json
@@ -47,14 +47,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_OLDALE_TOWN",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_OLDALE_TOWN",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/OldaleTown_Mart/map.json
+++ b/data/maps/OldaleTown_Mart/map.json
@@ -60,14 +60,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_OLDALE_TOWN",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_OLDALE_TOWN",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/OldaleTown_PokemonCenter_1F/map.json
+++ b/data/maps/OldaleTown_PokemonCenter_1F/map.json
@@ -73,21 +73,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_OLDALE_TOWN",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_OLDALE_TOWN",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_OLDALE_TOWN_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/OldaleTown_PokemonCenter_2F/map.json
+++ b/data/maps/OldaleTown_PokemonCenter_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_OLDALE_TOWN_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/PacifidlogTown/map.json
+++ b/data/maps/PacifidlogTown/map.json
@@ -71,42 +71,42 @@
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 16,
       "y": 13,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN_HOUSE1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 3,
       "y": 22,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN_HOUSE2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 12,
       "y": 24,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN_HOUSE3",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 2,
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN_HOUSE4",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 17,
       "y": 21,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN_HOUSE5",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/PacifidlogTown_House1/map.json
+++ b/data/maps/PacifidlogTown_House1/map.json
@@ -47,14 +47,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/PacifidlogTown_House2/map.json
+++ b/data/maps/PacifidlogTown_House2/map.json
@@ -60,14 +60,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/PacifidlogTown_House3/map.json
+++ b/data/maps/PacifidlogTown_House3/map.json
@@ -47,14 +47,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 5,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/PacifidlogTown_House4/map.json
+++ b/data/maps/PacifidlogTown_House4/map.json
@@ -60,14 +60,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 5,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/PacifidlogTown_House5/map.json
+++ b/data/maps/PacifidlogTown_House5/map.json
@@ -47,14 +47,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 5,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_PACIFIDLOG_TOWN",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/PacifidlogTown_PokemonCenter_1F/map.json
+++ b/data/maps/PacifidlogTown_PokemonCenter_1F/map.json
@@ -86,21 +86,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_PACIFIDLOG_TOWN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_PACIFIDLOG_TOWN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_PACIFIDLOG_TOWN_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/PacifidlogTown_PokemonCenter_2F/map.json
+++ b/data/maps/PacifidlogTown_PokemonCenter_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_PACIFIDLOG_TOWN_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/PetalburgCity/map.json
+++ b/data/maps/PetalburgCity/map.json
@@ -149,42 +149,42 @@
       "y": 19,
       "elevation": 0,
       "dest_map": "MAP_PETALBURG_CITY_HOUSE1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 7,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_PETALBURG_CITY_WALLYS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 15,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 20,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_PETALBURG_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 20,
       "y": 24,
       "elevation": 0,
       "dest_map": "MAP_PETALBURG_CITY_HOUSE2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 25,
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_PETALBURG_CITY_MART",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/PetalburgCity_Gym/map.json
+++ b/data/maps/PetalburgCity_Gym/map.json
@@ -164,266 +164,266 @@
       "y": 111,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 111,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 105,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 7,
       "y": 85,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 6,
       "y": 85,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 7,
       "y": 105,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 1,
       "y": 98,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 2,
       "y": 98,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 1,
       "y": 79,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     },
     {
       "x": 7,
       "y": 79,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 12
+      "dest_warp_id": "12"
     },
     {
       "x": 7,
       "y": 46,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 6,
       "y": 46,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 1,
       "y": 59,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     },
     {
       "x": 2,
       "y": 59,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     },
     {
       "x": 1,
       "y": 92,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 16
+      "dest_warp_id": "16"
     },
     {
       "x": 7,
       "y": 92,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 18
+      "dest_warp_id": "18"
     },
     {
       "x": 7,
       "y": 59,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 14
+      "dest_warp_id": "14"
     },
     {
       "x": 6,
       "y": 59,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 14
+      "dest_warp_id": "14"
     },
     {
       "x": 1,
       "y": 72,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 15
+      "dest_warp_id": "15"
     },
     {
       "x": 2,
       "y": 72,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 15
+      "dest_warp_id": "15"
     },
     {
       "x": 7,
       "y": 40,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 24
+      "dest_warp_id": "24"
     },
     {
       "x": 1,
       "y": 53,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 26
+      "dest_warp_id": "26"
     },
     {
       "x": 7,
       "y": 53,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 28
+      "dest_warp_id": "28"
     },
     {
       "x": 1,
       "y": 66,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 30
+      "dest_warp_id": "30"
     },
     {
       "x": 1,
       "y": 20,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 20
+      "dest_warp_id": "20"
     },
     {
       "x": 2,
       "y": 20,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 20
+      "dest_warp_id": "20"
     },
     {
       "x": 7,
       "y": 20,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 21
+      "dest_warp_id": "21"
     },
     {
       "x": 6,
       "y": 20,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 21
+      "dest_warp_id": "21"
     },
     {
       "x": 1,
       "y": 33,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 22
+      "dest_warp_id": "22"
     },
     {
       "x": 2,
       "y": 33,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 22
+      "dest_warp_id": "22"
     },
     {
       "x": 7,
       "y": 33,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 23
+      "dest_warp_id": "23"
     },
     {
       "x": 6,
       "y": 33,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 23
+      "dest_warp_id": "23"
     },
     {
       "x": 7,
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 34
+      "dest_warp_id": "34"
     },
     {
       "x": 1,
       "y": 27,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 36
+      "dest_warp_id": "36"
     },
     {
       "x": 1,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 32
+      "dest_warp_id": "32"
     },
     {
       "x": 2,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 32
+      "dest_warp_id": "32"
     },
     {
       "x": 7,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 33
+      "dest_warp_id": "33"
     },
     {
       "x": 6,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY_GYM",
-      "dest_warp_id": 33
+      "dest_warp_id": "33"
     }
   ],
   "coord_events": [],

--- a/data/maps/PetalburgCity_House1/map.json
+++ b/data/maps/PetalburgCity_House1/map.json
@@ -47,14 +47,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_PETALBURG_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_PETALBURG_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/PetalburgCity_House2/map.json
+++ b/data/maps/PetalburgCity_House2/map.json
@@ -47,14 +47,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_PETALBURG_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_PETALBURG_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/PetalburgCity_Mart/map.json
+++ b/data/maps/PetalburgCity_Mart/map.json
@@ -73,14 +73,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_PETALBURG_CITY",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_PETALBURG_CITY",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/PetalburgCity_PokemonCenter_1F/map.json
+++ b/data/maps/PetalburgCity_PokemonCenter_1F/map.json
@@ -86,21 +86,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_PETALBURG_CITY_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/PetalburgCity_PokemonCenter_2F/map.json
+++ b/data/maps/PetalburgCity_PokemonCenter_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_PETALBURG_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/PetalburgCity_WallysHouse/map.json
+++ b/data/maps/PetalburgCity_WallysHouse/map.json
@@ -47,14 +47,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_PETALBURG_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_PETALBURG_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/PetalburgWoods/map.json
+++ b/data/maps/PetalburgWoods/map.json
@@ -190,42 +190,42 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE104",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 15,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE104",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 16,
       "y": 38,
       "elevation": 0,
       "dest_map": "MAP_ROUTE104",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 17,
       "y": 38,
       "elevation": 0,
       "dest_map": "MAP_ROUTE104",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 36,
       "y": 38,
       "elevation": 0,
       "dest_map": "MAP_ROUTE104",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 37,
       "y": 38,
       "elevation": 0,
       "dest_map": "MAP_ROUTE104",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     }
   ],
   "coord_events": [

--- a/data/maps/RecordCorner/map.json
+++ b/data/maps/RecordCorner/map.json
@@ -34,28 +34,28 @@
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     },
     {
       "x": 9,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     },
     {
       "x": 11,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     },
     {
       "x": 10,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     }
   ],
   "coord_events": [

--- a/data/maps/RecordCorner/map.json
+++ b/data/maps/RecordCorner/map.json
@@ -33,28 +33,28 @@
       "x": 8,
       "y": 9,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     },
     {
       "x": 9,
       "y": 9,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     },
     {
       "x": 11,
       "y": 9,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     },
     {
       "x": 10,
       "y": 9,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     }
   ],

--- a/data/maps/Route103/map.json
+++ b/data/maps/Route103/map.json
@@ -292,7 +292,7 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_ALTERING_CAVE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route104/map.json
+++ b/data/maps/Route104/map.json
@@ -479,56 +479,56 @@
       "y": 50,
       "elevation": 0,
       "dest_map": "MAP_ROUTE104_MR_BRINEYS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 5,
       "y": 18,
       "elevation": 0,
       "dest_map": "MAP_ROUTE104_PRETTY_PETAL_FLOWER_SHOP",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 30,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_WOODS",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 11,
       "y": 30,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_WOODS",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 10,
       "y": 38,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_WOODS",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 11,
       "y": 38,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_WOODS",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 32,
       "y": 42,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_WOODS",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 33,
       "y": 42,
       "elevation": 3,
       "dest_map": "MAP_PETALBURG_WOODS",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [

--- a/data/maps/Route104_MrBrineysHouse/map.json
+++ b/data/maps/Route104_MrBrineysHouse/map.json
@@ -47,14 +47,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE104",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE104",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route104_PrettyPetalFlowerShop/map.json
+++ b/data/maps/Route104_PrettyPetalFlowerShop/map.json
@@ -60,14 +60,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE104",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 3,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE104",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route105/map.json
+++ b/data/maps/Route105/map.json
@@ -141,7 +141,7 @@
       "y": 20,
       "elevation": 0,
       "dest_map": "MAP_ISLAND_CAVE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route106/map.json
+++ b/data/maps/Route106/map.json
@@ -97,7 +97,7 @@
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_GRANITE_CAVE_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route108/map.json
+++ b/data/maps/Route108/map.json
@@ -123,7 +123,7 @@
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_ABANDONED_SHIP_DECK",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route109/map.json
+++ b/data/maps/Route109/map.json
@@ -344,7 +344,7 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE109_SEASHORE_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route109_SeashoreHouse/map.json
+++ b/data/maps/Route109_SeashoreHouse/map.json
@@ -73,14 +73,14 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_ROUTE109",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 7,
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_ROUTE109",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route110/map.json
+++ b/data/maps/Route110/map.json
@@ -505,42 +505,42 @@
       "y": 24,
       "elevation": 3,
       "dest_map": "MAP_NEW_MAUVILLE_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 11,
       "y": 66,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 15,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_SEASIDE_CYCLING_ROAD_SOUTH_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 18,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_SEASIDE_CYCLING_ROAD_SOUTH_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 16,
       "y": 88,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_SEASIDE_CYCLING_ROAD_NORTH_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 19,
       "y": 88,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_SEASIDE_CYCLING_ROAD_NORTH_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [

--- a/data/maps/Route110_SeasideCyclingRoadNorthEntrance/map.json
+++ b/data/maps/Route110_SeasideCyclingRoadNorthEntrance/map.json
@@ -34,28 +34,28 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 2,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 12,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 13,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [

--- a/data/maps/Route110_SeasideCyclingRoadSouthEntrance/map.json
+++ b/data/maps/Route110_SeasideCyclingRoadSouthEntrance/map.json
@@ -34,28 +34,28 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 2,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 12,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 13,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [

--- a/data/maps/Route110_TrickHouseCorridor/map.json
+++ b/data/maps/Route110_TrickHouseCorridor/map.json
@@ -20,28 +20,28 @@
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_END",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 14,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_END",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 4,
       "y": 23,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 23,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route110_TrickHouseEnd/map.json
+++ b/data/maps/Route110_TrickHouseEnd/map.json
@@ -34,14 +34,14 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_PUZZLE1",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 2,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_CORRIDOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/Route110_TrickHouseEntrance/map.json
+++ b/data/maps/Route110_TrickHouseEntrance/map.json
@@ -34,21 +34,21 @@
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 6,
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_PUZZLE1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/Route110_TrickHousePuzzle1/map.json
+++ b/data/maps/Route110_TrickHousePuzzle1/map.json
@@ -216,21 +216,21 @@
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 13,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_END",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route110_TrickHousePuzzle2/map.json
+++ b/data/maps/Route110_TrickHousePuzzle2/map.json
@@ -86,21 +86,21 @@
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 13,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_END",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/Route110_TrickHousePuzzle3/map.json
+++ b/data/maps/Route110_TrickHousePuzzle3/map.json
@@ -112,21 +112,21 @@
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 13,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_END",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/Route110_TrickHousePuzzle4/map.json
+++ b/data/maps/Route110_TrickHousePuzzle4/map.json
@@ -203,21 +203,21 @@
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 13,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_END",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route110_TrickHousePuzzle5/map.json
+++ b/data/maps/Route110_TrickHousePuzzle5/map.json
@@ -86,21 +86,21 @@
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 13,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_END",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/Route110_TrickHousePuzzle6/map.json
+++ b/data/maps/Route110_TrickHousePuzzle6/map.json
@@ -73,21 +73,21 @@
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 13,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_END",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route110_TrickHousePuzzle7/map.json
+++ b/data/maps/Route110_TrickHousePuzzle7/map.json
@@ -138,91 +138,91 @@
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 13,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_END",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 13,
       "y": 4,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_PUZZLE7",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 7,
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_PUZZLE7",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 13,
       "y": 11,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_PUZZLE7",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 4,
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_PUZZLE7",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 1,
       "y": 17,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_PUZZLE7",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 0,
       "y": 11,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_PUZZLE7",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 2,
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_PUZZLE7",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     },
     {
       "x": 4,
       "y": 13,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_PUZZLE7",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     },
     {
       "x": 1,
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_PUZZLE7",
-      "dest_warp_id": 12
+      "dest_warp_id": "12"
     },
     {
       "x": 8,
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_PUZZLE7",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     }
   ],
   "coord_events": [

--- a/data/maps/Route110_TrickHousePuzzle8/map.json
+++ b/data/maps/Route110_TrickHousePuzzle8/map.json
@@ -73,21 +73,21 @@
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 13,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_ROUTE110_TRICK_HOUSE_END",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route111/map.json
+++ b/data/maps/Route111/map.json
@@ -635,35 +635,35 @@
       "y": 113,
       "elevation": 0,
       "dest_map": "MAP_ROUTE111_WINSTRATE_FAMILYS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 29,
       "y": 87,
       "elevation": 0,
       "dest_map": "MAP_DESERT_RUINS",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 26,
       "y": 18,
       "elevation": 0,
       "dest_map": "MAP_ROUTE111_OLD_LADYS_REST_STOP",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 19,
       "y": 58,
       "elevation": 0,
       "dest_map": "MAP_MIRAGE_TOWER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 31,
       "y": 113,
       "elevation": 0,
       "dest_map": "MAP_TRAINER_HILL_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/Route111_OldLadysRestStop/map.json
+++ b/data/maps/Route111_OldLadysRestStop/map.json
@@ -34,14 +34,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_ROUTE111",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_ROUTE111",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route111_WinstrateFamilysHouse/map.json
+++ b/data/maps/Route111_WinstrateFamilysHouse/map.json
@@ -73,14 +73,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_ROUTE111",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_ROUTE111",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route112/map.json
+++ b/data/maps/Route112/map.json
@@ -219,42 +219,42 @@
       "y": 27,
       "elevation": 0,
       "dest_map": "MAP_ROUTE112_CABLE_CAR_STATION",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 29,
       "y": 27,
       "elevation": 0,
       "dest_map": "MAP_ROUTE112_CABLE_CAR_STATION",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 6,
       "y": 46,
       "elevation": 3,
       "dest_map": "MAP_JAGGED_PASS",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 7,
       "y": 46,
       "elevation": 3,
       "dest_map": "MAP_JAGGED_PASS",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 11,
       "y": 36,
       "elevation": 0,
       "dest_map": "MAP_FIERY_PATH",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 22,
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_FIERY_PATH",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route112_CableCarStation/map.json
+++ b/data/maps/Route112_CableCarStation/map.json
@@ -47,14 +47,14 @@
       "y": 11,
       "elevation": 0,
       "dest_map": "MAP_ROUTE112",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 7,
       "y": 11,
       "elevation": 0,
       "dest_map": "MAP_ROUTE112",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route113/map.json
+++ b/data/maps/Route113/map.json
@@ -245,21 +245,21 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE113_GLASS_WORKSHOP",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 41,
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_TERRA_CAVE_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 88,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_TERRA_CAVE_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/Route113_GlassWorkshop/map.json
+++ b/data/maps/Route113_GlassWorkshop/map.json
@@ -47,14 +47,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE113",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE113",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route114/map.json
+++ b/data/maps/Route114/map.json
@@ -383,35 +383,35 @@
       "y": 63,
       "elevation": 0,
       "dest_map": "MAP_METEOR_FALLS_1F_1R",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 29,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE114_FOSSIL_MANIACS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 27,
       "y": 36,
       "elevation": 0,
       "dest_map": "MAP_ROUTE114_LANETTES_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 46,
       "elevation": 0,
       "dest_map": "MAP_TERRA_CAVE_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 7,
       "y": 4,
       "elevation": 0,
       "dest_map": "MAP_TERRA_CAVE_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route114_FossilManiacsHouse/map.json
+++ b/data/maps/Route114_FossilManiacsHouse/map.json
@@ -34,21 +34,21 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_ROUTE114",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_ROUTE114",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 4,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_ROUTE114_FOSSIL_MANIACS_TUNNEL",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route114_FossilManiacsTunnel/map.json
+++ b/data/maps/Route114_FossilManiacsTunnel/map.json
@@ -34,21 +34,21 @@
       "y": 25,
       "elevation": 3,
       "dest_map": "MAP_ROUTE114_FOSSIL_MANIACS_HOUSE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 7,
       "y": 25,
       "elevation": 3,
       "dest_map": "MAP_ROUTE114_FOSSIL_MANIACS_HOUSE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 6,
       "y": 2,
       "elevation": 0,
       "dest_map": "MAP_DESERT_UNDERPASS",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/Route114_LanettesHouse/map.json
+++ b/data/maps/Route114_LanettesHouse/map.json
@@ -34,14 +34,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_ROUTE114",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 6,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_ROUTE114",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route115/map.json
+++ b/data/maps/Route115/map.json
@@ -331,21 +331,21 @@
       "y": 37,
       "elevation": 0,
       "dest_map": "MAP_METEOR_FALLS_1F_1R",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 21,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_TERRA_CAVE_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 36,
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_TERRA_CAVE_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route116/map.json
+++ b/data/maps/Route116/map.json
@@ -396,35 +396,35 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_RUSTURF_TUNNEL",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 38,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE116_TUNNELERS_REST_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 65,
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_RUSTURF_TUNNEL",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 59,
       "y": 13,
       "elevation": 0,
       "dest_map": "MAP_TERRA_CAVE_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 79,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_TERRA_CAVE_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/Route116_TunnelersRestHouse/map.json
+++ b/data/maps/Route116_TunnelersRestHouse/map.json
@@ -60,14 +60,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE116",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE116",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route117/map.json
+++ b/data/maps/Route117/map.json
@@ -344,7 +344,7 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE117_POKEMON_DAY_CARE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route117_PokemonDayCare/map.json
+++ b/data/maps/Route117_PokemonDayCare/map.json
@@ -34,14 +34,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE117",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 3,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE117",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route118/map.json
+++ b/data/maps/Route118/map.json
@@ -310,14 +310,14 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_TERRA_CAVE_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_TERRA_CAVE_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/Route119/map.json
+++ b/data/maps/Route119/map.json
@@ -591,14 +591,14 @@
       "y": 32,
       "elevation": 0,
       "dest_map": "MAP_ROUTE119_WEATHER_INSTITUTE_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 33,
       "y": 109,
       "elevation": 0,
       "dest_map": "MAP_ROUTE119_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/Route119_House/map.json
+++ b/data/maps/Route119_House/map.json
@@ -112,14 +112,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE119",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 4,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE119",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route119_WeatherInstitute_1F/map.json
+++ b/data/maps/Route119_WeatherInstitute_1F/map.json
@@ -86,21 +86,21 @@
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_ROUTE119",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_ROUTE119",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 17,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_ROUTE119_WEATHER_INSTITUTE_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route119_WeatherInstitute_2F/map.json
+++ b/data/maps/Route119_WeatherInstitute_2F/map.json
@@ -125,7 +125,7 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_ROUTE119_WEATHER_INSTITUTE_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route120/map.json
+++ b/data/maps/Route120/map.json
@@ -604,14 +604,14 @@
       "y": 55,
       "elevation": 0,
       "dest_map": "MAP_ANCIENT_TOMB",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 19,
       "y": 23,
       "elevation": 1,
       "dest_map": "MAP_SCORCHED_SLAB",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/Route121/map.json
+++ b/data/maps/Route121/map.json
@@ -414,7 +414,7 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_ROUTE121_SAFARI_ZONE_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [

--- a/data/maps/Route121_SafariZoneEntrance/map.json
+++ b/data/maps/Route121_SafariZoneEntrance/map.json
@@ -60,28 +60,28 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_SAFARI_ZONE_SOUTH",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 3,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_SAFARI_ZONE_SOUTH",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 14,
       "y": 13,
       "elevation": 0,
       "dest_map": "MAP_ROUTE121",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 15,
       "y": 13,
       "elevation": 0,
       "dest_map": "MAP_ROUTE121",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/Route122/map.json
+++ b/data/maps/Route122/map.json
@@ -31,7 +31,7 @@
       "y": 29,
       "elevation": 0,
       "dest_map": "MAP_MT_PYRE_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route123/map.json
+++ b/data/maps/Route123/map.json
@@ -591,7 +591,7 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_ROUTE123_BERRY_MASTERS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/Route123_BerryMastersHouse/map.json
+++ b/data/maps/Route123_BerryMastersHouse/map.json
@@ -47,14 +47,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_ROUTE123",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_ROUTE123",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route124/map.json
+++ b/data/maps/Route124/map.json
@@ -203,7 +203,7 @@
       "y": 48,
       "elevation": 3,
       "dest_map": "MAP_ROUTE124_DIVING_TREASURE_HUNTERS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route124_DivingTreasureHuntersHouse/map.json
+++ b/data/maps/Route124_DivingTreasureHuntersHouse/map.json
@@ -34,14 +34,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE124",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_ROUTE124",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route125/map.json
+++ b/data/maps/Route125/map.json
@@ -167,7 +167,7 @@
       "y": 19,
       "elevation": 0,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_ENTRANCE_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Route131/map.json
+++ b/data/maps/Route131/map.json
@@ -136,7 +136,7 @@
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity/map.json
+++ b/data/maps/RustboroCity/map.json
@@ -245,84 +245,84 @@
       "y": 19,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_GYM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 13,
       "y": 30,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_FLAT1_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 16,
       "y": 45,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_MART",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 16,
       "y": 38,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 27,
       "y": 34,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_POKEMON_SCHOOL",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 11,
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_DEVON_CORP_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 12,
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_DEVON_CORP_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 33,
       "y": 19,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_HOUSE1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 38,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_CUTTERS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 30,
       "y": 28,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_HOUSE2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 5,
       "y": 51,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_FLAT2_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 26,
       "y": 46,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_HOUSE3",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/RustboroCity_CuttersHouse/map.json
+++ b/data/maps/RustboroCity_CuttersHouse/map.json
@@ -47,14 +47,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_DevonCorp_1F/map.json
+++ b/data/maps/RustboroCity_DevonCorp_1F/map.json
@@ -60,21 +60,21 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 14,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_DEVON_CORP_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_DevonCorp_2F/map.json
+++ b/data/maps/RustboroCity_DevonCorp_2F/map.json
@@ -99,14 +99,14 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_DEVON_CORP_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 2,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_DEVON_CORP_3F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_DevonCorp_3F/map.json
+++ b/data/maps/RustboroCity_DevonCorp_3F/map.json
@@ -60,7 +60,7 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_DEVON_CORP_2F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_Flat1_1F/map.json
+++ b/data/maps/RustboroCity_Flat1_1F/map.json
@@ -47,21 +47,21 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 7,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 2,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_FLAT1_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_Flat1_2F/map.json
+++ b/data/maps/RustboroCity_Flat1_2F/map.json
@@ -125,7 +125,7 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_FLAT1_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_Flat2_1F/map.json
+++ b/data/maps/RustboroCity_Flat2_1F/map.json
@@ -47,21 +47,21 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     },
     {
       "x": 3,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     },
     {
       "x": 3,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_FLAT2_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_Flat2_2F/map.json
+++ b/data/maps/RustboroCity_Flat2_2F/map.json
@@ -47,14 +47,14 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_FLAT2_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_FLAT2_3F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_Flat2_3F/map.json
+++ b/data/maps/RustboroCity_Flat2_3F/map.json
@@ -47,7 +47,7 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY_FLAT2_2F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_Gym/map.json
+++ b/data/maps/RustboroCity_Gym/map.json
@@ -86,14 +86,14 @@
       "y": 19,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 19,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_House1/map.json
+++ b/data/maps/RustboroCity_House1/map.json
@@ -47,14 +47,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 6,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_House2/map.json
+++ b/data/maps/RustboroCity_House2/map.json
@@ -47,14 +47,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_House3/map.json
+++ b/data/maps/RustboroCity_House3/map.json
@@ -60,14 +60,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_Mart/map.json
+++ b/data/maps/RustboroCity_Mart/map.json
@@ -73,14 +73,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_PokemonCenter_1F/map.json
+++ b/data/maps/RustboroCity_PokemonCenter_1F/map.json
@@ -73,21 +73,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_RUSTBORO_CITY_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_PokemonCenter_2F/map.json
+++ b/data/maps/RustboroCity_PokemonCenter_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_RUSTBORO_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/RustboroCity_PokemonSchool/map.json
+++ b/data/maps/RustboroCity_PokemonSchool/map.json
@@ -112,14 +112,14 @@
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 6,
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_RUSTBORO_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/RusturfTunnel/map.json
+++ b/data/maps/RusturfTunnel/map.json
@@ -151,21 +151,21 @@
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_ROUTE116",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 29,
       "y": 16,
       "elevation": 3,
       "dest_map": "MAP_VERDANTURF_TOWN",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 18,
       "y": 20,
       "elevation": 3,
       "dest_map": "MAP_ROUTE116",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [

--- a/data/maps/SSTidalCorridor/map.json
+++ b/data/maps/SSTidalCorridor/map.json
@@ -86,63 +86,63 @@
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_SS_TIDAL_ROOMS",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 7,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_SS_TIDAL_ROOMS",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 10,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_SS_TIDAL_ROOMS",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 13,
       "y": 9,
       "elevation": 3,
       "dest_map": "MAP_SS_TIDAL_ROOMS",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 4,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_SS_TIDAL_ROOMS",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 7,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_SS_TIDAL_ROOMS",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     },
     {
       "x": 10,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_SS_TIDAL_ROOMS",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     },
     {
       "x": 13,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_SS_TIDAL_ROOMS",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     },
     {
       "x": 16,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_SS_TIDAL_LOWER_DECK",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SSTidalLowerDeck/map.json
+++ b/data/maps/SSTidalLowerDeck/map.json
@@ -47,7 +47,7 @@
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_SS_TIDAL_CORRIDOR",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     }
   ],
   "coord_events": [],

--- a/data/maps/SSTidalRooms/map.json
+++ b/data/maps/SSTidalRooms/map.json
@@ -125,84 +125,84 @@
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_SS_TIDAL_CORRIDOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 5,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_SS_TIDAL_CORRIDOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 13,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_SS_TIDAL_CORRIDOR",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 14,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_SS_TIDAL_CORRIDOR",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 22,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_SS_TIDAL_CORRIDOR",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 23,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_SS_TIDAL_CORRIDOR",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 31,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_SS_TIDAL_CORRIDOR",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 32,
       "y": 16,
       "elevation": 0,
       "dest_map": "MAP_SS_TIDAL_CORRIDOR",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 4,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_SS_TIDAL_CORRIDOR",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 13,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_SS_TIDAL_CORRIDOR",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 22,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_SS_TIDAL_CORRIDOR",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 31,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_SS_TIDAL_CORRIDOR",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     }
   ],
   "coord_events": [],

--- a/data/maps/SafariZone_RestHouse/map.json
+++ b/data/maps/SafariZone_RestHouse/map.json
@@ -60,14 +60,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_SAFARI_ZONE_SOUTHWEST",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_SAFARI_ZONE_SOUTHWEST",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SafariZone_South/map.json
+++ b/data/maps/SafariZone_South/map.json
@@ -115,7 +115,7 @@
       "y": 33,
       "elevation": 0,
       "dest_map": "MAP_ROUTE121_SAFARI_ZONE_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SafariZone_Southwest/map.json
+++ b/data/maps/SafariZone_Southwest/map.json
@@ -58,7 +58,7 @@
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_SAFARI_ZONE_REST_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/ScorchedSlab/map.json
+++ b/data/maps/ScorchedSlab/map.json
@@ -34,7 +34,7 @@
       "y": 16,
       "elevation": 1,
       "dest_map": "MAP_ROUTE120",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/SeafloorCavern_Entrance/map.json
+++ b/data/maps/SeafloorCavern_Entrance/map.json
@@ -34,14 +34,14 @@
       "y": 18,
       "elevation": 3,
       "dest_map": "MAP_UNDERWATER_ROUTE128",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SeafloorCavern_Room1/map.json
+++ b/data/maps/SeafloorCavern_Room1/map.json
@@ -86,21 +86,21 @@
       "y": 18,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ENTRANCE",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 17,
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM5",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SeafloorCavern_Room2/map.json
+++ b/data/maps/SeafloorCavern_Room2/map.json
@@ -125,28 +125,28 @@
       "y": 7,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM1",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 4,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM4",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM6",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 11,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM7",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SeafloorCavern_Room3/map.json
+++ b/data/maps/SeafloorCavern_Room3/map.json
@@ -138,21 +138,21 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM8",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 9,
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM7",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 4,
       "y": 15,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM6",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/SeafloorCavern_Room4/map.json
+++ b/data/maps/SeafloorCavern_Room4/map.json
@@ -47,28 +47,28 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM2",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 4,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM5",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 9,
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM5",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 10,
       "y": 15,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ENTRANCE",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/SeafloorCavern_Room5/map.json
+++ b/data/maps/SeafloorCavern_Room5/map.json
@@ -99,21 +99,21 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM1",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 15,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM4",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 7,
       "y": 17,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM4",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/SeafloorCavern_Room6/map.json
+++ b/data/maps/SeafloorCavern_Room6/map.json
@@ -20,21 +20,21 @@
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM2",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 4,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM3",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 14,
       "y": 8,
       "elevation": 1,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ENTRANCE",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/SeafloorCavern_Room7/map.json
+++ b/data/maps/SeafloorCavern_Room7/map.json
@@ -20,14 +20,14 @@
       "y": 23,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM2",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM3",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/SeafloorCavern_Room8/map.json
+++ b/data/maps/SeafloorCavern_Room8/map.json
@@ -177,14 +177,14 @@
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM9",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 5,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM3",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SeafloorCavern_Room9/map.json
+++ b/data/maps/SeafloorCavern_Room9/map.json
@@ -112,7 +112,7 @@
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_SEAFLOOR_CAVERN_ROOM8",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/SealedChamber_InnerRoom/map.json
+++ b/data/maps/SealedChamber_InnerRoom/map.json
@@ -20,7 +20,7 @@
       "y": 19,
       "elevation": 3,
       "dest_map": "MAP_SEALED_CHAMBER_OUTER_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SealedChamber_OuterRoom/map.json
+++ b/data/maps/SealedChamber_OuterRoom/map.json
@@ -20,7 +20,7 @@
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_SEALED_CHAMBER_INNER_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_BlueCave1/map.json
+++ b/data/maps/SecretBase_BlueCave1/map.json
@@ -216,7 +216,7 @@
       "x": 5,
       "y": 7,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_BlueCave1/map.json
+++ b/data/maps/SecretBase_BlueCave1/map.json
@@ -217,7 +217,7 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_BlueCave2/map.json
+++ b/data/maps/SecretBase_BlueCave2/map.json
@@ -216,7 +216,7 @@
       "x": 7,
       "y": 5,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_BlueCave2/map.json
+++ b/data/maps/SecretBase_BlueCave2/map.json
@@ -217,7 +217,7 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_BlueCave3/map.json
+++ b/data/maps/SecretBase_BlueCave3/map.json
@@ -216,7 +216,7 @@
       "x": 4,
       "y": 15,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_BlueCave3/map.json
+++ b/data/maps/SecretBase_BlueCave3/map.json
@@ -217,7 +217,7 @@
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_BlueCave4/map.json
+++ b/data/maps/SecretBase_BlueCave4/map.json
@@ -216,7 +216,7 @@
       "x": 4,
       "y": 15,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_BlueCave4/map.json
+++ b/data/maps/SecretBase_BlueCave4/map.json
@@ -217,7 +217,7 @@
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_BrownCave1/map.json
+++ b/data/maps/SecretBase_BrownCave1/map.json
@@ -216,7 +216,7 @@
       "x": 5,
       "y": 7,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_BrownCave1/map.json
+++ b/data/maps/SecretBase_BrownCave1/map.json
@@ -217,7 +217,7 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_BrownCave2/map.json
+++ b/data/maps/SecretBase_BrownCave2/map.json
@@ -216,7 +216,7 @@
       "x": 1,
       "y": 7,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_BrownCave2/map.json
+++ b/data/maps/SecretBase_BrownCave2/map.json
@@ -217,7 +217,7 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_BrownCave3/map.json
+++ b/data/maps/SecretBase_BrownCave3/map.json
@@ -217,7 +217,7 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_BrownCave3/map.json
+++ b/data/maps/SecretBase_BrownCave3/map.json
@@ -216,7 +216,7 @@
       "x": 11,
       "y": 9,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_BrownCave4/map.json
+++ b/data/maps/SecretBase_BrownCave4/map.json
@@ -216,7 +216,7 @@
       "x": 2,
       "y": 8,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_BrownCave4/map.json
+++ b/data/maps/SecretBase_BrownCave4/map.json
@@ -217,7 +217,7 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_RedCave1/map.json
+++ b/data/maps/SecretBase_RedCave1/map.json
@@ -216,7 +216,7 @@
       "x": 5,
       "y": 7,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_RedCave1/map.json
+++ b/data/maps/SecretBase_RedCave1/map.json
@@ -217,7 +217,7 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_RedCave2/map.json
+++ b/data/maps/SecretBase_RedCave2/map.json
@@ -216,7 +216,7 @@
       "x": 3,
       "y": 14,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_RedCave2/map.json
+++ b/data/maps/SecretBase_RedCave2/map.json
@@ -217,7 +217,7 @@
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_RedCave3/map.json
+++ b/data/maps/SecretBase_RedCave3/map.json
@@ -217,7 +217,7 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_RedCave3/map.json
+++ b/data/maps/SecretBase_RedCave3/map.json
@@ -216,7 +216,7 @@
       "x": 3,
       "y": 6,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_RedCave4/map.json
+++ b/data/maps/SecretBase_RedCave4/map.json
@@ -216,7 +216,7 @@
       "x": 2,
       "y": 12,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_RedCave4/map.json
+++ b/data/maps/SecretBase_RedCave4/map.json
@@ -217,7 +217,7 @@
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_Shrub1/map.json
+++ b/data/maps/SecretBase_Shrub1/map.json
@@ -216,7 +216,7 @@
       "x": 5,
       "y": 7,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_Shrub1/map.json
+++ b/data/maps/SecretBase_Shrub1/map.json
@@ -217,7 +217,7 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_Shrub2/map.json
+++ b/data/maps/SecretBase_Shrub2/map.json
@@ -216,7 +216,7 @@
       "x": 7,
       "y": 5,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_Shrub2/map.json
+++ b/data/maps/SecretBase_Shrub2/map.json
@@ -217,7 +217,7 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_Shrub3/map.json
+++ b/data/maps/SecretBase_Shrub3/map.json
@@ -216,7 +216,7 @@
       "x": 6,
       "y": 9,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_Shrub3/map.json
+++ b/data/maps/SecretBase_Shrub3/map.json
@@ -217,7 +217,7 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_Shrub4/map.json
+++ b/data/maps/SecretBase_Shrub4/map.json
@@ -216,7 +216,7 @@
       "x": 11,
       "y": 8,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_Shrub4/map.json
+++ b/data/maps/SecretBase_Shrub4/map.json
@@ -217,7 +217,7 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_Tree1/map.json
+++ b/data/maps/SecretBase_Tree1/map.json
@@ -216,7 +216,7 @@
       "x": 5,
       "y": 7,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_Tree1/map.json
+++ b/data/maps/SecretBase_Tree1/map.json
@@ -217,7 +217,7 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_Tree2/map.json
+++ b/data/maps/SecretBase_Tree2/map.json
@@ -216,7 +216,7 @@
       "x": 3,
       "y": 14,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_Tree2/map.json
+++ b/data/maps/SecretBase_Tree2/map.json
@@ -217,7 +217,7 @@
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_Tree3/map.json
+++ b/data/maps/SecretBase_Tree3/map.json
@@ -216,7 +216,7 @@
       "x": 8,
       "y": 6,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_Tree3/map.json
+++ b/data/maps/SecretBase_Tree3/map.json
@@ -217,7 +217,7 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_Tree4/map.json
+++ b/data/maps/SecretBase_Tree4/map.json
@@ -216,7 +216,7 @@
       "x": 7,
       "y": 12,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_Tree4/map.json
+++ b/data/maps/SecretBase_Tree4/map.json
@@ -217,7 +217,7 @@
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_YellowCave1/map.json
+++ b/data/maps/SecretBase_YellowCave1/map.json
@@ -216,7 +216,7 @@
       "x": 5,
       "y": 7,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_YellowCave1/map.json
+++ b/data/maps/SecretBase_YellowCave1/map.json
@@ -217,7 +217,7 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_YellowCave2/map.json
+++ b/data/maps/SecretBase_YellowCave2/map.json
@@ -216,7 +216,7 @@
       "x": 12,
       "y": 7,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_YellowCave2/map.json
+++ b/data/maps/SecretBase_YellowCave2/map.json
@@ -217,7 +217,7 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_YellowCave3/map.json
+++ b/data/maps/SecretBase_YellowCave3/map.json
@@ -216,7 +216,7 @@
       "x": 5,
       "y": 9,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_YellowCave3/map.json
+++ b/data/maps/SecretBase_YellowCave3/map.json
@@ -217,7 +217,7 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/SecretBase_YellowCave4/map.json
+++ b/data/maps/SecretBase_YellowCave4/map.json
@@ -216,7 +216,7 @@
       "x": 6,
       "y": 12,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 126
     }
   ],

--- a/data/maps/SecretBase_YellowCave4/map.json
+++ b/data/maps/SecretBase_YellowCave4/map.json
@@ -217,7 +217,7 @@
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 126
+      "dest_warp_id": "WARP_ID_SECRET_BASE"
     }
   ],
   "coord_events": [],

--- a/data/maps/ShoalCave_LowTideEntranceRoom/map.json
+++ b/data/maps/ShoalCave_LowTideEntranceRoom/map.json
@@ -47,28 +47,28 @@
       "y": 30,
       "elevation": 3,
       "dest_map": "MAP_ROUTE125",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 19,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_INNER_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_INNER_ROOM",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 27,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_INNER_ROOM",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     }
   ],
   "coord_events": [],

--- a/data/maps/ShoalCave_LowTideIceRoom/map.json
+++ b/data/maps/ShoalCave_LowTideIceRoom/map.json
@@ -47,7 +47,7 @@
       "y": 10,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_LOWER_ROOM",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/ShoalCave_LowTideInnerRoom/map.json
+++ b/data/maps/ShoalCave_LowTideInnerRoom/map.json
@@ -34,56 +34,56 @@
       "y": 29,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_ENTRANCE_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 38,
       "y": 15,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_STAIRS_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 42,
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_STAIRS_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 19,
       "y": 14,
       "elevation": 4,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_LOWER_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 15,
       "y": 19,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_LOWER_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 30,
       "y": 25,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_LOWER_ROOM",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 14,
       "y": 33,
       "elevation": 5,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_ENTRANCE_ROOM",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 40,
       "y": 33,
       "elevation": 5,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_ENTRANCE_ROOM",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/ShoalCave_LowTideLowerRoom/map.json
+++ b/data/maps/ShoalCave_LowTideLowerRoom/map.json
@@ -47,28 +47,28 @@
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_INNER_ROOM",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 2,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_INNER_ROOM",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 19,
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_INNER_ROOM",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 28,
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_ICE_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/ShoalCave_LowTideStairsRoom/map.json
+++ b/data/maps/ShoalCave_LowTideStairsRoom/map.json
@@ -34,14 +34,14 @@
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_INNER_ROOM",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 7,
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_SHOAL_CAVE_LOW_TIDE_INNER_ROOM",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/SkyPillar_1F/map.json
+++ b/data/maps/SkyPillar_1F/map.json
@@ -20,21 +20,21 @@
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_OUTSIDE",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 7,
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_OUTSIDE",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 10,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SkyPillar_2F/map.json
+++ b/data/maps/SkyPillar_2F/map.json
@@ -20,14 +20,14 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 3,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_3F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SkyPillar_3F/map.json
+++ b/data/maps/SkyPillar_3F/map.json
@@ -20,21 +20,21 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_2F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 11,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_4F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 7,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_4F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/SkyPillar_4F/map.json
+++ b/data/maps/SkyPillar_4F/map.json
@@ -20,21 +20,21 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_3F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 7,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_3F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 3,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_5F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SkyPillar_5F/map.json
+++ b/data/maps/SkyPillar_5F/map.json
@@ -20,14 +20,14 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_4F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 10,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_TOP",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SkyPillar_Entrance/map.json
+++ b/data/maps/SkyPillar_Entrance/map.json
@@ -20,14 +20,14 @@
       "y": 16,
       "elevation": 3,
       "dest_map": "MAP_ROUTE131",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 14,
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_OUTSIDE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SkyPillar_Outside/map.json
+++ b/data/maps/SkyPillar_Outside/map.json
@@ -34,14 +34,14 @@
       "y": 13,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_ENTRANCE",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 14,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_SKY_PILLAR_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SkyPillar_Top/map.json
+++ b/data/maps/SkyPillar_Top/map.json
@@ -47,7 +47,7 @@
       "y": 14,
       "elevation": 3,
       "dest_map": "MAP_SKY_PILLAR_5F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [

--- a/data/maps/SlateportCity/map.json
+++ b/data/maps/SlateportCity/map.json
@@ -492,77 +492,77 @@
       "y": 19,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 13,
       "y": 26,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_MART",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 26,
       "y": 38,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_STERNS_SHIPYARD_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_BATTLE_TENT_LOBBY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 4,
       "y": 26,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_POKEMON_FAN_CLUB",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 30,
       "y": 26,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_OCEANIC_MUSEUM_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 5,
       "y": 19,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_NAME_RATERS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 31,
       "y": 26,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_OCEANIC_MUSEUM_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 28,
       "y": 12,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_HARBOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 40,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_HARBOR",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 21,
       "y": 44,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/SlateportCity_BattleTentLobby/map.json
+++ b/data/maps/SlateportCity_BattleTentLobby/map.json
@@ -86,14 +86,14 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 7,
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/SlateportCity_Harbor/map.json
+++ b/data/maps/SlateportCity_Harbor/map.json
@@ -125,28 +125,28 @@
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 12,
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 19,
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     },
     {
       "x": 20,
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     }
   ],
   "coord_events": [

--- a/data/maps/SlateportCity_House/map.json
+++ b/data/maps/SlateportCity_House/map.json
@@ -47,14 +47,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     }
   ],
   "coord_events": [],

--- a/data/maps/SlateportCity_Mart/map.json
+++ b/data/maps/SlateportCity_Mart/map.json
@@ -60,14 +60,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/SlateportCity_NameRatersHouse/map.json
+++ b/data/maps/SlateportCity_NameRatersHouse/map.json
@@ -34,14 +34,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     }
   ],
   "coord_events": [],

--- a/data/maps/SlateportCity_OceanicMuseum_1F/map.json
+++ b/data/maps/SlateportCity_OceanicMuseum_1F/map.json
@@ -203,21 +203,21 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 10,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 6,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_OCEANIC_MUSEUM_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/SlateportCity_OceanicMuseum_2F/map.json
+++ b/data/maps/SlateportCity_OceanicMuseum_2F/map.json
@@ -112,7 +112,7 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_OCEANIC_MUSEUM_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/SlateportCity_PokemonCenter_1F/map.json
+++ b/data/maps/SlateportCity_PokemonCenter_1F/map.json
@@ -60,21 +60,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_SLATEPORT_CITY_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SlateportCity_PokemonCenter_2F/map.json
+++ b/data/maps/SlateportCity_PokemonCenter_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_SLATEPORT_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SlateportCity_PokemonFanClub/map.json
+++ b/data/maps/SlateportCity_PokemonFanClub/map.json
@@ -138,14 +138,14 @@
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 7,
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/SlateportCity_SternsShipyard_1F/map.json
+++ b/data/maps/SlateportCity_SternsShipyard_1F/map.json
@@ -73,21 +73,21 @@
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 3,
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 3,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_STERNS_SHIPYARD_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SlateportCity_SternsShipyard_2F/map.json
+++ b/data/maps/SlateportCity_SternsShipyard_2F/map.json
@@ -60,7 +60,7 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_SLATEPORT_CITY_STERNS_SHIPYARD_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity/map.json
+++ b/data/maps/SootopolisCity/map.json
@@ -255,91 +255,91 @@
       "y": 31,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 17,
       "y": 29,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY_MART",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 31,
       "y": 32,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY_GYM_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 31,
       "y": 16,
       "elevation": 3,
       "dest_map": "MAP_CAVE_OF_ORIGIN_ENTRANCE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY_HOUSE1",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 45,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY_HOUSE2",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 17,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY_HOUSE3",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 44,
       "y": 17,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY_HOUSE4",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 26,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY_HOUSE5",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 53,
       "y": 28,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY_HOUSE6",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 8,
       "y": 35,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY_HOUSE7",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 48,
       "y": 25,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY_LOTAD_AND_SEEDOT_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 51,
       "y": 36,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY_MYSTERY_EVENTS_HOUSE_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_Gym_1F/map.json
+++ b/data/maps/SootopolisCity_Gym_1F/map.json
@@ -47,21 +47,21 @@
       "y": 25,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 9,
       "y": 25,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 11,
       "y": 22,
       "elevation": 3,
       "dest_map": "MAP_SOOTOPOLIS_CITY_GYM_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_Gym_B1F/map.json
+++ b/data/maps/SootopolisCity_Gym_B1F/map.json
@@ -151,7 +151,7 @@
       "y": 22,
       "elevation": 3,
       "dest_map": "MAP_SOOTOPOLIS_CITY_GYM_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_House1/map.json
+++ b/data/maps/SootopolisCity_House1/map.json
@@ -47,14 +47,14 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 4,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_House2/map.json
+++ b/data/maps/SootopolisCity_House2/map.json
@@ -34,14 +34,14 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 4,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_House3/map.json
+++ b/data/maps/SootopolisCity_House3/map.json
@@ -47,14 +47,14 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 4,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_House4/map.json
+++ b/data/maps/SootopolisCity_House4/map.json
@@ -60,14 +60,14 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     },
     {
       "x": 4,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 7
+      "dest_warp_id": "7"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_House5/map.json
+++ b/data/maps/SootopolisCity_House5/map.json
@@ -47,14 +47,14 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     },
     {
       "x": 4,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 8
+      "dest_warp_id": "8"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_House6/map.json
+++ b/data/maps/SootopolisCity_House6/map.json
@@ -34,14 +34,14 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     },
     {
       "x": 4,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 9
+      "dest_warp_id": "9"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_House7/map.json
+++ b/data/maps/SootopolisCity_House7/map.json
@@ -47,14 +47,14 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     },
     {
       "x": 4,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 10
+      "dest_warp_id": "10"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_LotadAndSeedotHouse/map.json
+++ b/data/maps/SootopolisCity_LotadAndSeedotHouse/map.json
@@ -47,14 +47,14 @@
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     },
     {
       "x": 4,
       "y": 6,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 11
+      "dest_warp_id": "11"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_Mart/map.json
+++ b/data/maps/SootopolisCity_Mart/map.json
@@ -60,14 +60,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_MysteryEventsHouse_1F/map.json
+++ b/data/maps/SootopolisCity_MysteryEventsHouse_1F/map.json
@@ -34,21 +34,21 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 12
+      "dest_warp_id": "12"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 12
+      "dest_warp_id": "12"
     },
     {
       "x": 3,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_SOOTOPOLIS_CITY_MYSTERY_EVENTS_HOUSE_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_MysteryEventsHouse_B1F/map.json
+++ b/data/maps/SootopolisCity_MysteryEventsHouse_B1F/map.json
@@ -34,7 +34,7 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_SOOTOPOLIS_CITY_MYSTERY_EVENTS_HOUSE_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_PokemonCenter_1F/map.json
+++ b/data/maps/SootopolisCity_PokemonCenter_1F/map.json
@@ -73,21 +73,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_SOOTOPOLIS_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_SOOTOPOLIS_CITY_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SootopolisCity_PokemonCenter_2F/map.json
+++ b/data/maps/SootopolisCity_PokemonCenter_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_SOOTOPOLIS_CITY_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/SouthernIsland_Exterior/map.json
+++ b/data/maps/SouthernIsland_Exterior/map.json
@@ -47,14 +47,14 @@
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_SOUTHERN_ISLAND_INTERIOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 15,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_SOUTHERN_ISLAND_INTERIOR",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/SouthernIsland_Interior/map.json
+++ b/data/maps/SouthernIsland_Interior/map.json
@@ -47,14 +47,14 @@
       "y": 18,
       "elevation": 3,
       "dest_map": "MAP_SOUTHERN_ISLAND_EXTERIOR",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 14,
       "y": 18,
       "elevation": 3,
       "dest_map": "MAP_SOUTHERN_ISLAND_EXTERIOR",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/TerraCave_End/map.json
+++ b/data/maps/TerraCave_End/map.json
@@ -34,7 +34,7 @@
       "y": 4,
       "elevation": 3,
       "dest_map": "MAP_TERRA_CAVE_ENTRANCE",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [

--- a/data/maps/TerraCave_Entrance/map.json
+++ b/data/maps/TerraCave_Entrance/map.json
@@ -20,14 +20,14 @@
       "y": 18,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     },
     {
       "x": 14,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TERRA_CAVE_END",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/TerraCave_Entrance/map.json
+++ b/data/maps/TerraCave_Entrance/map.json
@@ -19,7 +19,7 @@
       "x": 8,
       "y": 18,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     },
     {

--- a/data/maps/TradeCenter/map.json
+++ b/data/maps/TradeCenter/map.json
@@ -33,14 +33,14 @@
       "x": 5,
       "y": 8,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     }
   ],

--- a/data/maps/TradeCenter/map.json
+++ b/data/maps/TradeCenter/map.json
@@ -34,14 +34,14 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     }
   ],
   "coord_events": [

--- a/data/maps/TrainerHill_1F/map.json
+++ b/data/maps/TrainerHill_1F/map.json
@@ -20,14 +20,14 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRAINER_HILL_ENTRANCE",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 12,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRAINER_HILL_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/TrainerHill_2F/map.json
+++ b/data/maps/TrainerHill_2F/map.json
@@ -20,14 +20,14 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRAINER_HILL_1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 12,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRAINER_HILL_3F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/TrainerHill_3F/map.json
+++ b/data/maps/TrainerHill_3F/map.json
@@ -20,14 +20,14 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRAINER_HILL_2F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 12,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRAINER_HILL_4F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/TrainerHill_4F/map.json
+++ b/data/maps/TrainerHill_4F/map.json
@@ -20,14 +20,14 @@
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRAINER_HILL_3F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 12,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRAINER_HILL_ROOF",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/TrainerHill_Elevator/map.json
+++ b/data/maps/TrainerHill_Elevator/map.json
@@ -34,14 +34,14 @@
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_TRAINER_HILL_ROOF",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 2,
       "y": 6,
       "elevation": 3,
       "dest_map": "MAP_TRAINER_HILL_ROOF",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/TrainerHill_Entrance/map.json
+++ b/data/maps/TrainerHill_Entrance/map.json
@@ -86,21 +86,21 @@
       "y": 16,
       "elevation": 3,
       "dest_map": "MAP_ROUTE111",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 10,
       "y": 16,
       "elevation": 3,
       "dest_map": "MAP_ROUTE111",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRAINER_HILL_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [

--- a/data/maps/TrainerHill_Roof/map.json
+++ b/data/maps/TrainerHill_Roof/map.json
@@ -34,14 +34,14 @@
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_TRAINER_HILL_4F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 15,
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_TRAINER_HILL_ELEVATOR",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/Underwater_MarineCave/map.json
+++ b/data/maps/Underwater_MarineCave/map.json
@@ -20,7 +20,7 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     }
   ],
   "coord_events": [],

--- a/data/maps/Underwater_MarineCave/map.json
+++ b/data/maps/Underwater_MarineCave/map.json
@@ -19,7 +19,7 @@
       "x": 9,
       "y": 8,
       "elevation": 0,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     }
   ],

--- a/data/maps/Underwater_Route105/map.json
+++ b/data/maps/Underwater_Route105/map.json
@@ -26,14 +26,14 @@
       "y": 4,
       "elevation": 0,
       "dest_map": "MAP_UNDERWATER_MARINE_CAVE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 17,
       "y": 66,
       "elevation": 0,
       "dest_map": "MAP_UNDERWATER_MARINE_CAVE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Underwater_Route125/map.json
+++ b/data/maps/Underwater_Route125/map.json
@@ -26,14 +26,14 @@
       "y": 10,
       "elevation": 0,
       "dest_map": "MAP_UNDERWATER_MARINE_CAVE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 45,
       "y": 30,
       "elevation": 0,
       "dest_map": "MAP_UNDERWATER_MARINE_CAVE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Underwater_Route126/map.json
+++ b/data/maps/Underwater_Route126/map.json
@@ -36,7 +36,7 @@
       "y": 65,
       "elevation": 0,
       "dest_map": "MAP_UNDERWATER_SOOTOPOLIS_CITY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Underwater_Route127/map.json
+++ b/data/maps/Underwater_Route127/map.json
@@ -36,14 +36,14 @@
       "y": 5,
       "elevation": 0,
       "dest_map": "MAP_UNDERWATER_MARINE_CAVE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 67,
       "y": 38,
       "elevation": 0,
       "dest_map": "MAP_UNDERWATER_MARINE_CAVE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Underwater_Route128/map.json
+++ b/data/maps/Underwater_Route128/map.json
@@ -31,7 +31,7 @@
       "y": 26,
       "elevation": 3,
       "dest_map": "MAP_UNDERWATER_SEAFLOOR_CAVERN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Underwater_Route129/map.json
+++ b/data/maps/Underwater_Route129/map.json
@@ -26,14 +26,14 @@
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_UNDERWATER_MARINE_CAVE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 32,
       "y": 21,
       "elevation": 0,
       "dest_map": "MAP_UNDERWATER_MARINE_CAVE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Underwater_Route134/map.json
+++ b/data/maps/Underwater_Route134/map.json
@@ -20,7 +20,7 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_UNDERWATER_SEALED_CHAMBER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Underwater_SeafloorCavern/map.json
+++ b/data/maps/Underwater_SeafloorCavern/map.json
@@ -73,7 +73,7 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_UNDERWATER_ROUTE128",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Underwater_SealedChamber/map.json
+++ b/data/maps/Underwater_SealedChamber/map.json
@@ -20,7 +20,7 @@
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_UNDERWATER_ROUTE134",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/Underwater_SootopolisCity/map.json
+++ b/data/maps/Underwater_SootopolisCity/map.json
@@ -20,14 +20,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_UNDERWATER_ROUTE126",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_UNDERWATER_ROUTE126",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/UnionRoom/map.json
+++ b/data/maps/UnionRoom/map.json
@@ -138,14 +138,14 @@
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     },
     {
       "x": 8,
       "y": 11,
       "elevation": 3,
       "dest_map": "MAP_DYNAMIC",
-      "dest_warp_id": 127
+      "dest_warp_id": "WARP_ID_DYNAMIC"
     }
   ],
   "coord_events": [],

--- a/data/maps/UnionRoom/map.json
+++ b/data/maps/UnionRoom/map.json
@@ -137,14 +137,14 @@
       "x": 7,
       "y": 11,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     },
     {
       "x": 8,
       "y": 11,
       "elevation": 3,
-      "dest_map": "MAP_NONE",
+      "dest_map": "MAP_DYNAMIC",
       "dest_warp_id": 127
     }
   ],

--- a/data/maps/VerdanturfTown/map.json
+++ b/data/maps/VerdanturfTown/map.json
@@ -84,49 +84,49 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN_BATTLE_TENT_LOBBY",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 12,
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN_MART",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 16,
       "y": 3,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN_POKEMON_CENTER_1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 10,
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN_WANDAS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 8,
       "y": 1,
       "elevation": 0,
       "dest_map": "MAP_RUSTURF_TUNNEL",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 1,
       "y": 14,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN_FRIENDSHIP_RATERS_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 17,
       "y": 15,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN_HOUSE",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/VerdanturfTown_BattleTentLobby/map.json
+++ b/data/maps/VerdanturfTown_BattleTentLobby/map.json
@@ -99,14 +99,14 @@
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 7,
       "y": 9,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/VerdanturfTown_FriendshipRatersHouse/map.json
+++ b/data/maps/VerdanturfTown_FriendshipRatersHouse/map.json
@@ -47,14 +47,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     }
   ],
   "coord_events": [],

--- a/data/maps/VerdanturfTown_House/map.json
+++ b/data/maps/VerdanturfTown_House/map.json
@@ -47,14 +47,14 @@
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     },
     {
       "x": 4,
       "y": 8,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     }
   ],
   "coord_events": [],

--- a/data/maps/VerdanturfTown_Mart/map.json
+++ b/data/maps/VerdanturfTown_Mart/map.json
@@ -73,14 +73,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 4,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     }
   ],
   "coord_events": [],

--- a/data/maps/VerdanturfTown_PokemonCenter_1F/map.json
+++ b/data/maps/VerdanturfTown_PokemonCenter_1F/map.json
@@ -73,21 +73,21 @@
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_VERDANTURF_TOWN",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 6,
       "y": 8,
       "elevation": 3,
       "dest_map": "MAP_VERDANTURF_TOWN",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 1,
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_VERDANTURF_TOWN_POKEMON_CENTER_2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/VerdanturfTown_PokemonCenter_2F/map.json
+++ b/data/maps/VerdanturfTown_PokemonCenter_2F/map.json
@@ -73,21 +73,21 @@
       "y": 6,
       "elevation": 4,
       "dest_map": "MAP_VERDANTURF_TOWN_POKEMON_CENTER_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_UNION_ROOM",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 9,
       "y": 1,
       "elevation": 3,
       "dest_map": "MAP_TRADE_CENTER",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     }
   ],
   "coord_events": [],

--- a/data/maps/VerdanturfTown_WandasHouse/map.json
+++ b/data/maps/VerdanturfTown_WandasHouse/map.json
@@ -86,14 +86,14 @@
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 8,
       "y": 7,
       "elevation": 0,
       "dest_map": "MAP_VERDANTURF_TOWN",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/VictoryRoad_1F/map.json
+++ b/data/maps/VictoryRoad_1F/map.json
@@ -138,35 +138,35 @@
       "y": 40,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 39,
       "y": 5,
       "elevation": 3,
       "dest_map": "MAP_EVER_GRANDE_CITY",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 21,
       "y": 32,
       "elevation": 3,
       "dest_map": "MAP_VICTORY_ROAD_B1F",
-      "dest_warp_id": 5
+      "dest_warp_id": "5"
     },
     {
       "x": 42,
       "y": 38,
       "elevation": 4,
       "dest_map": "MAP_VICTORY_ROAD_B1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 9,
       "y": 14,
       "elevation": 4,
       "dest_map": "MAP_VICTORY_ROAD_B1F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     }
   ],
   "coord_events": [

--- a/data/maps/VictoryRoad_B1F/map.json
+++ b/data/maps/VictoryRoad_B1F/map.json
@@ -294,49 +294,49 @@
       "y": 25,
       "elevation": 3,
       "dest_map": "MAP_VICTORY_ROAD_B2F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 17,
       "y": 16,
       "elevation": 3,
       "dest_map": "MAP_VICTORY_ROAD_B2F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 42,
       "y": 25,
       "elevation": 3,
       "dest_map": "MAP_VICTORY_ROAD_1F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 42,
       "y": 2,
       "elevation": 4,
       "dest_map": "MAP_VICTORY_ROAD_B2F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 8,
       "y": 3,
       "elevation": 3,
       "dest_map": "MAP_VICTORY_ROAD_1F",
-      "dest_warp_id": 4
+      "dest_warp_id": "4"
     },
     {
       "x": 20,
       "y": 21,
       "elevation": 3,
       "dest_map": "MAP_VICTORY_ROAD_1F",
-      "dest_warp_id": 2
+      "dest_warp_id": "2"
     },
     {
       "x": 5,
       "y": 26,
       "elevation": 3,
       "dest_map": "MAP_VICTORY_ROAD_B2F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     }
   ],
   "coord_events": [],

--- a/data/maps/VictoryRoad_B2F/map.json
+++ b/data/maps/VictoryRoad_B2F/map.json
@@ -112,28 +112,28 @@
       "y": 25,
       "elevation": 3,
       "dest_map": "MAP_VICTORY_ROAD_B1F",
-      "dest_warp_id": 0
+      "dest_warp_id": "0"
     },
     {
       "x": 43,
       "y": 2,
       "elevation": 3,
       "dest_map": "MAP_VICTORY_ROAD_B1F",
-      "dest_warp_id": 3
+      "dest_warp_id": "3"
     },
     {
       "x": 19,
       "y": 12,
       "elevation": 3,
       "dest_map": "MAP_VICTORY_ROAD_B1F",
-      "dest_warp_id": 1
+      "dest_warp_id": "1"
     },
     {
       "x": 5,
       "y": 26,
       "elevation": 3,
       "dest_map": "MAP_VICTORY_ROAD_B1F",
-      "dest_warp_id": 6
+      "dest_warp_id": "6"
     }
   ],
   "coord_events": [],

--- a/include/constants/maps.h
+++ b/include/constants/maps.h
@@ -3,14 +3,17 @@
 
 #include "map_groups.h"
 
-#define MAP_NONE (0x7F | (0x7F << 8))
+// Warps using this map will instead use the warp data stored in gSaveBlock1Ptr->dynamicWarp.
+// Used for warps that need to change destinations, e.g. when stepping off an elevator.
+#define MAP_DYNAMIC (0x7F | (0x7F << 8))
+
 #define MAP_UNDEFINED (0xFF | (0xFF << 8))
 
 #define MAP_GROUP(map) (MAP_##map >> 8)
 #define MAP_NUM(map) (MAP_##map & 0xFF)
 
 // IDs for dynamic warps. Both are used in the dest_warp_id field for warp events, but they
-// are never read in practice. A dest_map of MAP_NONE is used to indicate that a
+// are never read in practice. A dest_map of MAP_DYNAMIC is used to indicate that a
 // dynamic warp should be used, at which point the warp id is ignored. It can be passed to
 // SetDynamicWarp/SetDynamicWarpWithCoords as the first argument, but this argument is unused.
 // As only one dynamic warp is saved at a time there's no need to distinguish between them.

--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -815,7 +815,7 @@ static void SetupWarp(struct MapHeader *unused, s8 warpEventId, struct MapPositi
         warpEvent = &gMapHeader.events->warps[warpEventId];
     }
 
-    if (warpEvent->mapNum == MAP_NUM(NONE))
+    if (warpEvent->mapNum == MAP_NUM(DYNAMIC))
     {
         SetWarpDestinationToDynamicWarp(warpEvent->warpId);
     }
@@ -826,7 +826,7 @@ static void SetupWarp(struct MapHeader *unused, s8 warpEventId, struct MapPositi
         SetWarpDestinationToMapWarp(warpEvent->mapGroup, warpEvent->mapNum, warpEvent->warpId);
         UpdateEscapeWarp(position->x, position->y);
         mapHeader = Overworld_GetMapHeaderByGroupAndId(warpEvent->mapGroup, warpEvent->mapNum);
-        if (mapHeader->events->warps[warpEvent->warpId].mapNum == MAP_NUM(NONE))
+        if (mapHeader->events->warps[warpEvent->warpId].mapNum == MAP_NUM(DYNAMIC))
             SetDynamicWarp(mapHeader->events->warps[warpEventId].warpId, gSaveBlock1Ptr->location.mapGroup, gSaveBlock1Ptr->location.mapNum, warpEventId);
     }
 }

--- a/tools/mapjson/mapjson.cpp
+++ b/tools/mapjson/mapjson.cpp
@@ -191,7 +191,7 @@ string generate_map_events_text(Json map_data) {
                  << warp_event["x"].int_value() << ", "
                  << warp_event["y"].int_value() << ", "
                  << warp_event["elevation"].int_value() << ", "
-                 << warp_event["dest_warp_id"].int_value() << ", "
+                 << warp_event["dest_warp_id"].string_value() << ", "
                  << warp_event["dest_map"].string_value() << "\n";
         }
         text << "\n";


### PR DESCRIPTION
**NOTE**: The following script will automate the changes in this PR
<https://gist.github.com/huderlem/b4e342f44093cb40971b36b5aed411c0>

This addresses two changes that are breaking changes for Porymap 4.5.0.
- The map constant currently called `MAP_NONE` is a special indicator value used exclusively by dynamic warps (warps with more than one potential destination). It's been renamed to `MAP_DYNAMIC`. `MAP_UNDEFINED` could reasonably take the name `MAP_NONE`, but this would be likely to silently break downstream changes.
- Treat warp ids as strings. This allows constants to be used for them (which happens in vanilla for dynamic warps). This was done with a basic regex find (`"dest_warp_id": ([0-9]+)`) and replace (`"dest_warp_id": "\1"`) in Sublime Text.

As usual this has been opened as a draft until a version of Porymap is released that supports these changes.