### PR TITLE
Undefined temporary preproc macro HIBYTE

### DIFF
--- a/src/pokeball.c
+++ b/src/pokeball.c
@@ -977,6 +977,8 @@ static void SpriteCB_PlayerMonSendOut_2(struct Sprite *sprite)
     }
 }
 
+#undef HIBYTE
+
 static void SpriteCB_ReleaseMon2FromBall(struct Sprite *sprite)
 {
     if (sprite->data[0]++ > 24)


### PR DESCRIPTION
## Description
Earlier, I noticed that there's a macro used in `src/pokeball.c` that is never undefined.
I looked around, and it seems to be good practice to `#undef` a local preproc macro after it served its purpose in the off chance that a function that is compiled after the function/s in which it was used also make use of a macro with the same name :eyes:

## **Discord contact info**
Lunos#4026