### PR TITLE
Added MOVE_EFFECT_NONE

### DIFF
--- a/include/constants/battle.h
+++ b/include/constants/battle.h
@@ -231,6 +231,7 @@
 #define B_WEATHER_ANY                 (B_WEATHER_RAIN | B_WEATHER_SANDSTORM | B_WEATHER_SUN | B_WEATHER_HAIL)
 
 // Move Effects
+#define MOVE_EFFECT_NONE                0
 #define MOVE_EFFECT_SLEEP               1
 #define MOVE_EFFECT_POISON              2
 #define MOVE_EFFECT_BURN                3

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2196,17 +2196,17 @@ u8 GetBattlerTurnOrderNum(u8 battlerId)
     return i;
 }
 
-#define INCREMENT_RESET_RETURN                  \
-{                                               \
-    gBattlescriptCurrInstr++;                   \
-    gBattleCommunication[MOVE_EFFECT_BYTE] = 0; \
-    return;                                     \
+#define INCREMENT_RESET_RETURN                                 \
+{                                                              \
+    gBattlescriptCurrInstr++;                                  \
+    gBattleCommunication[MOVE_EFFECT_BYTE] = MOVE_EFFECT_NONE; \
+    return;                                                    \
 }
 
-#define RESET_RETURN                            \
-{                                               \
-    gBattleCommunication[MOVE_EFFECT_BYTE] = 0; \
-    return;                                     \
+#define RESET_RETURN                                           \
+{                                                              \
+    gBattleCommunication[MOVE_EFFECT_BYTE] = MOVE_EFFECT_NONE; \
+    return;                                                    \
 }
 
 void SetMoveEffect(bool8 primary, u8 certain)
@@ -2487,7 +2487,7 @@ void SetMoveEffect(bool8 primary, u8 certain)
         }
         else if (statusChanged == FALSE)
         {
-            gBattleCommunication[MOVE_EFFECT_BYTE] = 0;
+            gBattleCommunication[MOVE_EFFECT_BYTE] = MOVE_EFFECT_NONE;
             gBattlescriptCurrInstr++;
             return;
         }
@@ -2876,7 +2876,7 @@ void SetMoveEffect(bool8 primary, u8 certain)
         }
     }
 
-    gBattleCommunication[MOVE_EFFECT_BYTE] = 0;
+    gBattleCommunication[MOVE_EFFECT_BYTE] = MOVE_EFFECT_NONE;
 }
 
 static void Cmd_seteffectwithchance(void)
@@ -2908,7 +2908,7 @@ static void Cmd_seteffectwithchance(void)
         gBattlescriptCurrInstr++;
     }
 
-    gBattleCommunication[MOVE_EFFECT_BYTE] = 0;
+    gBattleCommunication[MOVE_EFFECT_BYTE] = MOVE_EFFECT_NONE;
     gBattleScripting.multihitMoveEffect = 0;
 }
 
@@ -2931,7 +2931,7 @@ static void Cmd_clearstatusfromeffect(void)
     else
         gBattleMons[gActiveBattler].status2 &= (~sStatusFlagsForMoveEffects[gBattleCommunication[MOVE_EFFECT_BYTE]]);
 
-    gBattleCommunication[MOVE_EFFECT_BYTE] = 0;
+    gBattleCommunication[MOVE_EFFECT_BYTE] = MOVE_EFFECT_NONE;
     gBattlescriptCurrInstr += 2;
     gBattleScripting.multihitMoveEffect = 0;
 }
@@ -3594,7 +3594,7 @@ static void MoveValuesCleanUp(void)
     gMoveResultFlags = 0;
     gBattleScripting.dmgMultiplier = 1;
     gCritMultiplier = 1;
-    gBattleCommunication[MOVE_EFFECT_BYTE] = 0;
+    gBattleCommunication[MOVE_EFFECT_BYTE] = MOVE_EFFECT_NONE;
     gBattleCommunication[MISS_TYPE] = 0;
     gHitMarker &= ~HITMARKER_DESTINYBOND;
     gHitMarker &= ~HITMARKER_SYNCHRONISE_EFFECT;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -607,6 +607,7 @@ static const u16 sCriticalHitChance[] = {16, 8, 4, 3, 2};
 
 static const u32 sStatusFlagsForMoveEffects[NUM_MOVE_EFFECTS] =
 {
+    [MOVE_EFFECT_NONE]           = STATUS1_NONE,
     [MOVE_EFFECT_SLEEP]          = STATUS1_SLEEP,
     [MOVE_EFFECT_POISON]         = STATUS1_POISON,
     [MOVE_EFFECT_BURN]           = STATUS1_BURN,
@@ -626,7 +627,7 @@ static const u32 sStatusFlagsForMoveEffects[NUM_MOVE_EFFECTS] =
 
 static const u8 *const sMoveEffectBS_Ptrs[] =
 {
-    [0]                            = BattleScript_MoveEffectSleep,
+    [MOVE_EFFECT_NONE]             = BattleScript_MoveEffectSleep,
     [MOVE_EFFECT_SLEEP]            = BattleScript_MoveEffectSleep,
     [MOVE_EFFECT_POISON]           = BattleScript_MoveEffectPoison,
     [MOVE_EFFECT_BURN]             = BattleScript_MoveEffectBurn,


### PR DESCRIPTION
## Description
While reading Tri-Attack's move effect and looking at the relevant parts of the code, I brought up a doubt that I was having and that GriffinR helped me with. He taught me that a status flag is chosen for the effect straight the `sMoveEffectBS_Ptrs` array.

The thing is that at a glance, `MOVE_EFFECT_SLEEP` is at the top of the list, which is a constant label with a value of 1.
That can be confusing if you're expecting it to hold a value of 0 as the first member of the array *(to be honest, I guess in itself that's kind of silly. Just because it's at the top of an array it doesn't mean its value is going to be 0.)*

Thus, I feel it would be a good idea to add a `MOVE_EFFECT_NONE` to make the codee clearer at a glance.
By doing this consistency is kept with how other constant labels are laid out too though. There's `SPECIES_NONE`, `ITEM_NONE` and `ABILITY_NONE` for example.

## **Discord contact info**
Lunos#4026