### PR TITLE
Document seldom-used trigger functionality

### DIFF
--- a/data/maps/FarawayIsland_Entrance/map.json
+++ b/data/maps/FarawayIsland_Entrance/map.json
@@ -63,7 +63,7 @@
       "x": 9,
       "y": 18,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "FarawayIsland_Entrance_EventScript_SetCloudsWeather"
     },
@@ -72,7 +72,7 @@
       "x": 10,
       "y": 20,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "FarawayIsland_Entrance_EventScript_ClearWeather"
     },
@@ -81,7 +81,7 @@
       "x": 22,
       "y": 9,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "FarawayIsland_Entrance_EventScript_SetCloudsWeather"
     }

--- a/data/maps/FarawayIsland_Entrance/map.json
+++ b/data/maps/FarawayIsland_Entrance/map.json
@@ -63,7 +63,7 @@
       "x": 9,
       "y": 18,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "FarawayIsland_Entrance_EventScript_SetCloudsWeather"
     },
@@ -72,7 +72,7 @@
       "x": 10,
       "y": 20,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "FarawayIsland_Entrance_EventScript_ClearWeather"
     },
@@ -81,7 +81,7 @@
       "x": 22,
       "y": 9,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "FarawayIsland_Entrance_EventScript_SetCloudsWeather"
     }

--- a/data/maps/LavaridgeTown/map.json
+++ b/data/maps/LavaridgeTown/map.json
@@ -188,7 +188,7 @@
       "x": 6,
       "y": 3,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "LavaridgeTown_EventScript_HotSpringsTrigger"
     }

--- a/data/maps/LavaridgeTown/map.json
+++ b/data/maps/LavaridgeTown/map.json
@@ -188,7 +188,7 @@
       "x": 6,
       "y": 3,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "LavaridgeTown_EventScript_HotSpringsTrigger"
     }

--- a/data/maps/MtPyre_Exterior/map.json
+++ b/data/maps/MtPyre_Exterior/map.json
@@ -70,7 +70,7 @@
       "x": 24,
       "y": 21,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "MtPyre_Exterior_EventScript_FogTrigger"
     },
@@ -79,7 +79,7 @@
       "x": 25,
       "y": 21,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "MtPyre_Exterior_EventScript_FogTrigger"
     },
@@ -88,7 +88,7 @@
       "x": 22,
       "y": 27,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "MtPyre_Exterior_EventScript_SunTrigger"
     },
@@ -97,7 +97,7 @@
       "x": 23,
       "y": 28,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "MtPyre_Exterior_EventScript_SunTrigger"
     },
@@ -106,7 +106,7 @@
       "x": 26,
       "y": 21,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "MtPyre_Exterior_EventScript_FogTrigger"
     }

--- a/data/maps/MtPyre_Exterior/map.json
+++ b/data/maps/MtPyre_Exterior/map.json
@@ -70,7 +70,7 @@
       "x": 24,
       "y": 21,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "MtPyre_Exterior_EventScript_FogTrigger"
     },
@@ -79,7 +79,7 @@
       "x": 25,
       "y": 21,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "MtPyre_Exterior_EventScript_FogTrigger"
     },
@@ -88,7 +88,7 @@
       "x": 22,
       "y": 27,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "MtPyre_Exterior_EventScript_SunTrigger"
     },
@@ -97,7 +97,7 @@
       "x": 23,
       "y": 28,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "MtPyre_Exterior_EventScript_SunTrigger"
     },
@@ -106,7 +106,7 @@
       "x": 26,
       "y": 21,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "MtPyre_Exterior_EventScript_FogTrigger"
     }

--- a/data/maps/Route111/map.json
+++ b/data/maps/Route111/map.json
@@ -672,7 +672,7 @@
       "x": 12,
       "y": 62,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -708,7 +708,7 @@
       "x": 7,
       "y": 63,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -762,7 +762,7 @@
       "x": 18,
       "y": 32,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -771,7 +771,7 @@
       "x": 17,
       "y": 31,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -780,7 +780,7 @@
       "x": 9,
       "y": 37,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -789,7 +789,7 @@
       "x": 10,
       "y": 36,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -816,7 +816,7 @@
       "x": 8,
       "y": 64,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -825,7 +825,7 @@
       "x": 9,
       "y": 65,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -834,7 +834,7 @@
       "x": 10,
       "y": 65,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -843,7 +843,7 @@
       "x": 11,
       "y": 66,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -852,7 +852,7 @@
       "x": 12,
       "y": 67,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -861,7 +861,7 @@
       "x": 13,
       "y": 68,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -870,7 +870,7 @@
       "x": 14,
       "y": 69,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -879,7 +879,7 @@
       "x": 10,
       "y": 61,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -888,7 +888,7 @@
       "x": 11,
       "y": 62,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -897,7 +897,7 @@
       "x": 13,
       "y": 62,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -906,7 +906,7 @@
       "x": 14,
       "y": 62,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -915,7 +915,7 @@
       "x": 17,
       "y": 38,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -924,7 +924,7 @@
       "x": 16,
       "y": 39,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -933,7 +933,7 @@
       "x": 15,
       "y": 40,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -942,7 +942,7 @@
       "x": 14,
       "y": 41,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -951,7 +951,7 @@
       "x": 13,
       "y": 42,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -960,7 +960,7 @@
       "x": 12,
       "y": 43,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -969,7 +969,7 @@
       "x": 11,
       "y": 44,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     }

--- a/data/maps/Route111/map.json
+++ b/data/maps/Route111/map.json
@@ -672,7 +672,7 @@
       "x": 12,
       "y": 62,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -708,7 +708,7 @@
       "x": 7,
       "y": 63,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -762,7 +762,7 @@
       "x": 18,
       "y": 32,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -771,7 +771,7 @@
       "x": 17,
       "y": 31,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -780,7 +780,7 @@
       "x": 9,
       "y": 37,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -789,7 +789,7 @@
       "x": 10,
       "y": 36,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -816,7 +816,7 @@
       "x": 8,
       "y": 64,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -825,7 +825,7 @@
       "x": 9,
       "y": 65,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -834,7 +834,7 @@
       "x": 10,
       "y": 65,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -843,7 +843,7 @@
       "x": 11,
       "y": 66,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -852,7 +852,7 @@
       "x": 12,
       "y": 67,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -861,7 +861,7 @@
       "x": 13,
       "y": 68,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -870,7 +870,7 @@
       "x": 14,
       "y": 69,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SunTrigger"
     },
@@ -879,7 +879,7 @@
       "x": 10,
       "y": 61,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -888,7 +888,7 @@
       "x": 11,
       "y": 62,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -897,7 +897,7 @@
       "x": 13,
       "y": 62,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -906,7 +906,7 @@
       "x": 14,
       "y": 62,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -915,7 +915,7 @@
       "x": 17,
       "y": 38,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -924,7 +924,7 @@
       "x": 16,
       "y": 39,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -933,7 +933,7 @@
       "x": 15,
       "y": 40,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -942,7 +942,7 @@
       "x": 14,
       "y": 41,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -951,7 +951,7 @@
       "x": 13,
       "y": 42,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -960,7 +960,7 @@
       "x": 12,
       "y": 43,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     },
@@ -969,7 +969,7 @@
       "x": 11,
       "y": 44,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "Route111_EventScript_SandstormTrigger"
     }

--- a/data/maps/RusturfTunnel/map.json
+++ b/data/maps/RusturfTunnel/map.json
@@ -174,7 +174,7 @@
       "x": 23,
       "y": 4,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "RusturfTunnel_EventScript_TunnelBlockagePos1"
     },
@@ -201,7 +201,7 @@
       "x": 25,
       "y": 4,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "RusturfTunnel_EventScript_TunnelBlockagePos2"
     },
@@ -210,7 +210,7 @@
       "x": 25,
       "y": 5,
       "elevation": 3,
-      "var": "0",
+      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
       "var_value": "0",
       "script": "RusturfTunnel_EventScript_TunnelBlockagePos3"
     }

--- a/data/maps/RusturfTunnel/map.json
+++ b/data/maps/RusturfTunnel/map.json
@@ -174,7 +174,7 @@
       "x": 23,
       "y": 4,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "RusturfTunnel_EventScript_TunnelBlockagePos1"
     },
@@ -201,7 +201,7 @@
       "x": 25,
       "y": 4,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "RusturfTunnel_EventScript_TunnelBlockagePos2"
     },
@@ -210,7 +210,7 @@
       "x": 25,
       "y": 5,
       "elevation": 3,
-      "var": "VAR_RUN_TRIGGER_IMMEDIATELY",
+      "var": "TRIGGER_RUN_IMMEDIATELY",
       "var_value": "0",
       "script": "RusturfTunnel_EventScript_TunnelBlockagePos3"
     }

--- a/include/constants/vars.h
+++ b/include/constants/vars.h
@@ -304,4 +304,10 @@
 
 #define SPECIAL_VARS_END              0x8015
 
+// If an overworld trigger uses this pseudo-variable as the trigger check,
+// then the script will be run using RunScriptImmediately instead of in the
+// global script context. This means it will run faster, but cannot do any
+// cutscenes nor call a wait command. Used for weather effects in vanilla.
+#define VAR_RUN_TRIGGER_IMMEDIATELY   0
+
 #endif // GUARD_CONSTANTS_VARS_H

--- a/include/constants/vars.h
+++ b/include/constants/vars.h
@@ -308,6 +308,6 @@
 // then the script will be run using RunScriptImmediately instead of in the
 // global script context. This means it will run faster, but cannot do any
 // cutscenes nor call a wait command. Used for weather effects in vanilla.
-#define VAR_RUN_TRIGGER_IMMEDIATELY   0
+#define TRIGGER_RUN_IMMEDIATELY   0
 
 #endif // GUARD_CONSTANTS_VARS_H

--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -884,7 +884,7 @@ static u8 *TryRunCoordEventScript(struct CoordEvent *coordEvent)
             DoCoordEventWeather(coordEvent->trigger);
             return NULL;
         }
-        if (coordEvent->trigger == 0)
+        if (coordEvent->trigger == VAR_RUN_TRIGGER_IMMEDIATELY)
         {
             RunScriptImmediately(coordEvent->script);
             return NULL;

--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -884,7 +884,7 @@ static u8 *TryRunCoordEventScript(struct CoordEvent *coordEvent)
             DoCoordEventWeather(coordEvent->trigger);
             return NULL;
         }
-        if (coordEvent->trigger == VAR_RUN_TRIGGER_IMMEDIATELY)
+        if (coordEvent->trigger == TRIGGER_RUN_IMMEDIATELY)
         {
             RunScriptImmediately(coordEvent->script);
             return NULL;


### PR DESCRIPTION
Added a define for use in overworld triggers where the goal is to run the provided script in the immediate script context instead of the global one like normal. This is used in triggers in the desert, on faraway island, and a couple other places to do weather effects quickly and on the same frame. 

Suggestions for a better define name are welcome. 

Also, problem: I put it in vars.h so it will be picked up by porymap, but I guess because it's defined as 0, it's sorting to the top of the dropdown list and consequently becoming the default for new triggers, which is very undesirable. This should be used sparingly, not as the default mode, as any script which has a `wait` command in it (eg, any `msgbox`) will lock up the game in an infinite loop. So it should be sorted *last* if anything.

## **Discord contact info**
Tustin2121#6219
<!--- Contributors must join https://discord.gg/d5dubZ3 -->