### PR TITLE
battle-anim:fix UB by subtracting by 16

### DIFF
--- a/src/battle_anim_fight.c
+++ b/src/battle_anim_fight.c
@@ -493,7 +493,7 @@ static void AnimFistOrFootRandomPos(struct Sprite *sprite)
         y *= -1;
 
     if (GET_BATTLER_SIDE2(battler) == B_SIDE_PLAYER)
-        y += 0xFFF0;
+        y -= 16;
 
     sprite->x += x;
     sprite->y += y;


### PR DESCRIPTION
The current code follows the nonsensical asm
generated by agbcc, which converted a
subtraction by 16 into an addition by
a halfword value of -16.

This conversion happened at the
portion of the compiler
that does platform-specific transformations.

This code in C is UB,
as it relies on overflowing of a negative value.

Signed-off-by:Arven