### PR TITLE
Fix spelling mistake for item flag

### DIFF
--- a/data/maps/PetalburgWoods/map.json
+++ b/data/maps/PetalburgWoods/map.json
@@ -168,7 +168,7 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "PetalburgWoods_EventScript_ItemParalyzeHeal",
-      "flag": "FLAG_ITEM_PETALBURD_WOODS_PARALYZE_HEAL"
+      "flag": "FLAG_ITEM_PETALBURG_WOODS_PARALYZE_HEAL"
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_GIRL_2",

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -1162,7 +1162,7 @@
 #define FLAG_ITEM_ROUTE_103_GUARD_SPEC                              0x45A
 #define FLAG_ITEM_ROUTE_104_X_ACCURACY                              0x45B
 #define FLAG_ITEM_MAUVILLE_CITY_X_SPEED                             0x45C
-#define FLAG_ITEM_PETALBURD_WOODS_PARALYZE_HEAL                     0x45D
+#define FLAG_ITEM_PETALBURG_WOODS_PARALYZE_HEAL                     0x45D
 #define FLAG_ITEM_ROUTE_115_GREAT_BALL                              0x45E
 #define FLAG_ITEM_SAFARI_ZONE_NORTH_CALCIUM                         0x45F
 #define FLAG_ITEM_MT_PYRE_3F_SUPER_REPEL                            0x460


### PR DESCRIPTION
## Description
An item flag was spelled
`FLAG_ITEM_PETALBURD_WOODS_PARALYZE_HEAL` instead of
`FLAG_ITEM_PETALBURG_WOODS_PARALYZE_HEAL`

`make compare` shows `OK` after the change.

## **Discord contact info**
Zunawe#0965
