### PR TITLE
event-object: Rewrite SetObjectEventDirection

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2341,12 +2341,10 @@ u8 CreateCopySpriteAt(struct Sprite *sprite, s16 x, s16 y, u8 subpriority)
 
 void SetObjectEventDirection(struct ObjectEvent *objectEvent, u8 direction)
 {
-    s8 d2;
     objectEvent->previousMovementDirection = objectEvent->facingDirection;
     if (!objectEvent->facingDirectionLocked)
     {
-        d2 = direction;
-        objectEvent->facingDirection = d2;
+        objectEvent->facingDirection = direction;
     }
     objectEvent->movementDirection = direction;
 }


### PR DESCRIPTION
agbcc now compiles this file matching
without the strange assignment to the s8

As for why it did not before, I cannot answer

Signed-off-by: Arven