### PR TITLE
Whitelist instead of Blacklist for TOOLDIRS in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,8 @@ JSONPROC := tools/jsonproc/jsonproc$(EXE)
 
 PERL := perl
 
-TOOLDIRS := $(filter-out tools/agbcc tools/binutils,$(wildcard tools/*))
+# Inclusive list. If you don't want a tool to be built, don't add it here.
+TOOLDIRS := tools/aif2pcm tools/bin2c tools/gbafix tools/gbagfx tools/jsonproc tools/mapjson tools/mid2agb tools/preproc tools/ramscrgen tools/rsfont tools/scaninc
 TOOLBASE = $(TOOLDIRS:tools/%=%)
 TOOLS = $(foreach tool,$(TOOLBASE),tools/$(tool)/$(tool)$(EXE))
 

--- a/make_tools.mk
+++ b/make_tools.mk
@@ -1,7 +1,8 @@
 
 MAKEFLAGS += --no-print-directory
 
-TOOLDIRS := $(filter-out tools/agbcc tools/binutils,$(wildcard tools/*))
+# Inclusive list. If you don't want a tool to be built, don't add it here.
+TOOLDIRS := tools/aif2pcm tools/bin2c tools/gbafix tools/gbagfx tools/jsonproc tools/mapjson tools/mid2agb tools/preproc tools/ramscrgen tools/rsfont tools/scaninc
 
 .PHONY: all $(TOOLDIRS)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Originally by @mrgriffin.

When switching from a branch with additional tools back to vanilla pokeemerald, the those tools' folders lingered, meaning that it caused issues to build.
This PR fixes that by explicitely defining the tool folders, while also make it unnecesary to define an exception for poryscript.

## **Discord contact info**
AsparagusEduardo#6051