### PR TITLE
Format metatile_labels

### DIFF
--- a/data/maps/MossdeepCity_Gym/scripts.inc
+++ b/data/maps/MossdeepCity_Gym/scripts.inc
@@ -26,26 +26,26 @@ MossdeepCity_Gym_EventScript_CheckSwitch4::
 
 @ All the below set metatile scripts are leftover from RS and are functionally unused
 MossdeepCity_Gym_EventScript_SetSwitch1Metatiles::
-	setmetatile 5, 5, METATILE_RS_MossdeepGym_RedArrow_Right, FALSE
-	setmetatile 2, 7, METATILE_RS_MossdeepGym_Switch_Down, TRUE
+	setmetatile 5, 5, METATILE_RSMossdeepGym_RedArrow_Right, FALSE
+	setmetatile 2, 7, METATILE_RSMossdeepGym_Switch_Down, TRUE
 	goto MossdeepCity_Gym_EventScript_CheckSwitch2
 	end
 
 MossdeepCity_Gym_EventScript_SetSwitch2Metatiles::
-	setmetatile 8, 14, METATILE_RS_MossdeepGym_RedArrow_Right, FALSE
-	setmetatile 8, 10, METATILE_RS_MossdeepGym_Switch_Down, TRUE
+	setmetatile 8, 14, METATILE_RSMossdeepGym_RedArrow_Right, FALSE
+	setmetatile 8, 10, METATILE_RSMossdeepGym_Switch_Down, TRUE
 	goto MossdeepCity_Gym_EventScript_CheckSwitch3
 	end
 
 MossdeepCity_Gym_EventScript_SetSwitch3Metatiles::
-	setmetatile 15, 17, METATILE_RS_MossdeepGym_RedArrow_Left, FALSE
-	setmetatile 17, 15, METATILE_RS_MossdeepGym_Switch_Down, TRUE
+	setmetatile 15, 17, METATILE_RSMossdeepGym_RedArrow_Left, FALSE
+	setmetatile 17, 15, METATILE_RSMossdeepGym_Switch_Down, TRUE
 	goto MossdeepCity_Gym_EventScript_CheckSwitch4
 	end
 
 MossdeepCity_Gym_EventScript_SetSwitch4Metatiles::
-	setmetatile 1, 23, METATILE_RS_MossdeepGym_RedArrow_Up, FALSE
-	setmetatile 5, 24, METATILE_RS_MossdeepGym_Switch_Down, TRUE
+	setmetatile 1, 23, METATILE_RSMossdeepGym_RedArrow_Up, FALSE
+	setmetatile 5, 24, METATILE_RSMossdeepGym_Switch_Down, TRUE
 	end
 
 MossdeepCity_Gym_EventScript_TateAndLiza::
@@ -116,8 +116,8 @@ MossdeepCity_Gym_EventScript_Switch1::
 	setflag FLAG_MOSSDEEP_GYM_SWITCH_1
 	applymovement OBJ_EVENT_ID_PLAYER, MossdeepCity_Gym_Movement_WaitAfterSwitchUse
 	waitmovement 0
-	setmetatile 5, 5, METATILE_RS_MossdeepGym_RedArrow_Right, FALSE
-	setmetatile 2, 7, METATILE_RS_MossdeepGym_Switch_Down, TRUE
+	setmetatile 5, 5, METATILE_RSMossdeepGym_RedArrow_Right, FALSE
+	setmetatile 2, 7, METATILE_RSMossdeepGym_Switch_Down, TRUE
 	goto MossdeepCity_Gym_EventScript_DrawMapAfterSwitchUsed
 	end
 
@@ -131,8 +131,8 @@ MossdeepCity_Gym_EventScript_ClearSwitch1::
 	clearflag FLAG_MOSSDEEP_GYM_SWITCH_1
 	applymovement OBJ_EVENT_ID_PLAYER, MossdeepCity_Gym_Movement_WaitAfterSwitchUse
 	waitmovement 0
-	setmetatile 5, 5, METATILE_RS_MossdeepGym_RedArrow_Left, FALSE
-	setmetatile 2, 7, METATILE_RS_MossdeepGym_Switch_Up, TRUE
+	setmetatile 5, 5, METATILE_RSMossdeepGym_RedArrow_Left, FALSE
+	setmetatile 2, 7, METATILE_RSMossdeepGym_Switch_Up, TRUE
 	goto MossdeepCity_Gym_EventScript_DrawMapAfterSwitchUsed
 	end
 
@@ -142,8 +142,8 @@ MossdeepCity_Gym_EventScript_Switch2::
 	setflag FLAG_MOSSDEEP_GYM_SWITCH_2
 	applymovement OBJ_EVENT_ID_PLAYER, MossdeepCity_Gym_Movement_WaitAfterSwitchUse
 	waitmovement 0
-	setmetatile 8, 14, METATILE_RS_MossdeepGym_RedArrow_Right, FALSE
-	setmetatile 8, 10, METATILE_RS_MossdeepGym_Switch_Down, TRUE
+	setmetatile 8, 14, METATILE_RSMossdeepGym_RedArrow_Right, FALSE
+	setmetatile 8, 10, METATILE_RSMossdeepGym_Switch_Down, TRUE
 	goto MossdeepCity_Gym_EventScript_DrawMapAfterSwitchUsed
 	end
 
@@ -151,8 +151,8 @@ MossdeepCity_Gym_EventScript_ClearSwitch2::
 	clearflag FLAG_MOSSDEEP_GYM_SWITCH_2
 	applymovement OBJ_EVENT_ID_PLAYER, MossdeepCity_Gym_Movement_WaitAfterSwitchUse
 	waitmovement 0
-	setmetatile 8, 14, METATILE_RS_MossdeepGym_RedArrow_Down, FALSE
-	setmetatile 8, 10, METATILE_RS_MossdeepGym_Switch_Up, TRUE
+	setmetatile 8, 14, METATILE_RSMossdeepGym_RedArrow_Down, FALSE
+	setmetatile 8, 10, METATILE_RSMossdeepGym_Switch_Up, TRUE
 	goto MossdeepCity_Gym_EventScript_DrawMapAfterSwitchUsed
 	end
 
@@ -162,8 +162,8 @@ MossdeepCity_Gym_EventScript_Switch3::
 	setflag FLAG_MOSSDEEP_GYM_SWITCH_3
 	applymovement OBJ_EVENT_ID_PLAYER, MossdeepCity_Gym_Movement_WaitAfterSwitchUse
 	waitmovement 0
-	setmetatile 15, 17, METATILE_RS_MossdeepGym_RedArrow_Left, FALSE
-	setmetatile 17, 15, METATILE_RS_MossdeepGym_Switch_Down, TRUE
+	setmetatile 15, 17, METATILE_RSMossdeepGym_RedArrow_Left, FALSE
+	setmetatile 17, 15, METATILE_RSMossdeepGym_Switch_Down, TRUE
 	goto MossdeepCity_Gym_EventScript_DrawMapAfterSwitchUsed
 	end
 
@@ -171,8 +171,8 @@ MossdeepCity_Gym_EventScript_ClearSwitch3::
 	clearflag FLAG_MOSSDEEP_GYM_SWITCH_3
 	applymovement OBJ_EVENT_ID_PLAYER, MossdeepCity_Gym_Movement_WaitAfterSwitchUse
 	waitmovement 0
-	setmetatile 15, 17, METATILE_RS_MossdeepGym_RedArrow_Right, FALSE
-	setmetatile 17, 15, METATILE_RS_MossdeepGym_Switch_Up, TRUE
+	setmetatile 15, 17, METATILE_RSMossdeepGym_RedArrow_Right, FALSE
+	setmetatile 17, 15, METATILE_RSMossdeepGym_Switch_Up, TRUE
 	goto MossdeepCity_Gym_EventScript_DrawMapAfterSwitchUsed
 	end
 
@@ -182,8 +182,8 @@ MossdeepCity_Gym_EventScript_Switch4::
 	setflag FLAG_MOSSDEEP_GYM_SWITCH_4
 	applymovement OBJ_EVENT_ID_PLAYER, MossdeepCity_Gym_Movement_WaitAfterSwitchUse
 	waitmovement 0
-	setmetatile 1, 23, METATILE_RS_MossdeepGym_RedArrow_Up, FALSE
-	setmetatile 5, 24, METATILE_RS_MossdeepGym_Switch_Down, TRUE
+	setmetatile 1, 23, METATILE_RSMossdeepGym_RedArrow_Up, FALSE
+	setmetatile 5, 24, METATILE_RSMossdeepGym_Switch_Down, TRUE
 	goto MossdeepCity_Gym_EventScript_DrawMapAfterSwitchUsed
 	end
 
@@ -191,8 +191,8 @@ MossdeepCity_Gym_EventScript_ClearSwitch4::
 	clearflag FLAG_MOSSDEEP_GYM_SWITCH_4
 	applymovement OBJ_EVENT_ID_PLAYER, MossdeepCity_Gym_Movement_WaitAfterSwitchUse
 	waitmovement 0
-	setmetatile 1, 23, METATILE_RS_MossdeepGym_RedArrow_Right, FALSE
-	setmetatile 5, 24, METATILE_RS_MossdeepGym_Switch_Up, TRUE
+	setmetatile 1, 23, METATILE_RSMossdeepGym_RedArrow_Right, FALSE
+	setmetatile 5, 24, METATILE_RSMossdeepGym_Switch_Up, TRUE
 	goto MossdeepCity_Gym_EventScript_DrawMapAfterSwitchUsed
 	end
 

--- a/include/constants/metatile_labels.h
+++ b/include/constants/metatile_labels.h
@@ -47,12 +47,6 @@
 #define METATILE_Building_PC_Off 0x004
 #define METATILE_Building_PC_On  0x005
 
-// gTileset_PokemonCenter
-#define METATILE_PokemonCenter_Door_CableClub  0x264
-
-// gTileset_Shop
-#define METATILE_Shop_Door_Elevator 0x285
-
 // gTileset_Petalburg
 #define METATILE_Petalburg_Door_Littleroot    0x248
 #define METATILE_Petalburg_Door_BirchsLab     0x249
@@ -122,6 +116,7 @@
 #define METATILE_BrendansMaysHouse_BookOnTable      0x293
 
 // gTileset_Shop
+#define METATILE_Shop_Door_Elevator  0x285
 #define METATILE_Shop_Laptop1_Normal 0x29D
 #define METATILE_Shop_Laptop2_Normal 0x2A5
 #define METATILE_Shop_Laptop1_Flash  0x258
@@ -294,6 +289,7 @@
 #define METATILE_EverGrande_Door_PokemonLeague  0x21D
 
 // gTileset_PokemonCenter
+#define METATILE_PokemonCenter_Door_CableClub           0x264
 #define METATILE_PokemonCenter_Escalator1F_Tile0_Frame0 0x280
 #define METATILE_PokemonCenter_Escalator1F_Tile0_Frame1 0x282
 #define METATILE_PokemonCenter_Escalator1F_Tile0_Frame2 0x284

--- a/include/constants/metatile_labels.h
+++ b/include/constants/metatile_labels.h
@@ -95,15 +95,15 @@
 #define METATILE_PetalburgGym_SlidingDoor_Frame4 0x21C
 #define METATILE_PetalburgGym_Door               0x224
 
-// gTileset_MossdeepGym from R/S
-#define METATILE_RS_MossdeepGym_RedArrow_Right        0x204
-#define METATILE_RS_MossdeepGym_RedArrow_Left         0x20C
-#define METATILE_RS_MossdeepGym_RedArrow_Up           0x20D
-#define METATILE_RS_MossdeepGym_RedArrow_Down         0x205
-#define METATILE_RS_MossdeepGym_Switch_Up             0x238
-#define METATILE_RS_MossdeepGym_Switch_Down           0x239
+// gTileset_RSMossdeepGym
+#define METATILE_RSMossdeepGym_RedArrow_Right        0x204
+#define METATILE_RSMossdeepGym_RedArrow_Left         0x20C
+#define METATILE_RSMossdeepGym_RedArrow_Up           0x20D
+#define METATILE_RSMossdeepGym_RedArrow_Down         0x205
+#define METATILE_RSMossdeepGym_Switch_Up             0x238
+#define METATILE_RSMossdeepGym_Switch_Down           0x239
 
-// gTileset_MossdeepGym from Emerald
+// gTileset_MossdeepGym
 #define METATILE_MossdeepGym_YellowArrow_Right        0x250
 
 // gTileset_BrendansMaysHouse

--- a/include/constants/metatile_labels.h
+++ b/include/constants/metatile_labels.h
@@ -1,790 +1,790 @@
 #ifndef GUARD_METATILE_LABELS_H
 #define GUARD_METATILE_LABELS_H
 
-// gTileset_General
-#define METATILE_General_Grass                0x001
-#define METATILE_General_TallGrass            0x00D
-#define METATILE_General_LongGrass            0x015
-#define METATILE_General_TallGrass_TreeUp     0x025
-#define METATILE_General_Grass_TreeUp         0x00E
-#define METATILE_General_TallGrass_TreeLeft   0x1C6
-#define METATILE_General_TallGrass_TreeRight  0x1C7
-#define METATILE_General_Grass_TreeLeft       0x1CE
-#define METATILE_General_Grass_TreeRight      0x1CF
-#define METATILE_General_MuddySlope_Frame0    0x0E8
-#define METATILE_General_MuddySlope_Frame1    0x0E9
-#define METATILE_General_MuddySlope_Frame2    0x0EA
-#define METATILE_General_MuddySlope_Frame3    0x0EB
-#define METATILE_General_SandPit_Center       0x121
-#define METATILE_General_Door                 0x021
-#define METATILE_General_Door_PokeMart        0x041
-#define METATILE_General_Door_PokeCenter      0x061
-#define METATILE_General_Door_Gym             0x1CD
-#define METATILE_General_Door_Contest         0x1DB
-#define METATILE_General_CaveEntrance_Top     0x09F
-#define METATILE_General_CaveEntrance_Bottom  0x0A7
-#define METATILE_General_RockWall_GrassBase   0x079
-#define METATILE_General_RockWall_RockBase    0x07C
-#define METATILE_General_RockWall_SandBase    0x091
-#define METATILE_General_CalmWater            0x170
-#define METATILE_General_RoughWater           0x14E
-#define METATILE_General_RoughDeepWater       0x14F
-#define METATILE_General_ReflectiveWater      0x0A1
-#define METATILE_General_SecretBase_TreeLeft  0x026
-#define METATILE_General_SecretBase_TreeRight 0x027
-#define METATILE_General_SecretBase_VineLeft  0x036
-#define METATILE_General_SecretBase_VineRight 0x037
-#define METATILE_General_RedCaveIndent        0x1A0
-#define METATILE_General_RedCaveOpen          0x1A1
-#define METATILE_General_YellowCaveIndent     0x1A8
-#define METATILE_General_YellowCaveOpen       0x1A9
-#define METATILE_General_BlueCaveIndent       0x1B0
-#define METATILE_General_BlueCaveOpen         0x1B1
+// gTileset_BattleArena
+#define METATILE_BattleArena_Door  0x21B
 
-// gTileset_Building
-#define METATILE_Building_TV_Off 0x002
-#define METATILE_Building_TV_On  0x003
-#define METATILE_Building_PC_Off 0x004
-#define METATILE_Building_PC_On  0x005
-
-// gTileset_Petalburg
-#define METATILE_Petalburg_Door_Littleroot    0x248
-#define METATILE_Petalburg_Door_BirchsLab     0x249
-#define METATILE_Petalburg_Door_Oldale        0x287
-
-// gTileset_Rustboro
-#define METATILE_Rustboro_Door_Gray  0x21F
-#define METATILE_Rustboro_Door_Tan   0x22F
-
-// gTileset_MauvilleGym
-#define METATILE_MauvilleGym_RaisedSwitch    0x205
-#define METATILE_MauvilleGym_PressedSwitch   0x206
-#define METATILE_MauvilleGym_FloorTile       0x21A
-#define METATILE_MauvilleGym_GreenBeamH1_On  0x220
-#define METATILE_MauvilleGym_GreenBeamH2_On  0x221
-#define METATILE_MauvilleGym_GreenBeamH3_On  0x228
-#define METATILE_MauvilleGym_GreenBeamH4_On  0x229
-#define METATILE_MauvilleGym_GreenBeamH1_Off 0x230
-#define METATILE_MauvilleGym_GreenBeamH2_Off 0x231
-#define METATILE_MauvilleGym_GreenBeamH3_Off 0x238
-#define METATILE_MauvilleGym_GreenBeamH4_Off 0x239
-#define METATILE_MauvilleGym_RedBeamH1_On    0x222
-#define METATILE_MauvilleGym_RedBeamH2_On    0x223
-#define METATILE_MauvilleGym_RedBeamH3_On    0x22A
-#define METATILE_MauvilleGym_RedBeamH4_On    0x22B
-#define METATILE_MauvilleGym_RedBeamH1_Off   0x232
-#define METATILE_MauvilleGym_RedBeamH2_Off   0x233
-#define METATILE_MauvilleGym_RedBeamH3_Off   0x23A
-#define METATILE_MauvilleGym_RedBeamH4_Off   0x23B
-#define METATILE_MauvilleGym_GreenBeamV1_On  0x240
-#define METATILE_MauvilleGym_GreenBeamV2_On  0x248
-#define METATILE_MauvilleGym_RedBeamV1_On    0x241
-#define METATILE_MauvilleGym_RedBeamV2_On    0x249
-#define METATILE_MauvilleGym_PoleTop_On      0x250
-#define METATILE_MauvilleGym_PoleTop_Off     0x251
-#define METATILE_MauvilleGym_PoleBottom_On   0x242
-#define METATILE_MauvilleGym_PoleBottom_Off  0x243
-
-// gTileset_PetalburgGym
-#define METATILE_PetalburgGym_RoomEntrance_Left  0x210
-#define METATILE_PetalburgGym_RoomEntrance_Right 0x211
-#define METATILE_PetalburgGym_SlidingDoor_Frame0 0x218
-#define METATILE_PetalburgGym_SlidingDoor_Frame1 0x219
-#define METATILE_PetalburgGym_SlidingDoor_Frame2 0x21A
-#define METATILE_PetalburgGym_SlidingDoor_Frame3 0x21B
-#define METATILE_PetalburgGym_SlidingDoor_Frame4 0x21C
-#define METATILE_PetalburgGym_Door               0x224
-
-// gTileset_RSMossdeepGym
-#define METATILE_RSMossdeepGym_RedArrow_Right        0x204
-#define METATILE_RSMossdeepGym_RedArrow_Left         0x20C
-#define METATILE_RSMossdeepGym_RedArrow_Up           0x20D
-#define METATILE_RSMossdeepGym_RedArrow_Down         0x205
-#define METATILE_RSMossdeepGym_Switch_Up             0x238
-#define METATILE_RSMossdeepGym_Switch_Down           0x239
-
-// gTileset_MossdeepGym
-#define METATILE_MossdeepGym_YellowArrow_Right        0x250
-
-// gTileset_BrendansMaysHouse
-#define METATILE_BrendansMaysHouse_BrendanPC_Off    0x25A
-#define METATILE_BrendansMaysHouse_BrendanPC_On     0x27F
-#define METATILE_BrendansMaysHouse_MayPC_Off        0x259
-#define METATILE_BrendansMaysHouse_MayPC_On         0x27E
-#define METATILE_BrendansMaysHouse_MovingBox_Closed 0x268
-#define METATILE_BrendansMaysHouse_MovingBox_Open   0x270
-#define METATILE_BrendansMaysHouse_BookOnTable      0x293
-
-// gTileset_Shop
-#define METATILE_Shop_Door_Elevator  0x285
-#define METATILE_Shop_Laptop1_Normal 0x29D
-#define METATILE_Shop_Laptop2_Normal 0x2A5
-#define METATILE_Shop_Laptop1_Flash  0x258
-#define METATILE_Shop_Laptop2_Flash  0x260
-
-// gTileset_BattleFrontier
-#define METATILE_BattleFrontier_Door_Elevator           0x20E
-#define METATILE_BattleFrontier_Door_MultiCorridor      0x2AD
-#define METATILE_BattleFrontier_CorridorOpenDoor_Top    0x207
-#define METATILE_BattleFrontier_CorridorOpenDoor_Bottom 0x20F
-#define METATILE_BattleFrontier_Elevator_Top0           0x329
-#define METATILE_BattleFrontier_Elevator_Top1           0x32A
-#define METATILE_BattleFrontier_Elevator_Top2           0x32B
-#define METATILE_BattleFrontier_Elevator_Mid0           0x331
-#define METATILE_BattleFrontier_Elevator_Mid1           0x332
-#define METATILE_BattleFrontier_Elevator_Mid2           0x333
-#define METATILE_BattleFrontier_Elevator_Bottom0        0x339
-#define METATILE_BattleFrontier_Elevator_Bottom1        0x33A
-#define METATILE_BattleFrontier_Elevator_Bottom2        0x33B
-
-// gTileset_BattleFrontierOutsideWest
-#define METATILE_BattleFrontierOutsideWest_Door_BattleFactory  0x263
-#define METATILE_BattleFrontierOutsideWest_Door_BattleDome     0x28A
-#define METATILE_BattleFrontierOutsideWest_Door_Sliding        0x396
-#define METATILE_BattleFrontierOutsideWest_Door                0x3FC
+// gTileset_BattleDome
+#define METATILE_BattleDome_Door_Corridor       0x25E
+#define METATILE_BattleDome_Door_Lobby          0x209
+#define METATILE_BattleDome_Door_PreBattleRoom  0x20A
 
 // gTileset_BattleFrontierOutsideEast
+#define METATILE_BattleFrontierOutsideEast_Door              0x3FC
 #define METATILE_BattleFrontierOutsideEast_Door_BattleArena  0x291
 #define METATILE_BattleFrontierOutsideEast_Door_BattleTower  0x329
 #define METATILE_BattleFrontierOutsideEast_Door_Sliding      0x396
-#define METATILE_BattleFrontierOutsideEast_Door              0x3FC
 
-// gTileset_BattleDome
-#define METATILE_BattleDome_Door_Lobby          0x209
-#define METATILE_BattleDome_Door_PreBattleRoom  0x20A
-#define METATILE_BattleDome_Door_Corridor       0x25E
+// gTileset_BattleFrontierOutsideWest
+#define METATILE_BattleFrontierOutsideWest_Door                0x3FC
+#define METATILE_BattleFrontierOutsideWest_Door_BattleDome     0x28A
+#define METATILE_BattleFrontierOutsideWest_Door_BattleFactory  0x263
+#define METATILE_BattleFrontierOutsideWest_Door_Sliding        0x396
 
-// gTileset_BattleArena
-#define METATILE_BattleArena_Door  0x21B
+// gTileset_BattleFrontier
+#define METATILE_BattleFrontier_CorridorOpenDoor_Bottom  0x20F
+#define METATILE_BattleFrontier_CorridorOpenDoor_Top     0x207
+#define METATILE_BattleFrontier_Door_Elevator            0x20E
+#define METATILE_BattleFrontier_Door_MultiCorridor       0x2AD
+#define METATILE_BattleFrontier_Elevator_Bottom0         0x339
+#define METATILE_BattleFrontier_Elevator_Bottom1         0x33A
+#define METATILE_BattleFrontier_Elevator_Bottom2         0x33B
+#define METATILE_BattleFrontier_Elevator_Mid0            0x331
+#define METATILE_BattleFrontier_Elevator_Mid1            0x332
+#define METATILE_BattleFrontier_Elevator_Mid2            0x333
+#define METATILE_BattleFrontier_Elevator_Top0            0x329
+#define METATILE_BattleFrontier_Elevator_Top1            0x32A
+#define METATILE_BattleFrontier_Elevator_Top2            0x32B
 
 // gTileset_BattlePalace
 #define METATILE_BattlePalace_Door  0x219
 
+// gTileset_BattlePike
+#define METATILE_BattlePike_CurtainFrames_Start   0x201
+#define METATILE_BattlePike_Curtain_Stage0_Tile0  0x24A
+#define METATILE_BattlePike_Curtain_Stage0_Tile1  0x251
+#define METATILE_BattlePike_Curtain_Stage0_Tile2  0x252
+#define METATILE_BattlePike_Curtain_Stage0_Tile3  0x253
+#define METATILE_BattlePike_Curtain_Stage0_Tile4  0x259
+#define METATILE_BattlePike_Curtain_Stage0_Tile5  0x25A
+#define METATILE_BattlePike_Curtain_Stage0_Tile6  0x25B
+#define METATILE_BattlePike_Curtain_Stage1_Tile0  0x22A
+#define METATILE_BattlePike_Curtain_Stage1_Tile1  0x231
+#define METATILE_BattlePike_Curtain_Stage1_Tile2  0x232
+#define METATILE_BattlePike_Curtain_Stage1_Tile3  0x233
+#define METATILE_BattlePike_Curtain_Stage1_Tile4  0x239
+#define METATILE_BattlePike_Curtain_Stage1_Tile5  0x23A
+#define METATILE_BattlePike_Curtain_Stage1_Tile6  0x23B
+#define METATILE_BattlePike_Curtain_Stage2_Tile0  0x20A
+#define METATILE_BattlePike_Curtain_Stage2_Tile1  0x211
+#define METATILE_BattlePike_Curtain_Stage2_Tile2  0x212
+#define METATILE_BattlePike_Curtain_Stage2_Tile3  0x213
+#define METATILE_BattlePike_Curtain_Stage2_Tile4  0x219
+#define METATILE_BattlePike_Curtain_Stage2_Tile5  0x21A
+#define METATILE_BattlePike_Curtain_Stage2_Tile6  0x21B
+#define METATILE_BattlePike_Curtain_Stage3_Tile0  0x2AB
+#define METATILE_BattlePike_Curtain_Stage3_Tile1  0x2B2
+#define METATILE_BattlePike_Curtain_Stage3_Tile2  0x2B3
+#define METATILE_BattlePike_Curtain_Stage3_Tile3  0x2B4
+#define METATILE_BattlePike_Curtain_Stage3_Tile4  0x2BA
+#define METATILE_BattlePike_Curtain_Stage3_Tile5  0x2BB
+#define METATILE_BattlePike_Curtain_Stage3_Tile6  0x2BC
+
+// gTileset_BattlePyramid
+#define METATILE_BattlePyramid_Exit   0x28E
+#define METATILE_BattlePyramid_Floor  0x28D
+
+// gTileset_BattleTent
+#define METATILE_BattleTent_Door  0x26B
+
+// gTileset_BikeShop
+#define METATILE_BikeShop_Barrier_Blue_Bottom      0x2CF
+#define METATILE_BikeShop_Barrier_Blue_BottomMid   0x2C7
+#define METATILE_BikeShop_Barrier_Blue_Top         0x2B7
+#define METATILE_BikeShop_Barrier_Blue_TopMid      0x2BF
+#define METATILE_BikeShop_Barrier_Green_Bottom     0x2CE
+#define METATILE_BikeShop_Barrier_Green_BottomMid  0x2C6
+#define METATILE_BikeShop_Barrier_Green_Top        0x2B6
+#define METATILE_BikeShop_Barrier_Green_TopMid     0x2BE
+#define METATILE_BikeShop_Barrier_Hidden_Bottom    0x271
+#define METATILE_BikeShop_Barrier_Hidden_Top       0x269
+#define METATILE_BikeShop_Button_Blue              0x236
+#define METATILE_BikeShop_Button_Green             0x22E
+#define METATILE_BikeShop_Button_Pressed           0x24F
+#define METATILE_BikeShop_Floor_Shadow_Top         0x26D
+#define METATILE_BikeShop_Generator_Off_Tile0      0x2F0
+#define METATILE_BikeShop_Generator_Off_Tile1      0x2F1
+#define METATILE_BikeShop_Generator_Off_Tile2      0x2F2
+#define METATILE_BikeShop_Generator_Off_Tile3      0x2F3
+#define METATILE_BikeShop_Generator_Off_Tile4      0x2F4
+#define METATILE_BikeShop_Generator_Off_Tile5      0x2F5
+#define METATILE_BikeShop_Generator_Off_Tile6      0x2F6
+#define METATILE_BikeShop_Generator_Off_Tile7      0x2F7
+#define METATILE_BikeShop_Wall_Edge_Top            0x281
+
+// gTileset_BrendansMaysHouse
+#define METATILE_BrendansMaysHouse_BookOnTable       0x293
+#define METATILE_BrendansMaysHouse_BrendanPC_Off     0x25A
+#define METATILE_BrendansMaysHouse_BrendanPC_On      0x27F
+#define METATILE_BrendansMaysHouse_MayPC_Off         0x259
+#define METATILE_BrendansMaysHouse_MayPC_On          0x27E
+#define METATILE_BrendansMaysHouse_MovingBox_Closed  0x268
+#define METATILE_BrendansMaysHouse_MovingBox_Open    0x270
+
+// gTileset_Building
+#define METATILE_Building_PC_Off  0x004
+#define METATILE_Building_PC_On   0x005
+#define METATILE_Building_TV_Off  0x002
+#define METATILE_Building_TV_On   0x003
+
 // gTileset_Cave
-#define METATILE_Cave_EntranceCover                     0x229
-#define METATILE_Cave_CrackedFloor_Hole                 0x206
-#define METATILE_Cave_CrackedFloor                      0x22F
-#define METATILE_Cave_SealedChamberEntrance_TopLeft     0x22A
-#define METATILE_Cave_SealedChamberEntrance_TopMid      0x22B
-#define METATILE_Cave_SealedChamberEntrance_TopRight    0x22C
-#define METATILE_Cave_SealedChamberEntrance_BottomLeft  0x232
-#define METATILE_Cave_SealedChamberEntrance_BottomMid   0x233
-#define METATILE_Cave_SealedChamberEntrance_BottomRight 0x234
-#define METATILE_Cave_SealedChamberBraille_Mid          0x235
-#define METATILE_Cave_ShoalCave_DirtPile_Large          0x358
-#define METATILE_Cave_ShoalCave_DirtPile_Small          0x35A
-#define METATILE_Cave_ShoalCave_BlueStone_Large         0x359
-#define METATILE_Cave_ShoalCave_BlueStone_Small         0x35B
+#define METATILE_Cave_CrackedFloor                       0x22F
+#define METATILE_Cave_CrackedFloor_Hole                  0x206
+#define METATILE_Cave_EntranceCover                      0x229
+#define METATILE_Cave_SealedChamberBraille_Mid           0x235
+#define METATILE_Cave_SealedChamberEntrance_BottomLeft   0x232
+#define METATILE_Cave_SealedChamberEntrance_BottomMid    0x233
+#define METATILE_Cave_SealedChamberEntrance_BottomRight  0x234
+#define METATILE_Cave_SealedChamberEntrance_TopLeft      0x22A
+#define METATILE_Cave_SealedChamberEntrance_TopMid       0x22B
+#define METATILE_Cave_SealedChamberEntrance_TopRight     0x22C
+#define METATILE_Cave_ShoalCave_BlueStone_Large          0x359
+#define METATILE_Cave_ShoalCave_BlueStone_Small          0x35B
+#define METATILE_Cave_ShoalCave_DirtPile_Large           0x358
+#define METATILE_Cave_ShoalCave_DirtPile_Small           0x35A
 
-// gTileset_Pacifidlog
-#define METATILE_Pacifidlog_Door                              0x21A
-#define METATILE_Pacifidlog_FloatingLogs_HorizontalLeft       0x250
-#define METATILE_Pacifidlog_FloatingLogs_HorizontalRight      0x251
-#define METATILE_Pacifidlog_HalfSubmergedLogs_HorizontalLeft  0x252
-#define METATILE_Pacifidlog_HalfSubmergedLogs_HorizontalRight 0x253
-#define METATILE_Pacifidlog_SubmergedLogs_HorizontalLeft      0x254
-#define METATILE_Pacifidlog_SubmergedLogs_HorizontalRight     0x255
-#define METATILE_Pacifidlog_FloatingLogs_VerticalTop          0x258
-#define METATILE_Pacifidlog_FloatingLogs_VerticalBottom       0x260
-#define METATILE_Pacifidlog_HalfSubmergedLogs_VerticalTop     0x259
-#define METATILE_Pacifidlog_HalfSubmergedLogs_VerticalBottom  0x261
-#define METATILE_Pacifidlog_SubmergedLogs_VerticalTop         0x25A
-#define METATILE_Pacifidlog_SubmergedLogs_VerticalBottom      0x262
-#define METATILE_Pacifidlog_SkyPillar_CrackedFloor_Hole       0x237
-#define METATILE_Pacifidlog_SkyPillar_DoorOpen_Top            0x2AA
-#define METATILE_Pacifidlog_SkyPillar_DoorOpen_Bottom         0x2B2
-
-// gTileset_Fortree
-#define METATILE_Fortree_LongGrass_Root                   0x208
-#define METATILE_Fortree_BridgeOverGrass_Raised           0x24E
-#define METATILE_Fortree_BridgeOverGrass_Lowered          0x24F
-#define METATILE_Fortree_BridgeOverTrees_Raised           0x256
-#define METATILE_Fortree_BridgeOverTrees_Lowered          0x257
-#define METATILE_Fortree_SecretBase_Shrub                 0x271
-#define METATILE_Fortree_SecretBase_ShrubOpen             0x278
-#define METATILE_Fortree_SecretBase_LongGrass_TopLeft     0x279
-#define METATILE_Fortree_SecretBase_LongGrass_TopMid      0x27A
-#define METATILE_Fortree_SecretBase_LongGrass_TopRight    0x27B
-#define METATILE_Fortree_SecretBase_LongGrass_BottomLeft  0x281
-#define METATILE_Fortree_SecretBase_LongGrass_BottomMid   0x282
-#define METATILE_Fortree_SecretBase_LongGrass_BottomRight 0x283
-#define METATILE_Fortree_WoodBridge1_Top                  0x297
-#define METATILE_Fortree_WoodBridge1_Bottom               0x29F
-
-// gTileset_Sootopolis
-#define METATILE_Sootopolis_Door             0x21E
-#define METATILE_Sootopolis_Door_PeakedRoof  0x21C
-#define METATILE_Sootopolis_Door_Closed      0x248
-#define METATILE_Sootopolis_GymDoor_Closed   0x250
-#define METATILE_Sootopolis_RoughWater       0x290
-
-// gTileset_SootopolisGym
-#define METATILE_SootopolisGym_Ice_Cracked  0x20E
-#define METATILE_SootopolisGym_Ice_Broken   0x206
-#define METATILE_SootopolisGym_Stairs       0x207
-
-// gTileset_Fallarbor
-#define METATILE_Fallarbor_AshGrass                 0x20A
-#define METATILE_Fallarbor_BrownCaveIndent          0x208
-#define METATILE_Fallarbor_BrownCaveOpen            0x210
-#define METATILE_Fallarbor_NormalGrass              0x212
-#define METATILE_Fallarbor_AshField                 0x218
-#define METATILE_Fallarbor_BrownCaveEntrance_Top    0x259
-#define METATILE_Fallarbor_BrownCaveEntrance_Bottom 0x261
-#define METATILE_Fallarbor_RedCaveEntrance_Top      0x347
-#define METATILE_Fallarbor_RedCaveEntrance_Bottom   0x34F
-#define METATILE_Fallarbor_BrownRockWall            0x265
-#define METATILE_Fallarbor_RedRockWall              0x269
-#define METATILE_Fallarbor_Door_LightRoof           0x2A5
-#define METATILE_Fallarbor_Door_DarkRoof            0x2F7
-#define METATILE_Fallarbor_Door_BattleTent          0x36C
-
-// gTileset_Lavaridge
-#define METATILE_Lavaridge_NormalGrass         0x206
-#define METATILE_Lavaridge_AshGrass            0x207
-#define METATILE_Lavaridge_LavaField           0x271
-#define METATILE_Lavaridge_RockWall            0x274
-#define METATILE_Lavaridge_CaveEntrance_Top    0x256
-#define METATILE_Lavaridge_CaveEntrance_Bottom 0x25E
-
-// gTileset_Mauville
-#define METATILE_Mauville_Door               0x2AC
-#define METATILE_Mauville_Door_CyclingRoad   0x289
-#define METATILE_Mauville_Door_Verdanturf    0x3A1
-#define METATILE_Mauville_Door_BattleTent    0x3D4
-#define METATILE_Mauville_DeepSand_Center    0x251
-#define METATILE_Mauville_DeepSand_BottomMid 0x259
-#define METATILE_Mauville_MirageTower_Tile0  0x3D8
-#define METATILE_Mauville_MirageTower_Tile1  0x3D9
-#define METATILE_Mauville_MirageTower_Tile2  0x3DA
-#define METATILE_Mauville_MirageTower_Tile3  0x3E0
-#define METATILE_Mauville_MirageTower_Tile4  0x3E1
-#define METATILE_Mauville_MirageTower_Tile5  0x3E2
-#define METATILE_Mauville_MirageTower_Tile6  0x3E8
-#define METATILE_Mauville_MirageTower_Tile7  0x3E9
-#define METATILE_Mauville_MirageTower_Tile8  0x3EA
-#define METATILE_Mauville_MirageTower_Tile9  0x3F0
-#define METATILE_Mauville_MirageTower_TileA  0x3F1
-#define METATILE_Mauville_MirageTower_TileB  0x3F2
-#define METATILE_Mauville_MirageTower_TileC  0x3DB
-#define METATILE_Mauville_MirageTower_TileD  0x3DC
-#define METATILE_Mauville_MirageTower_TileE  0x3DD
-#define METATILE_Mauville_MirageTower_TileF  0x3E3
-#define METATILE_Mauville_MirageTower_Tile10 0x3E4
-#define METATILE_Mauville_MirageTower_Tile11 0x3E5
+// gTileset_Contest
+#define METATILE_Contest_CounterFlap_Bottom  0x2D9
+#define METATILE_Contest_CounterFlap_Top     0x2D1
+#define METATILE_Contest_FloorShadow         0x261
+#define METATILE_Contest_WallShadow          0x221
 
 // gTileset_Dewford
 #define METATILE_Dewford_Door              0x225
 #define METATILE_Dewford_Door_BattleTower  0x25D
 
-// gTileset_Slateport
-#define METATILE_Slateport_Door             0x2DC
-#define METATILE_Slateport_Door_BattleTent  0x393
+// gTileset_EliteFour
+#define METATILE_EliteFour_EntryDoor_ClosedBottom    0x20E
+#define METATILE_EliteFour_EntryDoor_ClosedTop       0x206
+#define METATILE_EliteFour_LeftSpotlightOff          0x2DD
+#define METATILE_EliteFour_OpenDoorChampion_Frame    0x346
+#define METATILE_EliteFour_OpenDoorChampion_Opening  0x347
+#define METATILE_EliteFour_OpenDoor_Frame            0x344
+#define METATILE_EliteFour_OpenDoor_Opening          0x345
+#define METATILE_EliteFour_RightSpotlightOff         0x2DE
+
+// gTileset_EverGrande
+#define METATILE_EverGrande_Door_PokemonLeague  0x21D
+
+// gTileset_Facility
+#define METATILE_Facility_DataPad                       0x3E4
+#define METATILE_Facility_NewMauvilleDoor_Closed_Tile0  0x314
+#define METATILE_Facility_NewMauvilleDoor_Closed_Tile1  0x315
+#define METATILE_Facility_NewMauvilleDoor_Closed_Tile2  0x316
+#define METATILE_Facility_NewMauvilleDoor_Closed_Tile3  0x31C
+#define METATILE_Facility_NewMauvilleDoor_Closed_Tile4  0x31D
+#define METATILE_Facility_NewMauvilleDoor_Closed_Tile5  0x31E
+#define METATILE_Facility_NewMauvilleDoor_Open_Tile0    0x2C3
+#define METATILE_Facility_NewMauvilleDoor_Open_Tile1    0x2C4
+#define METATILE_Facility_NewMauvilleDoor_Open_Tile2    0x2C5
+#define METATILE_Facility_NewMauvilleDoor_Open_Tile3    0x2CB
+#define METATILE_Facility_NewMauvilleDoor_Open_Tile4    0x2CC
+#define METATILE_Facility_NewMauvilleDoor_Open_Tile5    0x2CD
+
+// gTileset_Fallarbor
+#define METATILE_Fallarbor_AshField                  0x218
+#define METATILE_Fallarbor_AshGrass                  0x20A
+#define METATILE_Fallarbor_BrownCaveEntrance_Bottom  0x261
+#define METATILE_Fallarbor_BrownCaveEntrance_Top     0x259
+#define METATILE_Fallarbor_BrownCaveIndent           0x208
+#define METATILE_Fallarbor_BrownCaveOpen             0x210
+#define METATILE_Fallarbor_BrownRockWall             0x265
+#define METATILE_Fallarbor_Door_BattleTent           0x36C
+#define METATILE_Fallarbor_Door_DarkRoof             0x2F7
+#define METATILE_Fallarbor_Door_LightRoof            0x2A5
+#define METATILE_Fallarbor_NormalGrass               0x212
+#define METATILE_Fallarbor_RedCaveEntrance_Bottom    0x34F
+#define METATILE_Fallarbor_RedCaveEntrance_Top       0x347
+#define METATILE_Fallarbor_RedRockWall               0x269
+
+// gTileset_Fortree
+#define METATILE_Fortree_BridgeOverGrass_Lowered           0x24F
+#define METATILE_Fortree_BridgeOverGrass_Raised            0x24E
+#define METATILE_Fortree_BridgeOverTrees_Lowered           0x257
+#define METATILE_Fortree_BridgeOverTrees_Raised            0x256
+#define METATILE_Fortree_LongGrass_Root                    0x208
+#define METATILE_Fortree_SecretBase_LongGrass_BottomLeft   0x281
+#define METATILE_Fortree_SecretBase_LongGrass_BottomMid    0x282
+#define METATILE_Fortree_SecretBase_LongGrass_BottomRight  0x283
+#define METATILE_Fortree_SecretBase_LongGrass_TopLeft      0x279
+#define METATILE_Fortree_SecretBase_LongGrass_TopMid       0x27A
+#define METATILE_Fortree_SecretBase_LongGrass_TopRight     0x27B
+#define METATILE_Fortree_SecretBase_Shrub                  0x271
+#define METATILE_Fortree_SecretBase_ShrubOpen              0x278
+#define METATILE_Fortree_WoodBridge1_Bottom                0x29F
+#define METATILE_Fortree_WoodBridge1_Top                   0x297
+
+// gTileset_General
+#define METATILE_General_BlueCaveIndent        0x1B0
+#define METATILE_General_BlueCaveOpen          0x1B1
+#define METATILE_General_CalmWater             0x170
+#define METATILE_General_CaveEntrance_Bottom   0x0A7
+#define METATILE_General_CaveEntrance_Top      0x09F
+#define METATILE_General_Door                  0x021
+#define METATILE_General_Door_Contest          0x1DB
+#define METATILE_General_Door_Gym              0x1CD
+#define METATILE_General_Door_PokeCenter       0x061
+#define METATILE_General_Door_PokeMart         0x041
+#define METATILE_General_Grass                 0x001
+#define METATILE_General_Grass_TreeLeft        0x1CE
+#define METATILE_General_Grass_TreeRight       0x1CF
+#define METATILE_General_Grass_TreeUp          0x00E
+#define METATILE_General_LongGrass             0x015
+#define METATILE_General_MuddySlope_Frame0     0x0E8
+#define METATILE_General_MuddySlope_Frame1     0x0E9
+#define METATILE_General_MuddySlope_Frame2     0x0EA
+#define METATILE_General_MuddySlope_Frame3     0x0EB
+#define METATILE_General_RedCaveIndent         0x1A0
+#define METATILE_General_RedCaveOpen           0x1A1
+#define METATILE_General_ReflectiveWater       0x0A1
+#define METATILE_General_RockWall_GrassBase    0x079
+#define METATILE_General_RockWall_RockBase     0x07C
+#define METATILE_General_RockWall_SandBase     0x091
+#define METATILE_General_RoughDeepWater        0x14F
+#define METATILE_General_RoughWater            0x14E
+#define METATILE_General_SandPit_Center        0x121
+#define METATILE_General_SecretBase_TreeLeft   0x026
+#define METATILE_General_SecretBase_TreeRight  0x027
+#define METATILE_General_SecretBase_VineLeft   0x036
+#define METATILE_General_SecretBase_VineRight  0x037
+#define METATILE_General_TallGrass             0x00D
+#define METATILE_General_TallGrass_TreeLeft    0x1C6
+#define METATILE_General_TallGrass_TreeRight   0x1C7
+#define METATILE_General_TallGrass_TreeUp      0x025
+#define METATILE_General_YellowCaveIndent      0x1A8
+#define METATILE_General_YellowCaveOpen        0x1A9
+
+// gTileset_GenericBuilding
+#define METATILE_GenericBuilding_TableEdge               0x2F1
+#define METATILE_GenericBuilding_TrickHouse_Door_Closed  0x21B
+#define METATILE_GenericBuilding_TrickHouse_Stairs_Down  0x219
+
+// gTileset_InsideOfTruck
+#define METATILE_InsideOfTruck_DoorClosedFloor_Bottom  0x21D
+#define METATILE_InsideOfTruck_DoorClosedFloor_Mid     0x215
+#define METATILE_InsideOfTruck_DoorClosedFloor_Top     0x20D
+#define METATILE_InsideOfTruck_ExitLight_Bottom        0x218
+#define METATILE_InsideOfTruck_ExitLight_Mid           0x210
+#define METATILE_InsideOfTruck_ExitLight_Top           0x208
+
+// gTileset_InsideShip
+#define METATILE_InsideShip_DoorIndent_Locked           0x234
+#define METATILE_InsideShip_DoorIndent_Unlocked         0x21A
+#define METATILE_InsideShip_IntactDoor_Bottom_Interior  0x297
+#define METATILE_InsideShip_IntactDoor_Bottom_Locked    0x233
+#define METATILE_InsideShip_IntactDoor_Bottom_Unlocked  0x22B
+
+// gTileset_Lavaridge
+#define METATILE_Lavaridge_AshGrass             0x207
+#define METATILE_Lavaridge_CaveEntrance_Bottom  0x25E
+#define METATILE_Lavaridge_CaveEntrance_Top     0x256
+#define METATILE_Lavaridge_LavaField            0x271
+#define METATILE_Lavaridge_NormalGrass          0x206
+#define METATILE_Lavaridge_RockWall             0x274
+
+// gTileset_LilycoveMuseum
+#define METATILE_LilycoveMuseum_Painting0_Left   0x25A
+#define METATILE_LilycoveMuseum_Painting0_Right  0x25B
+#define METATILE_LilycoveMuseum_Painting1_Left   0x25C
+#define METATILE_LilycoveMuseum_Painting1_Right  0x25D
+#define METATILE_LilycoveMuseum_Painting2_Left   0x25E
+#define METATILE_LilycoveMuseum_Painting2_Right  0x25F
+#define METATILE_LilycoveMuseum_Painting3_Left   0x260
+#define METATILE_LilycoveMuseum_Painting3_Right  0x261
+#define METATILE_LilycoveMuseum_Painting4_Left   0x262
+#define METATILE_LilycoveMuseum_Painting4_Right  0x263
+
+// gTileset_Lilycove
+#define METATILE_Lilycove_Door             0x246
+#define METATILE_Lilycove_Door_DeptStore   0x30C
+#define METATILE_Lilycove_Door_SafariZone  0x32D
+#define METATILE_Lilycove_Door_Wooden      0x28E
+#define METATILE_Lilycove_Wailmer0         0x290
+#define METATILE_Lilycove_Wailmer0_Alt     0x298
+#define METATILE_Lilycove_Wailmer1         0x291
+#define METATILE_Lilycove_Wailmer1_Alt     0x299
+#define METATILE_Lilycove_Wailmer2         0x2A0
+#define METATILE_Lilycove_Wailmer3         0x2A1
+
+// gTileset_MauvilleGym
+#define METATILE_MauvilleGym_FloorTile        0x21A
+#define METATILE_MauvilleGym_GreenBeamH1_Off  0x230
+#define METATILE_MauvilleGym_GreenBeamH1_On   0x220
+#define METATILE_MauvilleGym_GreenBeamH2_Off  0x231
+#define METATILE_MauvilleGym_GreenBeamH2_On   0x221
+#define METATILE_MauvilleGym_GreenBeamH3_Off  0x238
+#define METATILE_MauvilleGym_GreenBeamH3_On   0x228
+#define METATILE_MauvilleGym_GreenBeamH4_Off  0x239
+#define METATILE_MauvilleGym_GreenBeamH4_On   0x229
+#define METATILE_MauvilleGym_GreenBeamV1_On   0x240
+#define METATILE_MauvilleGym_GreenBeamV2_On   0x248
+#define METATILE_MauvilleGym_PoleBottom_Off   0x243
+#define METATILE_MauvilleGym_PoleBottom_On    0x242
+#define METATILE_MauvilleGym_PoleTop_Off      0x251
+#define METATILE_MauvilleGym_PoleTop_On       0x250
+#define METATILE_MauvilleGym_PressedSwitch    0x206
+#define METATILE_MauvilleGym_RaisedSwitch     0x205
+#define METATILE_MauvilleGym_RedBeamH1_Off    0x232
+#define METATILE_MauvilleGym_RedBeamH1_On     0x222
+#define METATILE_MauvilleGym_RedBeamH2_Off    0x233
+#define METATILE_MauvilleGym_RedBeamH2_On     0x223
+#define METATILE_MauvilleGym_RedBeamH3_Off    0x23A
+#define METATILE_MauvilleGym_RedBeamH3_On     0x22A
+#define METATILE_MauvilleGym_RedBeamH4_Off    0x23B
+#define METATILE_MauvilleGym_RedBeamH4_On     0x22B
+#define METATILE_MauvilleGym_RedBeamV1_On     0x241
+#define METATILE_MauvilleGym_RedBeamV2_On     0x249
+
+// gTileset_Mauville
+#define METATILE_Mauville_DeepSand_BottomMid  0x259
+#define METATILE_Mauville_DeepSand_Center     0x251
+#define METATILE_Mauville_Door                0x2AC
+#define METATILE_Mauville_Door_BattleTent     0x3D4
+#define METATILE_Mauville_Door_CyclingRoad    0x289
+#define METATILE_Mauville_Door_Verdanturf     0x3A1
+#define METATILE_Mauville_MirageTower_Tile0   0x3D8
+#define METATILE_Mauville_MirageTower_Tile1   0x3D9
+#define METATILE_Mauville_MirageTower_Tile10  0x3E4
+#define METATILE_Mauville_MirageTower_Tile11  0x3E5
+#define METATILE_Mauville_MirageTower_Tile2   0x3DA
+#define METATILE_Mauville_MirageTower_Tile3   0x3E0
+#define METATILE_Mauville_MirageTower_Tile4   0x3E1
+#define METATILE_Mauville_MirageTower_Tile5   0x3E2
+#define METATILE_Mauville_MirageTower_Tile6   0x3E8
+#define METATILE_Mauville_MirageTower_Tile7   0x3E9
+#define METATILE_Mauville_MirageTower_Tile8   0x3EA
+#define METATILE_Mauville_MirageTower_Tile9   0x3F0
+#define METATILE_Mauville_MirageTower_TileA   0x3F1
+#define METATILE_Mauville_MirageTower_TileB   0x3F2
+#define METATILE_Mauville_MirageTower_TileC   0x3DB
+#define METATILE_Mauville_MirageTower_TileD   0x3DC
+#define METATILE_Mauville_MirageTower_TileE   0x3DD
+#define METATILE_Mauville_MirageTower_TileF   0x3E3
+
+// gTileset_MeteorFalls
+#define METATILE_MeteorFalls_CaveEntrance_Bottom  0x24E
+#define METATILE_MeteorFalls_CaveEntrance_Left    0x24D
+#define METATILE_MeteorFalls_CaveEntrance_Right   0x24F
+#define METATILE_MeteorFalls_CaveEntrance_Top     0x246
+
+// gTileset_MossdeepGameCorner
+#define METATILE_MossdeepGameCorner_CounterClosed_Bottom  0x232
+#define METATILE_MossdeepGameCorner_CounterClosed_Top     0x22A
+#define METATILE_MossdeepGameCorner_CounterOpen_Bottom    0x234
+#define METATILE_MossdeepGameCorner_CounterOpen_Top       0x22C
+
+// gTileset_MossdeepGym
+#define METATILE_MossdeepGym_YellowArrow_Right  0x250
 
 // gTileset_Mossdeep
 #define METATILE_Mossdeep_Door              0x2A1
 #define METATILE_Mossdeep_Door_SpaceCenter  0x2ED
 
-// gTileset_EverGrande
-#define METATILE_EverGrande_Door_PokemonLeague  0x21D
+// gTileset_Pacifidlog
+#define METATILE_Pacifidlog_Door                               0x21A
+#define METATILE_Pacifidlog_FloatingLogs_HorizontalLeft        0x250
+#define METATILE_Pacifidlog_FloatingLogs_HorizontalRight       0x251
+#define METATILE_Pacifidlog_FloatingLogs_VerticalBottom        0x260
+#define METATILE_Pacifidlog_FloatingLogs_VerticalTop           0x258
+#define METATILE_Pacifidlog_HalfSubmergedLogs_HorizontalLeft   0x252
+#define METATILE_Pacifidlog_HalfSubmergedLogs_HorizontalRight  0x253
+#define METATILE_Pacifidlog_HalfSubmergedLogs_VerticalBottom   0x261
+#define METATILE_Pacifidlog_HalfSubmergedLogs_VerticalTop      0x259
+#define METATILE_Pacifidlog_SkyPillar_CrackedFloor_Hole        0x237
+#define METATILE_Pacifidlog_SkyPillar_DoorOpen_Bottom          0x2B2
+#define METATILE_Pacifidlog_SkyPillar_DoorOpen_Top             0x2AA
+#define METATILE_Pacifidlog_SubmergedLogs_HorizontalLeft       0x254
+#define METATILE_Pacifidlog_SubmergedLogs_HorizontalRight      0x255
+#define METATILE_Pacifidlog_SubmergedLogs_VerticalBottom       0x262
+#define METATILE_Pacifidlog_SubmergedLogs_VerticalTop          0x25A
+
+// gTileset_PetalburgGym
+#define METATILE_PetalburgGym_Door                0x224
+#define METATILE_PetalburgGym_RoomEntrance_Left   0x210
+#define METATILE_PetalburgGym_RoomEntrance_Right  0x211
+#define METATILE_PetalburgGym_SlidingDoor_Frame0  0x218
+#define METATILE_PetalburgGym_SlidingDoor_Frame1  0x219
+#define METATILE_PetalburgGym_SlidingDoor_Frame2  0x21A
+#define METATILE_PetalburgGym_SlidingDoor_Frame3  0x21B
+#define METATILE_PetalburgGym_SlidingDoor_Frame4  0x21C
+
+// gTileset_Petalburg
+#define METATILE_Petalburg_Door_BirchsLab   0x249
+#define METATILE_Petalburg_Door_Littleroot  0x248
+#define METATILE_Petalburg_Door_Oldale      0x287
 
 // gTileset_PokemonCenter
-#define METATILE_PokemonCenter_Door_CableClub           0x264
-#define METATILE_PokemonCenter_Escalator1F_Tile0_Frame0 0x280
-#define METATILE_PokemonCenter_Escalator1F_Tile0_Frame1 0x282
-#define METATILE_PokemonCenter_Escalator1F_Tile0_Frame2 0x284
-#define METATILE_PokemonCenter_Escalator1F_Tile1_Frame0 0x281
-#define METATILE_PokemonCenter_Escalator1F_Tile1_Frame1 0x283
-#define METATILE_PokemonCenter_Escalator1F_Tile1_Frame2 0x285
-#define METATILE_PokemonCenter_Escalator1F_Tile2_Frame0 0x288
-#define METATILE_PokemonCenter_Escalator1F_Tile2_Frame1 0x28A
-#define METATILE_PokemonCenter_Escalator1F_Tile2_Frame2 0x28C
-#define METATILE_PokemonCenter_Escalator1F_Tile3_Frame0 0x289
-#define METATILE_PokemonCenter_Escalator1F_Tile3_Frame1 0x28B
-#define METATILE_PokemonCenter_Escalator1F_Tile3_Frame2 0x28D
-#define METATILE_PokemonCenter_Escalator2F_Tile0_Frame0 0x2A0
-#define METATILE_PokemonCenter_Escalator2F_Tile0_Frame1 0x2A2
-#define METATILE_PokemonCenter_Escalator2F_Tile0_Frame2 0x2A4
-#define METATILE_PokemonCenter_Escalator2F_Tile1_Frame0 0x2A1
-#define METATILE_PokemonCenter_Escalator2F_Tile1_Frame1 0x2A3
-#define METATILE_PokemonCenter_Escalator2F_Tile1_Frame2 0x2A5
-#define METATILE_PokemonCenter_Escalator2F_Tile2_Frame0 0x2A8
-#define METATILE_PokemonCenter_Escalator2F_Tile2_Frame1 0x2AA
-#define METATILE_PokemonCenter_Escalator2F_Tile2_Frame2 0x2AC
-#define METATILE_PokemonCenter_Floor_ShadowTop_Alt      0x2DC
-#define METATILE_PokemonCenter_Floor_Plain_Alt          0x2E4
-#define METATILE_PokemonCenter_Floor_ShadowTop          0x21E
-#define METATILE_PokemonCenter_CounterBarrier           0x25D
+#define METATILE_PokemonCenter_CounterBarrier            0x25D
+#define METATILE_PokemonCenter_Door_CableClub            0x264
+#define METATILE_PokemonCenter_Escalator1F_Tile0_Frame0  0x280
+#define METATILE_PokemonCenter_Escalator1F_Tile0_Frame1  0x282
+#define METATILE_PokemonCenter_Escalator1F_Tile0_Frame2  0x284
+#define METATILE_PokemonCenter_Escalator1F_Tile1_Frame0  0x281
+#define METATILE_PokemonCenter_Escalator1F_Tile1_Frame1  0x283
+#define METATILE_PokemonCenter_Escalator1F_Tile1_Frame2  0x285
+#define METATILE_PokemonCenter_Escalator1F_Tile2_Frame0  0x288
+#define METATILE_PokemonCenter_Escalator1F_Tile2_Frame1  0x28A
+#define METATILE_PokemonCenter_Escalator1F_Tile2_Frame2  0x28C
+#define METATILE_PokemonCenter_Escalator1F_Tile3_Frame0  0x289
+#define METATILE_PokemonCenter_Escalator1F_Tile3_Frame1  0x28B
+#define METATILE_PokemonCenter_Escalator1F_Tile3_Frame2  0x28D
+#define METATILE_PokemonCenter_Escalator2F_Tile0_Frame0  0x2A0
+#define METATILE_PokemonCenter_Escalator2F_Tile0_Frame1  0x2A2
+#define METATILE_PokemonCenter_Escalator2F_Tile0_Frame2  0x2A4
+#define METATILE_PokemonCenter_Escalator2F_Tile1_Frame0  0x2A1
+#define METATILE_PokemonCenter_Escalator2F_Tile1_Frame1  0x2A3
+#define METATILE_PokemonCenter_Escalator2F_Tile1_Frame2  0x2A5
+#define METATILE_PokemonCenter_Escalator2F_Tile2_Frame0  0x2A8
+#define METATILE_PokemonCenter_Escalator2F_Tile2_Frame1  0x2AA
+#define METATILE_PokemonCenter_Escalator2F_Tile2_Frame2  0x2AC
+#define METATILE_PokemonCenter_Floor_Plain_Alt           0x2E4
+#define METATILE_PokemonCenter_Floor_ShadowTop           0x21E
+#define METATILE_PokemonCenter_Floor_ShadowTop_Alt       0x2DC
 
-// gTileset_InsideOfTruck
-#define METATILE_InsideOfTruck_ExitLight_Top          0x208
-#define METATILE_InsideOfTruck_ExitLight_Mid          0x210
-#define METATILE_InsideOfTruck_ExitLight_Bottom       0x218
-#define METATILE_InsideOfTruck_DoorClosedFloor_Top    0x20D
-#define METATILE_InsideOfTruck_DoorClosedFloor_Mid    0x215
-#define METATILE_InsideOfTruck_DoorClosedFloor_Bottom 0x21D
+// gTileset_RSMossdeepGym
+#define METATILE_RSMossdeepGym_RedArrow_Down   0x205
+#define METATILE_RSMossdeepGym_RedArrow_Left   0x20C
+#define METATILE_RSMossdeepGym_RedArrow_Right  0x204
+#define METATILE_RSMossdeepGym_RedArrow_Up     0x20D
+#define METATILE_RSMossdeepGym_Switch_Down     0x239
+#define METATILE_RSMossdeepGym_Switch_Up       0x238
 
-// gTileset_MossdeepGameCorner
-#define METATILE_MossdeepGameCorner_CounterOpen_Top      0x22C
-#define METATILE_MossdeepGameCorner_CounterOpen_Bottom   0x234
-#define METATILE_MossdeepGameCorner_CounterClosed_Top    0x22A
-#define METATILE_MossdeepGameCorner_CounterClosed_Bottom 0x232
-
-// gTileset_EliteFour
-#define METATILE_EliteFour_OpenDoor_Frame           0x344
-#define METATILE_EliteFour_OpenDoor_Opening         0x345
-#define METATILE_EliteFour_OpenDoorChampion_Frame   0x346
-#define METATILE_EliteFour_OpenDoorChampion_Opening 0x347
-#define METATILE_EliteFour_LeftSpotlightOff         0x2DD
-#define METATILE_EliteFour_RightSpotlightOff        0x2DE
-#define METATILE_EliteFour_EntryDoor_ClosedTop      0x206
-#define METATILE_EliteFour_EntryDoor_ClosedBottom   0x20E
-
-// gTileset_InsideShip
-#define METATILE_InsideShip_IntactDoor_Bottom_Unlocked 0x22B
-#define METATILE_InsideShip_IntactDoor_Bottom_Locked   0x233
-#define METATILE_InsideShip_DoorIndent_Unlocked        0x21A
-#define METATILE_InsideShip_DoorIndent_Locked          0x234
-#define METATILE_InsideShip_IntactDoor_Bottom_Interior 0x297
-
-// gTileset_BattlePike
-#define METATILE_BattlePike_CurtainFrames_Start  0x201
-#define METATILE_BattlePike_Curtain_Stage0_Tile0 0x24A
-#define METATILE_BattlePike_Curtain_Stage0_Tile1 0x251
-#define METATILE_BattlePike_Curtain_Stage0_Tile2 0x252
-#define METATILE_BattlePike_Curtain_Stage0_Tile3 0x253
-#define METATILE_BattlePike_Curtain_Stage0_Tile4 0x259
-#define METATILE_BattlePike_Curtain_Stage0_Tile5 0x25A
-#define METATILE_BattlePike_Curtain_Stage0_Tile6 0x25B
-#define METATILE_BattlePike_Curtain_Stage1_Tile0 0x22A
-#define METATILE_BattlePike_Curtain_Stage1_Tile1 0x231
-#define METATILE_BattlePike_Curtain_Stage1_Tile2 0x232
-#define METATILE_BattlePike_Curtain_Stage1_Tile3 0x233
-#define METATILE_BattlePike_Curtain_Stage1_Tile4 0x239
-#define METATILE_BattlePike_Curtain_Stage1_Tile5 0x23A
-#define METATILE_BattlePike_Curtain_Stage1_Tile6 0x23B
-#define METATILE_BattlePike_Curtain_Stage2_Tile0 0x20A
-#define METATILE_BattlePike_Curtain_Stage2_Tile1 0x211
-#define METATILE_BattlePike_Curtain_Stage2_Tile2 0x212
-#define METATILE_BattlePike_Curtain_Stage2_Tile3 0x213
-#define METATILE_BattlePike_Curtain_Stage2_Tile4 0x219
-#define METATILE_BattlePike_Curtain_Stage2_Tile5 0x21A
-#define METATILE_BattlePike_Curtain_Stage2_Tile6 0x21B
-#define METATILE_BattlePike_Curtain_Stage3_Tile0 0x2AB
-#define METATILE_BattlePike_Curtain_Stage3_Tile1 0x2B2
-#define METATILE_BattlePike_Curtain_Stage3_Tile2 0x2B3
-#define METATILE_BattlePike_Curtain_Stage3_Tile3 0x2B4
-#define METATILE_BattlePike_Curtain_Stage3_Tile4 0x2BA
-#define METATILE_BattlePike_Curtain_Stage3_Tile5 0x2BB
-#define METATILE_BattlePike_Curtain_Stage3_Tile6 0x2BC
-
-// gTileset_Lilycove
-#define METATILE_Lilycove_Door            0x246
-#define METATILE_Lilycove_Door_Wooden     0x28E
-#define METATILE_Lilycove_Door_DeptStore  0x30C
-#define METATILE_Lilycove_Door_SafariZone 0x32D
-#define METATILE_Lilycove_Wailmer0        0x290
-#define METATILE_Lilycove_Wailmer1        0x291
-#define METATILE_Lilycove_Wailmer2        0x2A0
-#define METATILE_Lilycove_Wailmer3        0x2A1
-#define METATILE_Lilycove_Wailmer0_Alt    0x298
-#define METATILE_Lilycove_Wailmer1_Alt    0x299
-
-// gTileset_Contest
-#define METATILE_Contest_WallShadow         0x221
-#define METATILE_Contest_FloorShadow        0x261
-#define METATILE_Contest_CounterFlap_Top    0x2D1
-#define METATILE_Contest_CounterFlap_Bottom 0x2D9
-
-// gTileset_BattleTent
-#define METATILE_BattleTent_Door  0x26B
-
-// gTileset_LilycoveMuseum
-#define METATILE_LilycoveMuseum_Painting0_Left  0x25A
-#define METATILE_LilycoveMuseum_Painting0_Right 0x25B
-#define METATILE_LilycoveMuseum_Painting1_Left  0x25C
-#define METATILE_LilycoveMuseum_Painting1_Right 0x25D
-#define METATILE_LilycoveMuseum_Painting2_Left  0x25E
-#define METATILE_LilycoveMuseum_Painting2_Right 0x25F
-#define METATILE_LilycoveMuseum_Painting3_Left  0x260
-#define METATILE_LilycoveMuseum_Painting3_Right 0x261
-#define METATILE_LilycoveMuseum_Painting4_Left  0x262
-#define METATILE_LilycoveMuseum_Painting4_Right 0x263
-
-// gTileset_MeteorFalls
-#define METATILE_MeteorFalls_CaveEntrance_Top    0x246
-#define METATILE_MeteorFalls_CaveEntrance_Left   0x24D
-#define METATILE_MeteorFalls_CaveEntrance_Bottom 0x24E
-#define METATILE_MeteorFalls_CaveEntrance_Right  0x24F
-
-// gTileset_Facility
-#define METATILE_Facility_NewMauvilleDoor_Closed_Tile0 0x314
-#define METATILE_Facility_NewMauvilleDoor_Closed_Tile1 0x315
-#define METATILE_Facility_NewMauvilleDoor_Closed_Tile2 0x316
-#define METATILE_Facility_NewMauvilleDoor_Closed_Tile3 0x31C
-#define METATILE_Facility_NewMauvilleDoor_Closed_Tile4 0x31D
-#define METATILE_Facility_NewMauvilleDoor_Closed_Tile5 0x31E
-#define METATILE_Facility_NewMauvilleDoor_Open_Tile0   0x2C3
-#define METATILE_Facility_NewMauvilleDoor_Open_Tile1   0x2C4
-#define METATILE_Facility_NewMauvilleDoor_Open_Tile2   0x2C5
-#define METATILE_Facility_NewMauvilleDoor_Open_Tile3   0x2CB
-#define METATILE_Facility_NewMauvilleDoor_Open_Tile4   0x2CC
-#define METATILE_Facility_NewMauvilleDoor_Open_Tile5   0x2CD
-#define METATILE_Facility_DataPad                      0x3E4
-
-// gTileset_GenericBuilding
-#define METATILE_GenericBuilding_TableEdge              0x2F1
-#define METATILE_GenericBuilding_TrickHouse_Door_Closed 0x21B
-#define METATILE_GenericBuilding_TrickHouse_Stairs_Down 0x219
-
-// gTileset_TrickHousePuzzle
-#define METATILE_TrickHousePuzzle_Stairs_Down                0x20B
-#define METATILE_TrickHousePuzzle_Lever_Off                  0x23E
-#define METATILE_TrickHousePuzzle_Lever_On                   0x23F
-#define METATILE_TrickHousePuzzle_Button_Up                  0x258
-#define METATILE_TrickHousePuzzle_Button_Pressed             0x259
-#define METATILE_TrickHousePuzzle_Door_Shuttered             0x26A
-#define METATILE_TrickHousePuzzle_Floor_ShadowTop_Alt        0x252
-#define METATILE_TrickHousePuzzle_Floor_ShadowTop            0x255
-#define METATILE_TrickHousePuzzle_BlueDoorH_Open_Tile0       0x24B
-#define METATILE_TrickHousePuzzle_BlueDoorH_Open_Tile1       0x24C
-#define METATILE_TrickHousePuzzle_BlueDoorH_Open_Tile2       0x253
-#define METATILE_TrickHousePuzzle_BlueDoorH_Open_Tile3       0x254
-#define METATILE_TrickHousePuzzle_BlueDoorH_Closed_Tile0     0x23B
-#define METATILE_TrickHousePuzzle_BlueDoorH_Closed_Tile1     0x23C
-#define METATILE_TrickHousePuzzle_BlueDoorH_Closed_Tile2     0x243
-#define METATILE_TrickHousePuzzle_BlueDoorH_Closed_Tile3     0x244
-#define METATILE_TrickHousePuzzle_RedDoorH_Open_Tile0        0x248
-#define METATILE_TrickHousePuzzle_RedDoorH_Open_Tile1        0x249
-#define METATILE_TrickHousePuzzle_RedDoorH_Open_Tile2        0x250
-#define METATILE_TrickHousePuzzle_RedDoorH_Open_Tile3        0x251
-#define METATILE_TrickHousePuzzle_RedDoorH_Closed_Tile0      0x238
-#define METATILE_TrickHousePuzzle_RedDoorH_Closed_Tile1      0x239
-#define METATILE_TrickHousePuzzle_RedDoorH_Closed_Tile2      0x240
-#define METATILE_TrickHousePuzzle_RedDoorH_Closed_Tile3      0x241
-#define METATILE_TrickHousePuzzle_BlueDoorV_Retracted        0x24D
-#define METATILE_TrickHousePuzzle_RedDoorV_Retracted         0x24A
-#define METATILE_TrickHousePuzzle_RedDoorV_Open0             0x23A
-#define METATILE_TrickHousePuzzle_RedDoorV_Open1             0x242
-#define METATILE_TrickHousePuzzle_BlueDoorV_Open0            0x23D
-#define METATILE_TrickHousePuzzle_BlueDoorV_Open1            0x245
-#define METATILE_TrickHousePuzzle_Arrow_RedOnBlack_Right     0x260
-#define METATILE_TrickHousePuzzle_Arrow_RedOnBlack_Left      0x261
-#define METATILE_TrickHousePuzzle_Arrow_RedOnBlack_Up        0x262
-#define METATILE_TrickHousePuzzle_Arrow_RedOnBlack_Down      0x263
-#define METATILE_TrickHousePuzzle_Arrow_RedOnBlack_Left_Alt  0x27B
-#define METATILE_TrickHousePuzzle_Arrow_RedOnBlack_Right_Alt 0x27C
-#define METATILE_TrickHousePuzzle_Arrow_YellowOnWhite_Right  0x298
-
-// gTileset_BikeShop (also used by New Mauville)
-#define METATILE_BikeShop_Barrier_Hidden_Top      0x269
-#define METATILE_BikeShop_Barrier_Hidden_Bottom   0x271
-#define METATILE_BikeShop_Floor_Shadow_Top        0x26D
-#define METATILE_BikeShop_Wall_Edge_Top           0x281
-#define METATILE_BikeShop_Button_Pressed          0x24F
-#define METATILE_BikeShop_Button_Green            0x22E
-#define METATILE_BikeShop_Button_Blue             0x236
-#define METATILE_BikeShop_Barrier_Green_Top       0x2B6
-#define METATILE_BikeShop_Barrier_Green_TopMid    0x2BE
-#define METATILE_BikeShop_Barrier_Green_BottomMid 0x2C6
-#define METATILE_BikeShop_Barrier_Green_Bottom    0x2CE
-#define METATILE_BikeShop_Barrier_Blue_Top        0x2B7
-#define METATILE_BikeShop_Barrier_Blue_TopMid     0x2BF
-#define METATILE_BikeShop_Barrier_Blue_BottomMid  0x2C7
-#define METATILE_BikeShop_Barrier_Blue_Bottom     0x2CF
-#define METATILE_BikeShop_Generator_Off_Tile0     0x2F0
-#define METATILE_BikeShop_Generator_Off_Tile1     0x2F1
-#define METATILE_BikeShop_Generator_Off_Tile2     0x2F2
-#define METATILE_BikeShop_Generator_Off_Tile3     0x2F3
-#define METATILE_BikeShop_Generator_Off_Tile4     0x2F4
-#define METATILE_BikeShop_Generator_Off_Tile5     0x2F5
-#define METATILE_BikeShop_Generator_Off_Tile6     0x2F6
-#define METATILE_BikeShop_Generator_Off_Tile7     0x2F7
-
-// gTileset_TrainerHill
-#define METATILE_TrainerHill_GreenFloorTile       0x307
-#define METATILE_TrainerHill_CounterDoor          0x334
-#define METATILE_TrainerHill_Door_Elevator_Lobby  0x32C
-#define METATILE_TrainerHill_Door_Elevator_Roof   0x383
-
-// gTileset_Underwater
-#define METATILE_Underwater_RockWall    0x21E
-#define METATILE_Underwater_FloorShadow 0x228
+// gTileset_Rustboro
+#define METATILE_Rustboro_Door_Gray  0x21F
+#define METATILE_Rustboro_Door_Tan   0x22F
 
 // gTileset_SecretBase
-#define METATILE_SecretBase_Wall_TopMid                 0x202
-#define METATILE_SecretBase_Ground                      0x20A
-#define METATILE_SecretBase_PC                          0x220
-#define METATILE_SecretBase_RegisterPC                  0x221
-#define METATILE_SecretBase_PC_On                       0x224
-#define METATILE_SecretBase_RedBrick_Top                0x225
-#define METATILE_SecretBase_RedBrick_Bottom             0x22D
-#define METATILE_SecretBase_YellowBrick_Top             0x226
-#define METATILE_SecretBase_YellowBrick_Bottom          0x22E
-#define METATILE_SecretBase_BlueBrick_Top               0x227
+#define METATILE_SecretBase_AttractMat_BottomLeft       0x313
+#define METATILE_SecretBase_AttractMat_BottomMid        0x314
+#define METATILE_SecretBase_AttractMat_BottomRight      0x315
+#define METATILE_SecretBase_AttractMat_Center           0x30C
+#define METATILE_SecretBase_AttractMat_MidLeft          0x30B
+#define METATILE_SecretBase_AttractMat_MidRight         0x30D
+#define METATILE_SecretBase_AttractMat_TopLeft          0x303
+#define METATILE_SecretBase_AttractMat_TopMid           0x304
+#define METATILE_SecretBase_AttractMat_TopRight         0x305
+#define METATILE_SecretBase_BallPoster                  0x330
+#define METATILE_SecretBase_BigPlant_BaseLeft1          0x2EC
+#define METATILE_SecretBase_BigPlant_BaseLeft2          0x2EE
+#define METATILE_SecretBase_BigPlant_BaseRight1         0x2ED
+#define METATILE_SecretBase_BigPlant_BaseRight2         0x2EF
+#define METATILE_SecretBase_BigPlant_TopLeft            0x2E4
+#define METATILE_SecretBase_BigPlant_TopRight           0x2E6
+#define METATILE_SecretBase_BlueBalloon                 0x33C
 #define METATILE_SecretBase_BlueBrick_Bottom            0x22F
-#define METATILE_SecretBase_MudBall                     0x228
-#define METATILE_SecretBase_Fence_Horizontal            0x22C
-#define METATILE_SecretBase_Fence_Vertical              0x233
-#define METATILE_SecretBase_SolidBoard_Top              0x234
-#define METATILE_SecretBase_SolidBoard_Bottom           0x23C
-#define METATILE_SecretBase_RedTent_TopLeft             0x230
-#define METATILE_SecretBase_RedTent_TopMid              0x231
-#define METATILE_SecretBase_RedTent_TopRight            0x232
-#define METATILE_SecretBase_RedTent_MidLeft             0x238
-#define METATILE_SecretBase_RedTent_DoorTop             0x239
-#define METATILE_SecretBase_RedTent_MidRight            0x23A
-#define METATILE_SecretBase_RedTent_BottomLeft          0x240
-#define METATILE_SecretBase_RedTent_Door                0x241
-#define METATILE_SecretBase_RedTent_BottomRight         0x23B
+#define METATILE_SecretBase_BlueBrick_Top               0x227
+#define METATILE_SecretBase_BluePoster                  0x333
+#define METATILE_SecretBase_BlueTent_BottomLeft         0x258
+#define METATILE_SecretBase_BlueTent_BottomRight        0x269
+#define METATILE_SecretBase_BlueTent_Door               0x259
+#define METATILE_SecretBase_BlueTent_DoorTop            0x251
+#define METATILE_SecretBase_BlueTent_MidLeft            0x250
+#define METATILE_SecretBase_BlueTent_MidRight           0x270
 #define METATILE_SecretBase_BlueTent_TopLeft            0x248
 #define METATILE_SecretBase_BlueTent_TopMid             0x249
 #define METATILE_SecretBase_BlueTent_TopRight           0x268
-#define METATILE_SecretBase_BlueTent_MidLeft            0x250
-#define METATILE_SecretBase_BlueTent_DoorTop            0x251
-#define METATILE_SecretBase_BlueTent_MidRight           0x270
-#define METATILE_SecretBase_BlueTent_BottomLeft         0x258
-#define METATILE_SecretBase_BlueTent_Door               0x259
-#define METATILE_SecretBase_BlueTent_BottomRight        0x269
-#define METATILE_SecretBase_Slide_TopLeft               0x235
-#define METATILE_SecretBase_Slide_TopRight              0x236
-#define METATILE_SecretBase_Slide_StairLanding          0x23D
-#define METATILE_SecretBase_Slide_SlideTop              0x23E
-#define METATILE_SecretBase_Slide_Stairs                0x263
-#define METATILE_SecretBase_Slide_SlideBottom           0x264
-#define METATILE_SecretBase_Slide_MatLeft               0x26F
-#define METATILE_SecretBase_Slide_MatRight              0x277
-#define METATILE_SecretBase_Stand_CornerLeft            0x26A
-#define METATILE_SecretBase_Stand_MidLeft               0x26B
-#define METATILE_SecretBase_Stand_MidRight              0x26C
-#define METATILE_SecretBase_Stand_CornerRight           0x26D
-#define METATILE_SecretBase_Stand_StairsLeft            0x272
-#define METATILE_SecretBase_Stand_BaseLeft              0x273
-#define METATILE_SecretBase_Stand_BaseRight             0x274
-#define METATILE_SecretBase_Stand_StairsRight           0x275
-#define METATILE_SecretBase_BreakableDoor_TopClosed     0x237
 #define METATILE_SecretBase_BreakableDoor_BottomClosed  0x23F
-#define METATILE_SecretBase_BreakableDoor_TopOpen       0x26E
 #define METATILE_SecretBase_BreakableDoor_BottomOpen    0x276
+#define METATILE_SecretBase_BreakableDoor_TopClosed     0x237
+#define METATILE_SecretBase_BreakableDoor_TopOpen       0x26E
+#define METATILE_SecretBase_BrickChair                  0x2C8
+#define METATILE_SecretBase_BrickDesk_BottomLeft        0x2B0
+#define METATILE_SecretBase_BrickDesk_BottomMid         0x2B1
+#define METATILE_SecretBase_BrickDesk_BottomRight       0x2B2
+#define METATILE_SecretBase_BrickDesk_Center            0x2A9
+#define METATILE_SecretBase_BrickDesk_MidLeft           0x2A8
+#define METATILE_SecretBase_BrickDesk_MidRight          0x2AA
+#define METATILE_SecretBase_BrickDesk_TopLeft           0x2A0
+#define METATILE_SecretBase_BrickDesk_TopMid            0x2A1
+#define METATILE_SecretBase_BrickDesk_TopRight          0x2A2
+#define METATILE_SecretBase_CampChair                   0x2C9
+#define METATILE_SecretBase_CampDesk_BottomLeft         0x2B4
+#define METATILE_SecretBase_CampDesk_BottomMid          0x2B5
+#define METATILE_SecretBase_CampDesk_BottomRight        0x2B6
+#define METATILE_SecretBase_CampDesk_Center             0x2AD
+#define METATILE_SecretBase_CampDesk_MidLeft            0x2AC
+#define METATILE_SecretBase_CampDesk_MidRight           0x2AE
+#define METATILE_SecretBase_CampDesk_TopLeft            0x2A4
+#define METATILE_SecretBase_CampDesk_TopMid             0x2A5
+#define METATILE_SecretBase_CampDesk_TopRight           0x2A6
+#define METATILE_SecretBase_ColorfulPlant_BaseLeft1     0x2E8
+#define METATILE_SecretBase_ColorfulPlant_BaseLeft2     0x2EA
+#define METATILE_SecretBase_ColorfulPlant_BaseRight1    0x2E9
+#define METATILE_SecretBase_ColorfulPlant_BaseRight2    0x2EB
+#define METATILE_SecretBase_ColorfulPlant_TopLeft       0x2E0
+#define METATILE_SecretBase_ColorfulPlant_TopLeftWall   0x2E1
+#define METATILE_SecretBase_ColorfulPlant_TopRight      0x2E2
+#define METATILE_SecretBase_ColorfulPlant_TopRightWall  0x2E3
+#define METATILE_SecretBase_ComfortChair                0x2C1
+#define METATILE_SecretBase_ComfortDesk_BottomLeft      0x29E
+#define METATILE_SecretBase_ComfortDesk_BottomMid       0x29F
+#define METATILE_SecretBase_ComfortDesk_BottomRight     0x2AB
+#define METATILE_SecretBase_ComfortDesk_TopLeft         0x296
+#define METATILE_SecretBase_ComfortDesk_TopMid          0x297
+#define METATILE_SecretBase_ComfortDesk_TopRight        0x2A3
+#define METATILE_SecretBase_CutePoster                  0x334
+#define METATILE_SecretBase_CuteTV                      0x2F6
+#define METATILE_SecretBase_Fence_Horizontal            0x22C
+#define METATILE_SecretBase_Fence_Vertical              0x233
+#define METATILE_SecretBase_FireBlastMat_BottomLeft     0x265
+#define METATILE_SecretBase_FireBlastMat_BottomMid      0x266
+#define METATILE_SecretBase_FireBlastMat_BottomRight    0x267
+#define METATILE_SecretBase_FireBlastMat_Center         0x25E
+#define METATILE_SecretBase_FireBlastMat_MidLeft        0x25D
+#define METATILE_SecretBase_FireBlastMat_MidRight       0x25F
+#define METATILE_SecretBase_FireBlastMat_TopLeft        0x25A
+#define METATILE_SecretBase_FireBlastMat_TopMid         0x25B
+#define METATILE_SecretBase_FireBlastMat_TopRight       0x25C
+#define METATILE_SecretBase_FissureMat_BottomLeft       0x316
+#define METATILE_SecretBase_FissureMat_BottomMid        0x317
+#define METATILE_SecretBase_FissureMat_BottomRight      0x328
+#define METATILE_SecretBase_FissureMat_Center           0x30F
+#define METATILE_SecretBase_FissureMat_MidLeft          0x30E
+#define METATILE_SecretBase_FissureMat_MidRight         0x320
+#define METATILE_SecretBase_FissureMat_TopLeft          0x306
+#define METATILE_SecretBase_FissureMat_TopMid           0x307
+#define METATILE_SecretBase_FissureMat_TopRight         0x318
+#define METATILE_SecretBase_GlassOrnament_Base1         0x28A
+#define METATILE_SecretBase_GlassOrnament_Base2         0x28B
+#define METATILE_SecretBase_GlassOrnament_Top           0x282
+#define METATILE_SecretBase_GlassOrnament_TopWall       0x283
 #define METATILE_SecretBase_GlitterMat                  0x260
+#define METATILE_SecretBase_GoldShield_Base1            0x336
+#define METATILE_SecretBase_GoldShield_Base2            0x337
+#define METATILE_SecretBase_GoldShield_Top              0x32E
+#define METATILE_SecretBase_GoldShield_TopWall          0x32F
+#define METATILE_SecretBase_GorgeousPlant_BaseLeft1     0x2F8
+#define METATILE_SecretBase_GorgeousPlant_BaseLeft2     0x2FA
+#define METATILE_SecretBase_GorgeousPlant_BaseRight1    0x2F9
+#define METATILE_SecretBase_GorgeousPlant_BaseRight2    0x2FB
+#define METATILE_SecretBase_GorgeousPlant_TopLeft       0x2F0
+#define METATILE_SecretBase_GorgeousPlant_TopLeftWall   0x2F1
+#define METATILE_SecretBase_GorgeousPlant_TopRight      0x2F2
+#define METATILE_SecretBase_GorgeousPlant_TopRightWall  0x2F3
+#define METATILE_SecretBase_GreenPoster                 0x331
+#define METATILE_SecretBase_Ground                      0x20A
+#define METATILE_SecretBase_HardChair                   0x2CA
+#define METATILE_SecretBase_HardDesk_BottomLeft         0x2B7
+#define METATILE_SecretBase_HardDesk_BottomMid          0x2CB
+#define METATILE_SecretBase_HardDesk_BottomRight        0x2CC
+#define METATILE_SecretBase_HardDesk_Center             0x2C3
+#define METATILE_SecretBase_HardDesk_MidLeft            0x2AF
+#define METATILE_SecretBase_HardDesk_MidRight           0x2C4
+#define METATILE_SecretBase_HardDesk_TopLeft            0x2A7
+#define METATILE_SecretBase_HardDesk_TopMid             0x2BB
+#define METATILE_SecretBase_HardDesk_TopRight           0x2BC
+#define METATILE_SecretBase_HeavyChair                  0x2BA
+#define METATILE_SecretBase_HeavyDesk_BottomLeft        0x298
+#define METATILE_SecretBase_HeavyDesk_BottomMid         0x299
+#define METATILE_SecretBase_HeavyDesk_BottomRight       0x29A
+#define METATILE_SecretBase_HeavyDesk_TopLeft           0x290
+#define METATILE_SecretBase_HeavyDesk_TopMid            0x291
+#define METATILE_SecretBase_HeavyDesk_TopRight          0x292
 #define METATILE_SecretBase_JumpMat                     0x261
-#define METATILE_SecretBase_SpinMat                     0x262
+#define METATILE_SecretBase_KissPoster_Left             0x32C
+#define METATILE_SecretBase_KissPoster_Right            0x32D
+#define METATILE_SecretBase_LongPoster_Left             0x31E
+#define METATILE_SecretBase_LongPoster_Right            0x31F
+#define METATILE_SecretBase_MudBall                     0x228
+#define METATILE_SecretBase_NoteMat_A                   0x27D
+#define METATILE_SecretBase_NoteMat_B                   0x27E
+#define METATILE_SecretBase_NoteMat_C_High              0x2B3
 #define METATILE_SecretBase_NoteMat_C_Low               0x278
 #define METATILE_SecretBase_NoteMat_D                   0x279
 #define METATILE_SecretBase_NoteMat_E                   0x27A
 #define METATILE_SecretBase_NoteMat_F                   0x27B
 #define METATILE_SecretBase_NoteMat_G                   0x27C
-#define METATILE_SecretBase_NoteMat_A                   0x27D
-#define METATILE_SecretBase_NoteMat_B                   0x27E
-#define METATILE_SecretBase_NoteMat_C_High              0x2B3
-#define METATILE_SecretBase_Tire_TopLeft                0x280
-#define METATILE_SecretBase_Tire_TopRight               0x281
-#define METATILE_SecretBase_Tire_BottomLeft             0x288
-#define METATILE_SecretBase_Tire_BottomRight            0x289
-#define METATILE_SecretBase_GlassOrnament_Top           0x282
-#define METATILE_SecretBase_GlassOrnament_Base1         0x28A
-#define METATILE_SecretBase_GlassOrnament_TopWall       0x283
-#define METATILE_SecretBase_GlassOrnament_Base2         0x28B
-#define METATILE_SecretBase_SandOrnament_BrokenTop      0x284
-#define METATILE_SecretBase_SandOrnament_BrokenBase     0x28C
-#define METATILE_SecretBase_SandOrnament_Top            0x285
-#define METATILE_SecretBase_SandOrnament_Base1          0x28D
-#define METATILE_SecretBase_SandOrnament_TopWall        0x286
-#define METATILE_SecretBase_SandOrnament_Base2          0x28E
-#define METATILE_SecretBase_SmallDesk                   0x287
-#define METATILE_SecretBase_PokemonDesk                 0x28F
-#define METATILE_SecretBase_HeavyDesk_TopLeft           0x290
-#define METATILE_SecretBase_HeavyDesk_TopMid            0x291
-#define METATILE_SecretBase_HeavyDesk_TopRight          0x292
-#define METATILE_SecretBase_HeavyDesk_BottomLeft        0x298
-#define METATILE_SecretBase_HeavyDesk_BottomMid         0x299
-#define METATILE_SecretBase_HeavyDesk_BottomRight       0x29A
-#define METATILE_SecretBase_RaggedDesk_TopLeft          0x293
-#define METATILE_SecretBase_RaggedDesk_TopMid           0x294
-#define METATILE_SecretBase_RaggedDesk_TopRight         0x295
-#define METATILE_SecretBase_RaggedDesk_BottomLeft       0x29B
-#define METATILE_SecretBase_RaggedDesk_BottomMid        0x29C
-#define METATILE_SecretBase_RaggedDesk_BottomRight      0x29D
-#define METATILE_SecretBase_ComfortDesk_TopLeft         0x296
-#define METATILE_SecretBase_ComfortDesk_TopMid          0x297
-#define METATILE_SecretBase_ComfortDesk_TopRight        0x2A3
-#define METATILE_SecretBase_ComfortDesk_BottomLeft      0x29E
-#define METATILE_SecretBase_ComfortDesk_BottomMid       0x29F
-#define METATILE_SecretBase_ComfortDesk_BottomRight     0x2AB
-#define METATILE_SecretBase_BrickDesk_TopLeft           0x2A0
-#define METATILE_SecretBase_BrickDesk_TopMid            0x2A1
-#define METATILE_SecretBase_BrickDesk_TopRight          0x2A2
-#define METATILE_SecretBase_BrickDesk_MidLeft           0x2A8
-#define METATILE_SecretBase_BrickDesk_Center            0x2A9
-#define METATILE_SecretBase_BrickDesk_MidRight          0x2AA
-#define METATILE_SecretBase_BrickDesk_BottomLeft        0x2B0
-#define METATILE_SecretBase_BrickDesk_BottomMid         0x2B1
-#define METATILE_SecretBase_BrickDesk_BottomRight       0x2B2
-#define METATILE_SecretBase_CampDesk_TopLeft            0x2A4
-#define METATILE_SecretBase_CampDesk_TopMid             0x2A5
-#define METATILE_SecretBase_CampDesk_TopRight           0x2A6
-#define METATILE_SecretBase_CampDesk_MidLeft            0x2AC
-#define METATILE_SecretBase_CampDesk_Center             0x2AD
-#define METATILE_SecretBase_CampDesk_MidRight           0x2AE
-#define METATILE_SecretBase_CampDesk_BottomLeft         0x2B4
-#define METATILE_SecretBase_CampDesk_BottomMid          0x2B5
-#define METATILE_SecretBase_CampDesk_BottomRight        0x2B6
-#define METATILE_SecretBase_HardDesk_TopLeft            0x2A7
-#define METATILE_SecretBase_HardDesk_TopMid             0x2BB
-#define METATILE_SecretBase_HardDesk_TopRight           0x2BC
-#define METATILE_SecretBase_HardDesk_MidLeft            0x2AF
-#define METATILE_SecretBase_HardDesk_Center             0x2C3
-#define METATILE_SecretBase_HardDesk_MidRight           0x2C4
-#define METATILE_SecretBase_HardDesk_BottomLeft         0x2B7
-#define METATILE_SecretBase_HardDesk_BottomMid          0x2CB
-#define METATILE_SecretBase_HardDesk_BottomRight        0x2CC
-#define METATILE_SecretBase_PrettyDesk_TopLeft          0x2BD
-#define METATILE_SecretBase_PrettyDesk_TopMid           0x2BE
-#define METATILE_SecretBase_PrettyDesk_TopRight         0x2BF
-#define METATILE_SecretBase_PrettyDesk_MidLeft          0x2C5
-#define METATILE_SecretBase_PrettyDesk_Center           0x2C6
-#define METATILE_SecretBase_PrettyDesk_MidRight         0x2C7
-#define METATILE_SecretBase_PrettyDesk_BottomLeft       0x2CD
-#define METATILE_SecretBase_PrettyDesk_BottomMid        0x2CE
-#define METATILE_SecretBase_PrettyDesk_BottomRight      0x2CF
-#define METATILE_SecretBase_SmallChair                  0x2B8
-#define METATILE_SecretBase_PokemonChair                0x2B9
-#define METATILE_SecretBase_HeavyChair                  0x2BA
-#define METATILE_SecretBase_PrettyChair                 0x2C0
-#define METATILE_SecretBase_ComfortChair                0x2C1
-#define METATILE_SecretBase_RaggedChair                 0x2C2
-#define METATILE_SecretBase_BrickChair                  0x2C8
-#define METATILE_SecretBase_CampChair                   0x2C9
-#define METATILE_SecretBase_HardChair                   0x2CA
-#define METATILE_SecretBase_RedPlant_Top                0x2D0
-#define METATILE_SecretBase_RedPlant_Base1              0x2D8
-#define METATILE_SecretBase_RedPlant_TopWall            0x2D1
-#define METATILE_SecretBase_RedPlant_Base2              0x2D9
-#define METATILE_SecretBase_TropicalPlant_Top           0x2D2
-#define METATILE_SecretBase_TropicalPlant_Base1         0x2DA
-#define METATILE_SecretBase_TropicalPlant_TopWall       0x2D3
-#define METATILE_SecretBase_TropicalPlant_Base2         0x2DB
-#define METATILE_SecretBase_PrettyFlowers_Top           0x2D4
-#define METATILE_SecretBase_PrettyFlowers_Base1         0x2DC
-#define METATILE_SecretBase_PrettyFlowers_TopWall       0x2D5
-#define METATILE_SecretBase_PrettyFlowers_Base2         0x2DD
-#define METATILE_SecretBase_ColorfulPlant_TopLeft       0x2E0
-#define METATILE_SecretBase_ColorfulPlant_TopRight      0x2E2
-#define METATILE_SecretBase_ColorfulPlant_BaseLeft1     0x2E8
-#define METATILE_SecretBase_ColorfulPlant_BaseRight1    0x2E9
-#define METATILE_SecretBase_ColorfulPlant_TopLeftWall   0x2E1
-#define METATILE_SecretBase_ColorfulPlant_TopRightWall  0x2E3
-#define METATILE_SecretBase_ColorfulPlant_BaseLeft2     0x2EA
-#define METATILE_SecretBase_ColorfulPlant_BaseRight2    0x2EB
-#define METATILE_SecretBase_BigPlant_TopLeft            0x2E4
-#define METATILE_SecretBase_BigPlant_TopRight           0x2E6
-#define METATILE_SecretBase_BigPlant_BaseLeft1          0x2EC
-#define METATILE_SecretBase_BigPlant_BaseRight1         0x2ED
-#define METATILE_SecretBase_BigPlant_BaseLeft2          0x2EE
-#define METATILE_SecretBase_BigPlant_BaseRight2         0x2EF
-#define METATILE_SecretBase_GorgeousPlant_TopLeft       0x2F0
-#define METATILE_SecretBase_GorgeousPlant_TopRight      0x2F2
-#define METATILE_SecretBase_GorgeousPlant_BaseLeft1     0x2F8
-#define METATILE_SecretBase_GorgeousPlant_BaseRight1    0x2F9
-#define METATILE_SecretBase_GorgeousPlant_TopLeftWall   0x2F1
-#define METATILE_SecretBase_GorgeousPlant_TopRightWall  0x2F3
-#define METATILE_SecretBase_GorgeousPlant_BaseLeft2     0x2FA
-#define METATILE_SecretBase_GorgeousPlant_BaseRight2    0x2FB
-#define METATILE_SecretBase_TV                          0x2F4
-#define METATILE_SecretBase_RoundTV                     0x2F5
-#define METATILE_SecretBase_CuteTV                      0x2F6
+#define METATILE_SecretBase_PC                          0x220
+#define METATILE_SecretBase_PC_On                       0x224
 #define METATILE_SecretBase_PikaPoster_Left             0x31C
 #define METATILE_SecretBase_PikaPoster_Right            0x31D
-#define METATILE_SecretBase_LongPoster_Left             0x31E
-#define METATILE_SecretBase_LongPoster_Right            0x31F
-#define METATILE_SecretBase_SeaPoster_Left              0x324
-#define METATILE_SecretBase_SeaPoster_Right             0x325
-#define METATILE_SecretBase_SkyPoster_Left              0x326
-#define METATILE_SecretBase_SkyPoster_Right             0x327
-#define METATILE_SecretBase_KissPoster_Left             0x32C
-#define METATILE_SecretBase_KissPoster_Right            0x32D
-#define METATILE_SecretBase_BallPoster                  0x330
-#define METATILE_SecretBase_GreenPoster                 0x331
-#define METATILE_SecretBase_RedPoster                   0x332
-#define METATILE_SecretBase_BluePoster                  0x333
-#define METATILE_SecretBase_CutePoster                  0x334
-#define METATILE_SecretBase_SilverShield_Top            0x2D6
-#define METATILE_SecretBase_SilverShield_Base1          0x2DE
-#define METATILE_SecretBase_SilverShield_TopWall        0x2D7
-#define METATILE_SecretBase_SilverShield_Base2          0x2DF
-#define METATILE_SecretBase_GoldShield_Top              0x32E
-#define METATILE_SecretBase_GoldShield_Base1            0x336
-#define METATILE_SecretBase_GoldShield_TopWall          0x32F
-#define METATILE_SecretBase_GoldShield_Base2            0x337
-#define METATILE_SecretBase_RedBalloon                  0x338
-#define METATILE_SecretBase_BlueBalloon                 0x33C
-#define METATILE_SecretBase_YellowBalloon               0x340
-#define METATILE_SecretBase_SurfMat_TopLeft             0x242
-#define METATILE_SecretBase_SurfMat_TopMid              0x243
-#define METATILE_SecretBase_SurfMat_TopRight            0x244
-#define METATILE_SecretBase_SurfMat_MidLeft             0x24A
-#define METATILE_SecretBase_SurfMat_Center              0x24B
-#define METATILE_SecretBase_SurfMat_MidRight            0x24C
-#define METATILE_SecretBase_SurfMat_BottomLeft          0x252
-#define METATILE_SecretBase_SurfMat_BottomMid           0x253
-#define METATILE_SecretBase_SurfMat_BottomRight         0x254
-#define METATILE_SecretBase_ThunderMat_TopLeft          0x245
-#define METATILE_SecretBase_ThunderMat_TopMid           0x246
-#define METATILE_SecretBase_ThunderMat_TopRight         0x247
-#define METATILE_SecretBase_ThunderMat_MidLeft          0x24D
-#define METATILE_SecretBase_ThunderMat_Center           0x24E
-#define METATILE_SecretBase_ThunderMat_MidRight         0x24F
-#define METATILE_SecretBase_ThunderMat_BottomLeft       0x255
-#define METATILE_SecretBase_ThunderMat_BottomMid        0x256
-#define METATILE_SecretBase_ThunderMat_BottomRight      0x257
-#define METATILE_SecretBase_FireBlastMat_TopLeft        0x25A
-#define METATILE_SecretBase_FireBlastMat_TopMid         0x25B
-#define METATILE_SecretBase_FireBlastMat_TopRight       0x25C
-#define METATILE_SecretBase_FireBlastMat_MidLeft        0x25D
-#define METATILE_SecretBase_FireBlastMat_Center         0x25E
-#define METATILE_SecretBase_FireBlastMat_MidRight       0x25F
-#define METATILE_SecretBase_FireBlastMat_BottomLeft     0x265
-#define METATILE_SecretBase_FireBlastMat_BottomMid      0x266
-#define METATILE_SecretBase_FireBlastMat_BottomRight    0x267
-#define METATILE_SecretBase_PowderSnowMat_TopLeft       0x300
-#define METATILE_SecretBase_PowderSnowMat_TopMid        0x301
-#define METATILE_SecretBase_PowderSnowMat_TopRight      0x302
-#define METATILE_SecretBase_PowderSnowMat_MidLeft       0x308
-#define METATILE_SecretBase_PowderSnowMat_Center        0x309
-#define METATILE_SecretBase_PowderSnowMat_MidRight      0x30A
+#define METATILE_SecretBase_PokemonChair                0x2B9
+#define METATILE_SecretBase_PokemonDesk                 0x28F
 #define METATILE_SecretBase_PowderSnowMat_BottomLeft    0x310
 #define METATILE_SecretBase_PowderSnowMat_BottomMid     0x311
 #define METATILE_SecretBase_PowderSnowMat_BottomRight   0x312
-#define METATILE_SecretBase_AttractMat_TopLeft          0x303
-#define METATILE_SecretBase_AttractMat_TopMid           0x304
-#define METATILE_SecretBase_AttractMat_TopRight         0x305
-#define METATILE_SecretBase_AttractMat_MidLeft          0x30B
-#define METATILE_SecretBase_AttractMat_Center           0x30C
-#define METATILE_SecretBase_AttractMat_MidRight         0x30D
-#define METATILE_SecretBase_AttractMat_BottomLeft       0x313
-#define METATILE_SecretBase_AttractMat_BottomMid        0x314
-#define METATILE_SecretBase_AttractMat_BottomRight      0x315
-#define METATILE_SecretBase_FissureMat_TopLeft          0x306
-#define METATILE_SecretBase_FissureMat_TopMid           0x307
-#define METATILE_SecretBase_FissureMat_TopRight         0x318
-#define METATILE_SecretBase_FissureMat_MidLeft          0x30E
-#define METATILE_SecretBase_FissureMat_Center           0x30F
-#define METATILE_SecretBase_FissureMat_MidRight         0x320
-#define METATILE_SecretBase_FissureMat_BottomLeft       0x316
-#define METATILE_SecretBase_FissureMat_BottomMid        0x317
-#define METATILE_SecretBase_FissureMat_BottomRight      0x328
-#define METATILE_SecretBase_SpikesMat_TopLeft           0x319
-#define METATILE_SecretBase_SpikesMat_TopMid            0x31A
-#define METATILE_SecretBase_SpikesMat_TopRight          0x31B
-#define METATILE_SecretBase_SpikesMat_MidLeft           0x321
-#define METATILE_SecretBase_SpikesMat_Center            0x322
-#define METATILE_SecretBase_SpikesMat_MidRight          0x323
+#define METATILE_SecretBase_PowderSnowMat_Center        0x309
+#define METATILE_SecretBase_PowderSnowMat_MidLeft       0x308
+#define METATILE_SecretBase_PowderSnowMat_MidRight      0x30A
+#define METATILE_SecretBase_PowderSnowMat_TopLeft       0x300
+#define METATILE_SecretBase_PowderSnowMat_TopMid        0x301
+#define METATILE_SecretBase_PowderSnowMat_TopRight      0x302
+#define METATILE_SecretBase_PrettyChair                 0x2C0
+#define METATILE_SecretBase_PrettyDesk_BottomLeft       0x2CD
+#define METATILE_SecretBase_PrettyDesk_BottomMid        0x2CE
+#define METATILE_SecretBase_PrettyDesk_BottomRight      0x2CF
+#define METATILE_SecretBase_PrettyDesk_Center           0x2C6
+#define METATILE_SecretBase_PrettyDesk_MidLeft          0x2C5
+#define METATILE_SecretBase_PrettyDesk_MidRight         0x2C7
+#define METATILE_SecretBase_PrettyDesk_TopLeft          0x2BD
+#define METATILE_SecretBase_PrettyDesk_TopMid           0x2BE
+#define METATILE_SecretBase_PrettyDesk_TopRight         0x2BF
+#define METATILE_SecretBase_PrettyFlowers_Base1         0x2DC
+#define METATILE_SecretBase_PrettyFlowers_Base2         0x2DD
+#define METATILE_SecretBase_PrettyFlowers_Top           0x2D4
+#define METATILE_SecretBase_PrettyFlowers_TopWall       0x2D5
+#define METATILE_SecretBase_RaggedChair                 0x2C2
+#define METATILE_SecretBase_RaggedDesk_BottomLeft       0x29B
+#define METATILE_SecretBase_RaggedDesk_BottomMid        0x29C
+#define METATILE_SecretBase_RaggedDesk_BottomRight      0x29D
+#define METATILE_SecretBase_RaggedDesk_TopLeft          0x293
+#define METATILE_SecretBase_RaggedDesk_TopMid           0x294
+#define METATILE_SecretBase_RaggedDesk_TopRight         0x295
+#define METATILE_SecretBase_RedBalloon                  0x338
+#define METATILE_SecretBase_RedBrick_Bottom             0x22D
+#define METATILE_SecretBase_RedBrick_Top                0x225
+#define METATILE_SecretBase_RedPlant_Base1              0x2D8
+#define METATILE_SecretBase_RedPlant_Base2              0x2D9
+#define METATILE_SecretBase_RedPlant_Top                0x2D0
+#define METATILE_SecretBase_RedPlant_TopWall            0x2D1
+#define METATILE_SecretBase_RedPoster                   0x332
+#define METATILE_SecretBase_RedTent_BottomLeft          0x240
+#define METATILE_SecretBase_RedTent_BottomRight         0x23B
+#define METATILE_SecretBase_RedTent_Door                0x241
+#define METATILE_SecretBase_RedTent_DoorTop             0x239
+#define METATILE_SecretBase_RedTent_MidLeft             0x238
+#define METATILE_SecretBase_RedTent_MidRight            0x23A
+#define METATILE_SecretBase_RedTent_TopLeft             0x230
+#define METATILE_SecretBase_RedTent_TopMid              0x231
+#define METATILE_SecretBase_RedTent_TopRight            0x232
+#define METATILE_SecretBase_RegisterPC                  0x221
+#define METATILE_SecretBase_RoundTV                     0x2F5
+#define METATILE_SecretBase_SandOrnament_Base1          0x28D
+#define METATILE_SecretBase_SandOrnament_Base2          0x28E
+#define METATILE_SecretBase_SandOrnament_BrokenBase     0x28C
+#define METATILE_SecretBase_SandOrnament_BrokenTop      0x284
+#define METATILE_SecretBase_SandOrnament_Top            0x285
+#define METATILE_SecretBase_SandOrnament_TopWall        0x286
+#define METATILE_SecretBase_SeaPoster_Left              0x324
+#define METATILE_SecretBase_SeaPoster_Right             0x325
+#define METATILE_SecretBase_SilverShield_Base1          0x2DE
+#define METATILE_SecretBase_SilverShield_Base2          0x2DF
+#define METATILE_SecretBase_SilverShield_Top            0x2D6
+#define METATILE_SecretBase_SilverShield_TopWall        0x2D7
+#define METATILE_SecretBase_SkyPoster_Left              0x326
+#define METATILE_SecretBase_SkyPoster_Right             0x327
+#define METATILE_SecretBase_Slide_MatLeft               0x26F
+#define METATILE_SecretBase_Slide_MatRight              0x277
+#define METATILE_SecretBase_Slide_SlideBottom           0x264
+#define METATILE_SecretBase_Slide_SlideTop              0x23E
+#define METATILE_SecretBase_Slide_StairLanding          0x23D
+#define METATILE_SecretBase_Slide_Stairs                0x263
+#define METATILE_SecretBase_Slide_TopLeft               0x235
+#define METATILE_SecretBase_Slide_TopRight              0x236
+#define METATILE_SecretBase_SmallChair                  0x2B8
+#define METATILE_SecretBase_SmallDesk                   0x287
+#define METATILE_SecretBase_SolidBoard_Bottom           0x23C
+#define METATILE_SecretBase_SolidBoard_Top              0x234
 #define METATILE_SecretBase_SpikesMat_BottomLeft        0x329
 #define METATILE_SecretBase_SpikesMat_BottomMid         0x32A
 #define METATILE_SecretBase_SpikesMat_BottomRight       0x32B
+#define METATILE_SecretBase_SpikesMat_Center            0x322
+#define METATILE_SecretBase_SpikesMat_MidLeft           0x321
+#define METATILE_SecretBase_SpikesMat_MidRight          0x323
+#define METATILE_SecretBase_SpikesMat_TopLeft           0x319
+#define METATILE_SecretBase_SpikesMat_TopMid            0x31A
+#define METATILE_SecretBase_SpikesMat_TopRight          0x31B
+#define METATILE_SecretBase_SpinMat                     0x262
+#define METATILE_SecretBase_Stand_BaseLeft              0x273
+#define METATILE_SecretBase_Stand_BaseRight             0x274
+#define METATILE_SecretBase_Stand_CornerLeft            0x26A
+#define METATILE_SecretBase_Stand_CornerRight           0x26D
+#define METATILE_SecretBase_Stand_MidLeft               0x26B
+#define METATILE_SecretBase_Stand_MidRight              0x26C
+#define METATILE_SecretBase_Stand_StairsLeft            0x272
+#define METATILE_SecretBase_Stand_StairsRight           0x275
+#define METATILE_SecretBase_SurfMat_BottomLeft          0x252
+#define METATILE_SecretBase_SurfMat_BottomMid           0x253
+#define METATILE_SecretBase_SurfMat_BottomRight         0x254
+#define METATILE_SecretBase_SurfMat_Center              0x24B
+#define METATILE_SecretBase_SurfMat_MidLeft             0x24A
+#define METATILE_SecretBase_SurfMat_MidRight            0x24C
+#define METATILE_SecretBase_SurfMat_TopLeft             0x242
+#define METATILE_SecretBase_SurfMat_TopMid              0x243
+#define METATILE_SecretBase_SurfMat_TopRight            0x244
+#define METATILE_SecretBase_TV                          0x2F4
+#define METATILE_SecretBase_ThunderMat_BottomLeft       0x255
+#define METATILE_SecretBase_ThunderMat_BottomMid        0x256
+#define METATILE_SecretBase_ThunderMat_BottomRight      0x257
+#define METATILE_SecretBase_ThunderMat_Center           0x24E
+#define METATILE_SecretBase_ThunderMat_MidLeft          0x24D
+#define METATILE_SecretBase_ThunderMat_MidRight         0x24F
+#define METATILE_SecretBase_ThunderMat_TopLeft          0x245
+#define METATILE_SecretBase_ThunderMat_TopMid           0x246
+#define METATILE_SecretBase_ThunderMat_TopRight         0x247
+#define METATILE_SecretBase_Tire_BottomLeft             0x288
+#define METATILE_SecretBase_Tire_BottomRight            0x289
+#define METATILE_SecretBase_Tire_TopLeft                0x280
+#define METATILE_SecretBase_Tire_TopRight               0x281
+#define METATILE_SecretBase_TropicalPlant_Base1         0x2DA
+#define METATILE_SecretBase_TropicalPlant_Base2         0x2DB
+#define METATILE_SecretBase_TropicalPlant_Top           0x2D2
+#define METATILE_SecretBase_TropicalPlant_TopWall       0x2D3
+#define METATILE_SecretBase_Wall_TopMid                 0x202
+#define METATILE_SecretBase_YellowBalloon               0x340
+#define METATILE_SecretBase_YellowBrick_Bottom          0x22E
+#define METATILE_SecretBase_YellowBrick_Top             0x226
 
-// gTileset_BattlePyramid
-#define METATILE_BattlePyramid_Floor 0x28D
-#define METATILE_BattlePyramid_Exit  0x28E
+// gTileset_Shop
+#define METATILE_Shop_Door_Elevator   0x285
+#define METATILE_Shop_Laptop1_Flash   0x258
+#define METATILE_Shop_Laptop1_Normal  0x29D
+#define METATILE_Shop_Laptop2_Flash   0x260
+#define METATILE_Shop_Laptop2_Normal  0x2A5
+
+// gTileset_Slateport
+#define METATILE_Slateport_Door             0x2DC
+#define METATILE_Slateport_Door_BattleTent  0x393
+
+// gTileset_SootopolisGym
+#define METATILE_SootopolisGym_Ice_Broken   0x206
+#define METATILE_SootopolisGym_Ice_Cracked  0x20E
+#define METATILE_SootopolisGym_Stairs       0x207
+
+// gTileset_Sootopolis
+#define METATILE_Sootopolis_Door             0x21E
+#define METATILE_Sootopolis_Door_Closed      0x248
+#define METATILE_Sootopolis_Door_PeakedRoof  0x21C
+#define METATILE_Sootopolis_GymDoor_Closed   0x250
+#define METATILE_Sootopolis_RoughWater       0x290
+
+// gTileset_TrainerHill
+#define METATILE_TrainerHill_CounterDoor          0x334
+#define METATILE_TrainerHill_Door_Elevator_Lobby  0x32C
+#define METATILE_TrainerHill_Door_Elevator_Roof   0x383
+#define METATILE_TrainerHill_GreenFloorTile       0x307
+
+// gTileset_TrickHousePuzzle
+#define METATILE_TrickHousePuzzle_Arrow_RedOnBlack_Down       0x263
+#define METATILE_TrickHousePuzzle_Arrow_RedOnBlack_Left       0x261
+#define METATILE_TrickHousePuzzle_Arrow_RedOnBlack_Left_Alt   0x27B
+#define METATILE_TrickHousePuzzle_Arrow_RedOnBlack_Right      0x260
+#define METATILE_TrickHousePuzzle_Arrow_RedOnBlack_Right_Alt  0x27C
+#define METATILE_TrickHousePuzzle_Arrow_RedOnBlack_Up         0x262
+#define METATILE_TrickHousePuzzle_Arrow_YellowOnWhite_Right   0x298
+#define METATILE_TrickHousePuzzle_BlueDoorH_Closed_Tile0      0x23B
+#define METATILE_TrickHousePuzzle_BlueDoorH_Closed_Tile1      0x23C
+#define METATILE_TrickHousePuzzle_BlueDoorH_Closed_Tile2      0x243
+#define METATILE_TrickHousePuzzle_BlueDoorH_Closed_Tile3      0x244
+#define METATILE_TrickHousePuzzle_BlueDoorH_Open_Tile0        0x24B
+#define METATILE_TrickHousePuzzle_BlueDoorH_Open_Tile1        0x24C
+#define METATILE_TrickHousePuzzle_BlueDoorH_Open_Tile2        0x253
+#define METATILE_TrickHousePuzzle_BlueDoorH_Open_Tile3        0x254
+#define METATILE_TrickHousePuzzle_BlueDoorV_Open0             0x23D
+#define METATILE_TrickHousePuzzle_BlueDoorV_Open1             0x245
+#define METATILE_TrickHousePuzzle_BlueDoorV_Retracted         0x24D
+#define METATILE_TrickHousePuzzle_Button_Pressed              0x259
+#define METATILE_TrickHousePuzzle_Button_Up                   0x258
+#define METATILE_TrickHousePuzzle_Door_Shuttered              0x26A
+#define METATILE_TrickHousePuzzle_Floor_ShadowTop             0x255
+#define METATILE_TrickHousePuzzle_Floor_ShadowTop_Alt         0x252
+#define METATILE_TrickHousePuzzle_Lever_Off                   0x23E
+#define METATILE_TrickHousePuzzle_Lever_On                    0x23F
+#define METATILE_TrickHousePuzzle_RedDoorH_Closed_Tile0       0x238
+#define METATILE_TrickHousePuzzle_RedDoorH_Closed_Tile1       0x239
+#define METATILE_TrickHousePuzzle_RedDoorH_Closed_Tile2       0x240
+#define METATILE_TrickHousePuzzle_RedDoorH_Closed_Tile3       0x241
+#define METATILE_TrickHousePuzzle_RedDoorH_Open_Tile0         0x248
+#define METATILE_TrickHousePuzzle_RedDoorH_Open_Tile1         0x249
+#define METATILE_TrickHousePuzzle_RedDoorH_Open_Tile2         0x250
+#define METATILE_TrickHousePuzzle_RedDoorH_Open_Tile3         0x251
+#define METATILE_TrickHousePuzzle_RedDoorV_Open0              0x23A
+#define METATILE_TrickHousePuzzle_RedDoorV_Open1              0x242
+#define METATILE_TrickHousePuzzle_RedDoorV_Retracted          0x24A
+#define METATILE_TrickHousePuzzle_Stairs_Down                 0x20B
+
+// gTileset_Underwater
+#define METATILE_Underwater_FloorShadow  0x228
+#define METATILE_Underwater_RockWall     0x21E
 
 #endif // GUARD_METATILE_LABELS_H


### PR DESCRIPTION
Porymap alphabetizes `metatile_labels.h`, which is a lot of diff noise on the first tileset save. There was no particular order to these sections (some even had repeat sections), so alphabetizing them has the benefit of giving a reasonable order to the defines and reducing diff noise with Porymap.

Additionally standardized the spelling of the labels for `RS_MossdeepGym` to `RSMossdeepGym` (as in e.g. `gTileset_SSAnne`), which stops Porymap from thinking it's called `gTileset_RS`