### PR TITLE
Moved MAX_MONEY to constants/global.h

### DIFF
--- a/include/constants/global.h
+++ b/include/constants/global.h
@@ -63,6 +63,7 @@
 #define GIFT_RIBBONS_COUNT 11
 #define SAVED_TRENDS_COUNT 5
 #define PYRAMID_BAG_ITEMS_COUNT 10
+#define MAX_MONEY 999999
 
 // Number of facilities for Ranking Hall.
 // 7 facilities for single mode + tower double mode + tower multi mode.

--- a/src/money.c
+++ b/src/money.c
@@ -10,8 +10,6 @@
 #include "strings.h"
 #include "decompress.h"
 
-#define MAX_MONEY 999999
-
 EWRAM_DATA static u8 sMoneyBoxWindowId = 0;
 EWRAM_DATA static u8 sMoneyLabelSpriteId = 0;
 


### PR DESCRIPTION
## Description
I noticed that there was a handy constant label for the max. amount of money the Player can have, but that it was inside a .c file for some reason, so I decided to move it to a nicer location where it's easier to see and that allows to make use of it in other files easily too :eyes:

## **Discord contact info**
Lunos#4026