### PR TITLE
Changed IDE macros to allow their use in compound literals without IDE errors

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -27,8 +27,8 @@
 /// IDE support
 #if defined(__APPLE__) || defined(__CYGWIN__) || defined(__INTELLISENSE__)
 // We define these when using certain IDEs to fool preproc
-#define _(x)        (x)
-#define __(x)       (x)
+#define _(x)        {x}
+#define __(x)       {x}
 #define INCBIN(...) {0}
 #define INCBIN_U8   INCBIN
 #define INCBIN_U16  INCBIN


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I discovered while researching that when using compound literals with "GF strings", the IDEs start raising errors due to them converting it `_("x")` to `(x)`, which compound literals don't accept.
![image](https://user-images.githubusercontent.com/2904965/225109138-c972e9c7-5e9b-4198-b718-12bc704e3499.png)

I looked to make sure that existing instances of the macro didn't break the IDE and it seems to be the case:
![image](https://user-images.githubusercontent.com/2904965/225110193-04412aa8-0cf3-4021-8bf6-03afe6e4c439.png)
![image](https://user-images.githubusercontent.com/2904965/225110305-cf2c6de0-244f-47d1-8b82-b7107171e608.png)

## **Discord contact info**
AsparagusEduardo#6051