### PR TITLE
gReservedSpritePaletteCount using MAX_BATTLERS_COUNT for battles

### DIFF
--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -665,7 +665,7 @@ static void CB2_InitBattleInternal(void)
     ResetTasks();
     DrawBattleEntryBackground();
     FreeAllSpritePalettes();
-    gReservedSpritePaletteCount = 4;
+    gReservedSpritePaletteCount = MAX_BATTLERS_COUNT;
     SetVBlankCallback(VBlankCB_Battle);
     SetUpBattleVarsAndBirchZigzagoon();
 
@@ -2221,7 +2221,7 @@ void CB2_InitEndLinkBattle(void)
         DrawBattleEntryBackground();
         SetGpuReg(REG_OFFSET_WINOUT, WINOUT_WIN01_BG0 | WINOUT_WIN01_BG1 | WINOUT_WIN01_BG2 | WINOUT_WIN01_OBJ | WINOUT_WIN01_CLR);
         FreeAllSpritePalettes();
-        gReservedSpritePaletteCount = 4;
+        gReservedSpritePaletteCount = MAX_BATTLERS_COUNT;
         SetVBlankCallback(VBlankCB_Battle);
 
         // Show end Vs screen with battle results
@@ -2425,7 +2425,7 @@ static void CB2_InitAskRecordBattle(void)
     ResetSpriteData();
     ResetTasks();
     FreeAllSpritePalettes();
-    gReservedSpritePaletteCount = 4;
+    gReservedSpritePaletteCount = MAX_BATTLERS_COUNT;
     SetVBlankCallback(VBlankCB_Battle);
     SetMainCallback2(CB2_AskRecordBattle);
     BeginNormalPaletteFade(PALETTES_ALL, 0, 0x10, 0, RGB_BLACK);

--- a/src/reshow_battle_screen.c
+++ b/src/reshow_battle_screen.c
@@ -73,7 +73,7 @@ static void CB2_ReshowBattleScreenAfterMenu(void)
         break;
     case 4:
         FreeAllSpritePalettes();
-        gReservedSpritePaletteCount = 4;
+        gReservedSpritePaletteCount = MAX_BATTLERS_COUNT;
         break;
     case 5:
         ClearSpritesHealthboxAnimData();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Something I realized when I analized these commits by @16lawrencel: 
https://github.com/16lawrencel/triple-emerald/commit/8bd32bcdf0ef3e009ac50577975756be9b458964
https://github.com/16lawrencel/triple-emerald/commit/769ea783e1743832527305e419d0b9d5b8800173

...is that at least the uses of `gReservedSpritePaletteCount` in the following files are based on the number of battlers:
```
src/reshow_battle_screen.c
src/battle_main.c
```

I'm not sure about `src/battle_dome.c`, as I'm not familiar with it enough to tell at a glance if that's also affected or not.

## **Discord contact info**
AsparagusEduardo#6051