### PR TITLE
Combine "Unused" Field into Tile Buffer

### DIFF
--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -550,8 +550,7 @@ struct PokemonStorageSystemData
     u16 *displayMonTilePtr;
     struct Sprite *displayMonSprite;
     u16 displayMonPalBuffer[0x40];
-    u8 tileBuffer[0x800];
-    u8 unusedBuffer[0x1800]; // Unused
+    u8 tileBuffer[MON_PIC_SIZE * 4]; // 4x the size of a 'Mon sprite to account for Castform
     u8 itemIconBuffer[0x800];
     u8 wallpaperBgTilemapBuffer[0x1000];
     u8 displayMenuTilemapBuffer[0x800];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As discovered by @SBird1337 and confirmed by him and @GriffinRichards, these two fields are actually one large buffer in order to account for Castform's 4 forms; this fixes potential UB from reading out of bounds.

## **Discord contact info**
Kurausukun#9923