### PR TITLE
[doc] fix misnamed dma <--> aslr

### DIFF
--- a/include/load_save.h
+++ b/include/load_save.h
@@ -10,24 +10,24 @@
  * toolchains. If this is not done, the ClearSav functions will end up erasing
  * the wrong memory leading to various glitches.
  */
-struct SaveBlock2DMA {
+struct SaveBlock2ASLR {
     struct SaveBlock2 block;
-    u8 dma[SAVEBLOCK_MOVE_RANGE];
+    u8 aslr[SAVEBLOCK_MOVE_RANGE];
 };
 
-struct SaveBlock1DMA {
+struct SaveBlock1ASLR {
     struct SaveBlock1 block;
-    u8 dma[SAVEBLOCK_MOVE_RANGE];
+    u8 aslr[SAVEBLOCK_MOVE_RANGE];
 };
 
-struct PokemonStorageDMA {
+struct PokemonStorageASLR {
     struct PokemonStorage block;
-    u8 dma[SAVEBLOCK_MOVE_RANGE];
+    u8 aslr[SAVEBLOCK_MOVE_RANGE];
 };
 
-extern struct SaveBlock1DMA gSaveblock1;
-extern struct SaveBlock2DMA gSaveblock2;
-extern struct PokemonStorageDMA gPokemonStorage;
+extern struct SaveBlock1ASLR gSaveblock1;
+extern struct SaveBlock2ASLR gSaveblock2;
+extern struct PokemonStorageASLR gPokemonStorage;
 
 extern bool32 gFlashMemoryPresent;
 extern struct SaveBlock1 *gSaveBlock1Ptr;

--- a/src/load_save.c
+++ b/src/load_save.c
@@ -29,9 +29,9 @@ struct LoadedSaveData
 };
 
 // EWRAM DATA
-EWRAM_DATA struct SaveBlock2DMA gSaveblock2 = {0};
-EWRAM_DATA struct SaveBlock1DMA gSaveblock1 = {0};
-EWRAM_DATA struct PokemonStorageDMA gPokemonStorage = {0};
+EWRAM_DATA struct SaveBlock2ASLR gSaveblock2 = {0};
+EWRAM_DATA struct SaveBlock1ASLR gSaveblock1 = {0};
+EWRAM_DATA struct PokemonStorageASLR gPokemonStorage = {0};
 
 EWRAM_DATA struct LoadedSaveData gLoadedSaveData = {0};
 EWRAM_DATA u32 gLastEncryptionKey = 0;
@@ -58,12 +58,12 @@ void CheckForFlashMemory(void)
 
 void ClearSav2(void)
 {
-    CpuFill16(0, &gSaveblock2, sizeof(struct SaveBlock2DMA));
+    CpuFill16(0, &gSaveblock2, sizeof(struct SaveBlock2ASLR));
 }
 
 void ClearSav1(void)
 {
-    CpuFill16(0, &gSaveblock1, sizeof(struct SaveBlock1DMA));
+    CpuFill16(0, &gSaveblock1, sizeof(struct SaveBlock1ASLR));
 }
 
 // Offset is the sum of the trainer id bytes


### PR DESCRIPTION
Renames `struct SaveBlock1DMA` and its siblings to `struct SaveBlock1ASLR` etc. respectively. Resolves #1770

## Description
The structs are used to essentially achieve a simple form of ASLR (<https://en.wikipedia.org/wiki/Address_space_layout_randomization>) as a naive anti cheat protection. DMA <https://en.wikipedia.org/wiki/Direct_memory_access> is not used in the process. This should fix the ambiguities.

## **Discord contact info**
Karathan#1337