### PR TITLE
GF Header and Modern Builds

### DIFF
--- a/ld_script.txt
+++ b/ld_script.txt
@@ -27,7 +27,7 @@ SECTIONS {
         *libc.a:locale.o(.data);
         *libc.a:mallocr.o(.data);
         . = 0x40000;
-}
+    }
 
     . = 0x3000000;
 

--- a/ld_script_modern.txt
+++ b/ld_script_modern.txt
@@ -49,8 +49,11 @@ SECTIONS {
     ALIGN(4)
     {
         src/rom_header.o(.text*);
-        src/*.o(.text*);
+        src/rom_header_gf.o(.text.*);
+        src/crt0.o(.text);
+        src/main.o(.text);
         gflib/*.o(.text*);
+        src/*.o(.text*);
         asm/*.o(.text*);
     } =0
 

--- a/src/rom_header_gf.c
+++ b/src/rom_header_gf.c
@@ -6,6 +6,15 @@
 #include "item.h"
 #include "pokeball.h"
 
+// The purpose of this struct is for outside applications to be
+// able to access parts of the ROM or its save file, like a public API.
+// In vanilla, it was used by Colosseum and XD to access pokemon graphics.
+// 
+// If this struct is rearranged in any way, it defeats the purpose of 
+// having it at all. Applications like PKHex or streaming HUDs may find
+// these values useful, so there's some potential benefit to keeping it.
+// If there's a compilation problem below, just comment out the assignment
+// instead of changing this struct.
 struct GFRomHeader
 {
     u32 version;

--- a/tools/jsonproc/jsonproc.cpp
+++ b/tools/jsonproc/jsonproc.cpp
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
     env.add_callback("cleanString", 1, [](Arguments& args) {
         string badChars = ".'{} \n\t-\u00e9";
         string str = args.at(0)->get<string>();
-        for (uint i = 0; i < str.length(); i++) {
+        for (unsigned int i = 0; i < str.length(); i++) {
             if (badChars.find(str[i]) != std::string::npos) {
                 str[i] = '_';
             }


### PR DESCRIPTION
Adding documentation about GF Header and modifying the modern linker script to pin the header.

## Description
- Adding some documentation about the GF Header and how it is meant to function. 
- Also pinning said header (and crt0 and main) to the front of the ROM in modern builds, like it is pinned in non-modern builds.
- Also moving gflib to before the src/* include in the modern build, as the gflib is before the src files in the non-modern build, which should make patches smaller, theoretically.
- Fixing build as well, which is the least controversial part of this PR.

## **Discord contact info**
Tustin2121#6219