### PR TITLE
Subsprite Tables Documentation

### DIFF
--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -318,10 +318,17 @@ static const struct SpriteTemplate sHealthbarSpriteTemplates[MAX_BATTLERS_COUNT]
     }
 };
 
+/*   v-- Origin
+[0   +         ][1     ]
+[              ][      ]   sUnused_Subsprites_0
+[              ][      ]   
+[______________][______]   96x40
+[2     ][3     ][4     ]
+*/
 static const struct Subsprite sUnused_Subsprites_0[] =
 {
     {
-        .x = DISPLAY_WIDTH,
+        .x = -16,
         .y = 0,
         .shape = SPRITE_SHAPE(64x32),
         .size = SPRITE_SIZE(64x32),
@@ -337,7 +344,7 @@ static const struct Subsprite sUnused_Subsprites_0[] =
         .priority = 1
     },
     {
-        .x = DISPLAY_WIDTH,
+        .x = -16,
         .y = 32,
         .shape = SPRITE_SHAPE(32x8),
         .size = SPRITE_SIZE(32x8),
@@ -362,10 +369,11 @@ static const struct Subsprite sUnused_Subsprites_0[] =
     }
 };
 
+// This subsprite table has the same layout as above, but offset by 64 base tiles.
 static const struct Subsprite sUnused_Subsprites_2[] =
 {
     {
-        .x = DISPLAY_WIDTH,
+        .x = -16,
         .y = 0,
         .shape = SPRITE_SHAPE(64x32),
         .size = SPRITE_SIZE(64x32),
@@ -381,7 +389,7 @@ static const struct Subsprite sUnused_Subsprites_2[] =
         .priority = 1
     },
     {
-        .x = DISPLAY_WIDTH,
+        .x = -16,
         .y = 32,
         .shape = SPRITE_SHAPE(32x8),
         .size = SPRITE_SIZE(32x8),
@@ -406,10 +414,16 @@ static const struct Subsprite sUnused_Subsprites_2[] =
     }
 };
 
+/*   v-- Origin
+[0   +         ][1     ]
+[              ][      ]
+[              ][      ]
+[              ][      ]   96x32
+*/
 static const struct Subsprite sUnused_Subsprites_1[] =
 {
     {
-        .x = DISPLAY_WIDTH,
+        .x = -16,
         .y = 0,
         .shape = SPRITE_SHAPE(64x32),
         .size = SPRITE_SIZE(64x32),
@@ -426,10 +440,11 @@ static const struct Subsprite sUnused_Subsprites_1[] =
     }
 };
 
+// Same as above
 static const struct Subsprite sUnused_Subsprites_3[] =
 {
     {
-        .x = DISPLAY_WIDTH,
+        .x = -16,
         .y = 0,
         .shape = SPRITE_SHAPE(64x32),
         .size = SPRITE_SIZE(64x32),
@@ -446,10 +461,13 @@ static const struct Subsprite sUnused_Subsprites_3[] =
     }
 };
 
+/*  v-- Origin
+[0  +  ][1     ]   64x8
+*/
 static const struct Subsprite sHealthBar_Subsprites_Player[] =
 {
     {
-        .x = DISPLAY_WIDTH,
+        .x = -16,
         .y = 0,
         .shape = SPRITE_SHAPE(32x8),
         .size = SPRITE_SIZE(32x8),
@@ -466,10 +484,14 @@ static const struct Subsprite sHealthBar_Subsprites_Player[] =
     }
 };
 
+/*       v-- Origin
+[]  [0  +  ][1     ]   72x8
+2^ ^--- Note 8px space
+*/
 static const struct Subsprite sHealthBar_Subsprites_Opponent[] =
 {
     {
-        .x = DISPLAY_WIDTH,
+        .x = -16,
         .y = 0,
         .shape = SPRITE_SHAPE(32x8),
         .size = SPRITE_SIZE(32x8),
@@ -485,7 +507,7 @@ static const struct Subsprite sHealthBar_Subsprites_Opponent[] =
         .priority = 1
     },
     {
-        .x = DISPLAY_WIDTH - 16,
+        .x = -32,
         .y = 0,
         .shape = SPRITE_SHAPE(8x8),
         .size = SPRITE_SIZE(8x8),

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -320,8 +320,8 @@ static const struct SpriteTemplate sHealthbarSpriteTemplates[MAX_BATTLERS_COUNT]
 
 /*   v-- Origin
 [0   +         ][1     ]
-[              ][      ]   sUnused_Subsprites_0
-[              ][      ]   
+[              ][      ]
+[              ][      ]
 [______________][______]   96x40
 [2     ][3     ][4     ]
 */

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -485,7 +485,7 @@ static const struct Subsprite sHealthBar_Subsprites_Player[] =
 };
 
 /*       v-- Origin
-[]  [0  +  ][1     ]   72x8
+[]  [0  +  ][1     ]   8x8 + 64x8
 2^ ^--- Note 8px space
 */
 static const struct Subsprite sHealthBar_Subsprites_Opponent[] =
@@ -529,11 +529,13 @@ static const struct SubspriteTable sHealthBar_SubspriteTables[] =
     [B_SIDE_PLAYER]   = {ARRAY_COUNT(sHealthBar_Subsprites_Player), sHealthBar_Subsprites_Player},
     [B_SIDE_OPPONENT] = {ARRAY_COUNT(sHealthBar_Subsprites_Opponent), sHealthBar_Subsprites_Opponent}
 };
-
+/*                      v-- Origin
+[0     ][1     ][2     ][3     ]   128x8
+*/
 static const struct Subsprite sStatusSummaryBar_Subsprites_Enter[] =
 {
     {
-        .x = 32 * 5,
+        .x = 32 * -3,
         .y = 0,
         .shape = SPRITE_SHAPE(32x8),
         .size = SPRITE_SIZE(32x8),
@@ -541,7 +543,7 @@ static const struct Subsprite sStatusSummaryBar_Subsprites_Enter[] =
         .priority = 1
     },
     {
-        .x = 32 * 6,
+        .x = 32 * -2,
         .y = 0,
         .shape = SPRITE_SHAPE(32x8),
         .size = SPRITE_SIZE(32x8),
@@ -549,7 +551,7 @@ static const struct Subsprite sStatusSummaryBar_Subsprites_Enter[] =
         .priority = 1
     },
     {
-        .x = 32 * 7,
+        .x = 32 * -1,
         .y = 0,
         .shape = SPRITE_SHAPE(32x8),
         .size = SPRITE_SIZE(32x8),
@@ -566,10 +568,14 @@ static const struct Subsprite sStatusSummaryBar_Subsprites_Enter[] =
     }
 };
 
+/*                      v-- Origin
+[0     ][1     ][2     ][3     ][4     ][5     ]   192x8
+                 ^-- uses same tiles --^
+*/
 static const struct Subsprite sStatusSummaryBar_Subsprites_Exit[] =
 {
     {
-        .x = 32 * 5,
+        .x = 32 * -3,
         .y = 0,
         .shape = SPRITE_SHAPE(32x8),
         .size = SPRITE_SIZE(32x8),
@@ -577,7 +583,7 @@ static const struct Subsprite sStatusSummaryBar_Subsprites_Exit[] =
         .priority = 1
     },
     {
-        .x = 32 * 6,
+        .x = 32 * -2,
         .y = 0,
         .shape = SPRITE_SHAPE(32x8),
         .size = SPRITE_SIZE(32x8),
@@ -585,7 +591,7 @@ static const struct Subsprite sStatusSummaryBar_Subsprites_Exit[] =
         .priority = 1
     },
     {
-        .x = 32 * 7,
+        .x = 32 * -1,
         .y = 0,
         .shape = SPRITE_SHAPE(32x8),
         .size = SPRITE_SIZE(32x8),

--- a/src/contest.c
+++ b/src/contest.c
@@ -525,6 +525,9 @@ static const struct SpriteTemplate sSpriteTemplates_NextTurn[CONTESTANT_COUNT] =
     }
 };
 
+/*    v-- Origin
+[0    +][1     ]   64x8
+*/
 static const struct Subsprite sSubsprites_NextTurn[] =
 {
     {

--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -405,6 +405,11 @@ static const struct SpriteFrameImage sPicTable_HofMonitorSmall[] =
     {.data = sHofMonitorSmall_Gfx, .size = 0x200} // the macro breaks down here
 };
 
+/*
+[0_][] <-1    24x16
+[2 ][] <-3
+   ^-- Origin
+*/
 static const struct Subsprite sSubsprites_PokecenterMonitor[] =
 {
     {
@@ -443,6 +448,11 @@ static const struct Subsprite sSubsprites_PokecenterMonitor[] =
 
 static const struct SubspriteTable sSubspriteTable_PokecenterMonitor = subsprite_table(sSubsprites_PokecenterMonitor);
 
+/*
+[0_____][1_____]    24x16
+[2     ][3     ]
+        ^-- Origin
+*/
 static const struct Subsprite sSubsprites_HofMonitorBig[] =
 {
     {

--- a/src/intro.c
+++ b/src/intro.c
@@ -3322,24 +3322,29 @@ static u8 CreateGameFreakLogoSprites(s16 x, s16 y, s16 unused)
 #undef sLetterX
 #undef COLOR_CHANGES
 
+#define sScale   data[1]
+#define sRot     data[2]
+#define sPos     data[3]
+#define sTimer   data[7]
+
 static void SpriteCB_FlygonSilhouette(struct Sprite *sprite)
 {
-    sprite->data[7]++;
+    sprite->sTimer++;
 
     if (sprite->sState != 0)
     {
-        s16 sin1;
-        s16 sin2;
+        s16 sin;
+        s16 cos;
 
         s16 a, b, c, d;
-
-        sin1 = gSineTable[(u8)sprite->data[2]];
-        sin2 = gSineTable[(u8)(sprite->data[2] + 64)];
-
-        d = Q_8_8_TO_INT(sin2 * sprite->data[1]);
-        c = Q_8_8_TO_INT(-sin1 * sprite->data[1]);
-        b = Q_8_8_TO_INT(sin1 * sprite->data[1]);
-        a = Q_8_8_TO_INT(sin2 * sprite->data[1]);
+        // Determines rotation of the sprite
+        sin = gSineTable[(u8)sprite->sRot];
+        cos = gSineTable[(u8)(sprite->sRot + 64)];
+        // Converts rotation and scale into the OAM matrix
+        d = Q_8_8_TO_INT( cos * sprite->sScale);
+        c = Q_8_8_TO_INT(-sin * sprite->sScale);
+        b = Q_8_8_TO_INT( sin * sprite->sScale);
+        a = Q_8_8_TO_INT( cos * sprite->sScale);
 
         SetOamMatrix(1, a, b, c, d);
     }
@@ -3353,35 +3358,40 @@ static void SpriteCB_FlygonSilhouette(struct Sprite *sprite)
         CalcCenterToCornerVec(sprite, SPRITE_SHAPE(64x32), SPRITE_SIZE(64x32), ST_OAM_AFFINE_DOUBLE);
         sprite->invisible = FALSE;
         sprite->sState = 1;
-        sprite->data[1] = 0x80;
-        sprite->data[2] = 0;
-        sprite->data[3] = 0;
+        sprite->sScale = 128;
+        sprite->sRot = 0;
+        sprite->sPos = 0;
         break;
     case 1:
-        sprite->x2 = -Sin((u8)sprite->data[3], 140);
-        sprite->y2 = -Sin((u8)sprite->data[3], 120);
-        sprite->data[1] += 7;
-        sprite->data[3] += 3;
+        sprite->x2 = -Sin((u8)sprite->sPos, 140);
+        sprite->y2 = -Sin((u8)sprite->sPos, 120);
+        sprite->sScale += 7;
+        sprite->sPos += 3;
         if (sprite->x + sprite->x2 <= -16)
         {
             sprite->oam.priority = 3;
             sprite->sState++;
             sprite->x = 20;
             sprite->y = 40;
-            sprite->data[1] = 0x200;
-            sprite->data[2] = 0;
-            sprite->data[3] = 0x10;
+            sprite->sScale = 512;
+            sprite->sRot = 0;
+            sprite->sPos = 16;
         }
         break;
     case 2:
-        sprite->x2 = Sin((u8)sprite->data[3], 34);
-        sprite->y2 = -Cos((u8)sprite->data[3], 60);
-        sprite->data[1] += 2;
-        if (sprite->data[7] % 5 == 0)
-            sprite->data[3]++;
+        sprite->x2 = Sin((u8)sprite->sPos, 34);
+        sprite->y2 = -Cos((u8)sprite->sPos, 60);
+        sprite->sScale += 2;
+        if (sprite->sTimer % 5 == 0)
+            sprite->sPos++;
         break;
     }
 }
+
+#undef sScale
+#undef sRot
+#undef sPos
+#undef sTimer
 
 static void SpriteCB_RayquazaOrb(struct Sprite *sprite)
 {

--- a/src/naming_screen.c
+++ b/src/naming_screen.c
@@ -2280,7 +2280,7 @@ static const struct Subsprite sSubsprites_PageSwapText[] =
 /*
 [0_____][] <-1   40x24
 [2_____][] <-3
-[3___+_][] <-5/Origin
+[4___+_][] <-5/Origin
 */
 static const struct Subsprite sSubsprites_Button[] =
 {

--- a/src/naming_screen.c
+++ b/src/naming_screen.c
@@ -2179,6 +2179,12 @@ static const struct OamData sOam_32x16 =
     .paletteNum = 0,
 };
 
+/*
+[0_____][] <-1   40x32
+[2_____][] <-3
+[3___+_][] <-5/Origin
+[4     ][] <-7
+*/
 static const struct Subsprite sSubsprites_PageSwapFrame[] =
 {
     {
@@ -2247,6 +2253,10 @@ static const struct Subsprite sSubsprites_PageSwapFrame[] =
     }
 };
 
+/*
+[0_][] <-1    24x8
+   ^-- Origin
+*/
 static const struct Subsprite sSubsprites_PageSwapText[] =
 {
     {
@@ -2267,6 +2277,11 @@ static const struct Subsprite sSubsprites_PageSwapText[] =
     }
 };
 
+/*
+[0_____][] <-1   40x24
+[2_____][] <-3
+[3___+_][] <-5/Origin
+*/
 static const struct Subsprite sSubsprites_Button[] =
 {
     {
@@ -2319,6 +2334,11 @@ static const struct Subsprite sSubsprites_Button[] =
     }
 };
 
+/*
+[0_]    16x24
+[1+] <--Origin
+[2_]
+*/
 static const struct Subsprite sSubsprites_PCIcon[] =
 {
     {

--- a/src/naming_screen.c
+++ b/src/naming_screen.c
@@ -2182,8 +2182,8 @@ static const struct OamData sOam_32x16 =
 /*
 [0_____][] <-1   40x32
 [2_____][] <-3
-[3___+_][] <-5/Origin
-[4     ][] <-7
+[4___+_][] <-5/Origin
+[6     ][] <-7
 */
 static const struct Subsprite sSubsprites_PageSwapFrame[] =
 {

--- a/src/slot_machine.c
+++ b/src/slot_machine.c
@@ -6433,6 +6433,20 @@ static const struct SpriteTemplate sSpriteTemplate_PikaPowerBolt =
     .callback = SpriteCB_PikaPowerBolt
 };
 
+/*
+[0             ][1             ]
+[              ][              ]
+[              ][              ]
+[              ][              ]
+[              ][              ]
+[______________][______________]   128x128
+[              ]+ <- Origin    ]
+[              ][              ]
+[              ][              ]
+[              ][              ]
+[              ][              ]
+[2             ][3             ]
+*/
 static const struct Subsprite sSubsprites_ReelBackground[] =
 {
     {
@@ -6474,6 +6488,11 @@ static const struct SubspriteTable sSubspriteTable_ReelBackground[] =
     ARRAY_COUNT(sSubsprites_ReelBackground), sSubsprites_ReelBackground
 };
 
+/*      v-- Origin on 3
+[0_____][1_____]
+[2_____][3_____]   64x24
+[4     ][5     ]
+*/
 static const struct Subsprite sSubsprites_ReelTimeMachineAntennae[] =
 {
     {
@@ -6531,6 +6550,13 @@ static const struct SubspriteTable sSubspriteTable_ReelTimeMachineAntennae[] =
     ARRAY_COUNT(sSubsprites_ReelTimeMachineAntennae), sSubsprites_ReelTimeMachineAntennae
 };
 
+/*
+[0             ]
+[              ]
+[      + Origin]
+[______________]   64x40
+[1     ][2     ]
+*/
 static const struct Subsprite sSubsprites_ReelTimeMachine[] =
 {
     {
@@ -6564,6 +6590,14 @@ static const struct SubspriteTable sSubspriteTable_ReelTimeMachine[] =
     ARRAY_COUNT(sSubsprites_ReelTimeMachine), sSubsprites_ReelTimeMachine
 };
 
+/*
+[0             ]
+[              ]
+[      + Origin]
+[______________]   64x48
+[1     ][2     ]
+[3     ][4     ]
+*/
 static const struct Subsprite sSubsprites_BrokenReelTimeMachine[] =
 {
     {
@@ -6613,6 +6647,10 @@ static const struct SubspriteTable sSubspriteTable_BrokenReelTimeMachine[] =
     ARRAY_COUNT(sSubsprites_BrokenReelTimeMachine), sSubsprites_BrokenReelTimeMachine
 };
 
+/*      v-- Origin on 3
+[0_____][1_____]
+[2     ][3     ]   64x16
+*/
 static const struct Subsprite sSubsprites_ReelTimeShadow[] =
 {
     {
@@ -6654,6 +6692,11 @@ static const struct SubspriteTable sSubspriteTable_ReelTimeShadow[] =
     ARRAY_COUNT(sSubsprites_ReelTimeShadow), sSubsprites_ReelTimeShadow
 };
 
+/*
+[0_]    16x24
+[1+] <--Origin
+[2_]
+*/
 static const struct Subsprite sSubsprites_ReelTimeNumberGap[] =
 {
     {
@@ -6687,6 +6730,14 @@ static const struct SubspriteTable sSubspriteTable_ReelTimeNumberGap[] =
     ARRAY_COUNT(sSubsprites_ReelTimeNumberGap), sSubsprites_ReelTimeNumberGap
 };
 
+/*
+[0             ]
+[              ]
+[      + Origin]
+[______________]   64x48
+[1     ][2     ]
+[3     ][4     ]
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_Reel[] =
 {
     {
@@ -6736,6 +6787,10 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_Reel[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_Reel), sSubsprites_DigitalDisplay_Reel
 };
 
+/*      v-- Origin on 3
+[0_____][1_____]
+[2     ][3     ]   64x16
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_Time[] =
 {
     {
@@ -6777,6 +6832,10 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_Time[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_Time), sSubsprites_DigitalDisplay_Time
 };
 
+/*      v-- Origin on 3
+[0_____][1_____]
+[2     ][3     ]   64x16
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_Insert[] =
 {
     {
@@ -6818,6 +6877,10 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_Insert[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_Insert), sSubsprites_DigitalDisplay_Insert
 };
 
+/*      v-- Origin on 3
+[0_____][1_____]
+[2     ][3     ]   64x16
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_Unused1[] =
 {
     {
@@ -6859,6 +6922,11 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_Unused1[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_Unused1), sSubsprites_DigitalDisplay_Unused1
 };
 
+/*      v-- Origin on 3
+[0_____][1_____]
+[2_____][3_____]
+[4     ][5     ]   64x24
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_Win[] =
 {
     {
@@ -6950,6 +7018,14 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_Unused2[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_Unused2), sSubsprites_DigitalDisplay_Unused2
 };
 
+/*
+[0_____][1_]
+[2_____][3_]
+[4_____][5_]
+[6_____][7+] <-- Origin
+[8_____][9_]
+[10____][11]
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_Pokeball[] =
 {
     {
@@ -6962,7 +7038,7 @@ static const struct Subsprite sSubsprites_DigitalDisplay_Pokeball[] =
     },
     {
         .x = 8,
-        -24,
+        .y = -24,
         .shape = SPRITE_SHAPE(16x8),
         .size = SPRITE_SIZE(16x8),
         .tileOffset = 4,
@@ -7055,6 +7131,11 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_Pokeball[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_Pokeball), sSubsprites_DigitalDisplay_Pokeball
 };
 
+/*
+[0     ]   32x24
+[   +  ] <- Origin
+[1 ][2 ]
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_DPad[] =
 {
     {
@@ -7088,6 +7169,10 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_DPad[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_DPad), sSubsprites_DigitalDisplay_DPad
 };
 
+/*
+[0 ]   16x16
+[1+] <- Origin
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_StopS[] =
 {
     {
@@ -7113,6 +7198,10 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_StopS[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_StopS), sSubsprites_DigitalDisplay_StopS
 };
 
+/*
+[0 ]   16x16
+[1+] <- Origin
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_StopT[] =
 {
     {
@@ -7138,6 +7227,10 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_StopT[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_StopT), sSubsprites_DigitalDisplay_StopT
 };
 
+/*
+[0 ]   16x16
+[1+] <- Origin
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_StopO[] =
 {
     {
@@ -7163,6 +7256,10 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_StopO[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_StopO), sSubsprites_DigitalDisplay_StopO
 };
 
+/*
+[0 ]   16x16
+[1+] <- Origin
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_StopP[] =
 {
     {
@@ -7188,6 +7285,10 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_StopP[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_StopP), sSubsprites_DigitalDisplay_StopP
 };
 
+/*
+[0 ]   16x16
+[1+] <- Origin
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_BonusB[] =
 {
     {
@@ -7213,6 +7314,10 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_BonusB[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_BonusB), sSubsprites_DigitalDisplay_BonusB
 };
 
+/*
+[]<-0   16x16
+[]<-1 <- Origin
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_BonusO[] =
 {
     {
@@ -7238,6 +7343,10 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_BonusO[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_BonusO), sSubsprites_DigitalDisplay_BonusO
 };
 
+/*
+[0 ]   16x16
+[1+] <- Origin
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_BonusN[] =
 {
     {
@@ -7263,6 +7372,10 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_BonusN[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_BonusN), sSubsprites_DigitalDisplay_BonusN
 };
 
+/*
+[]<-0   16x16
+[]<-1 <- Origin
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_BonusU[] =
 {
     {
@@ -7288,6 +7401,10 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_BonusU[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_BonusU), sSubsprites_DigitalDisplay_BonusU
 };
 
+/*
+[0 ]   16x16
+[1+] <- Origin
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_BonusS[] =
 {
     {
@@ -7313,6 +7430,12 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_BonusS[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_BonusS), sSubsprites_DigitalDisplay_BonusS
 };
 
+/*
+[0_][] <-1
+[2_][] <-3
+[4_][] <-5
+    ^-- Origin on 3
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_BigB[] =
 {
     {
@@ -7370,6 +7493,11 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_BigB[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_BigB), sSubsprites_DigitalDisplay_BigB
 };
 
+/*
+[0_]    16x24
+[1+] <--Origin
+[2_]
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_BigI[] =
 {
     {
@@ -7403,6 +7531,12 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_BigI[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_BigI), sSubsprites_DigitalDisplay_BigI
 };
 
+/*
+[0_][] <-1
+[2_][] <-3
+[4_][] <-5
+    ^-- Origin on 3
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_BigG[] =
 {
     {
@@ -7460,6 +7594,12 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_BigG[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_BigG), sSubsprites_DigitalDisplay_BigG
 };
 
+/*
+[0_][] <-1
+[2_][] <-3
+[4_][] <-5
+    ^-- Origin on 3
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_RegR[] =
 {
     {
@@ -7517,6 +7657,11 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_RegR[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_RegR), sSubsprites_DigitalDisplay_RegR
 };
 
+/*
+[0_]    16x24
+[1+] <--Origin
+[2_]
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_RegE[] =
 {
     {
@@ -7550,6 +7695,12 @@ static const struct SubspriteTable sSubspriteTable_DigitalDisplay_RegE[] =
     ARRAY_COUNT(sSubsprites_DigitalDisplay_RegE), sSubsprites_DigitalDisplay_RegE
 };
 
+/*
+[0_][] <-1
+[2_][] <-3
+[4_][] <-5
+    ^-- Origin on 3
+*/
 static const struct Subsprite sSubsprites_DigitalDisplay_RegG[] =
 {
     {


### PR DESCRIPTION
Some things I figured out while working on my hack.

## Description
- Documented the subsprite tables, mainly by adding diagrams of the layout.
- A bunch of the definitions were specifying values as if they were u8s instead of s8's. This is fixed.
- Unrelated: Figured out the as-of-yet undocumented data in SpriteCB_FlygonSilhouette

## **Discord contact info**
Tustin2121#6219
<!--- Contributors must join https://discord.gg/d5dubZ3 -->