### PR TITLE
Fix wrong route in item flag name

### DIFF
--- a/data/maps/Route110/map.json
+++ b/data/maps/Route110/map.json
@@ -288,7 +288,7 @@
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
       "script": "Route110_EventScript_ItemRareCandy",
-      "flag": "FLAG_ITEM_ROUTE_109_RARE_CANDY"
+      "flag": "FLAG_ITEM_ROUTE_110_RARE_CANDY"
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_CYCLING_TRIATHLETE_M",

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -1051,7 +1051,7 @@
 #define FLAG_ITEM_ROUTE_105_IRON                                    0x3EB
 #define FLAG_ITEM_ROUTE_106_PROTEIN                                 0x3EC
 #define FLAG_ITEM_ROUTE_109_PP_UP                                   0x3ED
-#define FLAG_ITEM_ROUTE_109_RARE_CANDY                              0x3EE
+#define FLAG_ITEM_ROUTE_110_RARE_CANDY                              0x3EE
 #define FLAG_ITEM_ROUTE_110_DIRE_HIT                                0x3EF
 #define FLAG_ITEM_ROUTE_111_TM37                                    0x3F0
 #define FLAG_ITEM_ROUTE_111_STARDUST                                0x3F1


### PR DESCRIPTION
## Description
Fixes another flag name, similar to #1863 and #1862. If I find any more of these I'll start collecting them as I go and make a single PR for all of them. Hopefully this is the last one though.

This is for the rare candy on the island below the bike path.

## **Discord contact info**
Zunawe#0965