### PR TITLE
Added parenthesis to GET_SHINY_VALUE

### DIFF
--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -363,7 +363,7 @@ struct Evolution
     | (((personality) & 0x00000003) >> 0)  \
 ) % NUM_UNOWN_FORMS)
 
-#define GET_SHINY_VALUE(otId, personality)HIHALF(otId) ^ LOHALF(otId) ^ HIHALF(personality) ^ LOHALF(personality)
+#define GET_SHINY_VALUE(otId, personality) (HIHALF(otId) ^ LOHALF(otId) ^ HIHALF(personality) ^ LOHALF(personality))
 
 extern u8 gPlayerPartyCount;
 extern struct Pokemon gPlayerParty[PARTY_SIZE];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Trying to use `GET_SHINY_VALUE` in other contexts causes a warning:
```
warning: suggest parentheses around comparison in operand of ^
```

eg: `while (GET_SHINY_VALUE(value, personality) >= SHINY_ODDS && totalRerolls > 0)`

## **Discord contact info**
AsparagusEduardo#6051