### PR TITLE
#include isagbprint.h in include/global.h

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -5,6 +5,7 @@
 #include <limits.h>
 #include "config.h" // we need to define config before gba headers as print stuff needs the functions nulled before defines.
 #include "gba/gba.h"
+#include "gba/isagbprint.h"
 #include "constants/global.h"
 #include "constants/flags.h"
 #include "constants/vars.h"


### PR DESCRIPTION
## Description
So, I just found myself in need of using mGBA's printf.
I remembered that SBird implemented it here and that it was merged a few months ago.
However, I'm noticing that DebugPrintf which seems to be the basic function for your printf usage related needs is not super usable?
It seems to default to the Info level of mGBA's log without letting you choose, and it's not handling the action of printing a simple string correctly as the compiler throws a fit.
Thus I just said "Fuck it." and decided to use the reliable `MgbaPrintf` directly.
*But* I'm noticing that the header file in which the function is defined is not being `#include`d in a handy and global file such as `include/global.h`.
This means that the user needs to specificaly incorporate the `#include "gba/isagbprint.h"` directive inside the files they want to call `MgbaPrintf`.

So why not just do that? Why not let any file access `MgbaPrintf` at the user's will?
Using printf is more comfortable when you don't need to `#include` temporary header files to X and Y file and then remove them once you're ready to make a commit and stuff.

## **Discord contact info**
Lunos#4026