### PR TITLE
Adding FindObjectEventPaletteIndexByTag bugfix

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -497,7 +497,12 @@ static const struct SpritePalette sObjectEventSpritePalettes[] = {
     {gObjectEventPal_Lugia,                 OBJ_EVENT_PAL_TAG_LUGIA},
     {gObjectEventPal_RubySapphireBrendan,   OBJ_EVENT_PAL_TAG_RS_BRENDAN},
     {gObjectEventPal_RubySapphireMay,       OBJ_EVENT_PAL_TAG_RS_MAY},
-    {},
+#ifdef BUGFIX
+    {NULL,                                  OBJ_EVENT_PAL_TAG_NONE}, 
+#else
+    {}, // BUG: FindObjectEventPaletteIndexByTag looks for OBJ_EVENT_PAL_TAG_NONE and not 0x0.
+        // If it's looking for a tag that isn't in this table, the game locks in an infinite loop.
+#endif
 };
 
 static const u16 sReflectionPaletteTags_Brendan[] = {

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -1998,7 +1998,12 @@ static void LoadObjectEventPalette(u16 paletteTag)
 {
     u16 i = FindObjectEventPaletteIndexByTag(paletteTag);
 
-    if (i != OBJ_EVENT_PAL_TAG_NONE) // always true
+// FindObjectEventPaletteIndexByTag returns 0xFF on failure, not OBJ_EVENT_PAL_TAG_NONE.
+#ifdef BUGFIX
+    if (i != 0xFF)
+#else
+    if (i != OBJ_EVENT_PAL_TAG_NONE)
+#endif
         LoadSpritePaletteIfTagExists(&sObjectEventSpritePalettes[i]);
 }
 
@@ -2021,6 +2026,7 @@ static u8 LoadSpritePaletteIfTagExists(const struct SpritePalette *spritePalette
 
 void PatchObjectPalette(u16 paletteTag, u8 paletteSlot)
 {
+    // paletteTag is assumed to exist in sObjectEventSpritePalettes
     u8 paletteIndex = FindObjectEventPaletteIndexByTag(paletteTag);
 
     LoadPalette(sObjectEventSpritePalettes[paletteIndex].data, 16 * paletteSlot + 0x100, 0x20);


### PR DESCRIPTION
The code in event_object_movement.c indicates that `OBJ_EVENT_PAL_TAG_NONE` was meant to be a sentinel for the bottom of each of the tables involving palettes in there. `sObjectEventSpritePalettes` is the exception, but the functions that access it look for `OBJ_EVENT_PAL_TAG_NONE` even though it's not in the table. If the palette tag isn't in the table, the functions which scan it fall off the bottom of the table into an infinite loop of scanning 256 "entries" of the table (because it uses a u8 index), and the game locks up. In vanilla, the search simply never falls off the bottom of the table. It seems the developers intended for that last entry to be `{NULL, OBJ_EVENT_PAL_TAG_NONE}`.

## **Discord contact info**
Tustin2121#6219