### PR TITLE
[fix] DebugPrintf with no format arguments

### DIFF
--- a/include/gba/isagbprint.h
+++ b/include/gba/isagbprint.h
@@ -29,17 +29,17 @@ void AGBPrintInit(void);
 
 #if (LOG_HANDLER == LOG_HANDLER_MGBA_PRINT)
 
-#define DebugPrintf(pBuf, ...) MgbaPrintf(MGBA_LOG_INFO, pBuf, __VA_ARGS__)
+#define DebugPrintf(pBuf, ...) MgbaPrintf(MGBA_LOG_INFO, pBuf, ## __VA_ARGS__)
 #define DebugAssert(pFile, nLine, pExpression, nStopProgram) MgbaAssert(pFile, nLine, pExpression, nStopProgram)
 
 #elif (LOG_HANDLER == LOG_HANDLER_NOCASH_PRINT)
 
-#define DebugPrintf(pBuf, ...) NoCashGBAPrintf(pBuf, __VA_ARGS__)
+#define DebugPrintf(pBuf, ...) NoCashGBAPrintf(pBuf, ## __VA_ARGS__)
 #define DebugAssert(pFile, nLine, pExpression, nStopProgram) NoCashGBAAssert(pFile, nLine, pExpression, nStopProgram)
 
 #else // Default to AGBPrint
 
-#define DebugPrintf(pBuf, ...) AGBPrintf(const char *pBuf, ...)
+#define DebugPrintf(pBuf, ...) AGBPrintf(pBuf, ## __VA_ARGS__)
 #define DebugAssert(pFile, nLine, pExpression, nStopProgram) AGBAssert(pFile, nLine, pExpression, nStopProgram)
 
 #endif

--- a/include/gba/isagbprint.h
+++ b/include/gba/isagbprint.h
@@ -11,6 +11,7 @@
 
 #ifdef NDEBUG
 #define DebugPrintf(pBuf, ...)
+#define DebugPrintfLevel(level, pBuf, ...)
 #define MgbaOpen()
 #define MgbaClose()
 #define AGBPrintInit()
@@ -31,16 +32,19 @@ void AGBPrintInit(void);
 
 #define DebugPrintf(pBuf, ...) MgbaPrintf(MGBA_LOG_INFO, pBuf, ## __VA_ARGS__)
 #define DebugAssert(pFile, nLine, pExpression, nStopProgram) MgbaAssert(pFile, nLine, pExpression, nStopProgram)
+#define DebugPrintfLevel(level, pBuf, ...) MgbaPrintf(level, pBuf, ## __VA_ARGS__)
 
 #elif (LOG_HANDLER == LOG_HANDLER_NOCASH_PRINT)
 
 #define DebugPrintf(pBuf, ...) NoCashGBAPrintf(pBuf, ## __VA_ARGS__)
 #define DebugAssert(pFile, nLine, pExpression, nStopProgram) NoCashGBAAssert(pFile, nLine, pExpression, nStopProgram)
+#define DebugPrintfLevel(level, pBuf, ...) NoCashGBAPrintf(pBuf, ## __VA_ARGS__)
 
 #else // Default to AGBPrint
 
 #define DebugPrintf(pBuf, ...) AGBPrintf(pBuf, ## __VA_ARGS__)
 #define DebugAssert(pFile, nLine, pExpression, nStopProgram) AGBAssert(pFile, nLine, pExpression, nStopProgram)
+#define DebugPrintfLevel(level, pBuf, ...) AGBPrintf(pBuf, ## __VA_ARGS__)
 
 #endif
 #endif


### PR DESCRIPTION
Fixes `DebugPrintf` with no format arguments.

## Description
Using `DebugPrintf("Hello");` like that would error due to a malformation of `__VA_ARGS__` - this uses `##` escape which works on `cpp` and apparently also `clang` to remove the Comma `,` character if `__VA_ARGS__` is not set.

## **Discord contact info**
Karathan#1337