### PR TITLE
Better type conversions and errors for mapjson

### DIFF
--- a/tools/mapjson/mapjson.cpp
+++ b/tools/mapjson/mapjson.cpp
@@ -150,26 +150,26 @@ string generate_map_header_text(Json map_data, Json layouts_data, string version
 
     ostringstream text;
 
-    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/" 
-         << json_to_string(map_data["name"]) 
-         << "/map.json\n@\n\n";
+    string mapName = json_to_string(map_data["name"]);
 
-    text << json_to_string(map_data["name"]) << ":\n"
+    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/" << mapName << "/map.json\n@\n\n";
+
+    text << mapName << ":\n"
          << "\t.4byte " << json_to_string(layout["name"]) << "\n";
 
     if (map_data.object_items().find("shared_events_map") != map_data.object_items().end())
         text << "\t.4byte " << json_to_string(map_data["shared_events_map"]) << "_MapEvents\n";
     else
-        text << "\t.4byte " << json_to_string(map_data["name"]) << "_MapEvents\n";
+        text << "\t.4byte " << mapName << "_MapEvents\n";
 
     if (map_data.object_items().find("shared_scripts_map") != map_data.object_items().end())
         text << "\t.4byte " << json_to_string(map_data["shared_scripts_map"]) << "_MapScripts\n";
     else
-        text << "\t.4byte " << json_to_string(map_data["name"]) << "_MapScripts\n";
+        text << "\t.4byte " << mapName << "_MapScripts\n";
 
     if (map_data.object_items().find("connections") != map_data.object_items().end()
      && map_data["connections"].array_items().size() > 0)
-        text << "\t.4byte " << json_to_string(map_data["name"]) << "_MapConnections\n";
+        text << "\t.4byte " << mapName << "_MapConnections\n";
     else
         text << "\t.4byte 0x0\n";
 
@@ -201,11 +201,11 @@ string generate_map_connections_text(Json map_data) {
 
     ostringstream text;
 
-    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/" 
-         << json_to_string(map_data["name"]) 
-         << "/map.json\n@\n\n";
+    string mapName = json_to_string(map_data["name"]);
 
-    text << json_to_string(map_data["name"]) << "_MapConnectionsList:\n";
+    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/" << mapName << "/map.json\n@\n\n";
+
+    text << mapName << "_MapConnectionsList:\n";
 
     for (auto &connection : map_data["connections"].array_items()) {
         text << "\tconnection "
@@ -214,9 +214,9 @@ string generate_map_connections_text(Json map_data) {
              << json_to_string(connection["map"]) << "\n";
     }
 
-    text << "\n" << json_to_string(map_data["name"]) << "_MapConnections:\n"
+    text << "\n" << mapName << "_MapConnections:\n"
          << "\t.4byte " << map_data["connections"].array_items().size() << "\n"
-         << "\t.4byte " << json_to_string(map_data["name"]) << "_MapConnectionsList\n\n";
+         << "\t.4byte " << mapName << "_MapConnectionsList\n\n";
 
     return text.str();
 }
@@ -227,14 +227,14 @@ string generate_map_events_text(Json map_data) {
 
     ostringstream text;
 
-    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/" 
-         << json_to_string(map_data["name"]) 
-         << "/map.json\n@\n\n";
+    string mapName = json_to_string(map_data["name"]);
+
+    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/" << mapName << "/map.json\n@\n\n";
 
     string objects_label, warps_label, coords_label, bgs_label;
 
     if (map_data["object_events"].array_items().size() > 0) {
-        objects_label = json_to_string(map_data["name"]) + "_ObjectEvents";
+        objects_label = mapName + "_ObjectEvents";
         text << objects_label << ":\n";
         for (unsigned int i = 0; i < map_data["object_events"].array_items().size(); i++) {
             auto obj_event = map_data["object_events"].array_items()[i];
@@ -257,7 +257,7 @@ string generate_map_events_text(Json map_data) {
     }
 
     if (map_data["warp_events"].array_items().size() > 0) {
-        warps_label = json_to_string(map_data["name"]) + "_MapWarps";
+        warps_label = mapName + "_MapWarps";
         text << warps_label << ":\n";
         for (auto &warp_event : map_data["warp_events"].array_items()) {
             text << "\twarp_def "
@@ -273,7 +273,7 @@ string generate_map_events_text(Json map_data) {
     }
 
     if (map_data["coord_events"].array_items().size() > 0) {
-        coords_label = json_to_string(map_data["name"]) + "_MapCoordEvents";
+        coords_label = mapName + "_MapCoordEvents";
         text << coords_label << ":\n";
         for (auto &coord_event : map_data["coord_events"].array_items()) {
             if (json_to_string(coord_event["type"]) == "trigger") {
@@ -299,7 +299,7 @@ string generate_map_events_text(Json map_data) {
     }
 
     if (map_data["bg_events"].array_items().size() > 0) {
-        bgs_label = json_to_string(map_data["name"]) + "_MapBGEvents";
+        bgs_label = mapName + "_MapBGEvents";
         text << bgs_label << ":\n";
         for (auto &bg_event : map_data["bg_events"].array_items()) {
             if (bg_event["type"] == "sign") {
@@ -331,7 +331,7 @@ string generate_map_events_text(Json map_data) {
         bgs_label = "0x0";
     }
 
-    text << json_to_string(map_data["name"]) << "_MapEvents::\n"
+    text << mapName << "_MapEvents::\n"
          << "\tmap_events " << objects_label << ", " << warps_label << ", "
          << coords_label << ", " << bgs_label << "\n\n";
 
@@ -468,22 +468,25 @@ string generate_map_constants_text(string groups_filepath, Json groups_data) {
     int group_num = 0;
 
     for (auto &group : groups_data["group_order"].array_items()) {
-        text << "// " << json_to_string(group) << "\n";
+        string groupName = json_to_string(group);
+        text << "// " << groupName << "\n";
         vector<Json> map_ids;
         size_t max_length = 0;
 
-        for (auto &map_name : groups_data[json_to_string(group)].array_items()) {
+        for (auto &map_name : groups_data[groupName].array_items()) {
             string header_filepath = file_dir + json_to_string(map_name) + dir_separator + "map.json";
             string err_str;
             Json map_data = Json::parse(read_text_file(header_filepath), err_str);
             map_ids.push_back(map_data["id"]);
-            if (json_to_string(map_data["id"]).length() > max_length)
-                max_length = json_to_string(map_data["id"]).length();
+            string id = json_to_string(map_data["id"]);
+            if (id.length() > max_length)
+                max_length = id.length();
         }
 
         int map_id_num = 0;
         for (Json map_id : map_ids) {
-            text << "#define " << json_to_string(map_id) << string((max_length - json_to_string(map_id).length() + 1), ' ')
+            string id = json_to_string(map_id);
+            text << "#define " << id << string((max_length - id.length() + 1), ' ')
                  << "(" << map_id_num++ << " | (" << group_num << " << 8))\n";
         }
         text << "\n";
@@ -526,14 +529,15 @@ string generate_layout_headers_text(Json layouts_data) {
     text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/layouts/layouts.json\n@\n\n";
 
     for (auto &layout : layouts_data["layouts"].array_items()) {
-        string border_label = json_to_string(layout["name"]) + "_Border";
-        string blockdata_label = json_to_string(layout["name"]) + "_Blockdata";
+        string layoutName = json_to_string(layout["name"]);
+        string border_label = layoutName + "_Border";
+        string blockdata_label = layoutName + "_Blockdata";
         text << border_label << "::\n"
              << "\t.incbin \"" << json_to_string(layout["border_filepath"]) << "\"\n\n"
              << blockdata_label << "::\n"
              << "\t.incbin \"" << json_to_string(layout["blockdata_filepath"]) << "\"\n\n"
              << "\t.align 2\n"
-             << json_to_string(layout["name"]) << "::\n"
+             << layoutName << "::\n"
              << "\t.4byte " << json_to_int(layout["width"]) << "\n"
              << "\t.4byte " << json_to_int(layout["height"]) << "\n"
              << "\t.4byte " << border_label << "\n"

--- a/tools/mapjson/mapjson.cpp
+++ b/tools/mapjson/mapjson.cpp
@@ -60,13 +60,86 @@ void write_text_file(string filepath, string text) {
     out_file.close();
 }
 
+// Json values do not implicitly convert types. This will handle converting them
+// if the user's JSON data is not the expected type (which may happen if e.g. it's
+// written that way by a different version of Porymap).
+string json_to_string(const Json &value) {
+    string output = "";
+    switch (value.type()) {
+        case Json::Type::STRING:
+            output = value.string_value();
+            break;
+        case Json::Type::NUMBER:
+            output = std::to_string(value.int_value());
+            break;
+        case Json::Type::BOOL:
+            output = value.bool_value() ? "TRUE" : "FALSE";
+            break;
+        default:
+            FATAL_ERROR("Value for %s is unexpected type; expected string.\n",  /*field.c_str()*/ "JSON field");
+    }
+
+    if (output.empty())
+        FATAL_ERROR("Value for %s cannot be empty.\n",  /*field.c_str()*/ "JSON field");
+
+    return output;
+}
+
+int json_to_int(const Json &value) {
+    switch (value.type()) {
+        case Json::Type::STRING: {
+            string s = value.string_value();
+            if (s == "TRUE" || s == "true") return 1;
+            if (s == "FALSE" || s == "false") return 0;
+            int num;
+            try {
+                num = stoi(s);
+            } catch(std::invalid_argument& e){
+                FATAL_ERROR("Unable to convert value %s for %s to int.\n", s.c_str(), /*field.c_str()*/ "JSON field");
+            }
+            return num;
+        }
+        case Json::Type::NUMBER:
+            return value.int_value();
+        case Json::Type::BOOL:
+            return value.bool_value() ? 0 : 1;
+        default:
+            FATAL_ERROR("Value for %s is unexpected type; expected int.\n", /*field.c_str()*/ "JSON field");
+    }
+    return 0;
+}
+
+bool json_to_bool(const Json &value) {
+    switch (value.type()) {
+        case Json::Type::STRING: {
+            string s = value.string_value();
+            if (s == "TRUE" || s == "true") return true;
+            if (s == "FALSE" || s == "false") return false;
+            int num;
+            try {
+                num = stoi(s);
+            } catch(std::invalid_argument& e){
+                FATAL_ERROR("Value %s for %s is unexpected type; expected bool\n", e.what(), /*field.c_str()*/ "JSON field");
+            }
+            return num != 0;
+        }
+        case Json::Type::NUMBER:
+            return value.int_value() != 0;
+        case Json::Type::BOOL:
+            return value.bool_value();
+        default:
+            FATAL_ERROR("Value for %s is unexpected type; expected bool.\n", /*field.c_str()*/ "JSON field");
+    }
+    return false;
+}
+
 string generate_map_header_text(Json map_data, Json layouts_data, string version) {
-    string map_layout_id = map_data["layout"].string_value();
+    string map_layout_id = json_to_string(map_data["layout"]);
 
     vector<Json> matched;
 
     for (auto &field : layouts_data["layouts"].array_items()) {
-        if (map_layout_id == field["id"].string_value())
+        if (map_layout_id == json_to_string(field["id"]))
             matched.push_back(field);
     }
 
@@ -78,46 +151,46 @@ string generate_map_header_text(Json map_data, Json layouts_data, string version
     ostringstream text;
 
     text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/" 
-         << map_data["name"].string_value() 
+         << json_to_string(map_data["name"]) 
          << "/map.json\n@\n\n";
 
-    text << map_data["name"].string_value() << ":\n"
-         << "\t.4byte " << layout["name"].string_value() << "\n";
+    text << json_to_string(map_data["name"]) << ":\n"
+         << "\t.4byte " << json_to_string(layout["name"]) << "\n";
 
     if (map_data.object_items().find("shared_events_map") != map_data.object_items().end())
-        text << "\t.4byte " << map_data["shared_events_map"].string_value() << "_MapEvents\n";
+        text << "\t.4byte " << json_to_string(map_data["shared_events_map"]) << "_MapEvents\n";
     else
-        text << "\t.4byte " << map_data["name"].string_value() << "_MapEvents\n";
+        text << "\t.4byte " << json_to_string(map_data["name"]) << "_MapEvents\n";
 
     if (map_data.object_items().find("shared_scripts_map") != map_data.object_items().end())
-        text << "\t.4byte " << map_data["shared_scripts_map"].string_value() << "_MapScripts\n";
+        text << "\t.4byte " << json_to_string(map_data["shared_scripts_map"]) << "_MapScripts\n";
     else
-        text << "\t.4byte " << map_data["name"].string_value() << "_MapScripts\n";
+        text << "\t.4byte " << json_to_string(map_data["name"]) << "_MapScripts\n";
 
     if (map_data.object_items().find("connections") != map_data.object_items().end()
      && map_data["connections"].array_items().size() > 0)
-        text << "\t.4byte " << map_data["name"].string_value() << "_MapConnections\n";
+        text << "\t.4byte " << json_to_string(map_data["name"]) << "_MapConnections\n";
     else
         text << "\t.4byte 0x0\n";
 
-    text << "\t.2byte " << map_data["music"].string_value() << "\n"
-         << "\t.2byte " << layout["id"].string_value() << "\n"
-         << "\t.byte "  << map_data["region_map_section"].string_value() << "\n"
-         << "\t.byte "  << map_data["requires_flash"].bool_value() << "\n"
-         << "\t.byte "  << map_data["weather"].string_value() << "\n"
-         << "\t.byte "  << map_data["map_type"].string_value() << "\n"
+    text << "\t.2byte " << json_to_string(map_data["music"]) << "\n"
+         << "\t.2byte " << json_to_string(layout["id"]) << "\n"
+         << "\t.byte "  << json_to_string(map_data["region_map_section"]) << "\n"
+         << "\t.byte "  << json_to_bool(map_data["requires_flash"]) << "\n"
+         << "\t.byte "  << json_to_string(map_data["weather"]) << "\n"
+         << "\t.byte "  << json_to_string(map_data["map_type"]) << "\n"
          << "\t.2byte 0\n";
 
     if (version == "ruby")
-        text << "\t.byte " << map_data["show_map_name"].bool_value() << "\n";
+        text << "\t.byte " << json_to_bool(map_data["show_map_name"]) << "\n";
     else if (version == "emerald")
         text << "\tmap_header_flags "
-             << "allow_cycling=" << map_data["allow_cycling"].bool_value() << ", "
-             << "allow_escaping=" << map_data["allow_escaping"].bool_value() << ", "
-             << "allow_running=" << map_data["allow_running"].bool_value() << ", "
-             << "show_map_name=" << map_data["show_map_name"].bool_value() << "\n";
+             << "allow_cycling=" << json_to_bool(map_data["allow_cycling"]) << ", "
+             << "allow_escaping=" << json_to_bool(map_data["allow_escaping"]) << ", "
+             << "allow_running=" << json_to_bool(map_data["allow_running"]) << ", "
+             << "show_map_name=" << json_to_bool(map_data["show_map_name"]) << "\n";
 
-     text << "\t.byte " << map_data["battle_scene"].string_value() << "\n\n";
+     text << "\t.byte " << json_to_string(map_data["battle_scene"]) << "\n\n";
 
     return text.str();
 }
@@ -129,21 +202,21 @@ string generate_map_connections_text(Json map_data) {
     ostringstream text;
 
     text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/" 
-         << map_data["name"].string_value() 
+         << json_to_string(map_data["name"]) 
          << "/map.json\n@\n\n";
 
-    text << map_data["name"].string_value() << "_MapConnectionsList:\n";
+    text << json_to_string(map_data["name"]) << "_MapConnectionsList:\n";
 
     for (auto &connection : map_data["connections"].array_items()) {
         text << "\tconnection "
-             << connection["direction"].string_value() << ", "
-             << connection["offset"].int_value() << ", "
-             << connection["map"].string_value() << "\n";
+             << json_to_string(connection["direction"]) << ", "
+             << json_to_int(connection["offset"]) << ", "
+             << json_to_string(connection["map"]) << "\n";
     }
 
-    text << "\n" << map_data["name"].string_value() << "_MapConnections:\n"
+    text << "\n" << json_to_string(map_data["name"]) << "_MapConnections:\n"
          << "\t.4byte " << map_data["connections"].array_items().size() << "\n"
-         << "\t.4byte " << map_data["name"].string_value() << "_MapConnectionsList\n\n";
+         << "\t.4byte " << json_to_string(map_data["name"]) << "_MapConnectionsList\n\n";
 
     return text.str();
 }
@@ -155,28 +228,28 @@ string generate_map_events_text(Json map_data) {
     ostringstream text;
 
     text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/" 
-         << map_data["name"].string_value() 
+         << json_to_string(map_data["name"]) 
          << "/map.json\n@\n\n";
 
     string objects_label, warps_label, coords_label, bgs_label;
 
     if (map_data["object_events"].array_items().size() > 0) {
-        objects_label = map_data["name"].string_value() + "_ObjectEvents";
+        objects_label = json_to_string(map_data["name"]) + "_ObjectEvents";
         text << objects_label << ":\n";
         for (unsigned int i = 0; i < map_data["object_events"].array_items().size(); i++) {
             auto obj_event = map_data["object_events"].array_items()[i];
             text << "\tobject_event " << i + 1 << ", "
-                 << obj_event["graphics_id"].string_value() << ", 0, "
-                 << obj_event["x"].int_value() << ", "
-                 << obj_event["y"].int_value() << ", "
-                 << obj_event["elevation"].int_value() << ", "
-                 << obj_event["movement_type"].string_value() << ", "
-                 << obj_event["movement_range_x"].int_value() << ", "
-                 << obj_event["movement_range_y"].int_value() << ", "
-                 << obj_event["trainer_type"].string_value() << ", "
-                 << obj_event["trainer_sight_or_berry_tree_id"].string_value() << ", "
-                 << obj_event["script"].string_value() << ", "
-                 << obj_event["flag"].string_value() << "\n";
+                 << json_to_string(obj_event["graphics_id"]) << ", 0, "
+                 << json_to_int(obj_event["x"]) << ", "
+                 << json_to_int(obj_event["y"]) << ", "
+                 << json_to_int(obj_event["elevation"]) << ", "
+                 << json_to_string(obj_event["movement_type"]) << ", "
+                 << json_to_int(obj_event["movement_range_x"]) << ", "
+                 << json_to_int(obj_event["movement_range_y"]) << ", "
+                 << json_to_string(obj_event["trainer_type"]) << ", "
+                 << json_to_string(obj_event["trainer_sight_or_berry_tree_id"]) << ", "
+                 << json_to_string(obj_event["script"]) << ", "
+                 << json_to_string(obj_event["flag"]) << "\n";
         }
         text << "\n";
     } else {
@@ -184,15 +257,15 @@ string generate_map_events_text(Json map_data) {
     }
 
     if (map_data["warp_events"].array_items().size() > 0) {
-        warps_label = map_data["name"].string_value() + "_MapWarps";
+        warps_label = json_to_string(map_data["name"]) + "_MapWarps";
         text << warps_label << ":\n";
         for (auto &warp_event : map_data["warp_events"].array_items()) {
             text << "\twarp_def "
-                 << warp_event["x"].int_value() << ", "
-                 << warp_event["y"].int_value() << ", "
-                 << warp_event["elevation"].int_value() << ", "
-                 << warp_event["dest_warp_id"].string_value() << ", "
-                 << warp_event["dest_map"].string_value() << "\n";
+                 << json_to_int(warp_event["x"]) << ", "
+                 << json_to_int(warp_event["y"]) << ", "
+                 << json_to_int(warp_event["elevation"]) << ", "
+                 << json_to_string(warp_event["dest_warp_id"]) << ", "
+                 << json_to_string(warp_event["dest_map"]) << "\n";
         }
         text << "\n";
     } else {
@@ -200,24 +273,24 @@ string generate_map_events_text(Json map_data) {
     }
 
     if (map_data["coord_events"].array_items().size() > 0) {
-        coords_label = map_data["name"].string_value() + "_MapCoordEvents";
+        coords_label = json_to_string(map_data["name"]) + "_MapCoordEvents";
         text << coords_label << ":\n";
         for (auto &coord_event : map_data["coord_events"].array_items()) {
-            if (coord_event["type"].string_value() == "trigger") {
+            if (json_to_string(coord_event["type"]) == "trigger") {
                 text << "\tcoord_event "
-                     << coord_event["x"].int_value() << ", "
-                     << coord_event["y"].int_value() << ", "
-                     << coord_event["elevation"].int_value() << ", "
-                     << coord_event["var"].string_value() << ", "
-                     << coord_event["var_value"].string_value() << ", "
-                     << coord_event["script"].string_value() << "\n";
+                     << json_to_int(coord_event["x"]) << ", "
+                     << json_to_int(coord_event["y"]) << ", "
+                     << json_to_int(coord_event["elevation"]) << ", "
+                     << json_to_string(coord_event["var"]) << ", "
+                     << json_to_string(coord_event["var_value"]) << ", "
+                     << json_to_string(coord_event["script"]) << "\n";
             }
             else if (coord_event["type"] == "weather") {
                 text << "\tcoord_weather_event "
-                     << coord_event["x"].int_value() << ", "
-                     << coord_event["y"].int_value() << ", "
-                     << coord_event["elevation"].int_value() << ", "
-                     << coord_event["weather"].string_value() << "\n";
+                     << json_to_int(coord_event["x"]) << ", "
+                     << json_to_int(coord_event["y"]) << ", "
+                     << json_to_int(coord_event["elevation"]) << ", "
+                     << json_to_string(coord_event["weather"]) << "\n";
             }
         }
         text << "\n";
@@ -226,31 +299,31 @@ string generate_map_events_text(Json map_data) {
     }
 
     if (map_data["bg_events"].array_items().size() > 0) {
-        bgs_label = map_data["name"].string_value() + "_MapBGEvents";
+        bgs_label = json_to_string(map_data["name"]) + "_MapBGEvents";
         text << bgs_label << ":\n";
         for (auto &bg_event : map_data["bg_events"].array_items()) {
             if (bg_event["type"] == "sign") {
                 text << "\tbg_sign_event "
-                     << bg_event["x"].int_value() << ", "
-                     << bg_event["y"].int_value() << ", "
-                     << bg_event["elevation"].int_value() << ", "
-                     << bg_event["player_facing_dir"].string_value() << ", "
-                     << bg_event["script"].string_value() << "\n";
+                     << json_to_int(bg_event["x"]) << ", "
+                     << json_to_int(bg_event["y"]) << ", "
+                     << json_to_int(bg_event["elevation"]) << ", "
+                     << json_to_string(bg_event["player_facing_dir"]) << ", "
+                     << json_to_string(bg_event["script"]) << "\n";
             }
             else if (bg_event["type"] == "hidden_item") {
                 text << "\tbg_hidden_item_event "
-                     << bg_event["x"].int_value() << ", "
-                     << bg_event["y"].int_value() << ", "
-                     << bg_event["elevation"].int_value() << ", "
-                     << bg_event["item"].string_value() << ", "
-                     << bg_event["flag"].string_value() << "\n";
+                     << json_to_int(bg_event["x"]) << ", "
+                     << json_to_int(bg_event["y"]) << ", "
+                     << json_to_int(bg_event["elevation"]) << ", "
+                     << json_to_string(bg_event["item"]) << ", "
+                     << json_to_string(bg_event["flag"]) << "\n";
             }
             else if (bg_event["type"] == "secret_base") {
                 text << "\tbg_secret_base_event "
-                     << bg_event["x"].int_value() << ", "
-                     << bg_event["y"].int_value() << ", "
-                     << bg_event["elevation"].int_value() << ", "
-                     << bg_event["secret_base_id"].string_value() << "\n";
+                     << json_to_int(bg_event["x"]) << ", "
+                     << json_to_int(bg_event["y"]) << ", "
+                     << json_to_int(bg_event["elevation"]) << ", "
+                     << json_to_string(bg_event["secret_base_id"]) << "\n";
             }
         }
         text << "\n";
@@ -258,7 +331,7 @@ string generate_map_events_text(Json map_data) {
         bgs_label = "0x0";
     }
 
-    text << map_data["name"].string_value() << "_MapEvents::\n"
+    text << json_to_string(map_data["name"]) << "_MapEvents::\n"
          << "\tmap_events " << objects_label << ", " << warps_label << ", "
          << coords_label << ", " << bgs_label << "\n\n";
 
@@ -301,17 +374,17 @@ string generate_groups_text(Json groups_data) {
     text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/map_groups.json\n@\n\n";
 
     for (auto &key : groups_data["group_order"].array_items()) {
-        string group = key.string_value();
+        string group = json_to_string(key);
         text << group << "::\n";
         auto maps = groups_data[group].array_items();
         for (Json &map_name : maps)
-            text << "\t.4byte " << map_name.string_value() << "\n";
+            text << "\t.4byte " << json_to_string(map_name) << "\n";
         text << "\n";
     }
 
     text << "\t.align 2\n" << "gMapGroups::\n";
     for (auto &group : groups_data["group_order"].array_items())
-        text << "\t.4byte " << group.string_value() << "\n";
+        text << "\t.4byte " << json_to_string(group) << "\n";
     text << "\n";
 
     return text.str();
@@ -321,7 +394,7 @@ string generate_connections_text(Json groups_data) {
     vector<Json> map_names;
 
     for (auto &group : groups_data["group_order"].array_items())
-    for (auto map_name : groups_data[group.string_value()].array_items())
+    for (auto map_name : groups_data[json_to_string(group)].array_items())
         map_names.push_back(map_name);
 
     vector<Json> connections_include_order = groups_data["connections_include_order"].array_items();
@@ -342,7 +415,7 @@ string generate_connections_text(Json groups_data) {
     text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/map_groups.json\n@\n\n";
 
     for (Json map_name : map_names)
-        text << "\t.include \"data/maps/" << map_name.string_value() << "/connections.inc\"\n";
+        text << "\t.include \"data/maps/" << json_to_string(map_name) << "/connections.inc\"\n";
 
     return text.str();
 }
@@ -351,8 +424,8 @@ string generate_headers_text(Json groups_data) {
     vector<string> map_names;
 
     for (auto &group : groups_data["group_order"].array_items())
-    for (auto map_name : groups_data[group.string_value()].array_items())
-        map_names.push_back(map_name.string_value());
+    for (auto map_name : groups_data[json_to_string(group)].array_items())
+        map_names.push_back(json_to_string(map_name));
 
     ostringstream text;
 
@@ -368,8 +441,8 @@ string generate_events_text(Json groups_data) {
     vector<string> map_names;
 
     for (auto &group : groups_data["group_order"].array_items())
-    for (auto map_name : groups_data[group.string_value()].array_items())
-        map_names.push_back(map_name.string_value());
+    for (auto map_name : groups_data[json_to_string(group)].array_items())
+        map_names.push_back(json_to_string(map_name));
 
     ostringstream text;
 
@@ -395,22 +468,22 @@ string generate_map_constants_text(string groups_filepath, Json groups_data) {
     int group_num = 0;
 
     for (auto &group : groups_data["group_order"].array_items()) {
-        text << "// " << group.string_value() << "\n";
+        text << "// " << json_to_string(group) << "\n";
         vector<Json> map_ids;
         size_t max_length = 0;
 
-        for (auto &map_name : groups_data[group.string_value()].array_items()) {
-            string header_filepath = file_dir + map_name.string_value() + dir_separator + "map.json";
+        for (auto &map_name : groups_data[json_to_string(group)].array_items()) {
+            string header_filepath = file_dir + json_to_string(map_name) + dir_separator + "map.json";
             string err_str;
             Json map_data = Json::parse(read_text_file(header_filepath), err_str);
             map_ids.push_back(map_data["id"]);
-            if (map_data["id"].string_value().length() > max_length)
-                max_length = map_data["id"].string_value().length();
+            if (json_to_string(map_data["id"]).length() > max_length)
+                max_length = json_to_string(map_data["id"]).length();
         }
 
         int map_id_num = 0;
         for (Json map_id : map_ids) {
-            text << "#define " << map_id.string_value() << string((max_length - map_id.string_value().length() + 1), ' ')
+            text << "#define " << json_to_string(map_id) << string((max_length - json_to_string(map_id).length() + 1), ' ')
                  << "(" << map_id_num++ << " | (" << group_num << " << 8))\n";
         }
         text << "\n";
@@ -453,20 +526,20 @@ string generate_layout_headers_text(Json layouts_data) {
     text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/layouts/layouts.json\n@\n\n";
 
     for (auto &layout : layouts_data["layouts"].array_items()) {
-        string border_label = layout["name"].string_value() + "_Border";
-        string blockdata_label = layout["name"].string_value() + "_Blockdata";
+        string border_label = json_to_string(layout["name"]) + "_Border";
+        string blockdata_label = json_to_string(layout["name"]) + "_Blockdata";
         text << border_label << "::\n"
-             << "\t.incbin \"" << layout["border_filepath"].string_value() << "\"\n\n"
+             << "\t.incbin \"" << json_to_string(layout["border_filepath"]) << "\"\n\n"
              << blockdata_label << "::\n"
-             << "\t.incbin \"" << layout["blockdata_filepath"].string_value() << "\"\n\n"
+             << "\t.incbin \"" << json_to_string(layout["blockdata_filepath"]) << "\"\n\n"
              << "\t.align 2\n"
-             << layout["name"].string_value() << "::\n"
-             << "\t.4byte " << layout["width"].int_value() << "\n"
-             << "\t.4byte " << layout["height"].int_value() << "\n"
+             << json_to_string(layout["name"]) << "::\n"
+             << "\t.4byte " << json_to_int(layout["width"]) << "\n"
+             << "\t.4byte " << json_to_int(layout["height"]) << "\n"
              << "\t.4byte " << border_label << "\n"
              << "\t.4byte " << blockdata_label << "\n"
-             << "\t.4byte " << layout["primary_tileset"].string_value() << "\n"
-             << "\t.4byte " << layout["secondary_tileset"].string_value() << "\n\n";
+             << "\t.4byte " << json_to_string(layout["primary_tileset"]) << "\n"
+             << "\t.4byte " << json_to_string(layout["secondary_tileset"]) << "\n\n";
     }
 
     return text.str();
@@ -478,10 +551,10 @@ string generate_layouts_table_text(Json layouts_data) {
     text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/layouts/layouts.json\n@\n\n";
 
     text << "\t.align 2\n"
-         << layouts_data["layouts_table_label"].string_value() << "::\n";
+         << json_to_string(layouts_data["layouts_table_label"]) << "::\n";
 
     for (auto &layout : layouts_data["layouts"].array_items())
-        text << "\t.4byte " << layout["name"].string_value() << "\n";
+        text << "\t.4byte " << json_to_string(layout["name"]) << "\n";
 
     return text.str();
 }
@@ -496,7 +569,7 @@ string generate_layouts_constants_text(Json layouts_data) {
 
     int i = 0;
     for (auto &layout : layouts_data["layouts"].array_items())
-        text << "#define " << layout["id"].string_value() << " " << ++i << "\n";
+        text << "#define " << json_to_string(layout["id"]) << " " << ++i << "\n";
 
     text << "\n#endif // GUARD_CONSTANTS_LAYOUTS_H\n";
 


### PR DESCRIPTION
This fixes two problems with mapjson:
1. mapjson will now correctly produce an error for empty strings in .json files, instead of outputting nothing (which can confuse or break script macros). Closes #1261 
2. Users can now freely change data types in .json files between string, bool, and number. Prior to this if a user had e.g. `"dest_warp_id": "3",`, and mapjson expected a number instead of a string, it would output 0 instead of 3. This was likely to occur if a user had a version of Porymap that had a different type expectation than mapjson. Now mapjson correctly converts numbers and bools and leaves strings alone.