### PR TITLE
Gender icon in naming screen based on Pokémon name length

### DIFF
--- a/src/naming_screen.c
+++ b/src/naming_screen.c
@@ -1771,7 +1771,7 @@ static void DrawGenderIcon(void)
             StringCopy(text, gText_FemaleSymbol);
             isFemale = TRUE;
         }
-        AddTextPrinterParameterized3(sNamingScreen->windows[WIN_TEXT_ENTRY], FONT_NORMAL, 0x68, 1, sGenderColors[isFemale], TEXT_SKIP_DRAW, text);
+        AddTextPrinterParameterized3(sNamingScreen->windows[WIN_TEXT_ENTRY], FONT_NORMAL, (POKEMON_NAME_LENGTH * 4) + 64, 1, sGenderColors[isFemale], TEXT_SKIP_DRAW, text);
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
For comparison: 10, 11, 12 and 14
![image](https://user-images.githubusercontent.com/2904965/192126045-27df3c9d-86b5-48db-a633-644e787cda51.png) ![image](https://user-images.githubusercontent.com/2904965/192126053-a56ce1a2-632c-401f-99f2-0399c7ff3506.png) ![image](https://user-images.githubusercontent.com/2904965/192126059-8a668447-93e7-46e3-80fc-fbaadd621e51.png) ![image](https://user-images.githubusercontent.com/2904965/192126066-ee3a4766-0c6b-4da3-a709-c7919763ace5.png)

## **Discord contact info**
AsparagusEduardo#6051