### PR TITLE
Add macros for map script terminators

### DIFF
--- a/asm/macros/map.inc
+++ b/asm/macros/map.inc
@@ -12,11 +12,21 @@
 	.4byte \script
 	.endm
 
+	@ Terminates a list of map_script entries
+	.macro end_map_scripts
+	.byte 0
+	.endm
+
 	@ Defines an entry in a map script table (for either ON_WARP_INTO_MAP_TABLE or ON_FRAME_TABLE)
 	.macro map_script_2 var:req, compare:req, script:req
 	.2byte \var
 	.2byte \compare
 	.4byte \script
+	.endm
+
+	@ Terminates a list of map_script_2 entries
+	.macro end_map_script_table
+	.2byte 0
 	.endm
 
 	@ Defines an object event template for map data, to be used by a normal object. Mirrors the struct layout of ObjectEventTemplate in include/global.fieldmap.h

--- a/data/maps/AbandonedShip_CaptainsOffice/scripts.inc
+++ b/data/maps/AbandonedShip_CaptainsOffice/scripts.inc
@@ -1,5 +1,5 @@
 AbandonedShip_CaptainsOffice_MapScripts::
-	.byte 0
+	end_map_scripts
 
 AbandonedShip_CaptainsOffice_EventScript_CaptSternAide::
 	lock

--- a/data/maps/AbandonedShip_Corridors_1F/scripts.inc
+++ b/data/maps/AbandonedShip_Corridors_1F/scripts.inc
@@ -1,5 +1,5 @@
 AbandonedShip_Corridors_1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 AbandonedShip_Corridors_1F_EventScript_Youngster::
 	msgbox AbandonedShip_Corridors_1F_Text_IsntItFunHere, MSGBOX_NPC

--- a/data/maps/AbandonedShip_Corridors_B1F/scripts.inc
+++ b/data/maps/AbandonedShip_Corridors_B1F/scripts.inc
@@ -1,7 +1,7 @@
 AbandonedShip_Corridors_B1F_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, AbandonedShip_Corridors_B1F_OnResume
 	map_script MAP_SCRIPT_ON_LOAD, AbandonedShip_Corridors_B1F_OnLoad
-	.byte 0
+	end_map_scripts
 
 AbandonedShip_Corridors_B1F_OnResume:
 	setdivewarp MAP_ABANDONED_SHIP_UNDERWATER1, 5, 4

--- a/data/maps/AbandonedShip_Deck/scripts.inc
+++ b/data/maps/AbandonedShip_Deck/scripts.inc
@@ -1,6 +1,6 @@
 AbandonedShip_Deck_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, AbandonedShip_Deck_OnTransition
-	.byte 0
+	end_map_scripts
 
 AbandonedShip_Deck_OnTransition:
 	setflag FLAG_LANDMARK_ABANDONED_SHIP

--- a/data/maps/AbandonedShip_HiddenFloorCorridors/scripts.inc
+++ b/data/maps/AbandonedShip_HiddenFloorCorridors/scripts.inc
@@ -1,7 +1,7 @@
 AbandonedShip_HiddenFloorCorridors_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, AbandonedShip_HiddenFloorCorridors_OnResume
 	map_script MAP_SCRIPT_ON_LOAD, AbandonedShip_HiddenFloorCorridors_OnLoad
-	.byte 0
+	end_map_scripts
 
 AbandonedShip_HiddenFloorCorridors_OnResume:
 	setdivewarp MAP_ABANDONED_SHIP_UNDERWATER1, 5, 4

--- a/data/maps/AbandonedShip_HiddenFloorRooms/scripts.inc
+++ b/data/maps/AbandonedShip_HiddenFloorRooms/scripts.inc
@@ -1,10 +1,10 @@
 AbandonedShip_HiddenFloorRooms_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, AbandonedShip_HiddenFloorRooms_OnFrame
-	.byte 0
+	end_map_scripts
 
 AbandonedShip_HiddenFloorRooms_OnFrame:
 	map_script_2 VAR_TEMP_1, 0, AbandonedShip_HiddenFloorRooms_EventScript_DoHiddenItemSparkle
-	.2byte 0
+	end_map_script_table
 
 @ After the below calculation, VAR_TEMP_4 is the room number of the door the player entered
 @ Bottom row, left column   (Rm 1)

--- a/data/maps/AbandonedShip_Room_B1F/scripts.inc
+++ b/data/maps/AbandonedShip_Room_B1F/scripts.inc
@@ -1,3 +1,3 @@
 AbandonedShip_Room_B1F_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/AbandonedShip_Rooms2_1F/scripts.inc
+++ b/data/maps/AbandonedShip_Rooms2_1F/scripts.inc
@@ -1,5 +1,5 @@
 AbandonedShip_Rooms2_1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 AbandonedShip_Rooms2_1F_EventScript_Dan::
 	trainerbattle_double TRAINER_KIRA_AND_DAN_1, AbandonedShip_Rooms2_1F_Text_DanIntro, AbandonedShip_Rooms2_1F_Text_DanDefeat, AbandonedShip_Rooms2_1F_Text_DanNotEnoughMons, AbandonedShip_Rooms2_1F_EventScript_RegisterDan

--- a/data/maps/AbandonedShip_Rooms2_B1F/scripts.inc
+++ b/data/maps/AbandonedShip_Rooms2_B1F/scripts.inc
@@ -1,5 +1,5 @@
 AbandonedShip_Rooms2_B1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 AbandonedShip_Rooms2_B1F_EventScript_Camper::
 	msgbox AbandonedShip_Rooms2_B1F_Text_PerfectPlaceToGoExploring, MSGBOX_NPC

--- a/data/maps/AbandonedShip_Rooms_1F/scripts.inc
+++ b/data/maps/AbandonedShip_Rooms_1F/scripts.inc
@@ -1,5 +1,5 @@
 AbandonedShip_Rooms_1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 AbandonedShip_Rooms_1F_EventScript_Gentleman::
 	msgbox AbandonedShip_Rooms_1F_Text_TakingALookAround, MSGBOX_NPC

--- a/data/maps/AbandonedShip_Rooms_B1F/scripts.inc
+++ b/data/maps/AbandonedShip_Rooms_B1F/scripts.inc
@@ -1,6 +1,6 @@
 AbandonedShip_Rooms_B1F_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, AbandonedShip_Rooms_B1F_OnResume
-	.byte 0
+	end_map_scripts
 
 AbandonedShip_Rooms_B1F_OnResume:
 	setdivewarp MAP_ABANDONED_SHIP_UNDERWATER2, 17, 4

--- a/data/maps/AbandonedShip_Underwater1/scripts.inc
+++ b/data/maps/AbandonedShip_Underwater1/scripts.inc
@@ -1,6 +1,6 @@
 AbandonedShip_Underwater1_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, AbandonedShip_Underwater1_OnResume
-	.byte 0
+	end_map_scripts
 
 AbandonedShip_Underwater1_OnResume:
 	setdivewarp MAP_ABANDONED_SHIP_HIDDEN_FLOOR_CORRIDORS, 0, 10

--- a/data/maps/AbandonedShip_Underwater2/scripts.inc
+++ b/data/maps/AbandonedShip_Underwater2/scripts.inc
@@ -1,6 +1,6 @@
 AbandonedShip_Underwater2_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, AbandonedShip_Underwater2_OnResume
-	.byte 0
+	end_map_scripts
 
 AbandonedShip_Underwater2_OnResume:
 	setdivewarp MAP_ABANDONED_SHIP_ROOMS_B1F, 13, 7

--- a/data/maps/AlteringCave/scripts.inc
+++ b/data/maps/AlteringCave/scripts.inc
@@ -1,6 +1,6 @@
 AlteringCave_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, AlteringCave_OnTransition
-	.byte 0
+	end_map_scripts
 
 AlteringCave_OnTransition:
 	setflag FLAG_LANDMARK_ALTERING_CAVE

--- a/data/maps/AncientTomb/scripts.inc
+++ b/data/maps/AncientTomb/scripts.inc
@@ -2,7 +2,7 @@ AncientTomb_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, AncientTomb_OnResume
 	map_script MAP_SCRIPT_ON_LOAD, AncientTomb_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, AncientTomb_OnTransition
-	.byte 0
+	end_map_scripts
 
 AncientTomb_OnResume:
 	call_if_set FLAG_SYS_CTRL_OBJ_DELETE, AncientTomb_EventScript_TryRemoveRegisteel

--- a/data/maps/AquaHideout_1F/scripts.inc
+++ b/data/maps/AquaHideout_1F/scripts.inc
@@ -1,5 +1,5 @@
 AquaHideout_1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 @ The below two entrance guards give hints about what to do to progress the story
 AquaHideout_1F_EventScript_HideoutEntranceGrunt1::

--- a/data/maps/AquaHideout_B1F/scripts.inc
+++ b/data/maps/AquaHideout_B1F/scripts.inc
@@ -1,7 +1,7 @@
 AquaHideout_B1F_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, AquaHideout_B1F_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, AquaHideout_B1F_OnTransition
-	.byte 0
+	end_map_scripts
 
 AquaHideout_B1F_OnResume:
 	call_if_set FLAG_SYS_CTRL_OBJ_DELETE, AquaHideout_B1F_EventScript_TryRemoveElectrode

--- a/data/maps/AquaHideout_B2F/scripts.inc
+++ b/data/maps/AquaHideout_B2F/scripts.inc
@@ -3,7 +3,7 @@
 
 AquaHideout_B2F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, AquaHideout_B2F_OnTransition
-	.byte 0
+	end_map_scripts
 
 AquaHideout_B2F_OnTransition:
 	call_if_set FLAG_TEAM_AQUA_ESCAPED_IN_SUBMARINE, AquaHideout_B2F_EventScript_PreventMattNoticing

--- a/data/maps/AquaHideout_UnusedRubyMap1/scripts.inc
+++ b/data/maps/AquaHideout_UnusedRubyMap1/scripts.inc
@@ -1,3 +1,3 @@
 AquaHideout_UnusedRubyMap1_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/AquaHideout_UnusedRubyMap2/scripts.inc
+++ b/data/maps/AquaHideout_UnusedRubyMap2/scripts.inc
@@ -1,3 +1,3 @@
 AquaHideout_UnusedRubyMap2_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/AquaHideout_UnusedRubyMap3/scripts.inc
+++ b/data/maps/AquaHideout_UnusedRubyMap3/scripts.inc
@@ -1,3 +1,3 @@
 AquaHideout_UnusedRubyMap3_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/ArtisanCave_1F/scripts.inc
+++ b/data/maps/ArtisanCave_1F/scripts.inc
@@ -1,3 +1,3 @@
 ArtisanCave_1F_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/ArtisanCave_B1F/scripts.inc
+++ b/data/maps/ArtisanCave_B1F/scripts.inc
@@ -1,6 +1,6 @@
 ArtisanCave_B1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, ArtisanCave_B1F_OnTransition
-	.byte 0
+	end_map_scripts
 
 ArtisanCave_B1F_OnTransition:
 	setflag FLAG_LANDMARK_ARTISAN_CAVE

--- a/data/maps/BattleColosseum_2P/scripts.inc
+++ b/data/maps/BattleColosseum_2P/scripts.inc
@@ -1,3 +1,3 @@
 BattleColosseum_2P_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/BattleColosseum_4P/scripts.inc
+++ b/data/maps/BattleColosseum_4P/scripts.inc
@@ -1,3 +1,3 @@
 BattleColosseum_4P_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/BattleFrontier_BattleArenaBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleArenaBattleRoom/scripts.inc
@@ -12,7 +12,7 @@ BattleFrontier_BattleArenaBattleRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleArenaBattleRoom_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleArenaBattleRoom_OnWarp
 	map_script MAP_SCRIPT_ON_RESUME, BattleFrontier_BattleArenaBattleRoom_OnResume
-	.byte 0
+	end_map_scripts
 
 	@ On this map the player (OBJ_EVENT_ID_PLAYER) is hidden
 	@ The player is represented instead by LOCALID_PLAYER, which has the gfx id VAR_OBJ_GFX_ID_1
@@ -42,7 +42,7 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_SetPlayerGfxFemale::
 
 BattleFrontier_BattleArenaBattleRoom_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattleArenaBattleRoom_EventScript_EnterRoom
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleArenaBattleRoom_EventScript_EnterRoom::
 	lockall
@@ -466,7 +466,7 @@ BattleFrontier_BattleArenaBattleRoom_Movement_WalkInPlaceRight2:
 
 BattleFrontier_BattleArenaBattleRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleArenaBattleRoom_EventScript_SetUpRoomObjects
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleArenaBattleRoom_EventScript_SetUpRoomObjects::
 	hideobjectat LOCALID_PLAYER, MAP_BATTLE_FRONTIER_BATTLE_ARENA_BATTLE_ROOM

--- a/data/maps/BattleFrontier_BattleArenaCorridor/scripts.inc
+++ b/data/maps/BattleFrontier_BattleArenaCorridor/scripts.inc
@@ -2,11 +2,11 @@
 
 BattleFrontier_BattleArenaCorridor_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleArenaCorridor_OnFrame
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattleArenaCorridor_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattleArenaCorridor_EventScript_WalkToBattleRoom
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleArenaCorridor_EventScript_WalkToBattleRoom::
 	delay 16

--- a/data/maps/BattleFrontier_BattleArenaLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattleArenaLobby/scripts.inc
@@ -3,11 +3,11 @@
 BattleFrontier_BattleArenaLobby_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleArenaLobby_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleArenaLobby_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattleArenaLobby_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleArenaLobby_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleArenaLobby_EventScript_TurnPlayerNorth::
 	setvar VAR_TEMP_1, 1
@@ -20,7 +20,7 @@ BattleFrontier_BattleArenaLobby_OnFrame:
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_PAUSED, BattleFrontier_BattleArenaLobby_EventScript_ResumeChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_WON, BattleFrontier_BattleArenaLobby_EventScript_WonChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_LOST, BattleFrontier_BattleArenaLobby_EventScript_LostChallenge
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleArenaLobby_EventScript_GetChallengeStatus::
 	frontier_getstatus

--- a/data/maps/BattleFrontier_BattleDomeBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleDomeBattleRoom/scripts.inc
@@ -14,7 +14,7 @@ BattleFrontier_BattleDomeBattleRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleDomeBattleRoom_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleDomeBattleRoom_OnWarp
 	map_script MAP_SCRIPT_ON_RESUME, BattleFrontier_BattleDomeBattleRoom_OnResume
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattleDomeBattleRoom_OnTransition:
 	dome_setopponentgfx
@@ -40,7 +40,7 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_SetPlayerGfxFemale::
 
 BattleFrontier_BattleDomeBattleRoom_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattleDomeBattleRoom_EventScript_EnterRoom
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_EnterRoom::
 	lockall
@@ -459,7 +459,7 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_DoDomeBattle::
 
 BattleFrontier_BattleDomeBattleRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleDomeBattleRoom_EventScript_SetUpObjects
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleDomeBattleRoom_EventScript_SetUpObjects::
 	hideobjectat LOCALID_PLAYER, MAP_BATTLE_FRONTIER_BATTLE_DOME_BATTLE_ROOM

--- a/data/maps/BattleFrontier_BattleDomeCorridor/scripts.inc
+++ b/data/maps/BattleFrontier_BattleDomeCorridor/scripts.inc
@@ -2,11 +2,11 @@
 
 BattleFrontier_BattleDomeCorridor_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleDomeCorridor_OnFrame
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattleDomeCorridor_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattleDomeCorridor_EventScript_EnterCorridor
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleDomeCorridor_EventScript_EnterCorridor::
 	delay 16

--- a/data/maps/BattleFrontier_BattleDomeLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattleDomeLobby/scripts.inc
@@ -5,7 +5,7 @@ BattleFrontier_BattleDomeLobby_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, BattleFrontier_BattleDomeLobby_OnResume
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleDomeLobby_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleDomeLobby_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattleDomeLobby_OnResume:
 	dome_initresultstree
@@ -13,7 +13,7 @@ BattleFrontier_BattleDomeLobby_OnResume:
 
 BattleFrontier_BattleDomeLobby_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleDomeLobby_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleDomeLobby_EventScript_TurnPlayerNorth::
 	setvar VAR_TEMP_1, 1
@@ -26,7 +26,7 @@ BattleFrontier_BattleDomeLobby_OnFrame:
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_PAUSED, BattleFrontier_BattleDomeLobby_EventScript_ResumeChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_WON, BattleFrontier_BattleDomeLobby_EventScript_WonChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_LOST, BattleFrontier_BattleDomeLobby_EventScript_LostChallenge
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleDomeLobby_EventScript_GetChallengeStatus::
 	frontier_getstatus

--- a/data/maps/BattleFrontier_BattleDomePreBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleDomePreBattleRoom/scripts.inc
@@ -3,11 +3,11 @@
 BattleFrontier_BattleDomePreBattleRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleDomePreBattleRoom_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleDomePreBattleRoom_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattleDomePreBattleRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleDomePreBattleRoom_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_TurnPlayerNorth::
 	setvar VAR_TEMP_1, 1
@@ -16,7 +16,7 @@ BattleFrontier_BattleDomePreBattleRoom_EventScript_TurnPlayerNorth::
 
 BattleFrontier_BattleDomePreBattleRoom_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattleDomePreBattleRoom_EventScript_EnterRoom
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleDomePreBattleRoom_EventScript_EnterRoom::
 	goto_if_eq VAR_0x8006, 1, BattleFrontier_BattleDomePreBattleRoom_EventScript_ReturnFromBattle

--- a/data/maps/BattleFrontier_BattleFactoryBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleFactoryBattleRoom/scripts.inc
@@ -11,7 +11,7 @@ BattleFrontier_BattleFactoryBattleRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, BattleFrontier_BattleFactoryBattleRoom_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleFactoryBattleRoom_OnWarp
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleFactoryBattleRoom_OnFrame
-	.byte 0
+	end_map_scripts
 
 	@ On this map the player (OBJ_EVENT_ID_PLAYER) is hidden
 	@ The player is represented instead by LOCALID_PLAYER, which has the gfx id VAR_OBJ_GFX_ID_F
@@ -33,7 +33,7 @@ BattleFrontier_BattleFactoryBattleRoom_EventScript_SetUpFactoryHeadObj::
 
 BattleFrontier_BattleFactoryBattleRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleFactoryBattleRoom_EventScript_HideObjects
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleFactoryBattleRoom_EventScript_HideObjects::
 	setvar VAR_TEMP_1, 1
@@ -53,7 +53,7 @@ BattleFrontier_BattleFactoryBattleRoom_EventScript_SetPlayerGfxFemale::
 
 BattleFrontier_BattleFactoryBattleRoom_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattleFactoryBattleRoom_EventScript_EnterRoom
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleFactoryBattleRoom_EventScript_EnterRoomFactoryHeadBattle::
 	msgbox BattleFrontier_BattleFactoryBattleRoom_Text_GetAMoveOn, MSGBOX_DEFAULT

--- a/data/maps/BattleFrontier_BattleFactoryLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattleFactoryLobby/scripts.inc
@@ -4,11 +4,11 @@
 BattleFrontier_BattleFactoryLobby_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleFactoryLobby_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleFactoryLobby_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattleFactoryLobby_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleFactoryLobby_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleFactoryLobby_EventScript_TurnPlayerNorth::
 	setvar VAR_TEMP_1, 1
@@ -21,7 +21,7 @@ BattleFrontier_BattleFactoryLobby_OnFrame:
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_PAUSED, BattleFrontier_BattleFactoryLobby_EventScript_ResumeChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_WON, BattleFrontier_BattleFactoryLobby_EventScript_WonChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_LOST, BattleFrontier_BattleFactoryLobby_EventScript_LostChallenge
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleFactoryLobby_EventScript_GetChallengeStatus::
 	frontier_getstatus

--- a/data/maps/BattleFrontier_BattleFactoryPreBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleFactoryPreBattleRoom/scripts.inc
@@ -3,11 +3,11 @@
 BattleFrontier_BattleFactoryPreBattleRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleFactoryPreBattleRoom_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleFactoryPreBattleRoom_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattleFactoryPreBattleRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleFactoryPreBattleRoom_EventScript_SetUpObjects
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_SetUpObjects::
 	setvar VAR_TEMP_1, 1
@@ -20,7 +20,7 @@ BattleFrontier_BattleFactoryPreBattleRoom_EventScript_TurnPlayerNorth::
 
 BattleFrontier_BattleFactoryPreBattleRoom_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattleFactoryPreBattleRoom_EventScript_EnterRoom
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleFactoryPreBattleRoom_EventScript_EnterRoom::
 	goto_if_eq VAR_0x8006, 1, BattleFrontier_BattleFactoryPreBattleRoom_EventScript_ReturnToRoomFromBattle

--- a/data/maps/BattleFrontier_BattlePalaceBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePalaceBattleRoom/scripts.inc
@@ -8,7 +8,7 @@ BattleFrontier_BattlePalaceBattleRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, BattleFrontier_BattlePalaceBattleRoom_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattlePalaceBattleRoom_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattlePalaceBattleRoom_OnWarp
-	.byte 0
+	end_map_scripts
 
 	@ On this map the player (OBJ_EVENT_ID_PLAYER) is hidden
 	@ The player is represented instead by LOCALID_PLAYER, which has the gfx id VAR_OBJ_GFX_ID_0
@@ -38,7 +38,7 @@ BattleFrontier_BattlePalaceBattleRoom_EventScript_SetPlayerGfxFemale::
 
 BattleFrontier_BattlePalaceBattleRoom_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattlePalaceBattleRoom_EventScript_EnterRoom
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePalaceBattleRoom_EventScript_EnterRoom::
 	showobjectat LOCALID_PLAYER, MAP_BATTLE_FRONTIER_BATTLE_PALACE_BATTLE_ROOM
@@ -290,7 +290,7 @@ BattleFrontier_BattlePalaceBattleRoom_EventScript_DoPalaceBattle::
 
 BattleFrontier_BattlePalaceBattleRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattlePalaceBattleRoom_EventScript_SetUpRoomObjects
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePalaceBattleRoom_EventScript_SetUpRoomObjects::
 	hideobjectat LOCALID_PLAYER, MAP_BATTLE_FRONTIER_BATTLE_PALACE_BATTLE_ROOM

--- a/data/maps/BattleFrontier_BattlePalaceCorridor/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePalaceCorridor/scripts.inc
@@ -2,11 +2,11 @@
 
 BattleFrontier_BattlePalaceCorridor_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattlePalaceCorridor_OnFrame
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattlePalaceCorridor_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattlePalaceCorridor_EventScript_WalkThroughCorridor
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePalaceCorridor_EventScript_WalkThroughCorridor::
 	delay 16

--- a/data/maps/BattleFrontier_BattlePalaceLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePalaceLobby/scripts.inc
@@ -4,11 +4,11 @@
 BattleFrontier_BattlePalaceLobby_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattlePalaceLobby_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattlePalaceLobby_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattlePalaceLobby_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattlePalaceLobby_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePalaceLobby_EventScript_TurnPlayerNorth::
 	setvar VAR_TEMP_1, 1
@@ -21,7 +21,7 @@ BattleFrontier_BattlePalaceLobby_OnFrame:
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_PAUSED, BattleFrontier_BattlePalaceLobby_EventScript_ResumeChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_WON, BattleFrontier_BattlePalaceLobby_EventScript_WonChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_LOST, BattleFrontier_BattlePalaceLobby_EventScript_LostChallenge
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePalaceLobby_EventScript_GetChallengeStatus::
 	frontier_getstatus

--- a/data/maps/BattleFrontier_BattlePikeCorridor/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeCorridor/scripts.inc
@@ -3,11 +3,11 @@
 BattleFrontier_BattlePikeCorridor_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattlePikeCorridor_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattlePikeCorridor_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattlePikeCorridor_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattlePikeCorridor_EventScript_EnterCorridor
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePikeCorridor_EventScript_EnterCorridor::
 	delay 16
@@ -31,7 +31,7 @@ BattleFrontier_BattlePikeCorridor_EventScript_EnterCorridor::
 
 BattleFrontier_BattlePikeCorridor_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattlePikeCorridor_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePikeCorridor_EventScript_TurnPlayerNorth::
 	setvar VAR_TEMP_1, 1

--- a/data/maps/BattleFrontier_BattlePikeLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeLobby/scripts.inc
@@ -3,18 +3,18 @@
 BattleFrontier_BattlePikeLobby_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattlePikeLobby_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattlePikeLobby_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattlePikeLobby_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattlePikeLobby_EventScript_GetChallengeStatus
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_SAVING, BattleFrontier_BattlePikeLobby_EventScript_QuitWithoutSaving
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_WON, BattleFrontier_BattlePikeLobby_EventScript_WonChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_LOST, BattleFrontier_BattlePikeLobby_EventScript_LostChallenge
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePikeLobby_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattlePikeLobby_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePikeLobby_EventScript_TurnPlayerNorth::
 	setvar VAR_TEMP_1, 1

--- a/data/maps/BattleFrontier_BattlePikeRoomFinal/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeRoomFinal/scripts.inc
@@ -3,11 +3,11 @@
 BattleFrontier_BattlePikeRoomFinal_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattlePikeRoomFinal_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattlePikeRoomFinal_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattlePikeRoomFinal_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattlePikeRoomFinal_EventScript_EnterRoom
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePikeRoomFinal_EventScript_EnterRoom::
 	delay 16
@@ -29,7 +29,7 @@ BattleFrontier_BattlePikeRoomFinal_Movement_AttendantApproachPlayer:
 
 BattleFrontier_BattlePikeRoomFinal_OnWarp:
 	map_script_2 VAR_TEMP_4, 0, BattleFrontier_BattlePikeRoomFinal_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePikeRoomFinal_EventScript_TurnPlayerNorth::
 	setvar VAR_TEMP_4, 1

--- a/data/maps/BattleFrontier_BattlePikeRoomNormal/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeRoomNormal/scripts.inc
@@ -8,11 +8,11 @@ BattleFrontier_BattlePikeRoomNormal_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, BattleFrontier_BattlePikeRoom_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattlePikeRoomNormal_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattlePikeRoom_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattlePikeRoomNormal_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattlePikeRoomNormal_EventScript_EnterRoom
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePikeRoomNormal_EventScript_EnterRoom::
 	setvar VAR_TEMP_0, 1

--- a/data/maps/BattleFrontier_BattlePikeRoomWildMons/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeRoomWildMons/scripts.inc
@@ -2,12 +2,12 @@ BattleFrontier_BattlePikeRoomWildMons_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, BattleFrontier_BattlePikeRoomWildMons_OnResume
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattlePikeRoomWildMons_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattlePikeRoomWildMons_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattlePikeRoomWildMons_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattlePikeRoomWildMons_EventScript_SetInWildMonRoom
 	map_script_2 VAR_TEMP_1, 1, BattleFrontier_BattlePikeRoomWildMons_EventScript_WarpToLobbyLost
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePikeRoomWildMons_EventScript_SetInWildMonRoom::
 	setvar VAR_TEMP_0, 1
@@ -22,7 +22,7 @@ BattleFrontier_BattlePikeRoomWildMons_EventScript_WarpToLobbyLost::
 
 BattleFrontier_BattlePikeRoomWildMons_OnWarp:
 	map_script_2 VAR_TEMP_4, 0, BattleFrontier_BattlePikeRoomWildMons_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePikeRoomWildMons_EventScript_TurnPlayerNorth::
 	setvar VAR_TEMP_4, 1

--- a/data/maps/BattleFrontier_BattlePikeThreePathRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeThreePathRoom/scripts.inc
@@ -4,7 +4,7 @@ BattleFrontier_BattlePikeThreePathRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, BattleFrontier_BattlePikeRoom_OnResume
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattlePikeThreePathRoom_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattlePikeThreePathRoom_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattlePikeThreePathRoom_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattlePikeThreePathRoom_EventScript_GetChallengeStatus
@@ -12,11 +12,11 @@ BattleFrontier_BattlePikeThreePathRoom_OnFrame:
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_PAUSED, BattleFrontier_BattlePikeThreePathRoom_EventScript_ResumeChallenge
 	map_script_2 VAR_TEMP_5, 0, BattleFrontier_BattlePikeThreePathRoom_EventScript_SetHintRoom
 	map_script_2 VAR_TEMP_5, 1, BattleFrontier_BattlePikeThreePathRoom_EventScript_GivePikeQueenHint
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePikeThreePathRoom_OnWarp:
 	map_script_2 VAR_TEMP_4, 0, BattleFrontier_BattlePikeThreePathRoom_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePikeThreePathRoom_EventScript_TurnPlayerNorth::
 	setvar VAR_TEMP_4, 1

--- a/data/maps/BattleFrontier_BattlePyramidFloor/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePyramidFloor/scripts.inc
@@ -2,13 +2,13 @@ BattleFrontier_BattlePyramidFloor_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, BattleFrontier_BattlePyramidFloor_OnResume
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattlePyramidFloor_OnFrame
 	map_script MAP_SCRIPT_ON_TRANSITION, BattleFrontier_BattlePyramidFloor_OnTransition
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattlePyramidFloor_OnFrame:
 	map_script_2 VAR_TEMP_D, 1, BattleFrontier_BattlePyramidFloor_EventScript_UpdateLight
 	map_script_2 VAR_TEMP_E, 0, BattleFrontier_BattlePyramidFloor_EventScript_PlayPyramidMusic
 	map_script_2 VAR_TEMP_F, 1, BattleFrontier_BattlePyramidFloor_EventScript_ShowMapName
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePyramidFloor_EventScript_UpdateLight::
 	lockall

--- a/data/maps/BattleFrontier_BattlePyramidLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePyramidLobby/scripts.inc
@@ -4,12 +4,12 @@
 BattleFrontier_BattlePyramidLobby_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattlePyramidLobby_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleDomeLobby_OnWarp
-	.byte 0
+	end_map_scripts
 
 @ Unused. Pyramid uses Dome's OnWarp (presumably by mistake). Their effects are identical
 BattleFrontier_BattlePyramidLobby_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattlePyramidLobby_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePyramidLobby_EventScript_TurnPlayerNorth:
 	setvar VAR_TEMP_1, 1
@@ -22,7 +22,7 @@ BattleFrontier_BattlePyramidLobby_OnFrame:
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_PAUSED, BattleFrontier_BattlePyramidLobby_EventScript_ResumeChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_WON, BattleFrontier_BattlePyramidLobby_EventScript_WonChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_LOST, BattleFrontier_BattlePyramidLobby_EventScript_LostChallenge
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePyramidLobby_EventScript_GetChallengeStatus::
 	frontier_getstatus

--- a/data/maps/BattleFrontier_BattlePyramidTop/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePyramidTop/scripts.inc
@@ -6,7 +6,7 @@ BattleFrontier_BattlePyramidTop_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattlePyramidTop_OnFrame
 	map_script MAP_SCRIPT_ON_TRANSITION, BattleFrontier_BattlePyramidTop_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattlePyramidTop_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattlePyramidTop_OnTransition:
 	pyramid_updatelight 200, PYRAMID_LIGHT_SET_RADIUS
@@ -15,7 +15,7 @@ BattleFrontier_BattlePyramidTop_OnTransition:
 
 BattleFrontier_BattlePyramidTop_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattlePyramidTop_EventScript_SetUpObjects
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePyramidTop_EventScript_SetUpObjects::
 	setvar VAR_TEMP_1, 1
@@ -45,7 +45,7 @@ BattleFrontier_BattlePyramidTop_EventScript_CheckChallengeStatus::
 BattleFrontier_BattlePyramidTop_OnFrame:
 	map_script_2 VAR_TEMP_E, 0, BattleFrontier_BattlePyramidTop_EventScript_PlayPyramidMusic
 	map_script_2 VAR_TEMP_F, 1, BattleFrontier_BattlePyramidTop_EventScript_ShowMapName
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePyramidTop_EventScript_PlayPyramidMusic::
 	playbgm MUS_B_PYRAMID_TOP, FALSE

--- a/data/maps/BattleFrontier_BattleTowerBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerBattleRoom/scripts.inc
@@ -5,11 +5,11 @@
 BattleFrontier_BattleTowerBattleRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleTowerBattleRoom_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleTowerBattleRoom_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattleTowerBattleRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleTowerBattleRoom_EventScript_SetUpObjects
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleTowerBattleRoom_EventScript_SetUpObjects::
 	setvar VAR_TEMP_1, 1
@@ -18,7 +18,7 @@ BattleFrontier_BattleTowerBattleRoom_EventScript_SetUpObjects::
 
 BattleFrontier_BattleTowerBattleRoom_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattleTowerBattleRoom_EventScript_EnterRoom
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleTowerBattleRoom_EventScript_EnterRoom::
 	setvar VAR_TEMP_0, 1

--- a/data/maps/BattleFrontier_BattleTowerCorridor/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerCorridor/scripts.inc
@@ -3,7 +3,7 @@
 BattleFrontier_BattleTowerCorridor_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, BattleFrontier_BattleTowerCorridor_OnLoad
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleTowerCorridor_OnFrame
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattleTowerCorridor_OnLoad:
 	goto_if_eq VAR_0x8006, 1, BattleFrontier_BattleTowerCorridor_EventScript_OpenFarDoor
@@ -18,7 +18,7 @@ BattleFrontier_BattleTowerCorridor_EventScript_OpenFarDoor::
 
 BattleFrontier_BattleTowerCorridor_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattleTowerCorridor_EventScript_EnterCorridor
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleTowerCorridor_EventScript_EnterCorridor::
 	setvar VAR_TEMP_0, 1

--- a/data/maps/BattleFrontier_BattleTowerElevator/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerElevator/scripts.inc
@@ -3,11 +3,11 @@
 BattleFrontier_BattleTowerElevator_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleTowerElevator_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleTowerElevator_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattleTowerElevator_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattleTowerElevator_EventScript_EnterElevator
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleTowerElevator_EventScript_EnterElevator::
 	setvar VAR_TEMP_0, 1
@@ -79,7 +79,7 @@ BattleFrontier_BattleTowerElevator_Movement_PlayerExit:
 
 BattleFrontier_BattleTowerElevator_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleTowerElevator_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleTowerElevator_EventScript_TurnPlayerNorth::
 	setvar VAR_TEMP_1, 1

--- a/data/maps/BattleFrontier_BattleTowerLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerLobby/scripts.inc
@@ -10,7 +10,7 @@ BattleFrontier_BattleTowerLobby_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, BattleFrontier_BattleTowerLobby_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleTowerLobby_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleTowerLobby_OnWarp
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattleTowerLobby_OnResume:
 	special TryHideBattleTowerReporter
@@ -33,7 +33,7 @@ BattleFrontier_BattleTowerLobby_EventScript_HideApprentice::
 
 BattleFrontier_BattleTowerLobby_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleTowerLobby_EventScript_PlayerFaceNorth
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleTowerLobby_EventScript_PlayerFaceNorth::
 	setvar VAR_TEMP_1, 1
@@ -46,7 +46,7 @@ BattleFrontier_BattleTowerLobby_OnFrame:
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_PAUSED, BattleFrontier_BattleTowerLobby_EventScript_ResumeChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_WON, BattleFrontier_BattleTowerLobby_EventScript_WonChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_LOST, BattleFrontier_BattleTowerLobby_EventScript_LostChallenge
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleTowerLobby_EventScript_GetChallengeStatus::
 	frontier_getstatus

--- a/data/maps/BattleFrontier_BattleTowerMultiBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerMultiBattleRoom/scripts.inc
@@ -9,7 +9,7 @@ BattleFrontier_BattleTowerMultiBattleRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, BattleFrontier_BattleTowerMultiBattleRoom_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleTowerMultiBattleRoom_OnWarp
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleTowerMultiBattleRoom_OnFrame
-	.byte 0
+	end_map_scripts
 
 	@ On this map the player (OBJ_EVENT_ID_PLAYER) is hidden
 	@ The player is represented instead by LOCALID_PLAYER, which has the gfx id VAR_OBJ_GFX_ID_F
@@ -37,7 +37,7 @@ BattleFrontier_BattleTowerMultiBattleRoom_EventScript_SetLinkPlayerGfx::
 
 BattleFrontier_BattleTowerMultiBattleRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleTowerMultiBattleRoom_EventScript_HidePlayerObj
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleTowerMultiBattleRoom_EventScript_HidePlayerObj::
 	hideobjectat OBJ_EVENT_ID_PLAYER, MAP_BATTLE_FRONTIER_BATTLE_TOWER_MULTI_BATTLE_ROOM
@@ -45,7 +45,7 @@ BattleFrontier_BattleTowerMultiBattleRoom_EventScript_HidePlayerObj::
 
 BattleFrontier_BattleTowerMultiBattleRoom_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, BattleFrontier_BattleTowerMultiBattleRoom_EventScript_EnterRoom
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleTowerMultiBattleRoom_EventScript_EnterRoom::
 	setvar VAR_TEMP_0, 1

--- a/data/maps/BattleFrontier_BattleTowerMultiCorridor/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerMultiCorridor/scripts.inc
@@ -7,7 +7,7 @@ BattleFrontier_BattleTowerMultiCorridor_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, BattleFrontier_BattleTowerMultiCorridor_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleTowerMultiCorridor_OnWarp
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleTowerMultiCorridor_OnFrame
-	.byte 0
+	end_map_scripts
 
 	@ On this map the player (OBJ_EVENT_ID_PLAYER) is hidden
 	@ The player is represented instead by LOCALID_PLAYER, and has the gfx id VAR_OBJ_GFX_ID_F
@@ -35,7 +35,7 @@ BattleFrontier_BattleTowerMultiCorridor_EventScript_SetLinkPlayerGfx::
 
 BattleFrontier_BattleTowerMultiCorridor_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleTowerMultiCorridor_EventScript_SetUpObjects
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleTowerMultiCorridor_EventScript_SetUpObjects::
 	hideobjectat OBJ_EVENT_ID_PLAYER, MAP_BATTLE_FRONTIER_BATTLE_TOWER_MULTI_CORRIDOR
@@ -46,7 +46,7 @@ BattleFrontier_BattleTowerMultiCorridor_EventScript_SetUpObjects::
 
 BattleFrontier_BattleTowerMultiCorridor_OnFrame:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleTowerMultiCorridor_EventScript_EnterCorridor
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleTowerMultiCorridor_EventScript_EnterCorridor::
 	lockall

--- a/data/maps/BattleFrontier_BattleTowerMultiPartnerRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerMultiPartnerRoom/scripts.inc
@@ -5,7 +5,7 @@ BattleFrontier_BattleTowerMultiPartnerRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, BattleFrontier_BattleTowerMultiPartnerRoom_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, BattleFrontier_BattleTowerMultiPartnerRoom_OnWarp
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_BattleTowerMultiPartnerRoom_OnFrame
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_BattleTowerMultiPartnerRoom_OnResume:
 	pyramid_resetparty
@@ -40,7 +40,7 @@ BattleFrontier_BattleTowerMultiPartnerRoom_EventScript_ChosePartner::
 
 BattleFrontier_BattleTowerMultiPartnerRoom_OnWarp:
 	map_script_2 VAR_TEMP_3, 1, BattleFrontier_BattleTowerMultiPartnerRoom_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleTowerMultiPartnerRoom_EventScript_TurnPlayerNorth::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_NORTH
@@ -49,7 +49,7 @@ BattleFrontier_BattleTowerMultiPartnerRoom_EventScript_TurnPlayerNorth::
 BattleFrontier_BattleTowerMultiPartnerRoom_OnFrame:
 	map_script_2 VAR_TEMP_1, 0, BattleFrontier_BattleTowerMultiPartnerRoom_EventScript_EnterRoom
 	map_script_2 VAR_TEMP_3, 1, BattleFrontier_BattleTowerMultiPartnerRoom_EventScript_ExitRoom
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattleTowerMultiPartnerRoom_EventScript_ExitRoom::
 	lockall

--- a/data/maps/BattleFrontier_ExchangeServiceCorner/scripts.inc
+++ b/data/maps/BattleFrontier_ExchangeServiceCorner/scripts.inc
@@ -1,5 +1,5 @@
 BattleFrontier_ExchangeServiceCorner_MapScripts::
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_ExchangeServiceCorner_EventScript_ClerkWelcome::
 	msgbox BattleFrontier_ExchangeServiceCorner_Text_WelcomePleaseChoosePrize, MSGBOX_DEFAULT

--- a/data/maps/BattleFrontier_Lounge1/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge1/scripts.inc
@@ -1,5 +1,5 @@
 BattleFrontier_Lounge1_MapScripts::
-	.byte 0
+	end_map_scripts
 
 @ NPC that rates pokemon based on their IVs
 BattleFrontier_Lounge1_EventScript_Breeder::

--- a/data/maps/BattleFrontier_Lounge2/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge2/scripts.inc
@@ -1,5 +1,5 @@
 BattleFrontier_Lounge2_MapScripts::
-	.byte 0
+	end_map_scripts
 
 @ This NPC gives hints about a random facility or battle mode.
 @ For battle modes he gives generic advice

--- a/data/maps/BattleFrontier_Lounge3/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge3/scripts.inc
@@ -1,5 +1,5 @@
 BattleFrontier_Lounge3_MapScripts::
-	.byte 0
+	end_map_scripts
 
 	.set BET_AMOUNT_5,  5
 	.set BET_AMOUNT_10, 10

--- a/data/maps/BattleFrontier_Lounge4/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge4/scripts.inc
@@ -1,5 +1,5 @@
 BattleFrontier_Lounge4_MapScripts::
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_Lounge4_EventScript_Woman::
 	msgbox BattleFrontier_Lounge4_Text_WonderIfInterviewsAiring, MSGBOX_NPC

--- a/data/maps/BattleFrontier_Lounge5/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge5/scripts.inc
@@ -1,5 +1,5 @@
 BattleFrontier_Lounge5_MapScripts::
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_Lounge5_EventScript_NatureGirl::
 	lock

--- a/data/maps/BattleFrontier_Lounge6/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge6/scripts.inc
@@ -1,5 +1,5 @@
 BattleFrontier_Lounge6_MapScripts::
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_Lounge6_EventScript_Trader::
 	lock

--- a/data/maps/BattleFrontier_Lounge7/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge7/scripts.inc
@@ -1,5 +1,5 @@
 BattleFrontier_Lounge7_MapScripts::
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_Lounge7_EventScript_LeftMoveTutor::
 	lock

--- a/data/maps/BattleFrontier_Lounge8/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge8/scripts.inc
@@ -1,5 +1,5 @@
 BattleFrontier_Lounge8_MapScripts::
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_Lounge8_EventScript_Man::
 	msgbox BattleFrontier_Lounge8_Text_WhatATrainerNeeds, MSGBOX_NPC

--- a/data/maps/BattleFrontier_Lounge9/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge9/scripts.inc
@@ -1,3 +1,3 @@
 BattleFrontier_Lounge9_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/BattleFrontier_Mart/scripts.inc
+++ b/data/maps/BattleFrontier_Mart/scripts.inc
@@ -1,7 +1,7 @@
 .set LOCALID_OLD_WOMAN, 2
 
 BattleFrontier_Mart_MapScripts::
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_Mart_EventScript_Clerk::
 	lock

--- a/data/maps/BattleFrontier_OutsideEast/scripts.inc
+++ b/data/maps/BattleFrontier_OutsideEast/scripts.inc
@@ -3,7 +3,7 @@
 BattleFrontier_OutsideEast_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, BattleFrontier_OutsideEast_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, BattleFrontier_OutsideEast_OnTransition
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_OutsideEast_OnResume:
 	call_if_set FLAG_SYS_CTRL_OBJ_DELETE, BattleFrontier_OutsideEast_EventScript_TryRemoveSudowoodo

--- a/data/maps/BattleFrontier_OutsideWest/scripts.inc
+++ b/data/maps/BattleFrontier_OutsideWest/scripts.inc
@@ -9,7 +9,7 @@
 
 BattleFrontier_OutsideWest_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, BattleFrontier_OutsideWest_OnTransition
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_OutsideWest_OnTransition:
 	setvar VAR_BRAVO_TRAINER_BATTLE_TOWER_ON, 0

--- a/data/maps/BattleFrontier_PokemonCenter_1F/scripts.inc
+++ b/data/maps/BattleFrontier_PokemonCenter_1F/scripts.inc
@@ -3,7 +3,7 @@
 BattleFrontier_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, BattleFrontier_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_BATTLE_FRONTIER_OUTSIDE_EAST

--- a/data/maps/BattleFrontier_PokemonCenter_2F/scripts.inc
+++ b/data/maps/BattleFrontier_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ BattleFrontier_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 BattleFrontier_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/BattleFrontier_RankingHall/scripts.inc
+++ b/data/maps/BattleFrontier_RankingHall/scripts.inc
@@ -1,5 +1,5 @@
 BattleFrontier_RankingHall_MapScripts::
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_RankingHall_EventScript_TowerSinglesRecords::
 	lockall

--- a/data/maps/BattleFrontier_ReceptionGate/scripts.inc
+++ b/data/maps/BattleFrontier_ReceptionGate/scripts.inc
@@ -5,7 +5,7 @@
 BattleFrontier_ReceptionGate_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, BattleFrontier_ReceptionGate_OnFrame
 	map_script MAP_SCRIPT_ON_TRANSITION, BattleFrontier_ReceptionGate_OnTransition
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_ReceptionGate_OnTransition:
 	setflag FLAG_LANDMARK_BATTLE_FRONTIER
@@ -13,7 +13,7 @@ BattleFrontier_ReceptionGate_OnTransition:
 
 BattleFrontier_ReceptionGate_OnFrame:
 	map_script_2 VAR_HAS_ENTERED_BATTLE_FRONTIER, 0, BattleFrontier_ReceptionGate_EventScript_FirstTimeEntering
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_ReceptionGate_EventScript_FirstTimeEntering::
 	lockall

--- a/data/maps/BattleFrontier_ScottsHouse/scripts.inc
+++ b/data/maps/BattleFrontier_ScottsHouse/scripts.inc
@@ -1,7 +1,7 @@
 .set LOCALID_SCOTT, 1
 
 BattleFrontier_ScottsHouse_MapScripts::
-	.byte 0
+	end_map_scripts
 
 BattleFrontier_ScottsHouse_EventScript_Scott::
 	lock

--- a/data/maps/BattlePyramidSquare01/scripts.inc
+++ b/data/maps/BattlePyramidSquare01/scripts.inc
@@ -1,2 +1,2 @@
 BattlePyramidSquare01_MapScripts::
-	.byte 0
+	end_map_scripts

--- a/data/maps/BirthIsland_Exterior/scripts.inc
+++ b/data/maps/BirthIsland_Exterior/scripts.inc
@@ -6,7 +6,7 @@ BirthIsland_Exterior_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, BirthIsland_Exterior_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, BirthIsland_Exterior_OnResume
 	map_script MAP_SCRIPT_ON_RETURN_TO_FIELD, BirthIsland_Exterior_OnReturnToField
-	.byte 0
+	end_map_scripts
 
 BirthIsland_Exterior_OnReturnToField:
 	special SetDeoxysRockPalette

--- a/data/maps/BirthIsland_Harbor/scripts.inc
+++ b/data/maps/BirthIsland_Harbor/scripts.inc
@@ -2,7 +2,7 @@
 .set LOCALID_SS_TIDAL, 2
 
 BirthIsland_Harbor_MapScripts::
-	.byte 0
+	end_map_scripts
 
 BirthIsland_Harbor_EventScript_Sailor::
 	lock

--- a/data/maps/CaveOfOrigin_1F/scripts.inc
+++ b/data/maps/CaveOfOrigin_1F/scripts.inc
@@ -1,6 +1,6 @@
 CaveOfOrigin_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, CaveOfOrigin_1F_OnTransition
-	.byte 0
+	end_map_scripts
 
 CaveOfOrigin_1F_OnTransition:
 	call_if_set FLAG_UNUSED_RS_LEGENDARY_BATTLE_DONE, CaveOfOrigin_EventScript_DisableTriggers

--- a/data/maps/CaveOfOrigin_B1F/scripts.inc
+++ b/data/maps/CaveOfOrigin_B1F/scripts.inc
@@ -1,7 +1,7 @@
 .set LOCALID_WALLACE, 1
 
 CaveOfOrigin_B1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 CaveOfOrigin_B1F_EventScript_Wallace::
 	lock

--- a/data/maps/CaveOfOrigin_Entrance/scripts.inc
+++ b/data/maps/CaveOfOrigin_Entrance/scripts.inc
@@ -1,6 +1,6 @@
 CaveOfOrigin_Entrance_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, CaveOfOrigin_Entrance_OnResume
-	.byte 0
+	end_map_scripts
 
 CaveOfOrigin_Entrance_OnResume:
 	setescapewarp MAP_SOOTOPOLIS_CITY, 31, 17

--- a/data/maps/CaveOfOrigin_UnusedRubySapphireMap1/scripts.inc
+++ b/data/maps/CaveOfOrigin_UnusedRubySapphireMap1/scripts.inc
@@ -1,6 +1,6 @@
 CaveOfOrigin_UnusedRubySapphireMap1_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, CaveOfOrigin_UnusedRubySapphireMap1_OnTransition
-	.byte 0
+	end_map_scripts
 
 CaveOfOrigin_UnusedRubySapphireMap1_OnTransition:
 	call_if_set FLAG_UNUSED_RS_LEGENDARY_BATTLE_DONE, CaveOfOrigin_EventScript_DisableTriggers

--- a/data/maps/CaveOfOrigin_UnusedRubySapphireMap2/scripts.inc
+++ b/data/maps/CaveOfOrigin_UnusedRubySapphireMap2/scripts.inc
@@ -1,6 +1,6 @@
 CaveOfOrigin_UnusedRubySapphireMap2_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, CaveOfOrigin_UnusedRubySapphireMap2_OnTransition
-	.byte 0
+	end_map_scripts
 
 CaveOfOrigin_UnusedRubySapphireMap2_OnTransition:
 	call_if_set FLAG_UNUSED_RS_LEGENDARY_BATTLE_DONE, CaveOfOrigin_EventScript_DisableTriggers

--- a/data/maps/CaveOfOrigin_UnusedRubySapphireMap3/scripts.inc
+++ b/data/maps/CaveOfOrigin_UnusedRubySapphireMap3/scripts.inc
@@ -1,6 +1,6 @@
 CaveOfOrigin_UnusedRubySapphireMap3_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, CaveOfOrigin_UnusedRubySapphireMap3_OnTransition
-	.byte 0
+	end_map_scripts
 
 CaveOfOrigin_UnusedRubySapphireMap3_OnTransition:
 	call_if_set FLAG_UNUSED_RS_LEGENDARY_BATTLE_DONE, CaveOfOrigin_EventScript_DisableTriggers

--- a/data/maps/ContestHall/scripts.inc
+++ b/data/maps/ContestHall/scripts.inc
@@ -4,7 +4,7 @@ ContestHall_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, ContestHall_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, ContestHall_OnResume
 	map_script MAP_SCRIPT_ON_RETURN_TO_FIELD, ContestHall_OnReturn
-	.byte 0
+	end_map_scripts
 
 ContestHall_OnReturn:
 	special LoadLinkContestPlayerPalettes
@@ -56,11 +56,11 @@ ContestHall_EventScript_ReShowAudience::
 
 ContestHall_OnFrame:
 	map_script_2 VAR_CONTEST_HALL_STATE, 1, ContestHall_EventScript_Contest
-	.2byte 0
+	end_map_script_table
 
 ContestHall_OnWarp:
 	map_script_2 VAR_CONTEST_HALL_STATE, 1, ContestHall_EventScript_SetContestObjects
-	.2byte 0
+	end_map_script_table
 
 ContestHall_EventScript_Contest::
 	call ContestHall_EventScript_DoContest

--- a/data/maps/DesertRuins/scripts.inc
+++ b/data/maps/DesertRuins/scripts.inc
@@ -2,7 +2,7 @@ DesertRuins_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, DesertRuins_OnResume
 	map_script MAP_SCRIPT_ON_LOAD, DesertRuins_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, DesertRuins_OnTransition
-	.byte 0
+	end_map_scripts
 
 DesertRuins_OnResume:
 	call_if_set FLAG_SYS_CTRL_OBJ_DELETE, DesertRuins_EventScript_TryRemoveRegirock

--- a/data/maps/DesertUnderpass/scripts.inc
+++ b/data/maps/DesertUnderpass/scripts.inc
@@ -2,7 +2,7 @@
 
 DesertUnderpass_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, DesertUnderpass_OnTransition
-	.byte 0
+	end_map_scripts
 
 DesertUnderpass_OnTransition:
 	setflag FLAG_LANDMARK_DESERT_UNDERPASS

--- a/data/maps/DewfordTown/scripts.inc
+++ b/data/maps/DewfordTown/scripts.inc
@@ -12,7 +12,7 @@
 
 DewfordTown_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, DewfordTown_OnTransition
-	.byte 0
+	end_map_scripts
 
 DewfordTown_OnTransition:
 	setflag FLAG_VISITED_DEWFORD_TOWN

--- a/data/maps/DewfordTown_Gym/scripts.inc
+++ b/data/maps/DewfordTown_Gym/scripts.inc
@@ -1,6 +1,6 @@
 DewfordTown_Gym_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, DewfordTown_Gym_OnTransition
-	.byte 0
+	end_map_scripts
 
 DewfordTown_Gym_OnTransition:
 	call DewfordTown_Gym_EventScript_SetFlashLevel

--- a/data/maps/DewfordTown_Hall/scripts.inc
+++ b/data/maps/DewfordTown_Hall/scripts.inc
@@ -4,7 +4,7 @@
 .set LOCALID_PSYCHIC_M, 8
 
 DewfordTown_Hall_MapScripts::
-	.byte 0
+	end_map_scripts
 
 DewfordTown_Hall_EventScript_Girl::
 	lock

--- a/data/maps/DewfordTown_House1/scripts.inc
+++ b/data/maps/DewfordTown_House1/scripts.inc
@@ -1,5 +1,5 @@
 DewfordTown_House1_MapScripts::
-	.byte 0
+	end_map_scripts
 
 DewfordTown_House1_EventScript_Man::
 	msgbox DewfordTown_House1_Text_LotToBeSaidForLivingOnIsland, MSGBOX_NPC

--- a/data/maps/DewfordTown_House2/scripts.inc
+++ b/data/maps/DewfordTown_House2/scripts.inc
@@ -1,5 +1,5 @@
 DewfordTown_House2_MapScripts::
-	.byte 0
+	end_map_scripts
 
 DewfordTown_House2_EventScript_Man::
 	lock

--- a/data/maps/DewfordTown_PokemonCenter_1F/scripts.inc
+++ b/data/maps/DewfordTown_PokemonCenter_1F/scripts.inc
@@ -3,7 +3,7 @@
 DewfordTown_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, DewfordTown_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 DewfordTown_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_DEWFORD_TOWN

--- a/data/maps/DewfordTown_PokemonCenter_2F/scripts.inc
+++ b/data/maps/DewfordTown_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ DewfordTown_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 DewfordTown_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/EverGrandeCity/scripts.inc
+++ b/data/maps/EverGrandeCity/scripts.inc
@@ -1,6 +1,6 @@
 EverGrandeCity_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, EverGrandeCity_OnTransition
-	.byte 0
+	end_map_scripts
 
 EverGrandeCity_OnTransition:
 	call_if_set FLAG_SYS_WEATHER_CTRL, Common_EventScript_SetAbnormalWeather

--- a/data/maps/EverGrandeCity_ChampionsRoom/scripts.inc
+++ b/data/maps/EverGrandeCity_ChampionsRoom/scripts.inc
@@ -6,7 +6,7 @@ EverGrandeCity_ChampionsRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, EverGrandeCity_ChampionsRoom_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, EverGrandeCity_ChampionsRoom_OnWarp
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, EverGrandeCity_ChampionsRoom_OnFrame
-	.byte 0
+	end_map_scripts
 
 EverGrandeCity_ChampionsRoom_OnTransition:
 	call Common_EventScript_SetupRivalGfxId
@@ -14,7 +14,7 @@ EverGrandeCity_ChampionsRoom_OnTransition:
 
 EverGrandeCity_ChampionsRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, EverGrandeCity_ChampionsRoom_EventScript_PlayerTurnNorth
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_ChampionsRoom_EventScript_PlayerTurnNorth::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_NORTH
@@ -22,7 +22,7 @@ EverGrandeCity_ChampionsRoom_EventScript_PlayerTurnNorth::
 
 EverGrandeCity_ChampionsRoom_OnFrame:
 	map_script_2 VAR_TEMP_1, 0, EverGrandeCity_ChampionsRoom_EventScript_EnterRoom
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_ChampionsRoom_EventScript_EnterRoom::
 	lockall

--- a/data/maps/EverGrandeCity_DrakesRoom/scripts.inc
+++ b/data/maps/EverGrandeCity_DrakesRoom/scripts.inc
@@ -2,12 +2,12 @@ EverGrandeCity_DrakesRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, EverGrandeCity_DrakesRoom_OnFrame
 	map_script MAP_SCRIPT_ON_LOAD, EverGrandeCity_DrakesRoom_OnLoad
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, EverGrandeCity_SidneysRoom_OnWarp
-	.byte 0
+	end_map_scripts
 
 @ Unused, Drake uses Sidneys identical OnWarp for some reason
 EverGrandeCity_DrakesRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, EverGrandeCity_DrakesRoom_EventScript_PlayerTurnNorth
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_DrakesRoom_EventScript_PlayerTurnNorth::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_NORTH
@@ -15,7 +15,7 @@ EverGrandeCity_DrakesRoom_EventScript_PlayerTurnNorth::
 
 EverGrandeCity_DrakesRoom_OnFrame:
 	map_script_2 VAR_ELITE_4_STATE, 3, EverGrandeCity_DrakesRoom_EventScript_WalkInCloseDoor
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_DrakesRoom_EventScript_WalkInCloseDoor::
 	lockall

--- a/data/maps/EverGrandeCity_GlaciasRoom/scripts.inc
+++ b/data/maps/EverGrandeCity_GlaciasRoom/scripts.inc
@@ -2,11 +2,11 @@ EverGrandeCity_GlaciasRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, EverGrandeCity_GlaciasRoom_OnFrame
 	map_script MAP_SCRIPT_ON_LOAD, EverGrandeCity_GlaciasRoom_OnLoad
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, EverGrandeCity_GlaciasRoom_OnWarp
-	.byte 0
+	end_map_scripts
 
 EverGrandeCity_GlaciasRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, EverGrandeCity_GlaciasRoom_EventScript_PlayerTurnNorth
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_GlaciasRoom_EventScript_PlayerTurnNorth::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_NORTH
@@ -14,7 +14,7 @@ EverGrandeCity_GlaciasRoom_EventScript_PlayerTurnNorth::
 
 EverGrandeCity_GlaciasRoom_OnFrame:
 	map_script_2 VAR_ELITE_4_STATE, 2, EverGrandeCity_GlaciasRoom_EventScript_WalkInCloseDoor
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_GlaciasRoom_EventScript_WalkInCloseDoor::
 	lockall

--- a/data/maps/EverGrandeCity_Hall1/scripts.inc
+++ b/data/maps/EverGrandeCity_Hall1/scripts.inc
@@ -1,10 +1,10 @@
 EverGrandeCity_Hall1_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, EverGrandeCity_Hall1_OnWarp
-	.byte 0
+	end_map_scripts
 
 EverGrandeCity_Hall1_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, EverGrandeCity_Hall1_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_Hall1_EventScript_TurnPlayerNorth::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_NORTH

--- a/data/maps/EverGrandeCity_Hall2/scripts.inc
+++ b/data/maps/EverGrandeCity_Hall2/scripts.inc
@@ -1,10 +1,10 @@
 EverGrandeCity_Hall2_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, EverGrandeCity_Hall2_OnWarp
-	.byte 0
+	end_map_scripts
 
 EverGrandeCity_Hall2_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, EverGrandeCity_Hall2_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_Hall2_EventScript_TurnPlayerNorth::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_NORTH

--- a/data/maps/EverGrandeCity_Hall3/scripts.inc
+++ b/data/maps/EverGrandeCity_Hall3/scripts.inc
@@ -1,10 +1,10 @@
 EverGrandeCity_Hall3_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, EverGrandeCity_Hall3_OnWarp
-	.byte 0
+	end_map_scripts
 
 EverGrandeCity_Hall3_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, EverGrandeCity_Hall3_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_Hall3_EventScript_TurnPlayerNorth::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_NORTH

--- a/data/maps/EverGrandeCity_Hall4/scripts.inc
+++ b/data/maps/EverGrandeCity_Hall4/scripts.inc
@@ -1,10 +1,10 @@
 EverGrandeCity_Hall4_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, EverGrandeCity_Hall4_OnWarp
-	.byte 0
+	end_map_scripts
 
 EverGrandeCity_Hall4_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, EverGrandeCity_Hall4_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_Hall4_EventScript_TurnPlayerNorth::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_NORTH

--- a/data/maps/EverGrandeCity_Hall5/scripts.inc
+++ b/data/maps/EverGrandeCity_Hall5/scripts.inc
@@ -1,10 +1,10 @@
 EverGrandeCity_Hall5_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, EverGrandeCity_Hall5_OnWarp
-	.byte 0
+	end_map_scripts
 
 EverGrandeCity_Hall5_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, EverGrandeCity_Hall5_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_Hall5_EventScript_TurnPlayerNorth::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_NORTH

--- a/data/maps/EverGrandeCity_HallOfFame/scripts.inc
+++ b/data/maps/EverGrandeCity_HallOfFame/scripts.inc
@@ -3,11 +3,11 @@
 EverGrandeCity_HallOfFame_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, EverGrandeCity_HallOfFame_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, EverGrandeCity_HallOfFame_OnWarp
-	.byte 0
+	end_map_scripts
 
 EverGrandeCity_HallOfFame_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, EverGrandeCity_HallOfFame_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_HallOfFame_EventScript_TurnPlayerNorth::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_NORTH
@@ -15,7 +15,7 @@ EverGrandeCity_HallOfFame_EventScript_TurnPlayerNorth::
 
 EverGrandeCity_HallOfFame_OnFrame:
 	map_script_2 VAR_TEMP_1, 0, EverGrandeCity_HallOfFame_EventScript_EnterHallOfFame
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_HallOfFame_EventScript_EnterHallOfFame::
 	lockall

--- a/data/maps/EverGrandeCity_PhoebesRoom/scripts.inc
+++ b/data/maps/EverGrandeCity_PhoebesRoom/scripts.inc
@@ -2,11 +2,11 @@ EverGrandeCity_PhoebesRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, EverGrandeCity_PhoebesRoom_OnLoad
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, EverGrandeCity_PhoebesRoom_OnWarp
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, EverGrandeCity_PhoebesRoom_OnFrame
-	.byte 0
+	end_map_scripts
 
 EverGrandeCity_PhoebesRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, EverGrandeCity_PhoebesRoom_EventScript_PlayerTurnNorth
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_PhoebesRoom_EventScript_PlayerTurnNorth::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_NORTH
@@ -14,7 +14,7 @@ EverGrandeCity_PhoebesRoom_EventScript_PlayerTurnNorth::
 
 EverGrandeCity_PhoebesRoom_OnFrame:
 	map_script_2 VAR_ELITE_4_STATE, 1, EverGrandeCity_PhoebesRoom_EventScript_WalkInCloseDoor
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_PhoebesRoom_EventScript_WalkInCloseDoor::
 	lockall

--- a/data/maps/EverGrandeCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/EverGrandeCity_PokemonCenter_1F/scripts.inc
@@ -4,7 +4,7 @@
 EverGrandeCity_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, EverGrandeCity_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 EverGrandeCity_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_EVER_GRANDE_CITY

--- a/data/maps/EverGrandeCity_PokemonCenter_2F/scripts.inc
+++ b/data/maps/EverGrandeCity_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ EverGrandeCity_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 EverGrandeCity_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/EverGrandeCity_PokemonLeague_1F/scripts.inc
+++ b/data/maps/EverGrandeCity_PokemonLeague_1F/scripts.inc
@@ -5,7 +5,7 @@
 EverGrandeCity_PokemonLeague_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, EverGrandeCity_PokemonLeague_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 EverGrandeCity_PokemonLeague_1F_OnTransition:
 	setrespawn HEAL_LOCATION_EVER_GRANDE_CITY_POKEMON_LEAGUE

--- a/data/maps/EverGrandeCity_PokemonLeague_2F/scripts.inc
+++ b/data/maps/EverGrandeCity_PokemonLeague_2F/scripts.inc
@@ -3,7 +3,7 @@ EverGrandeCity_PokemonLeague_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 EverGrandeCity_PokemonLeague_2F_EventScript_Colosseum::

--- a/data/maps/EverGrandeCity_SidneysRoom/scripts.inc
+++ b/data/maps/EverGrandeCity_SidneysRoom/scripts.inc
@@ -3,7 +3,7 @@ EverGrandeCity_SidneysRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, EverGrandeCity_SidneysRoom_OnWarp
 	map_script MAP_SCRIPT_ON_TRANSITION, EverGrandeCity_SidneysRoom_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, EverGrandeCity_SidneysRoom_OnFrame
-	.byte 0
+	end_map_scripts
 
 EverGrandeCity_SidneysRoom_OnTransition:
 	setflag FLAG_MET_SCOTT_IN_EVERGRANDE
@@ -25,7 +25,7 @@ EverGrandeCity_SidneysRoom_EventScript_CloseDoor::
 
 EverGrandeCity_SidneysRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, EverGrandeCity_SidneysRoom_EventScript_PlayerTurnNorth
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_SidneysRoom_EventScript_PlayerTurnNorth::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_NORTH
@@ -33,7 +33,7 @@ EverGrandeCity_SidneysRoom_EventScript_PlayerTurnNorth::
 
 EverGrandeCity_SidneysRoom_OnFrame:
 	map_script_2 VAR_ELITE_4_STATE, 0, EverGrandeCity_SidneysRoom_EventScript_WalkInCloseDoor
-	.2byte 0
+	end_map_script_table
 
 EverGrandeCity_SidneysRoom_EventScript_WalkInCloseDoor::
 	lockall

--- a/data/maps/FallarborTown/scripts.inc
+++ b/data/maps/FallarborTown/scripts.inc
@@ -1,6 +1,6 @@
 FallarborTown_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, FallarborTown_OnTransition
-	.byte 0
+	end_map_scripts
 
 FallarborTown_OnTransition:
 	setflag FLAG_VISITED_FALLARBOR_TOWN

--- a/data/maps/FallarborTown_BattleTentBattleRoom/scripts.inc
+++ b/data/maps/FallarborTown_BattleTentBattleRoom/scripts.inc
@@ -6,7 +6,7 @@ FallarborTown_BattleTentBattleRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, FallarborTown_BattleTentBattleRoom_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, FallarborTown_BattleTentBattleRoom_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, FallarborTown_BattleTentBattleRoom_OnWarp
-	.byte 0
+	end_map_scripts
 
 	@ On this map the player (OBJ_EVENT_ID_PLAYER) is hidden
 	@ The player is represented instead by object event 1, which has the gfx id VAR_OBJ_GFX_ID_1
@@ -34,7 +34,7 @@ FallarborTown_BattleTentBattleRoom_EventScript_SetPlayerGfxFemale::
 
 FallarborTown_BattleTentBattleRoom_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, FallarborTown_BattleTentBattleRoom_EventScript_EnterRoom
-	.2byte 0
+	end_map_script_table
 
 FallarborTown_BattleTentBattleRoom_EventScript_EnterRoom::
 	lockall
@@ -231,7 +231,7 @@ FallarborTown_BattleTentBattleRoom_Movement_AttendantReturnToPos:
 
 FallarborTown_BattleTentBattleRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, FallarborTown_BattleTentBattleRoom_EventScript_SetUpObjects
-	.2byte 0
+	end_map_script_table
 
 FallarborTown_BattleTentBattleRoom_EventScript_SetUpObjects::
 	hideobjectat OBJ_EVENT_ID_PLAYER, MAP_FALLARBOR_TOWN_BATTLE_TENT_BATTLE_ROOM

--- a/data/maps/FallarborTown_BattleTentCorridor/scripts.inc
+++ b/data/maps/FallarborTown_BattleTentCorridor/scripts.inc
@@ -2,11 +2,11 @@
 
 FallarborTown_BattleTentCorridor_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, FallarborTown_BattleTentCorridor_OnFrame
-	.byte 0
+	end_map_scripts
 
 FallarborTown_BattleTentCorridor_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, FallarborTown_BattleTentCorridor_EventScript_EnterCorridor
-	.2byte 0
+	end_map_script_table
 
 FallarborTown_BattleTentCorridor_EventScript_EnterCorridor::
 	lockall

--- a/data/maps/FallarborTown_BattleTentLobby/scripts.inc
+++ b/data/maps/FallarborTown_BattleTentLobby/scripts.inc
@@ -3,11 +3,11 @@
 FallarborTown_BattleTentLobby_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, FallarborTown_BattleTentLobby_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, FallarborTown_BattleTentLobby_OnWarp
-	.byte 0
+	end_map_scripts
 
 FallarborTown_BattleTentLobby_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, FallarborTown_BattleTentLobby_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 FallarborTown_BattleTentLobby_EventScript_TurnPlayerNorth::
 	setvar VAR_TEMP_1, 1
@@ -20,7 +20,7 @@ FallarborTown_BattleTentLobby_OnFrame:
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_PAUSED, FallarborTown_BattleTentLobby_EventScript_ResumeChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_WON, FallarborTown_BattleTentLobby_EventScript_WonChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_LOST, FallarborTown_BattleTentLobby_EventScript_LostChallenge
-	.2byte 0
+	end_map_script_table
 
 FallarborTown_BattleTentLobby_EventScript_GetChallengeStatus::
 	frontier_getstatus

--- a/data/maps/FallarborTown_CozmosHouse/scripts.inc
+++ b/data/maps/FallarborTown_CozmosHouse/scripts.inc
@@ -1,5 +1,5 @@
 FallarborTown_CozmosHouse_MapScripts::
-	.byte 0
+	end_map_scripts
 
 FallarborTown_CozmosHouse_EventScript_ProfCozmo::
 	lock

--- a/data/maps/FallarborTown_Mart/scripts.inc
+++ b/data/maps/FallarborTown_Mart/scripts.inc
@@ -1,5 +1,5 @@
 FallarborTown_Mart_MapScripts::
-	.byte 0
+	end_map_scripts
 
 FallarborTown_Mart_EventScript_Clerk::
 	lock

--- a/data/maps/FallarborTown_MoveRelearnersHouse/scripts.inc
+++ b/data/maps/FallarborTown_MoveRelearnersHouse/scripts.inc
@@ -1,7 +1,7 @@
 .set LOCALID_MOVE_RELEARNER, 1
 
 FallarborTown_MoveRelearnersHouse_MapScripts::
-	.byte 0
+	end_map_scripts
 
 FallarborTown_MoveRelearnersHouse_EventScript_MoveRelearner::
 	lockall

--- a/data/maps/FallarborTown_PokemonCenter_1F/scripts.inc
+++ b/data/maps/FallarborTown_PokemonCenter_1F/scripts.inc
@@ -4,7 +4,7 @@
 FallarborTown_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, FallarborTown_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 FallarborTown_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_FALLARBOR_TOWN

--- a/data/maps/FallarborTown_PokemonCenter_2F/scripts.inc
+++ b/data/maps/FallarborTown_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ FallarborTown_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 FallarborTown_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/FarawayIsland_Entrance/scripts.inc
+++ b/data/maps/FarawayIsland_Entrance/scripts.inc
@@ -3,7 +3,7 @@
 
 FarawayIsland_Entrance_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, FarawayIsland_Entrance_OnTransition
-	.byte 0
+	end_map_scripts
 
 FarawayIsland_Entrance_OnTransition:
 	setflag FLAG_ARRIVED_ON_FARAWAY_ISLAND

--- a/data/maps/FarawayIsland_Interior/scripts.inc
+++ b/data/maps/FarawayIsland_Interior/scripts.inc
@@ -5,7 +5,7 @@ FarawayIsland_Interior_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, FarawayIsland_Interior_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, FarawayIsland_Interior_OnFrame
 	map_script MAP_SCRIPT_ON_RETURN_TO_FIELD, FarawayIsland_Interior_OnReturnToField
-	.byte 0
+	end_map_scripts
 
 FarawayIsland_Interior_OnReturnToField:
 	call_if_set FLAG_SYS_CTRL_OBJ_DELETE, FarawayIsland_Interior_EventScript_TrySetMewAboveGrass
@@ -48,7 +48,7 @@ FarawayIsland_Interior_EventScript_TryShowMew::
 
 FarawayIsland_Interior_OnFrame:
 	map_script_2 VAR_TEMP_1, 0, FarawayIsland_Interior_EventScript_FindMew
-	.2byte 0
+	end_map_script_table
 
 FarawayIsland_Interior_EventScript_FindMew::
 	lockall

--- a/data/maps/FieryPath/scripts.inc
+++ b/data/maps/FieryPath/scripts.inc
@@ -1,6 +1,6 @@
 FieryPath_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, FieryPath_OnTransition
-	.byte 0
+	end_map_scripts
 
 FieryPath_OnTransition:
 	call_if_unset FLAG_LANDMARK_FIERY_PATH, FieryPath_EventScript_MoveScottToFallarbor

--- a/data/maps/FortreeCity/scripts.inc
+++ b/data/maps/FortreeCity/scripts.inc
@@ -1,7 +1,7 @@
 FortreeCity_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, FortreeCity_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, FortreeCity_OnResume
-	.byte 0
+	end_map_scripts
 
 FortreeCity_OnTransition:
 	setflag FLAG_VISITED_FORTREE_CITY

--- a/data/maps/FortreeCity_DecorationShop/scripts.inc
+++ b/data/maps/FortreeCity_DecorationShop/scripts.inc
@@ -1,5 +1,5 @@
 FortreeCity_DecorationShop_MapScripts::
-	.byte 0
+	end_map_scripts
 
 FortreeCity_DecorationShop_EventScript_PokefanM::
 	msgbox FortreeCity_DecorationShop_Text_MerchandiseSentToPC, MSGBOX_NPC

--- a/data/maps/FortreeCity_Gym/scripts.inc
+++ b/data/maps/FortreeCity_Gym/scripts.inc
@@ -1,7 +1,7 @@
 FortreeCity_Gym_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, FortreeCity_Gym_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, FortreeCity_Gym_OnWarp
-	.byte 0
+	end_map_scripts
 
 FortreeCity_Gym_OnTransition:
 	special RotatingGate_InitPuzzle
@@ -9,7 +9,7 @@ FortreeCity_Gym_OnTransition:
 
 FortreeCity_Gym_OnWarp:
 	map_script_2 VAR_TEMP_0, VAR_TEMP_0, FortreeCity_Gym_EventScript_InitRotatingGates
-	.2byte 0
+	end_map_script_table
 
 FortreeCity_Gym_EventScript_InitRotatingGates::
 	special RotatingGate_InitPuzzleAndGraphics

--- a/data/maps/FortreeCity_House1/scripts.inc
+++ b/data/maps/FortreeCity_House1/scripts.inc
@@ -1,5 +1,5 @@
 FortreeCity_House1_MapScripts::
-	.byte 0
+	end_map_scripts
 
 FortreeCity_House1_EventScript_Trader::
 	lock

--- a/data/maps/FortreeCity_House2/scripts.inc
+++ b/data/maps/FortreeCity_House2/scripts.inc
@@ -1,5 +1,5 @@
 FortreeCity_House2_MapScripts::
-	.byte 0
+	end_map_scripts
 
 FortreeCity_House2_EventScript_HiddenPowerGiver::
 	lock

--- a/data/maps/FortreeCity_House3/scripts.inc
+++ b/data/maps/FortreeCity_House3/scripts.inc
@@ -1,5 +1,5 @@
 FortreeCity_House3_MapScripts::
-	.byte 0
+	end_map_scripts
 
 FortreeCity_House3_EventScript_Maniac::
 	msgbox FortreeCity_House3_Text_MetStevenHadAmazingPokemon, MSGBOX_NPC

--- a/data/maps/FortreeCity_House4/scripts.inc
+++ b/data/maps/FortreeCity_House4/scripts.inc
@@ -1,7 +1,7 @@
 .set LOCALID_WINGULL, 3
 
 FortreeCity_House4_MapScripts::
-	.byte 0
+	end_map_scripts
 
 FortreeCity_House4_EventScript_Woman::
 	msgbox FortreeCity_House4_Text_BringsWorldCloserTogether, MSGBOX_NPC

--- a/data/maps/FortreeCity_House5/scripts.inc
+++ b/data/maps/FortreeCity_House5/scripts.inc
@@ -1,5 +1,5 @@
 FortreeCity_House5_MapScripts::
-	.byte 0
+	end_map_scripts
 
 FortreeCity_House5_EventScript_PokefanF::
 	msgbox FortreeCity_House5_Text_TreeHousesAreGreat, MSGBOX_NPC

--- a/data/maps/FortreeCity_Mart/scripts.inc
+++ b/data/maps/FortreeCity_Mart/scripts.inc
@@ -1,5 +1,5 @@
 FortreeCity_Mart_MapScripts::
-	.byte 0
+	end_map_scripts
 
 FortreeCity_Mart_EventScript_Clerk::
 	lock

--- a/data/maps/FortreeCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/FortreeCity_PokemonCenter_1F/scripts.inc
@@ -3,7 +3,7 @@
 FortreeCity_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, FortreeCity_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 FortreeCity_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_FORTREE_CITY

--- a/data/maps/FortreeCity_PokemonCenter_2F/scripts.inc
+++ b/data/maps/FortreeCity_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ FortreeCity_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 FortreeCity_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/GraniteCave_1F/scripts.inc
+++ b/data/maps/GraniteCave_1F/scripts.inc
@@ -1,5 +1,5 @@
 GraniteCave_1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 GraniteCave_1F_EventScript_Hiker::
 	lock

--- a/data/maps/GraniteCave_B1F/scripts.inc
+++ b/data/maps/GraniteCave_B1F/scripts.inc
@@ -2,7 +2,7 @@ GraniteCave_B1F_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, CaveHole_CheckFallDownHole
 	map_script MAP_SCRIPT_ON_TRANSITION, CaveHole_FixCrackedGround
 	map_script MAP_SCRIPT_ON_RESUME, GraniteCave_B1F_SetHoleWarp
-	.byte 0
+	end_map_scripts
 
 GraniteCave_B1F_SetHoleWarp:
 	setstepcallback STEP_CB_CRACKED_FLOOR

--- a/data/maps/GraniteCave_B2F/scripts.inc
+++ b/data/maps/GraniteCave_B2F/scripts.inc
@@ -1,3 +1,3 @@
 GraniteCave_B2F_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/GraniteCave_StevensRoom/scripts.inc
+++ b/data/maps/GraniteCave_StevensRoom/scripts.inc
@@ -1,7 +1,7 @@
 .set LOCALID_STEVEN, 1
 
 GraniteCave_StevensRoom_MapScripts::
-	.byte 0
+	end_map_scripts
 
 GraniteCave_StevensRoom_EventScript_Steven::
 	lock

--- a/data/maps/InsideOfTruck/scripts.inc
+++ b/data/maps/InsideOfTruck/scripts.inc
@@ -1,7 +1,7 @@
 InsideOfTruck_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, InsideOfTruck_OnLoad
 	map_script MAP_SCRIPT_ON_RESUME, InsideOfTruck_OnResume
-	.byte 0
+	end_map_scripts
 
 InsideOfTruck_OnLoad:
 	setmetatile 4, 1, METATILE_InsideOfTruck_ExitLight_Top, FALSE

--- a/data/maps/IslandCave/scripts.inc
+++ b/data/maps/IslandCave/scripts.inc
@@ -2,7 +2,7 @@ IslandCave_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, IslandCave_OnResume
 	map_script MAP_SCRIPT_ON_LOAD, IslandCave_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, IslandCave_OnTransition
-	.byte 0
+	end_map_scripts
 
 IslandCave_OnResume:
 	call_if_set FLAG_SYS_CTRL_OBJ_DELETE, IslandCave_EventScript_TryRemoveRegice

--- a/data/maps/JaggedPass/scripts.inc
+++ b/data/maps/JaggedPass/scripts.inc
@@ -4,7 +4,7 @@ JaggedPass_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, JaggedPass_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, JaggedPass_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, JaggedPass_OnLoad
-	.byte 0
+	end_map_scripts
 
 JaggedPass_OnResume:
 	setstepcallback STEP_CB_ASH

--- a/data/maps/LavaridgeTown/scripts.inc
+++ b/data/maps/LavaridgeTown/scripts.inc
@@ -4,7 +4,7 @@
 LavaridgeTown_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LavaridgeTown_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, LavaridgeTown_OnFrame
-	.byte 0
+	end_map_scripts
 
 LavaridgeTown_OnTransition:
 	setflag FLAG_VISITED_LAVARIDGE_TOWN
@@ -42,7 +42,7 @@ LavaridgeTown_EventScript_HideMapNamePopup::
 
 LavaridgeTown_OnFrame:
 	map_script_2 VAR_LAVARIDGE_TOWN_STATE, 1, LavaridgeTown_EventScript_RivalGiveGoGoggles
-	.2byte 0
+	end_map_script_table
 
 LavaridgeTown_EventScript_RivalGiveGoGoggles::
 	lockall

--- a/data/maps/LavaridgeTown_Gym_1F/scripts.inc
+++ b/data/maps/LavaridgeTown_Gym_1F/scripts.inc
@@ -5,7 +5,7 @@
 
 LavaridgeTown_Gym_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LavaridgeTown_Gym_1F_OnTransition
-	.byte 0
+	end_map_scripts
 
 LavaridgeTown_Gym_1F_OnTransition:
 	call LavaridgeTown_Gym_1F_EventScript_SetTrainerTempVars

--- a/data/maps/LavaridgeTown_Gym_B1F/scripts.inc
+++ b/data/maps/LavaridgeTown_Gym_B1F/scripts.inc
@@ -5,7 +5,7 @@
 
 LavaridgeTown_Gym_B1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LavaridgeTown_Gym_B1F_OnTransition
-	.byte 0
+	end_map_scripts
 
 LavaridgeTown_Gym_B1F_OnTransition:
 	call LavaridgeTown_Gym_B1F_EventScript_SetTrainerTempVars

--- a/data/maps/LavaridgeTown_HerbShop/scripts.inc
+++ b/data/maps/LavaridgeTown_HerbShop/scripts.inc
@@ -1,5 +1,5 @@
 LavaridgeTown_HerbShop_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LavaridgeTown_HerbShop_EventScript_Clerk::
 	lock

--- a/data/maps/LavaridgeTown_House/scripts.inc
+++ b/data/maps/LavaridgeTown_House/scripts.inc
@@ -1,5 +1,5 @@
 LavaridgeTown_House_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LavaridgeTown_House_EventScript_OldMan::
 	msgbox LavaridgeTown_House_Text_WifeWarmingEggInHotSprings, MSGBOX_NPC

--- a/data/maps/LavaridgeTown_Mart/scripts.inc
+++ b/data/maps/LavaridgeTown_Mart/scripts.inc
@@ -1,5 +1,5 @@
 LavaridgeTown_Mart_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LavaridgeTown_Mart_EventScript_Clerk::
 	lock

--- a/data/maps/LavaridgeTown_PokemonCenter_1F/scripts.inc
+++ b/data/maps/LavaridgeTown_PokemonCenter_1F/scripts.inc
@@ -3,7 +3,7 @@
 LavaridgeTown_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LavaridgeTown_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 LavaridgeTown_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_LAVARIDGE_TOWN

--- a/data/maps/LavaridgeTown_PokemonCenter_2F/scripts.inc
+++ b/data/maps/LavaridgeTown_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ LavaridgeTown_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 LavaridgeTown_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/LilycoveCity/scripts.inc
+++ b/data/maps/LilycoveCity/scripts.inc
@@ -4,7 +4,7 @@
 LilycoveCity_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LilycoveCity_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, LilycoveCity_OnLoad
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_OnTransition:
 	setflag FLAG_VISITED_LILYCOVE_CITY

--- a/data/maps/LilycoveCity_ContestHall/scripts.inc
+++ b/data/maps/LilycoveCity_ContestHall/scripts.inc
@@ -28,7 +28,7 @@
 .set LOCALID_CUTE_AUDIENCE_2, 31
 
 LilycoveCity_ContestHall_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_ContestHall_EventScript_Boy1::
 	msgbox LilycoveCity_ContestHall_Text_TodayWonSmartnessContest, MSGBOX_NPC

--- a/data/maps/LilycoveCity_ContestLobby/scripts.inc
+++ b/data/maps/LilycoveCity_ContestLobby/scripts.inc
@@ -7,7 +7,7 @@
 LilycoveCity_ContestLobby_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LilycoveCity_ContestLobby_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, LilycoveCity_ContestLobby_OnFrame
-	.byte 0
+	end_map_scripts
 
 @ Some scripts for this room are split into data/scripts/contest_hall and data/scripts/berry_blender
 
@@ -31,7 +31,7 @@ LilycoveCity_ContestLobby_EventScript_ShowBlendMaster::
 LilycoveCity_ContestLobby_OnFrame:
 	map_script_2 VAR_LILYCOVE_CONTEST_LOBBY_STATE, 1, LilycoveCity_ContestLobby_EventScript_TryDoContestArtist
 	map_script_2 VAR_LILYCOVE_CONTEST_LOBBY_STATE, 2, LilycoveCity_ContestLobby_EventScript_TryDoLinkContestArtist
-	.2byte 0
+	end_map_script_table
 
 LilycoveCity_ContestLobby_EventScript_TryDoContestArtist::
 	goto_if_set FLAG_HIDE_LILYCOVE_MUSEUM_CURATOR, LilycoveCity_ContestLobby_EventScript_ContestArtist

--- a/data/maps/LilycoveCity_CoveLilyMotel_1F/scripts.inc
+++ b/data/maps/LilycoveCity_CoveLilyMotel_1F/scripts.inc
@@ -1,7 +1,7 @@
 .set LOCALID_OWNER, 1
 
 LilycoveCity_CoveLilyMotel_1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_CoveLilyMotel_1F_EventScript_MotelOwner::
 	lockall

--- a/data/maps/LilycoveCity_CoveLilyMotel_2F/scripts.inc
+++ b/data/maps/LilycoveCity_CoveLilyMotel_2F/scripts.inc
@@ -1,5 +1,5 @@
 LilycoveCity_CoveLilyMotel_2F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_CoveLilyMotel_2F_EventScript_GameDesigner::
 	lock

--- a/data/maps/LilycoveCity_DepartmentStoreElevator/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStoreElevator/scripts.inc
@@ -1,5 +1,5 @@
 LilycoveCity_DepartmentStoreElevator_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_DepartmentStoreElevator_EventScript_Attendant::
 	lock

--- a/data/maps/LilycoveCity_DepartmentStoreRooftop/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStoreRooftop/scripts.inc
@@ -1,6 +1,6 @@
 LilycoveCity_DepartmentStoreRooftop_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LilycoveCity_DepartmentStoreRooftop_OnTransition
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_DepartmentStoreRooftop_OnTransition:
 	getpokenewsactive POKENEWS_LILYCOVE
@@ -42,7 +42,7 @@ LilycoveCity_DepartmentStoreRooftop_PokemartDecor_ClearOutSale:
 	.2byte DECOR_CUTE_TV
 	.2byte DECOR_WAILMER_DOLL
 	.2byte DECOR_RHYDON_DOLL
-	.2byte 0
+	end_map_script_table
 	release
 	end
 

--- a/data/maps/LilycoveCity_DepartmentStore_1F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_1F/scripts.inc
@@ -1,7 +1,7 @@
 .set LOCALID_LOTTERY_CLERK, 2
 
 LilycoveCity_DepartmentStore_1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_DepartmentStore_1F_EventScript_Greeter::
 	msgbox LilycoveCity_DepartmentStore_1F_Text_WelcomeToDeptStore, MSGBOX_NPC

--- a/data/maps/LilycoveCity_DepartmentStore_2F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_2F/scripts.inc
@@ -1,5 +1,5 @@
 LilycoveCity_DepartmentStore_2F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_DepartmentStore_2F_EventScript_Cook::
 	msgbox LilycoveCity_DepartmentStore_2F_Text_LearnToUseItemsProperly, MSGBOX_NPC

--- a/data/maps/LilycoveCity_DepartmentStore_3F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_3F/scripts.inc
@@ -1,5 +1,5 @@
 LilycoveCity_DepartmentStore_3F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_DepartmentStore_3F_EventScript_ClerkLeft::
 	lock

--- a/data/maps/LilycoveCity_DepartmentStore_4F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_4F/scripts.inc
@@ -1,5 +1,5 @@
 LilycoveCity_DepartmentStore_4F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_DepartmentStore_4F_EventScript_Gentleman::
 	msgbox LilycoveCity_DepartmentStore_4F_Text_AttackOrDefenseTM, MSGBOX_NPC

--- a/data/maps/LilycoveCity_DepartmentStore_5F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_5F/scripts.inc
@@ -2,7 +2,7 @@
 
 LilycoveCity_DepartmentStore_5F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, LilycoveCity_DepartmentStore_5F_OnWarp
-	.byte 0
+	end_map_scripts
 
 @ During the abnormal weather from Kyogre/Groudon awakening the dept store rooftop is inaccessible
 @ Likely done to avoid dealing with showing the weather. Technically the rooftop is indoors
@@ -10,7 +10,7 @@ LilycoveCity_DepartmentStore_5F_OnWarp:
 	map_script_2 VAR_SOOTOPOLIS_CITY_STATE, 1, LilycoveCity_DepartmentStore_5F_EventScript_BlockRoofStairs
 	map_script_2 VAR_SOOTOPOLIS_CITY_STATE, 2, LilycoveCity_DepartmentStore_5F_EventScript_BlockRoofStairs
 	map_script_2 VAR_SOOTOPOLIS_CITY_STATE, 3, LilycoveCity_DepartmentStore_5F_EventScript_BlockRoofStairs
-	.2byte 0
+	end_map_script_table
 
 LilycoveCity_DepartmentStore_5F_EventScript_BlockRoofStairs::
 	setobjectxy LOCALID_WOMAN, 16, 2

--- a/data/maps/LilycoveCity_Harbor/scripts.inc
+++ b/data/maps/LilycoveCity_Harbor/scripts.inc
@@ -5,7 +5,7 @@
 
 LilycoveCity_Harbor_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LilycoveCity_Harbor_OnTransition
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_Harbor_OnTransition:
 	setescapewarp MAP_LILYCOVE_CITY, 12, 33

--- a/data/maps/LilycoveCity_House1/scripts.inc
+++ b/data/maps/LilycoveCity_House1/scripts.inc
@@ -1,5 +1,5 @@
 LilycoveCity_House1_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_House1_EventScript_ExpertM::
 	msgbox LilycoveCity_House1_Text_PokemonPartnersNotTools, MSGBOX_NPC

--- a/data/maps/LilycoveCity_House2/scripts.inc
+++ b/data/maps/LilycoveCity_House2/scripts.inc
@@ -1,5 +1,5 @@
 LilycoveCity_House2_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_House2_EventScript_FatMan::
 	lock

--- a/data/maps/LilycoveCity_House3/scripts.inc
+++ b/data/maps/LilycoveCity_House3/scripts.inc
@@ -1,6 +1,6 @@
 LilycoveCity_House3_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LilycoveCity_House3_OnTransition
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_House3_OnTransition:
 	random 4

--- a/data/maps/LilycoveCity_House4/scripts.inc
+++ b/data/maps/LilycoveCity_House4/scripts.inc
@@ -1,5 +1,5 @@
 LilycoveCity_House4_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_House4_EventScript_Man1::
 	msgbox LilycoveCity_House4_Text_MysteriesAtBottomOfSea, MSGBOX_NPC

--- a/data/maps/LilycoveCity_LilycoveMuseum_1F/scripts.inc
+++ b/data/maps/LilycoveCity_LilycoveMuseum_1F/scripts.inc
@@ -2,7 +2,7 @@
 .set LOCALID_ARTIST_2, 8
 
 LilycoveCity_LilycoveMuseum_1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_LilycoveMuseum_1F_EventScript_Greeter::
 	msgbox LilycoveCity_LilycoveMuseum_1F_Text_WelcomeToLilycoveMuseum, MSGBOX_SIGN

--- a/data/maps/LilycoveCity_LilycoveMuseum_2F/scripts.inc
+++ b/data/maps/LilycoveCity_LilycoveMuseum_2F/scripts.inc
@@ -3,7 +3,7 @@
 LilycoveCity_LilycoveMuseum_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, LilycoveCity_LilycoveMuseum_2F_OnLoad
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, LilycoveCity_LilycoveMuseum_2F_OnFrame
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_LilycoveMuseum_2F_OnLoad:
 	goto_if_set FLAG_COOL_PAINTING_MADE, LilycoveCity_LilycoveMuseum_2F_EventScript_SetCoolPainting
@@ -60,7 +60,7 @@ LilycoveCity_LilycoveMuseum_2F_EventScript_SetToughPainting::
 
 LilycoveCity_LilycoveMuseum_2F_OnFrame:
 	map_script_2 VAR_LILYCOVE_MUSEUM_2F_STATE, 0, LilycoveCity_LilycoveMuseum_2F_EventScript_ShowExhibitHall
-	.2byte 0
+	end_map_script_table
 
 LilycoveCity_LilycoveMuseum_2F_EventScript_ShowExhibitHall::
 	lockall

--- a/data/maps/LilycoveCity_MoveDeletersHouse/scripts.inc
+++ b/data/maps/LilycoveCity_MoveDeletersHouse/scripts.inc
@@ -1,7 +1,7 @@
 .set LOCALID_MOVE_DELETER, 1
 
 LilycoveCity_MoveDeletersHouse_MapScripts::
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_MoveDeletersHouse_EventScript_MoveDeleter::
 	lockall

--- a/data/maps/LilycoveCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/LilycoveCity_PokemonCenter_1F/scripts.inc
@@ -3,7 +3,7 @@
 LilycoveCity_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LilycoveCity_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 LilycoveCity_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_LILYCOVE_CITY

--- a/data/maps/LilycoveCity_PokemonCenter_2F/scripts.inc
+++ b/data/maps/LilycoveCity_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ LilycoveCity_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 LilycoveCity_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/LilycoveCity_PokemonTrainerFanClub/scripts.inc
+++ b/data/maps/LilycoveCity_PokemonTrainerFanClub/scripts.inc
@@ -10,13 +10,13 @@
 LilycoveCity_PokemonTrainerFanClub_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, LilycoveCity_PokemonTrainerFanClub_OnFrame
 	map_script MAP_SCRIPT_ON_TRANSITION, LilycoveCity_PokemonTrainerFanClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 	@ See field_specials.c for a breakdown of the Fan Club and its variables
 
 LilycoveCity_PokemonTrainerFanClub_OnFrame:
 	map_script_2 VAR_LILYCOVE_FAN_CLUB_STATE, 1, LilycoveCity_PokemonTrainerFanClub_EventScript_MeetFirstFans
-	.2byte 0
+	end_map_script_table
 
 LilycoveCity_PokemonTrainerFanClub_EventScript_MeetFirstFans::
 	lockall

--- a/data/maps/LilycoveCity_UnusedMart/scripts.inc
+++ b/data/maps/LilycoveCity_UnusedMart/scripts.inc
@@ -1,3 +1,3 @@
 LilycoveCity_UnusedMart_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/LittlerootTown/scripts.inc
+++ b/data/maps/LittlerootTown/scripts.inc
@@ -7,7 +7,7 @@ LittlerootTown_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LittlerootTown_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, LittlerootTown_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, LittlerootTown_OnWarp
-	.byte 0
+	end_map_scripts
 
 	@ State descriptions for VAR_LITTLEROOT_TOWN_STATE
 	@ 1: Met Rival
@@ -110,7 +110,7 @@ LittlerootTown_OnFrame:
 	map_script_2 VAR_LITTLEROOT_INTRO_STATE, 1, LittlerootTown_EventScript_StepOffTruckMale
 	map_script_2 VAR_LITTLEROOT_INTRO_STATE, 2, LittlerootTown_EventScript_StepOffTruckFemale
 	map_script_2 VAR_DEX_UPGRADE_JOHTO_STARTER_STATE, 1, LittlerootTown_EventScript_BeginDexUpgradeScene
-	.2byte 0
+	end_map_script_table
 
 LittlerootTown_EventScript_StepOffTruckMale::
 	lockall
@@ -226,7 +226,7 @@ LittlerootTown_EventScript_BeginDexUpgradeScene::
 
 LittlerootTown_OnWarp:
 	map_script_2 VAR_DEX_UPGRADE_JOHTO_STARTER_STATE, 1, LittlerootTown_EventScript_SetRivalBirchPosForDexUpgrade
-	.2byte 0
+	end_map_script_table
 
 LittlerootTown_EventScript_SetRivalBirchPosForDexUpgrade::
 	addobject LOCALID_BIRCH

--- a/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_BrendansHouse_1F/scripts.inc
@@ -6,7 +6,7 @@ LittlerootTown_BrendansHouse_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, LittlerootTown_BrendansHouse_1F_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, LittlerootTown_BrendansHouse_1F_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, LittlerootTown_BrendansHouse_1F_OnFrame
-	.byte 0
+	end_map_scripts
 
 LittlerootTown_BrendansHouse_1F_OnLoad:
 	call_if_lt VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_BrendansHouse_1F_EventScript_SetMovingBoxes
@@ -56,7 +56,7 @@ LittlerootTown_BrendansHouse_1F_OnFrame:
 	map_script_2 VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_BrendansHouse_1F_EventScript_PetalburgGymReport
 	map_script_2 VAR_LITTLEROOT_HOUSES_STATE_MAY, 1, LittlerootTown_BrendansHouse_1F_EventScript_YoureNewNeighbor
 	map_script_2 VAR_LITTLEROOT_HOUSES_STATE_MAY, 3, PlayersHouse_1F_EventScript_GetSSTicketAndSeeLatiTV
-	.2byte 0
+	end_map_script_table
 
 LittlerootTown_BrendansHouse_1F_EventScript_GoUpstairsToSetClock::
 	lockall

--- a/data/maps/LittlerootTown_BrendansHouse_2F/scripts.inc
+++ b/data/maps/LittlerootTown_BrendansHouse_2F/scripts.inc
@@ -3,7 +3,7 @@
 LittlerootTown_BrendansHouse_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LittlerootTown_BrendansHouse_2F_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, LittlerootTown_BrendansHouse_2F_OnWarp
-	.byte 0
+	end_map_scripts
 
 LittlerootTown_BrendansHouse_2F_OnTransition:
 	call_if_lt VAR_LITTLEROOT_RIVAL_STATE, 2, LittlerootTown_BrendansHouse_2F_EventScript_CheckSetReadyToMeetBrendan
@@ -41,7 +41,7 @@ LittlerootTown_BrendansHouse_2F_EventScript_SetReadyToMeetBrendan::
 
 LittlerootTown_BrendansHouse_2F_OnWarp:
 	map_script_2 VAR_SECRET_BASE_INITIALIZED, 0, LittlerootTown_BrendansHouse_2F_EventScript_CheckInitDecor
-	.2byte 0
+	end_map_script_table
 
 LittlerootTown_BrendansHouse_2F_EventScript_CheckInitDecor::
 	checkplayergender

--- a/data/maps/LittlerootTown_MaysHouse_1F/scripts.inc
+++ b/data/maps/LittlerootTown_MaysHouse_1F/scripts.inc
@@ -6,7 +6,7 @@ LittlerootTown_MaysHouse_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, LittlerootTown_MaysHouse_1F_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, LittlerootTown_MaysHouse_1F_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, LittlerootTown_MaysHouse_1F_OnFrame
-	.byte 0
+	end_map_scripts
 
 LittlerootTown_MaysHouse_1F_OnLoad:
 	call_if_lt VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_MaysHouse_1F_EventScript_SetMovingBoxes
@@ -55,7 +55,7 @@ LittlerootTown_MaysHouse_1F_OnFrame:
 	map_script_2 VAR_LITTLEROOT_INTRO_STATE, 6, LittlerootTown_MaysHouse_1F_EventScript_PetalburgGymReport
 	map_script_2 VAR_LITTLEROOT_HOUSES_STATE_BRENDAN, 1, LittlerootTown_MaysHouse_1F_EventScript_YoureNewNeighbor
 	map_script_2 VAR_LITTLEROOT_HOUSES_STATE_MAY, 3, PlayersHouse_1F_EventScript_GetSSTicketAndSeeLatiTV
-	.2byte 0
+	end_map_script_table
 
 LittlerootTown_MaysHouse_1F_EventScript_GoUpstairsToSetClock::
 	lockall

--- a/data/maps/LittlerootTown_MaysHouse_2F/scripts.inc
+++ b/data/maps/LittlerootTown_MaysHouse_2F/scripts.inc
@@ -3,7 +3,7 @@
 LittlerootTown_MaysHouse_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LittlerootTown_MaysHouse_2F_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, LittlerootTown_MaysHouse_2F_OnWarp
-	.byte 0
+	end_map_scripts
 
 LittlerootTown_MaysHouse_2F_OnTransition:
 	call_if_lt VAR_LITTLEROOT_RIVAL_STATE, 2, LittlerootTown_MaysHouse_2F_EventScript_CheckSetReadyToMeetMay
@@ -40,7 +40,7 @@ LittlerootTown_MaysHouse_2F_EventScript_SetReadyToMeetMay::
 
 LittlerootTown_MaysHouse_2F_OnWarp:
 	map_script_2 VAR_SECRET_BASE_INITIALIZED, 0, LittlerootTown_MaysHouse_2F_EventScript_CheckInitDecor
-	.2byte 0
+	end_map_script_table
 
 LittlerootTown_MaysHouse_2F_EventScript_CheckInitDecor::
 	checkplayergender

--- a/data/maps/LittlerootTown_ProfessorBirchsLab/scripts.inc
+++ b/data/maps/LittlerootTown_ProfessorBirchsLab/scripts.inc
@@ -9,7 +9,7 @@ LittlerootTown_ProfessorBirchsLab_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, LittlerootTown_ProfessorBirchsLab_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, LittlerootTown_ProfessorBirchsLab_OnWarp
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, LittlerootTown_ProfessorBirchsLab_OnFrame
-	.byte 0
+	end_map_scripts
 
 	@ State descriptions for VAR_DEX_UPGRADE_JOHTO_STARTER_STATE
 	@ 1: Beat Elite Four, Dex upgrade ready
@@ -63,7 +63,7 @@ LittlerootTown_ProfessorBirchsLab_OnWarp:
 	map_script_2 VAR_DEX_UPGRADE_JOHTO_STARTER_STATE, 6, LittlerootTown_ProfessorBirchsLab_EventScript_AddRivalObject
 	map_script_2 VAR_DEX_UPGRADE_JOHTO_STARTER_STATE, 4, LittlerootTown_ProfessorBirchsLab_EventScript_SetObjectPosForJohtoStarters
 	map_script_2 VAR_DEX_UPGRADE_JOHTO_STARTER_STATE, 5, LittlerootTown_ProfessorBirchsLab_EventScript_SetObjectPosForJohtoStarters
-	.2byte 0
+	end_map_script_table
 
 LittlerootTown_ProfessorBirchsLab_EventScript_SetPlayerPosForReceiveStarter::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_NORTH
@@ -107,7 +107,7 @@ LittlerootTown_ProfessorBirchsLab_OnFrame:
 	map_script_2 VAR_BIRCH_LAB_STATE, 4, LittlerootTown_ProfessorBirchsLab_EventScript_GivePokedexEvent
 	map_script_2 VAR_DEX_UPGRADE_JOHTO_STARTER_STATE, 1, LittlerootTown_ProfessorBirchsLab_EventScript_UpgradeToNationalDex
 	map_script_2 VAR_DEX_UPGRADE_JOHTO_STARTER_STATE, 4, LittlerootTown_ProfessorBirchsLab_EventScript_ChooseJohtoStarter
-	.2byte 0
+	end_map_script_table
 
 @ The starter is technically given prior to this on Route 101 by special ChooseStarter
 @ This is just where the game tells you its yours and lets you nickname it

--- a/data/maps/MagmaHideout_1F/scripts.inc
+++ b/data/maps/MagmaHideout_1F/scripts.inc
@@ -1,6 +1,6 @@
 MagmaHideout_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, MagmaHideout_1F_OnTransition
-	.byte 0
+	end_map_scripts
 
 MagmaHideout_1F_OnTransition:
 	setvar VAR_JAGGED_PASS_ASH_WEATHER, 0

--- a/data/maps/MagmaHideout_2F_1R/scripts.inc
+++ b/data/maps/MagmaHideout_2F_1R/scripts.inc
@@ -1,5 +1,5 @@
 MagmaHideout_2F_1R_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MagmaHideout_2F_1R_EventScript_Grunt14::
 	trainerbattle_single TRAINER_GRUNT_MAGMA_HIDEOUT_14, MagmaHideout_2F_1R_Text_Grunt14Intro, MagmaHideout_2F_1R_Text_Grunt14Defeat

--- a/data/maps/MagmaHideout_2F_2R/scripts.inc
+++ b/data/maps/MagmaHideout_2F_2R/scripts.inc
@@ -1,5 +1,5 @@
 MagmaHideout_2F_2R_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MagmaHideout_2F_2R_EventScript_Grunt15::
 	trainerbattle_single TRAINER_GRUNT_MAGMA_HIDEOUT_15, MagmaHideout_2F_2R_Text_Grunt15Intro, MagmaHideout_2F_2R_Text_Grunt15Defeat

--- a/data/maps/MagmaHideout_2F_3R/scripts.inc
+++ b/data/maps/MagmaHideout_2F_3R/scripts.inc
@@ -1,3 +1,3 @@
 MagmaHideout_2F_3R_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/MagmaHideout_3F_1R/scripts.inc
+++ b/data/maps/MagmaHideout_3F_1R/scripts.inc
@@ -1,5 +1,5 @@
 MagmaHideout_3F_1R_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MagmaHideout_3F_1R_EventScript_Grunt9::
 	trainerbattle_single TRAINER_GRUNT_MAGMA_HIDEOUT_9, MagmaHideout_3F_1R_Text_Grunt9Intro, MagmaHideout_3F_1R_Text_Grunt9Defeat

--- a/data/maps/MagmaHideout_3F_2R/scripts.inc
+++ b/data/maps/MagmaHideout_3F_2R/scripts.inc
@@ -1,5 +1,5 @@
 MagmaHideout_3F_2R_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MagmaHideout_3F_2R_EventScript_Grunt10::
 	trainerbattle_single TRAINER_GRUNT_MAGMA_HIDEOUT_10, MagmaHideout_3F_2R_Text_Grunt10Intro, MagmaHideout_3F_2R_Text_Grunt10Defeat

--- a/data/maps/MagmaHideout_3F_3R/scripts.inc
+++ b/data/maps/MagmaHideout_3F_3R/scripts.inc
@@ -1,3 +1,3 @@
 MagmaHideout_3F_3R_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/MagmaHideout_4F/scripts.inc
+++ b/data/maps/MagmaHideout_4F/scripts.inc
@@ -7,7 +7,7 @@
 .set LOCALID_GROUDON_SLEEPING, 7
 
 MagmaHideout_4F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MagmaHideout_4F_EventScript_Maxie::
 	lockall

--- a/data/maps/MarineCave_End/scripts.inc
+++ b/data/maps/MarineCave_End/scripts.inc
@@ -3,7 +3,7 @@
 MarineCave_End_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, MarineCave_End_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, MarineCave_End_OnTransition
-	.byte 0
+	end_map_scripts
 
 MarineCave_End_OnResume:
 	call_if_set FLAG_SYS_CTRL_OBJ_DELETE, MarineCave_End_EventScript_TryRemoveKyogre

--- a/data/maps/MarineCave_Entrance/scripts.inc
+++ b/data/maps/MarineCave_Entrance/scripts.inc
@@ -1,6 +1,6 @@
 MarineCave_Entrance_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, MarineCave_Entrance_OnResume
-	.byte 0
+	end_map_scripts
 
 MarineCave_Entrance_OnResume:
 	setdivewarp MAP_UNDERWATER_MARINE_CAVE, 9, 6

--- a/data/maps/MauvilleCity/scripts.inc
+++ b/data/maps/MauvilleCity/scripts.inc
@@ -4,7 +4,7 @@
 
 MauvilleCity_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, MauvilleCity_OnTransition
-	.byte 0
+	end_map_scripts
 
 MauvilleCity_OnTransition:
 	setflag FLAG_VISITED_MAUVILLE_CITY

--- a/data/maps/MauvilleCity_BikeShop/scripts.inc
+++ b/data/maps/MauvilleCity_BikeShop/scripts.inc
@@ -1,5 +1,5 @@
 MauvilleCity_BikeShop_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MauvilleCity_BikeShop_EventScript_Rydel::
 	lock

--- a/data/maps/MauvilleCity_GameCorner/scripts.inc
+++ b/data/maps/MauvilleCity_GameCorner/scripts.inc
@@ -1,5 +1,5 @@
 MauvilleCity_GameCorner_MapScripts::
-	.byte 0
+	end_map_scripts
 
     @ Game Corner prices
 	.set TM32_COINS,  1500

--- a/data/maps/MauvilleCity_Gym/scripts.inc
+++ b/data/maps/MauvilleCity_Gym/scripts.inc
@@ -1,6 +1,6 @@
 MauvilleCity_Gym_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, MauvilleCity_Gym_OnLoad
-	.byte 0
+	end_map_scripts
 
 MauvilleCity_Gym_OnLoad:
 	goto_if_set FLAG_DEFEATED_MAUVILLE_GYM, MauvilleCity_Gym_EventScript_DeactivatePuzzle

--- a/data/maps/MauvilleCity_House1/scripts.inc
+++ b/data/maps/MauvilleCity_House1/scripts.inc
@@ -1,5 +1,5 @@
 MauvilleCity_House1_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MauvilleCity_House1_EventScript_RockSmashDude::
 	lock

--- a/data/maps/MauvilleCity_House2/scripts.inc
+++ b/data/maps/MauvilleCity_House2/scripts.inc
@@ -1,5 +1,5 @@
 MauvilleCity_House2_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MauvilleCity_House2_EventScript_Woman::
 	lock

--- a/data/maps/MauvilleCity_Mart/scripts.inc
+++ b/data/maps/MauvilleCity_Mart/scripts.inc
@@ -1,5 +1,5 @@
 MauvilleCity_Mart_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MauvilleCity_Mart_EventScript_Clerk::
 	lock

--- a/data/maps/MauvilleCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/MauvilleCity_PokemonCenter_1F/scripts.inc
@@ -3,7 +3,7 @@
 MauvilleCity_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, MauvilleCity_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 MauvilleCity_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_MAUVILLE_CITY

--- a/data/maps/MauvilleCity_PokemonCenter_2F/scripts.inc
+++ b/data/maps/MauvilleCity_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ MauvilleCity_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 MauvilleCity_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/MeteorFalls_1F_1R/scripts.inc
+++ b/data/maps/MeteorFalls_1F_1R/scripts.inc
@@ -6,7 +6,7 @@
 
 MeteorFalls_1F_1R_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, MeteorFalls_1F_1R_OnLoad
-	.byte 0
+	end_map_scripts
 
 MeteorFalls_1F_1R_OnLoad:
 	call_if_set FLAG_SYS_GAME_CLEAR, MeteorFalls_1F_1R_EventScript_OpenStevensCave

--- a/data/maps/MeteorFalls_1F_2R/scripts.inc
+++ b/data/maps/MeteorFalls_1F_2R/scripts.inc
@@ -1,5 +1,5 @@
 MeteorFalls_1F_2R_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MeteorFalls_1F_2R_EventScript_Nicolas::
 	trainerbattle_single TRAINER_NICOLAS_1, MeteorFalls_1F_2R_Text_NicolasIntro, MeteorFalls_1F_2R_Text_NicolasDefeat, MeteorFalls_1F_2R_EventScript_RegisterNicolas

--- a/data/maps/MeteorFalls_B1F_1R/scripts.inc
+++ b/data/maps/MeteorFalls_B1F_1R/scripts.inc
@@ -1,3 +1,3 @@
 MeteorFalls_B1F_1R_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/MeteorFalls_B1F_2R/scripts.inc
+++ b/data/maps/MeteorFalls_B1F_2R/scripts.inc
@@ -1,3 +1,3 @@
 MeteorFalls_B1F_2R_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/MeteorFalls_StevensCave/scripts.inc
+++ b/data/maps/MeteorFalls_StevensCave/scripts.inc
@@ -1,7 +1,7 @@
 .set LOCALID_STEVEN, 1
 
 MeteorFalls_StevensCave_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MeteorFalls_StevensCave_EventScript_Steven::
 	lock

--- a/data/maps/MirageTower_1F/scripts.inc
+++ b/data/maps/MirageTower_1F/scripts.inc
@@ -1,6 +1,6 @@
 MirageTower_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, MirageTower_1F_OnTransition
-	.byte 0
+	end_map_scripts
 
 MirageTower_1F_OnTransition:
 	setflag FLAG_ENTERED_MIRAGE_TOWER

--- a/data/maps/MirageTower_2F/scripts.inc
+++ b/data/maps/MirageTower_2F/scripts.inc
@@ -2,7 +2,7 @@ MirageTower_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, CaveHole_CheckFallDownHole
 	map_script MAP_SCRIPT_ON_TRANSITION, CaveHole_FixCrackedGround
 	map_script MAP_SCRIPT_ON_RESUME, MirageTower_2F_SetHoleWarp
-	.byte 0
+	end_map_scripts
 
 MirageTower_2F_SetHoleWarp:
 	setstepcallback STEP_CB_CRACKED_FLOOR

--- a/data/maps/MirageTower_3F/scripts.inc
+++ b/data/maps/MirageTower_3F/scripts.inc
@@ -2,7 +2,7 @@ MirageTower_3F_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, CaveHole_CheckFallDownHole
 	map_script MAP_SCRIPT_ON_TRANSITION, CaveHole_FixCrackedGround
 	map_script MAP_SCRIPT_ON_RESUME, MirageTower_3F_SetHoleWarp
-	.byte 0
+	end_map_scripts
 
 MirageTower_3F_SetHoleWarp:
 	setstepcallback STEP_CB_CRACKED_FLOOR

--- a/data/maps/MirageTower_4F/scripts.inc
+++ b/data/maps/MirageTower_4F/scripts.inc
@@ -2,7 +2,7 @@
 .set LOCALID_CLAW_FOSSIL, 2
 
 MirageTower_4F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MirageTower_4F_EventScript_RootFossil::
 	lock

--- a/data/maps/MossdeepCity/scripts.inc
+++ b/data/maps/MossdeepCity/scripts.inc
@@ -7,7 +7,7 @@
 
 MossdeepCity_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, MossdeepCity_OnTransition
-	.byte 0
+	end_map_scripts
 
 MossdeepCity_OnTransition:
 	clearflag FLAG_MOSSDEEP_GYM_SWITCH_1

--- a/data/maps/MossdeepCity_GameCorner_1F/scripts.inc
+++ b/data/maps/MossdeepCity_GameCorner_1F/scripts.inc
@@ -2,15 +2,15 @@ MossdeepCity_GameCorner_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, MossdeepCity_GameCorner_1F_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, MossdeepCity_GameCorner_1F_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
-	.byte 0
+	end_map_scripts
 
 MossdeepCity_GameCorner_1F_OnWarp:
 	map_script_2 VAR_CABLE_CLUB_STATE, USING_MINIGAME, CableClub_EventScript_CheckTurnAttendant
-	.2byte 0
+	end_map_script_table
 
 MossdeepCity_GameCorner_1F_OnFrame:
 	map_script_2 VAR_CABLE_CLUB_STATE, USING_MINIGAME, CableClub_EventScript_ExitMinigameRoom
-	.2byte 0
+	end_map_script_table
 
 @ Script is redundant, the label in the goto also does lock and faceplayer
 MossdeepCity_GameCorner_1F_EventScript_InfoMan::

--- a/data/maps/MossdeepCity_GameCorner_B1F/scripts.inc
+++ b/data/maps/MossdeepCity_GameCorner_B1F/scripts.inc
@@ -1,3 +1,3 @@
 MossdeepCity_GameCorner_B1F_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/MossdeepCity_Gym/scripts.inc
+++ b/data/maps/MossdeepCity_Gym/scripts.inc
@@ -1,6 +1,6 @@
 MossdeepCity_Gym_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, MossdeepCity_Gym_OnLoad
-	.byte 0
+	end_map_scripts
 
 @ NOTE: Mossdeep Gym was redesigned between R/S and E. Leftover (and now functionally unused) scripts are commented below
 

--- a/data/maps/MossdeepCity_House1/scripts.inc
+++ b/data/maps/MossdeepCity_House1/scripts.inc
@@ -1,5 +1,5 @@
 MossdeepCity_House1_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MossdeepCity_House1_EventScript_BlackBelt::
 	lock

--- a/data/maps/MossdeepCity_House2/scripts.inc
+++ b/data/maps/MossdeepCity_House2/scripts.inc
@@ -1,7 +1,7 @@
 .set LOCALID_WINGULL, 3
 
 MossdeepCity_House2_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MossdeepCity_House2_EventScript_Man::
 	msgbox MossdeepCity_House2_Text_SisterMailsBoyfriendInFortree, MSGBOX_NPC

--- a/data/maps/MossdeepCity_House3/scripts.inc
+++ b/data/maps/MossdeepCity_House3/scripts.inc
@@ -1,5 +1,5 @@
 MossdeepCity_House3_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MossdeepCity_House3_EventScript_SuperRodFisherman::
 	lock

--- a/data/maps/MossdeepCity_House4/scripts.inc
+++ b/data/maps/MossdeepCity_House4/scripts.inc
@@ -1,5 +1,5 @@
 MossdeepCity_House4_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MossdeepCity_House4_EventScript_Woman::
 	lock

--- a/data/maps/MossdeepCity_Mart/scripts.inc
+++ b/data/maps/MossdeepCity_Mart/scripts.inc
@@ -1,5 +1,5 @@
 MossdeepCity_Mart_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MossdeepCity_Mart_EventScript_Clerk::
 	lock

--- a/data/maps/MossdeepCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/MossdeepCity_PokemonCenter_1F/scripts.inc
@@ -3,7 +3,7 @@
 MossdeepCity_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, MossdeepCity_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 MossdeepCity_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_MOSSDEEP_CITY

--- a/data/maps/MossdeepCity_PokemonCenter_2F/scripts.inc
+++ b/data/maps/MossdeepCity_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ MossdeepCity_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 MossdeepCity_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/MossdeepCity_SpaceCenter_1F/scripts.inc
+++ b/data/maps/MossdeepCity_SpaceCenter_1F/scripts.inc
@@ -8,7 +8,7 @@
 MossdeepCity_SpaceCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, MossdeepCity_SpaceCenter_1F_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, MossdeepCity_SpaceCenter_1F_OnTransition
-	.byte 0
+	end_map_scripts
 
 MossdeepCity_SpaceCenter_1F_OnTransition:
 	goto_if_eq VAR_MOSSDEEP_CITY_STATE, 2, MossdeepCity_SpaceCenter_1F_EventScript_MoveObjectsForTeamMagma

--- a/data/maps/MossdeepCity_SpaceCenter_2F/scripts.inc
+++ b/data/maps/MossdeepCity_SpaceCenter_2F/scripts.inc
@@ -12,7 +12,7 @@
 MossdeepCity_SpaceCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, MossdeepCity_SpaceCenter_2F_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, MossdeepCity_SpaceCenter_2F_OnFrame
-	.byte 0
+	end_map_scripts
 
 MossdeepCity_SpaceCenter_2F_OnTransition:
 	call_if_eq VAR_MOSSDEEP_CITY_STATE, 2, MossdeepCity_SpaceCenter_2F_EventScript_MoveCivilians
@@ -37,7 +37,7 @@ MossdeepCity_SpaceCenter_2F_EventScript_MoveDefeatedGrunts::
 
 MossdeepCity_SpaceCenter_2F_OnFrame:
 	map_script_2 VAR_MOSSDEEP_SPACE_CENTER_STATE, 1, MossdeepCity_SpaceCenter_2F_EventScript_ThreeMagmaGrunts
-	.2byte 0
+	end_map_script_table
 
 MossdeepCity_SpaceCenter_2F_EventScript_ThreeMagmaGrunts::
 	playse SE_PIN

--- a/data/maps/MossdeepCity_StevensHouse/scripts.inc
+++ b/data/maps/MossdeepCity_StevensHouse/scripts.inc
@@ -5,7 +5,7 @@ MossdeepCity_StevensHouse_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, MossdeepCity_StevensHouse_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, MossdeepCity_StevensHouse_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, MossdeepCity_StevensHouse_OnFrame
-	.byte 0
+	end_map_scripts
 
 MossdeepCity_StevensHouse_OnLoad:
 	call_if_unset FLAG_SYS_GAME_CLEAR, MossdeepCity_StevensHouse_EventScript_HideStevensNote
@@ -26,7 +26,7 @@ MossdeepCity_StevensHouse_EventScript_SetStevenPos::
 
 MossdeepCity_StevensHouse_OnFrame:
 	map_script_2 VAR_STEVENS_HOUSE_STATE, 1, MossdeepCity_StevensHouse_EventScript_StevenGivesDive
-	.2byte 0
+	end_map_script_table
 
 MossdeepCity_StevensHouse_EventScript_StevenGivesDive::
 	lockall

--- a/data/maps/MtChimney/scripts.inc
+++ b/data/maps/MtChimney/scripts.inc
@@ -8,7 +8,7 @@
 MtChimney_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, MtChimney_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, MtChimney_OnTransition
-	.byte 0
+	end_map_scripts
 
 MtChimney_OnTransition:
 	setvar VAR_JAGGED_PASS_ASH_WEATHER, 1

--- a/data/maps/MtChimney_CableCarStation/scripts.inc
+++ b/data/maps/MtChimney_CableCarStation/scripts.inc
@@ -3,7 +3,7 @@
 MtChimney_CableCarStation_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, MtChimney_CableCarStation_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, MtChimney_CableCarStation_OnFrame
-	.byte 0
+	end_map_scripts
 
 MtChimney_CableCarStation_OnTransition:
 	call_if_eq VAR_CABLE_CAR_STATION_STATE, 1, MtChimney_CableCarStation_EventScript_MoveAttendantAside
@@ -16,7 +16,7 @@ MtChimney_CableCarStation_EventScript_MoveAttendantAside::
 
 MtChimney_CableCarStation_OnFrame:
 	map_script_2 VAR_CABLE_CAR_STATION_STATE, 1, MtChimney_CableCarStation_EventScript_ExitCableCar
-	.2byte 0
+	end_map_script_table
 
 MtChimney_CableCarStation_EventScript_ExitCableCar::
 	lockall

--- a/data/maps/MtPyre_1F/scripts.inc
+++ b/data/maps/MtPyre_1F/scripts.inc
@@ -1,5 +1,5 @@
 MtPyre_1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MtPyre_1F_EventScript_CleanseTagWoman::
 	lock

--- a/data/maps/MtPyre_2F/scripts.inc
+++ b/data/maps/MtPyre_2F/scripts.inc
@@ -2,7 +2,7 @@ MtPyre_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, CaveHole_CheckFallDownHole
 	map_script MAP_SCRIPT_ON_TRANSITION, CaveHole_FixCrackedGround
 	map_script MAP_SCRIPT_ON_RESUME, MtPyre_2F_SetHoleWarp
-	.byte 0
+	end_map_scripts
 
 MtPyre_2F_SetHoleWarp:
 	setstepcallback STEP_CB_CRACKED_FLOOR

--- a/data/maps/MtPyre_3F/scripts.inc
+++ b/data/maps/MtPyre_3F/scripts.inc
@@ -1,5 +1,5 @@
 MtPyre_3F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MtPyre_3F_EventScript_William::
 	trainerbattle_single TRAINER_WILLIAM, MtPyre_3F_Text_WilliamIntro, MtPyre_3F_Text_WilliamDefeat

--- a/data/maps/MtPyre_4F/scripts.inc
+++ b/data/maps/MtPyre_4F/scripts.inc
@@ -1,5 +1,5 @@
 MtPyre_4F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 @ Seems like the scripts for the 4F and 5F were swapped
 

--- a/data/maps/MtPyre_5F/scripts.inc
+++ b/data/maps/MtPyre_5F/scripts.inc
@@ -1,5 +1,5 @@
 MtPyre_5F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 @ Seems like the scripts for the 4F and 5F were swapped
 

--- a/data/maps/MtPyre_6F/scripts.inc
+++ b/data/maps/MtPyre_6F/scripts.inc
@@ -1,5 +1,5 @@
 MtPyre_6F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 MtPyre_6F_EventScript_Valerie::
 	trainerbattle_single TRAINER_VALERIE_1, MtPyre_6F_Text_ValerieIntro, MtPyre_6F_Text_ValerieDefeat, MtPyre_6F_EventScript_RegisterValerie

--- a/data/maps/MtPyre_Exterior/scripts.inc
+++ b/data/maps/MtPyre_Exterior/scripts.inc
@@ -1,6 +1,6 @@
 MtPyre_Exterior_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, MtPyre_Exterior_OnTransition
-	.byte 0
+	end_map_scripts
 
 MtPyre_Exterior_OnTransition:
 	call MtPyre_Exterior_EventScript_CheckEnterFromSummit

--- a/data/maps/MtPyre_Summit/scripts.inc
+++ b/data/maps/MtPyre_Summit/scripts.inc
@@ -8,7 +8,7 @@
 
 MtPyre_Summit_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, MtPyre_Summit_OnTransition
-	.byte 0
+	end_map_scripts
 
 MtPyre_Summit_OnTransition:
 	call_if_eq VAR_MT_PYRE_STATE, 2, MtPyre_Summit_EventScript_SetArchieMaxiePositions

--- a/data/maps/NavelRock_B1F/scripts.inc
+++ b/data/maps/NavelRock_B1F/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_B1F_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Bottom/scripts.inc
+++ b/data/maps/NavelRock_Bottom/scripts.inc
@@ -3,7 +3,7 @@
 NavelRock_Bottom_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, NavelRock_Bottom_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, NavelRock_Bottom_OnResume
-	.byte 0
+	end_map_scripts
 
 NavelRock_Bottom_OnTransition:
 	call_if_set FLAG_CAUGHT_LUGIA, NavelRock_Bottom_EventScript_HideLugia

--- a/data/maps/NavelRock_Down01/scripts.inc
+++ b/data/maps/NavelRock_Down01/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Down01_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Down02/scripts.inc
+++ b/data/maps/NavelRock_Down02/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Down02_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Down03/scripts.inc
+++ b/data/maps/NavelRock_Down03/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Down03_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Down04/scripts.inc
+++ b/data/maps/NavelRock_Down04/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Down04_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Down05/scripts.inc
+++ b/data/maps/NavelRock_Down05/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Down05_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Down06/scripts.inc
+++ b/data/maps/NavelRock_Down06/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Down06_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Down07/scripts.inc
+++ b/data/maps/NavelRock_Down07/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Down07_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Down08/scripts.inc
+++ b/data/maps/NavelRock_Down08/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Down08_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Down09/scripts.inc
+++ b/data/maps/NavelRock_Down09/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Down09_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Down10/scripts.inc
+++ b/data/maps/NavelRock_Down10/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Down10_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Down11/scripts.inc
+++ b/data/maps/NavelRock_Down11/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Down11_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Entrance/scripts.inc
+++ b/data/maps/NavelRock_Entrance/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Entrance_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Exterior/scripts.inc
+++ b/data/maps/NavelRock_Exterior/scripts.inc
@@ -1,6 +1,6 @@
 NavelRock_Exterior_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, NavelRock_Exterior_OnTransition
-	.byte 0
+	end_map_scripts
 
 NavelRock_Exterior_OnTransition:
 	setflag FLAG_ARRIVED_AT_NAVEL_ROCK

--- a/data/maps/NavelRock_Fork/scripts.inc
+++ b/data/maps/NavelRock_Fork/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Fork_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Harbor/scripts.inc
+++ b/data/maps/NavelRock_Harbor/scripts.inc
@@ -2,7 +2,7 @@
 .set LOCALID_SS_TIDAL, 2
 
 NavelRock_Harbor_MapScripts::
-	.byte 0
+	end_map_scripts
 
 NavelRock_Harbor_EventScript_Sailor::
 	lock

--- a/data/maps/NavelRock_Top/scripts.inc
+++ b/data/maps/NavelRock_Top/scripts.inc
@@ -3,7 +3,7 @@
 NavelRock_Top_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, NavelRock_Top_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, NavelRock_Top_OnResume
-	.byte 0
+	end_map_scripts
 
 NavelRock_Top_OnTransition:
 	call_if_set FLAG_CAUGHT_HO_OH, NavelRock_Top_EventScript_HideHoOh

--- a/data/maps/NavelRock_Up1/scripts.inc
+++ b/data/maps/NavelRock_Up1/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Up1_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Up2/scripts.inc
+++ b/data/maps/NavelRock_Up2/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Up2_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Up3/scripts.inc
+++ b/data/maps/NavelRock_Up3/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Up3_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NavelRock_Up4/scripts.inc
+++ b/data/maps/NavelRock_Up4/scripts.inc
@@ -1,3 +1,3 @@
 NavelRock_Up4_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/NewMauville_Entrance/scripts.inc
+++ b/data/maps/NewMauville_Entrance/scripts.inc
@@ -1,7 +1,7 @@
 NewMauville_Entrance_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, NewMauville_Entrance_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, NewMauville_Entrance_OnTransition
-	.byte 0
+	end_map_scripts
 
 NewMauville_Entrance_OnLoad:
 	call_if_eq VAR_NEW_MAUVILLE_STATE, 0, NewMauville_Entrance_EventScript_CloseDoor

--- a/data/maps/NewMauville_Inside/scripts.inc
+++ b/data/maps/NewMauville_Inside/scripts.inc
@@ -2,7 +2,7 @@ NewMauville_Inside_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, NewMauville_Inside_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, NewMauville_Inside_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, NewMauville_Inside_OnLoad
-	.byte 0
+	end_map_scripts
 
 NewMauville_Inside_OnResume:
 	call_if_eq VAR_TEMP_1, 1, NewMauville_Inside_EventScript_SetBarrierStateBlueButton

--- a/data/maps/OldaleTown/scripts.inc
+++ b/data/maps/OldaleTown/scripts.inc
@@ -4,7 +4,7 @@
 
 OldaleTown_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, OldaleTown_OnTransition
-	.byte 0
+	end_map_scripts
 
 OldaleTown_OnTransition:
 	call Common_EventScript_SetupRivalGfxId

--- a/data/maps/OldaleTown_House1/scripts.inc
+++ b/data/maps/OldaleTown_House1/scripts.inc
@@ -1,5 +1,5 @@
 OldaleTown_House1_MapScripts::
-	.byte 0
+	end_map_scripts
 
 OldaleTown_House1_EventScript_Woman::
 	msgbox OldaleTown_House1_Text_LeftPokemonGoesOutFirst, MSGBOX_NPC

--- a/data/maps/OldaleTown_House2/scripts.inc
+++ b/data/maps/OldaleTown_House2/scripts.inc
@@ -1,5 +1,5 @@
 OldaleTown_House2_MapScripts::
-	.byte 0
+	end_map_scripts
 
 OldaleTown_House2_EventScript_Woman::
 	msgbox OldaleTown_House2_Text_PokemonLevelUp, MSGBOX_NPC

--- a/data/maps/OldaleTown_Mart/scripts.inc
+++ b/data/maps/OldaleTown_Mart/scripts.inc
@@ -1,5 +1,5 @@
 OldaleTown_Mart_MapScripts::
-	.byte 0
+	end_map_scripts
 
 OldaleTown_Mart_EventScript_Clerk::
 	lock

--- a/data/maps/OldaleTown_PokemonCenter_1F/scripts.inc
+++ b/data/maps/OldaleTown_PokemonCenter_1F/scripts.inc
@@ -3,7 +3,7 @@
 OldaleTown_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, OldaleTown_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 OldaleTown_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_OLDALE_TOWN

--- a/data/maps/OldaleTown_PokemonCenter_2F/scripts.inc
+++ b/data/maps/OldaleTown_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ OldaleTown_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 OldaleTown_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/PacifidlogTown/scripts.inc
+++ b/data/maps/PacifidlogTown/scripts.inc
@@ -1,7 +1,7 @@
 PacifidlogTown_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, PacifidlogTown_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, PacifidlogTown_OnResume
-	.byte 0
+	end_map_scripts
 
 PacifidlogTown_OnTransition:
 	setflag FLAG_VISITED_PACIFIDLOG_TOWN

--- a/data/maps/PacifidlogTown_House1/scripts.inc
+++ b/data/maps/PacifidlogTown_House1/scripts.inc
@@ -1,5 +1,5 @@
 PacifidlogTown_House1_MapScripts::
-	.byte 0
+	end_map_scripts
 
 PacifidlogTown_House1_EventScript_Man::
 	msgbox PacifidlogTown_House1_Text_RegiStory, MSGBOX_NPC

--- a/data/maps/PacifidlogTown_House2/scripts.inc
+++ b/data/maps/PacifidlogTown_House2/scripts.inc
@@ -1,5 +1,5 @@
 PacifidlogTown_House2_MapScripts::
-	.byte 0
+	end_map_scripts
 
 PacifidlogTown_House2_EventScript_FanClubYoungerBrother::
 	lock

--- a/data/maps/PacifidlogTown_House3/scripts.inc
+++ b/data/maps/PacifidlogTown_House3/scripts.inc
@@ -1,5 +1,5 @@
 PacifidlogTown_House3_MapScripts::
-	.byte 0
+	end_map_scripts
 
 PacifidlogTown_House3_EventScript_Trader::
 	lock

--- a/data/maps/PacifidlogTown_House4/scripts.inc
+++ b/data/maps/PacifidlogTown_House4/scripts.inc
@@ -1,5 +1,5 @@
 PacifidlogTown_House4_MapScripts::
-	.byte 0
+	end_map_scripts
 
 PacifidlogTown_House4_EventScript_LittleGirl::
 	msgbox PacifidlogTown_House4_Text_SkyPokemon, MSGBOX_NPC

--- a/data/maps/PacifidlogTown_House5/scripts.inc
+++ b/data/maps/PacifidlogTown_House5/scripts.inc
@@ -1,5 +1,5 @@
 PacifidlogTown_House5_MapScripts::
-	.byte 0
+	end_map_scripts
 
 PacifidlogTown_House5_EventScript_MirageIslandWatcher::
 	lock

--- a/data/maps/PacifidlogTown_PokemonCenter_1F/scripts.inc
+++ b/data/maps/PacifidlogTown_PokemonCenter_1F/scripts.inc
@@ -3,7 +3,7 @@
 PacifidlogTown_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, PacifidlogTown_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 PacifidlogTown_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_PACIFIDLOG_TOWN

--- a/data/maps/PacifidlogTown_PokemonCenter_2F/scripts.inc
+++ b/data/maps/PacifidlogTown_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ PacifidlogTown_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 PacifidlogTown_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/PetalburgCity/scripts.inc
+++ b/data/maps/PetalburgCity/scripts.inc
@@ -7,7 +7,7 @@
 PetalburgCity_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, PetalburgCity_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, PetalburgCity_OnFrame
-	.byte 0
+	end_map_scripts
 
 PetalburgCity_OnTransition:
 	setflag FLAG_VISITED_PETALBURG_CITY
@@ -33,7 +33,7 @@ PetalburgCity_EventScript_SetGymDoorsUnlocked::
 PetalburgCity_OnFrame:
 	map_script_2 VAR_PETALBURG_CITY_STATE, 2, PetalburgCity_EventScript_WallyTutorial
 	map_script_2 VAR_PETALBURG_CITY_STATE, 4, PetalburgCity_EventScript_WalkToWallyHouse
-	.2byte 0
+	end_map_script_table
 
 PetalburgCity_EventScript_WallyTutorial::
 	lockall

--- a/data/maps/PetalburgCity_Gym/scripts.inc
+++ b/data/maps/PetalburgCity_Gym/scripts.inc
@@ -7,7 +7,7 @@ PetalburgCity_Gym_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, PetalburgCity_Gym_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, PetalburgCity_Gym_OnWarp
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, PetalburgCity_Gym_OnFrame
-	.byte 0
+	end_map_scripts
 
 PetalburgCity_Gym_OnLoad:
 	goto_if_eq VAR_PETALBURG_GYM_STATE, 6, PetalburgCity_Gym_EventScript_OpenUnlockedDoors
@@ -67,7 +67,7 @@ PetalburgCity_Gym_EventScript_DontMoveNormanToFront::
 
 PetalburgCity_Gym_OnWarp:
 	map_script_2 VAR_PETALBURG_GYM_STATE, 1, PetalburgCity_Gym_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 PetalburgCity_Gym_EventScript_TurnPlayerNorth::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_NORTH
@@ -75,7 +75,7 @@ PetalburgCity_Gym_EventScript_TurnPlayerNorth::
 
 PetalburgCity_Gym_OnFrame:
 	map_script_2 VAR_PETALBURG_GYM_STATE, 1, PetalburgCity_Gym_EventScript_ReturnFromWallyTutorial
-	.2byte 0
+	end_map_script_table
 
 PetalburgCity_Gym_EventScript_ReturnFromWallyTutorial::
 	lockall

--- a/data/maps/PetalburgCity_House1/scripts.inc
+++ b/data/maps/PetalburgCity_House1/scripts.inc
@@ -1,5 +1,5 @@
 PetalburgCity_House1_MapScripts::
-	.byte 0
+	end_map_scripts
 
 PetalburgCity_House1_EventScript_Man::
 	msgbox PetalburgCity_House1_Text_TravelingIsWonderful, MSGBOX_NPC

--- a/data/maps/PetalburgCity_House2/scripts.inc
+++ b/data/maps/PetalburgCity_House2/scripts.inc
@@ -1,5 +1,5 @@
 PetalburgCity_House2_MapScripts::
-	.byte 0
+	end_map_scripts
 
 PetalburgCity_House2_EventScript_Woman::
 	msgbox PetalburgCity_House2_Text_NormanBecameGymLeader, MSGBOX_NPC

--- a/data/maps/PetalburgCity_Mart/scripts.inc
+++ b/data/maps/PetalburgCity_Mart/scripts.inc
@@ -1,5 +1,5 @@
 PetalburgCity_Mart_MapScripts::
-	.byte 0
+	end_map_scripts
 
 PetalburgCity_Mart_EventScript_Clerk::
 	lock

--- a/data/maps/PetalburgCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/PetalburgCity_PokemonCenter_1F/scripts.inc
@@ -3,7 +3,7 @@
 PetalburgCity_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, PetalburgCity_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 PetalburgCity_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_PETALBURG_CITY

--- a/data/maps/PetalburgCity_PokemonCenter_2F/scripts.inc
+++ b/data/maps/PetalburgCity_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ PetalburgCity_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 PetalburgCity_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/PetalburgCity_WallysHouse/scripts.inc
+++ b/data/maps/PetalburgCity_WallysHouse/scripts.inc
@@ -3,11 +3,11 @@
 PetalburgCity_WallysHouse_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, PetalburgCity_WallysHouse_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, PetalburgCity_WallysHouse_OnWarp
-	.byte 0
+	end_map_scripts
 
 PetalburgCity_WallysHouse_OnWarp:
 	map_script_2 VAR_PETALBURG_CITY_STATE, 4, PetalburgCity_WallysHouse_EventScript_PlayerWallysDadFaceEachOther
-	.2byte 0
+	end_map_script_table
 
 PetalburgCity_WallysHouse_EventScript_PlayerWallysDadFaceEachOther::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_EAST
@@ -16,7 +16,7 @@ PetalburgCity_WallysHouse_EventScript_PlayerWallysDadFaceEachOther::
 
 PetalburgCity_WallysHouse_OnFrame:
 	map_script_2 VAR_PETALBURG_CITY_STATE, 4, PetalburgCity_WallysHouse_EventScript_GiveHM03Surf
-	.2byte 0
+	end_map_script_table
 
 PetalburgCity_WallysHouse_EventScript_GiveHM03Surf::
 	lockall

--- a/data/maps/PetalburgWoods/scripts.inc
+++ b/data/maps/PetalburgWoods/scripts.inc
@@ -2,7 +2,7 @@
 .set LOCALID_DEVON_EMPLOYEE, 4
 
 PetalburgWoods_MapScripts::
-	.byte 0
+	end_map_scripts
 
 PetalburgWoods_EventScript_DevonResearcherLeft::
 	lockall

--- a/data/maps/RecordCorner/scripts.inc
+++ b/data/maps/RecordCorner/scripts.inc
@@ -1,3 +1,3 @@
 RecordCorner_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/Route101/scripts.inc
+++ b/data/maps/Route101/scripts.inc
@@ -4,7 +4,7 @@
 Route101_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route101_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route101_OnFrame
-	.byte 0
+	end_map_scripts
 
 Route101_OnTransition:
 	call ProfBirch_EventScript_UpdateLocation
@@ -12,7 +12,7 @@ Route101_OnTransition:
 
 Route101_OnFrame:
 	map_script_2 VAR_ROUTE101_STATE, 0, Route101_EventScript_HideMapNamePopup
-	.2byte 0
+	end_map_script_table
 
 Route101_EventScript_HideMapNamePopup::
 	setflag FLAG_HIDE_MAP_NAME_POPUP

--- a/data/maps/Route102/scripts.inc
+++ b/data/maps/Route102/scripts.inc
@@ -1,5 +1,5 @@
 Route102_MapScripts::
-	.byte 0
+	end_map_scripts
 
 Route102_EventScript_LittleBoy::
 	msgbox Route102_Text_ImNotVeryTall, MSGBOX_NPC

--- a/data/maps/Route103/scripts.inc
+++ b/data/maps/Route103/scripts.inc
@@ -3,7 +3,7 @@
 Route103_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route103_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, Route103_OnLoad
-	.byte 0
+	end_map_scripts
 
 Route103_OnTransition:
 	call Common_EventScript_SetupRivalGfxId

--- a/data/maps/Route104/scripts.inc
+++ b/data/maps/Route104/scripts.inc
@@ -5,11 +5,11 @@
 Route104_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route104_OnFrame
 	map_script MAP_SCRIPT_ON_TRANSITION, Route104_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route104_OnFrame:
 	map_script_2 VAR_BOARD_BRINEY_BOAT_STATE, 1, Route104_EventScript_StartSailToDewford
-	.2byte 0
+	end_map_script_table
 
 Route104_EventScript_StartSailToDewford::
 	lockall

--- a/data/maps/Route104_MrBrineysHouse/scripts.inc
+++ b/data/maps/Route104_MrBrineysHouse/scripts.inc
@@ -3,7 +3,7 @@
 
 Route104_MrBrineysHouse_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route104_MrBrineysHouse_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route104_MrBrineysHouse_OnTransition:
 	setflag FLAG_LANDMARK_MR_BRINEY_HOUSE

--- a/data/maps/Route104_PrettyPetalFlowerShop/scripts.inc
+++ b/data/maps/Route104_PrettyPetalFlowerShop/scripts.inc
@@ -2,7 +2,7 @@
 
 Route104_PrettyPetalFlowerShop_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route104_PrettyPetalFlowerShop_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route104_PrettyPetalFlowerShop_OnTransition:
 	setflag FLAG_LANDMARK_FLOWER_SHOP

--- a/data/maps/Route104_Prototype/scripts.inc
+++ b/data/maps/Route104_Prototype/scripts.inc
@@ -1,3 +1,3 @@
 Route104_Prototype_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/Route104_PrototypePrettyPetalFlowerShop/scripts.inc
+++ b/data/maps/Route104_PrototypePrettyPetalFlowerShop/scripts.inc
@@ -1,3 +1,3 @@
 Route104_PrototypePrettyPetalFlowerShop_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/Route105/scripts.inc
+++ b/data/maps/Route105/scripts.inc
@@ -2,7 +2,7 @@ Route105_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, Route105_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, Route105_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route105_OnFrame
-	.byte 0
+	end_map_scripts
 
 Route105_OnLoad:
 	call_if_unset FLAG_REGI_DOORS_OPENED, Route105_CloseRegiEntrance
@@ -23,7 +23,7 @@ Route105_OnTransition:
 
 Route105_OnFrame:
 	map_script_2 VAR_SHOULD_END_ABNORMAL_WEATHER, 1, AbnormalWeather_EventScript_EndEventAndCleanup_1
-	.2byte 0
+	end_map_script_table
 
 Route105_EventScript_Foster::
 	trainerbattle_single TRAINER_FOSTER, Route105_Text_FosterIntro, Route105_Text_FosterDefeated

--- a/data/maps/Route106/scripts.inc
+++ b/data/maps/Route106/scripts.inc
@@ -1,5 +1,5 @@
 Route106_MapScripts::
-	.byte 0
+	end_map_scripts
 
 Route106_EventScript_TrainerTipsSign::
 	msgbox Route106_Text_TrainerTips, MSGBOX_SIGN

--- a/data/maps/Route107/scripts.inc
+++ b/data/maps/Route107/scripts.inc
@@ -1,5 +1,5 @@
 Route107_MapScripts::
-	.byte 0
+	end_map_scripts
 
 Route107_EventScript_Darrin::
 	trainerbattle_single TRAINER_DARRIN, Route107_Text_DarrinIntro, Route107_Text_DarrinDefeated

--- a/data/maps/Route108/scripts.inc
+++ b/data/maps/Route108/scripts.inc
@@ -1,5 +1,5 @@
 Route108_MapScripts::
-	.byte 0
+	end_map_scripts
 
 Route108_EventScript_Jerome::
 	trainerbattle_single TRAINER_JEROME, Route108_Text_JeromeIntro, Route108_Text_JeromeDefeated

--- a/data/maps/Route109/scripts.inc
+++ b/data/maps/Route109/scripts.inc
@@ -2,7 +2,7 @@
 @  These are labeled in DewfordTown/scripts.inc
 
 Route109_MapScripts::
-	.byte 0
+	end_map_scripts
 
 Route109_EventScript_StartDepartForDewford::
 	call EventScript_BackupMrBrineyLocation

--- a/data/maps/Route109_SeashoreHouse/scripts.inc
+++ b/data/maps/Route109_SeashoreHouse/scripts.inc
@@ -1,6 +1,6 @@
 Route109_SeashoreHouse_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route109_SeashoreHouse_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route109_SeashoreHouse_OnTransition:
 	setflag FLAG_LANDMARK_SEASHORE_HOUSE

--- a/data/maps/Route110/scripts.inc
+++ b/data/maps/Route110/scripts.inc
@@ -7,7 +7,7 @@ Route110_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Route110_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, Route110_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route110_OnFrame
-	.byte 0
+	end_map_scripts
 
 Route110_OnResume:
 	special UpdateCyclingRoadState
@@ -25,7 +25,7 @@ Route110_EventScript_SaveCyclingMusic::
 
 Route110_OnFrame:
 	map_script_2 VAR_CYCLING_CHALLENGE_STATE, 1, Route110_EventScript_BeginCylcingRoadChallenge
-	.2byte 0
+	end_map_script_table
 
 Route110_EventScript_BeginCylcingRoadChallenge::
 	special Special_BeginCyclingRoadChallenge

--- a/data/maps/Route110_SeasideCyclingRoadNorthEntrance/scripts.inc
+++ b/data/maps/Route110_SeasideCyclingRoadNorthEntrance/scripts.inc
@@ -1,5 +1,5 @@
 Route110_SeasideCyclingRoadNorthEntrance_MapScripts::
-	.byte 0
+	end_map_scripts
 
 Route110_SeasideCyclingRoadNorthEntrance_EventScript_Clerk::
 	lock

--- a/data/maps/Route110_SeasideCyclingRoadSouthEntrance/scripts.inc
+++ b/data/maps/Route110_SeasideCyclingRoadSouthEntrance/scripts.inc
@@ -1,6 +1,6 @@
 Route110_SeasideCyclingRoadSouthEntrance_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route110_SeasideCyclingRoadSouthEntrance_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route110_SeasideCyclingRoadSouthEntrance_OnTransition:
 	call_if_eq VAR_CYCLING_CHALLENGE_STATE, 3, Route110_SeasideCyclingRoadSouthEntrance_EventScript_RestartChallenge

--- a/data/maps/Route110_TrickHouseCorridor/scripts.inc
+++ b/data/maps/Route110_TrickHouseCorridor/scripts.inc
@@ -1,6 +1,6 @@
 Route110_TrickHouseCorridor_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route110_TrickHouseCorridor_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route110_TrickHouseCorridor_OnTransition:
 	setvar VAR_TRICK_HOUSE_ENTER_FROM_CORRIDOR, 1

--- a/data/maps/Route110_TrickHouseEnd/scripts.inc
+++ b/data/maps/Route110_TrickHouseEnd/scripts.inc
@@ -5,7 +5,7 @@ Route110_TrickHouseEnd_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route110_TrickHouseEnd_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route110_TrickHouseEnd_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, Route110_TrickHouseEnd_OnWarp
-	.byte 0
+	end_map_scripts
 
 Route110_TrickHouseEnd_OnResume:
 	call_if_eq VAR_TEMP_1, 1, Route110_TrickHouseEnd_EventScript_SetDoorClosedMetatile
@@ -19,7 +19,7 @@ Route110_TrickHouseEnd_OnTransition:
 
 Route110_TrickHouseEnd_OnWarp:
 	map_script_2 VAR_TEMP_2, 0, Route110_TrickHouseEnd_EventScript_SetTrickMasterPos
-	.2byte 0
+	end_map_script_table
 
 Route110_TrickHouseEnd_EventScript_SetTrickMasterPos::
 	addobject LOCALID_TRICK_MASTER
@@ -29,7 +29,7 @@ Route110_TrickHouseEnd_EventScript_SetTrickMasterPos::
 
 Route110_TrickHouseEnd_OnFrame:
 	map_script_2 VAR_TEMP_1, 0, Route110_TrickHouseEnd_EventScript_CloseDoor
-	.2byte 0
+	end_map_script_table
 
 Route110_TrickHouseEnd_EventScript_CloseDoor::
 	setvar VAR_TEMP_1, 1

--- a/data/maps/Route110_TrickHouseEntrance/scripts.inc
+++ b/data/maps/Route110_TrickHouseEntrance/scripts.inc
@@ -4,7 +4,7 @@ Route110_TrickHouseEntrance_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route110_TrickHouseEntrance_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route110_TrickHouseEntrance_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, Route110_TrickHouseEntrance_OnWarp
-	.byte 0
+	end_map_scripts
 
 	@ State descriptions for VAR_TRICK_HOUSE_ENTRANCE_STATE
 	@ 0: Trick Master is hiding
@@ -123,7 +123,7 @@ Route110_TrickHouseEntrance_OnWarp:
 	map_script_2 VAR_TRICK_HOUSE_ENTRANCE_STATE, 4, Route110_TrickHouseEntrance_EventScript_RemoveTrickMaster
 	map_script_2 VAR_TRICK_HOUSE_ENTRANCE_STATE, 5, Route110_TrickHouseEntrance_EventScript_RemoveTrickMaster
 	map_script_2 VAR_TRICK_HOUSE_ENTRANCE_STATE, 6, Route110_TrickHouseEntrance_EventScript_SetTrickMasterInFrontOfDoor
-	.2byte 0
+	end_map_script_table
 
 Route110_TrickHouseEntrance_EventScript_TrickMasterFound::
 	addobject LOCALID_TRICK_MASTER
@@ -196,7 +196,7 @@ Route110_TrickHouseEntrance_EventScript_SetTrickMasterInFrontOfDoor::
 
 Route110_TrickHouseEntrance_OnFrame:
 	map_script_2 VAR_TRICK_HOUSE_FOUND_TRICK_MASTER, 1, Route110_TrickHouseEntrance_EventScript_BeginChallenge
-	.2byte 0
+	end_map_script_table
 
 Route110_TrickHouseEntrance_EventScript_BeginChallenge::
 	lockall

--- a/data/maps/Route110_TrickHousePuzzle1/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle1/scripts.inc
@@ -1,6 +1,6 @@
 Route110_TrickHousePuzzle1_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, Route110_TrickHousePuzzle1_OnLoad
-	.byte 0
+	end_map_scripts
 
 Route110_TrickHousePuzzle1_OnLoad:
 	goto_if_eq VAR_TRICK_HOUSE_PUZZLE_1_STATE, 2, Route110_TrickHousePuzzle1_EventScript_OpenDoor

--- a/data/maps/Route110_TrickHousePuzzle2/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle2/scripts.inc
@@ -1,7 +1,7 @@
 Route110_TrickHousePuzzle2_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Route110_TrickHousePuzzle2_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, Route110_TrickHousePuzzle2_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route110_TrickHousePuzzle2_OnResume:
 	call_if_eq VAR_TEMP_1, 1, Route110_TrickHousePuzzle2_EventScript_PressButton1

--- a/data/maps/Route110_TrickHousePuzzle3/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle3/scripts.inc
@@ -1,7 +1,7 @@
 Route110_TrickHousePuzzle3_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Route110_TrickHousePuzzle3_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, Route110_TrickHousePuzzle3_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route110_TrickHousePuzzle3_OnResume:
 	call Route110_TrickHousePuzzle3_EventScript_UpdateButtonMetatiles

--- a/data/maps/Route110_TrickHousePuzzle4/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle4/scripts.inc
@@ -1,5 +1,5 @@
 Route110_TrickHousePuzzle4_MapScripts::
-	.byte 0
+	end_map_scripts
 
 Route110_TrickHousePuzzle4_EventScript_Scroll::
 	lockall

--- a/data/maps/Route110_TrickHousePuzzle5/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle5/scripts.inc
@@ -6,7 +6,7 @@
 
 Route110_TrickHousePuzzle5_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route110_TrickHousePuzzle5_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route110_TrickHousePuzzle5_OnTransition:
 	setvar VAR_TEMP_1, 0

--- a/data/maps/Route110_TrickHousePuzzle6/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle6/scripts.inc
@@ -1,7 +1,7 @@
 Route110_TrickHousePuzzle6_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route110_TrickHousePuzzle6_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, Route110_TrickHousePuzzle6_OnWarp
-	.byte 0
+	end_map_scripts
 
 Route110_TrickHousePuzzle6_OnTransition:
 	special RotatingGate_InitPuzzle
@@ -9,7 +9,7 @@ Route110_TrickHousePuzzle6_OnTransition:
 
 Route110_TrickHousePuzzle6_OnWarp:
 	map_script_2 VAR_TEMP_0, VAR_TEMP_0, Route110_TrickHousePuzzle6_EventScript_InitPuzzle
-	.2byte 0
+	end_map_script_table
 
 Route110_TrickHousePuzzle6_EventScript_InitPuzzle::
 	special RotatingGate_InitPuzzleAndGraphics

--- a/data/maps/Route110_TrickHousePuzzle7/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle7/scripts.inc
@@ -3,7 +3,7 @@ Route110_TrickHousePuzzle7_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route110_TrickHousePuzzle7_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, Route110_TrickHousePuzzle7_OnLoad
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route110_TrickHousePuzzle7_OnFrame
-	.byte 0
+	end_map_scripts
 
 @ Puzzle Room 7 in RSE uses whatever puzzle Mossdeep Gym uses
 @ Because Mossdeep Gym was redesigned for Emerald, theres a good deal of leftover script from the old R/S puzzle
@@ -89,7 +89,7 @@ Route110_TrickHousePuzzle7_OnLoad:
 
 Route110_TrickHousePuzzle7_OnFrame:
 	map_script_2 VAR_TRICK_HOUSE_PUZZLE_7_STATE_2, 1, Route110_TrickHousePuzzle7_EventScript_ClearState2
-	.2byte 0
+	end_map_script_table
 
 Route110_TrickHousePuzzle7_EventScript_ClearState2::
 	setvar VAR_TRICK_HOUSE_PUZZLE_7_STATE_2, 0

--- a/data/maps/Route110_TrickHousePuzzle8/scripts.inc
+++ b/data/maps/Route110_TrickHousePuzzle8/scripts.inc
@@ -1,5 +1,5 @@
 Route110_TrickHousePuzzle8_MapScripts::
-	.byte 0
+	end_map_scripts
 
 Route110_TrickHousePuzzle8_EventScript_Scroll::
 	lockall

--- a/data/maps/Route111/scripts.inc
+++ b/data/maps/Route111/scripts.inc
@@ -11,7 +11,7 @@ Route111_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route111_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, Route111_OnWarp
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route111_OnFrame
-	.byte 0
+	end_map_scripts
 
 Route111_OnLoad:
 	call_if_unset FLAG_REGI_DOORS_OPENED, Route111_EventScript_CloseDesertRuins
@@ -102,7 +102,7 @@ Route111_EventScript_SetMirageTowerGone::
 
 Route111_OnWarp:
 	map_script_2 VAR_MIRAGE_TOWER_STATE, 1, Route111_EventScript_HidePlayerForMirageTower
-	.2byte 0
+	end_map_script_table
 
 Route111_EventScript_HidePlayerForMirageTower::
 	hideobjectat OBJ_EVENT_ID_PLAYER, MAP_LITTLEROOT_TOWN
@@ -110,7 +110,7 @@ Route111_EventScript_HidePlayerForMirageTower::
 
 Route111_OnFrame:
 	map_script_2 VAR_MIRAGE_TOWER_STATE, 1, Route111_EventScript_MirageTowerDisappear
-	.2byte 0
+	end_map_script_table
 
 Route111_EventScript_MirageTowerDisappear::
 	lockall

--- a/data/maps/Route111_OldLadysRestStop/scripts.inc
+++ b/data/maps/Route111_OldLadysRestStop/scripts.inc
@@ -1,6 +1,6 @@
 Route111_OldLadysRestStop_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route111_OldLadysRestStop_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route111_OldLadysRestStop_OnTransition:
 	setflag FLAG_LANDMARK_OLD_LADY_REST_SHOP

--- a/data/maps/Route111_WinstrateFamilysHouse/scripts.inc
+++ b/data/maps/Route111_WinstrateFamilysHouse/scripts.inc
@@ -4,7 +4,7 @@
 .set LOCALID_VICKY, 4
 
 Route111_WinstrateFamilysHouse_MapScripts::
-	.byte 0
+	end_map_scripts
 
 Route111_WinstrateFamilysHouse_EventScript_Victor::
 	lock

--- a/data/maps/Route112/scripts.inc
+++ b/data/maps/Route112/scripts.inc
@@ -3,7 +3,7 @@
 
 Route112_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route112_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route112_OnTransition:
 	clearflag FLAG_FORCE_MIRAGE_TOWER_VISIBLE

--- a/data/maps/Route112_CableCarStation/scripts.inc
+++ b/data/maps/Route112_CableCarStation/scripts.inc
@@ -3,7 +3,7 @@
 Route112_CableCarStation_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route112_CableCarStation_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route112_CableCarStation_OnFrame
-	.byte 0
+	end_map_scripts
 
 Route112_CableCarStation_OnTransition:
 	setescapewarp MAP_ROUTE112, 28, 28
@@ -17,7 +17,7 @@ Route112_CableCarStation_EventScript_MoveAttendantAside::
 
 Route112_CableCarStation_OnFrame:
 	map_script_2 VAR_CABLE_CAR_STATION_STATE, 2, Route112_CableCarStation_EventScript_ExitCableCar
-	.2byte 0
+	end_map_script_table
 
 Route112_CableCarStation_EventScript_ExitCableCar::
 	lockall

--- a/data/maps/Route113/scripts.inc
+++ b/data/maps/Route113/scripts.inc
@@ -1,7 +1,7 @@
 Route113_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Route113_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, Route113_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route113_OnResume:
 	setstepcallback STEP_CB_ASH

--- a/data/maps/Route113_GlassWorkshop/scripts.inc
+++ b/data/maps/Route113_GlassWorkshop/scripts.inc
@@ -1,6 +1,6 @@
 Route113_GlassWorkshop_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route113_GlassWorkshop_OnTransition
-	.byte 0
+	end_map_scripts
 
 	.set BLUE_FLUTE_PRICE,   250
 	.set YELLOW_FLUTE_PRICE, 500

--- a/data/maps/Route114/scripts.inc
+++ b/data/maps/Route114/scripts.inc
@@ -2,7 +2,7 @@ Route114_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route114_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, Route114_OnLoad
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route114_OnFrame
-	.byte 0
+	end_map_scripts
 
 Route114_OnTransition:
 	call_if_eq VAR_SHOULD_END_ABNORMAL_WEATHER, 1, AbnormalWeather_EventScript_HideMapNamePopup
@@ -17,7 +17,7 @@ Route114_OnLoad:
 
 Route114_OnFrame:
 	map_script_2 VAR_SHOULD_END_ABNORMAL_WEATHER, 1, AbnormalWeather_EventScript_EndEventAndCleanup_1
-	.2byte 0
+	end_map_script_table
 
 Route114_EventScript_Man::
 	lock

--- a/data/maps/Route114_FossilManiacsHouse/scripts.inc
+++ b/data/maps/Route114_FossilManiacsHouse/scripts.inc
@@ -1,6 +1,6 @@
 Route114_FossilManiacsHouse_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route114_FossilManiacsHouse_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route114_FossilManiacsHouse_OnTransition:
 	setflag FLAG_LANDMARK_FOSSIL_MANIACS_HOUSE

--- a/data/maps/Route114_FossilManiacsTunnel/scripts.inc
+++ b/data/maps/Route114_FossilManiacsTunnel/scripts.inc
@@ -3,7 +3,7 @@
 Route114_FossilManiacsTunnel_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route114_FossilManiacsTunnel_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, Route114_FossilManiacsTunnel_OnLoad
-	.byte 0
+	end_map_scripts
 
 Route114_FossilManiacsTunnel_OnTransition:
 	call_if_set FLAG_SYS_GAME_CLEAR, Route114_FossilManiacsTunnel_EventScript_MoveFossilManiac

--- a/data/maps/Route114_LanettesHouse/scripts.inc
+++ b/data/maps/Route114_LanettesHouse/scripts.inc
@@ -1,6 +1,6 @@
 Route114_LanettesHouse_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route114_LanettesHouse_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route114_LanettesHouse_OnTransition:
 	setflag FLAG_LANDMARK_LANETTES_HOUSE

--- a/data/maps/Route115/scripts.inc
+++ b/data/maps/Route115/scripts.inc
@@ -2,7 +2,7 @@ Route115_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, Route115_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, Route115_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route115_OnFrame
-	.byte 0
+	end_map_scripts
 
 Route115_OnLoad:
 	call_if_eq VAR_ABNORMAL_WEATHER_LOCATION, ABNORMAL_WEATHER_ROUTE_115_WEST, AbnormalWeather_EventScript_PlaceTilesRoute115West
@@ -17,7 +17,7 @@ Route115_OnTransition:
 
 Route115_OnFrame:
 	map_script_2 VAR_SHOULD_END_ABNORMAL_WEATHER, 1, AbnormalWeather_EventScript_EndEventAndCleanup_1
-	.2byte 0
+	end_map_script_table
 
 Route115_EventScript_Woman::
 	msgbox Route115_Text_NeverKnowWhenCavePokemonWillAppear, MSGBOX_NPC

--- a/data/maps/Route116/scripts.inc
+++ b/data/maps/Route116/scripts.inc
@@ -5,7 +5,7 @@ Route116_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route116_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, Route116_OnLoad
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route116_OnFrame
-	.byte 0
+	end_map_scripts
 
 Route116_OnTransition:
 	call_if_set FLAG_RECOVERED_DEVON_GOODS, Route116_EventScript_SetWandasBoyfriendPos
@@ -25,7 +25,7 @@ Route116_OnLoad:
 
 Route116_OnFrame:
 	map_script_2 VAR_SHOULD_END_ABNORMAL_WEATHER, 1, AbnormalWeather_EventScript_EndEventAndCleanup_1
-	.2byte 0
+	end_map_script_table
 
 Route116_EventScript_WandasBoyfriend::
 	lock

--- a/data/maps/Route116_TunnelersRestHouse/scripts.inc
+++ b/data/maps/Route116_TunnelersRestHouse/scripts.inc
@@ -1,6 +1,6 @@
 Route116_TunnelersRestHouse_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route116_TunnelersRestHouse_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route116_TunnelersRestHouse_OnTransition:
 	setflag FLAG_LANDMARK_TUNNELERS_REST_HOUSE

--- a/data/maps/Route117/scripts.inc
+++ b/data/maps/Route117/scripts.inc
@@ -2,7 +2,7 @@
 
 Route117_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route117_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route117_OnTransition:
 	call Route117_EventScript_TryMoveDayCareMan

--- a/data/maps/Route117_PokemonDayCare/scripts.inc
+++ b/data/maps/Route117_PokemonDayCare/scripts.inc
@@ -1,6 +1,6 @@
 Route117_PokemonDayCare_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route117_PokemonDayCare_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route117_PokemonDayCare_OnTransition:
 	setflag FLAG_LANDMARK_POKEMON_DAYCARE

--- a/data/maps/Route118/scripts.inc
+++ b/data/maps/Route118/scripts.inc
@@ -4,7 +4,7 @@ Route118_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route118_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, Route118_OnLoad
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route118_OnFrame
-	.byte 0
+	end_map_scripts
 
 Route118_OnTransition:
 	call GabbyAndTy_EventScript_UpdateLocation
@@ -20,7 +20,7 @@ Route118_OnLoad:
 
 Route118_OnFrame:
 	map_script_2 VAR_SHOULD_END_ABNORMAL_WEATHER, 1, AbnormalWeather_EventScript_EndEventAndCleanup_1
-	.2byte 0
+	end_map_script_table
 
 Route118_EventScript_GoodRodFisherman::
 	lock

--- a/data/maps/Route119/scripts.inc
+++ b/data/maps/Route119/scripts.inc
@@ -5,7 +5,7 @@
 Route119_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Route119_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, Route119_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route119_OnResume:
 	call_if_set FLAG_SYS_CTRL_OBJ_DELETE, Route119_EventScript_TryRemoveKecleon

--- a/data/maps/Route119_House/scripts.inc
+++ b/data/maps/Route119_House/scripts.inc
@@ -1,5 +1,5 @@
 Route119_House_MapScripts::
-	.byte 0
+	end_map_scripts
 
 Route119_House_EventScript_Woman::
 	msgbox Route119_House_Text_RumorAboutCaveOfOrigin, MSGBOX_NPC

--- a/data/maps/Route119_WeatherInstitute_1F/scripts.inc
+++ b/data/maps/Route119_WeatherInstitute_1F/scripts.inc
@@ -2,7 +2,7 @@
 
 Route119_WeatherInstitute_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route119_WeatherInstitute_1F_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route119_WeatherInstitute_1F_OnTransition:
 	call_if_eq VAR_WEATHER_INSTITUTE_STATE, 0, Route119_WeatherInstitute_1F_EventScript_SetLittleBoyPos

--- a/data/maps/Route119_WeatherInstitute_2F/scripts.inc
+++ b/data/maps/Route119_WeatherInstitute_2F/scripts.inc
@@ -7,7 +7,7 @@
 
 Route119_WeatherInstitute_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route119_WeatherInstitute_2F_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route119_WeatherInstitute_2F_OnTransition:
 	call_if_eq VAR_WEATHER_INSTITUTE_STATE, 0, Route119_WeatherInstitute_2F_EventScript_SetScientistPosAquaHere

--- a/data/maps/Route120/scripts.inc
+++ b/data/maps/Route120/scripts.inc
@@ -6,7 +6,7 @@ Route120_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Route120_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, Route120_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, Route120_OnLoad
-	.byte 0
+	end_map_scripts
 
 Route120_OnResume:
 	call_if_set FLAG_SYS_CTRL_OBJ_DELETE, Route120_EventScript_RemoveKecleonObject

--- a/data/maps/Route121/scripts.inc
+++ b/data/maps/Route121/scripts.inc
@@ -3,7 +3,7 @@
 .set LOCALID_GRUNT_3, 14
 
 Route121_MapScripts::
-	.byte 0
+	end_map_scripts
 
 Route121_EventScript_Woman::
 	msgbox Route121_Text_AheadLoomsMtPyre, MSGBOX_NPC

--- a/data/maps/Route121_SafariZoneEntrance/scripts.inc
+++ b/data/maps/Route121_SafariZoneEntrance/scripts.inc
@@ -1,10 +1,10 @@
 Route121_SafariZoneEntrance_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route121_SafariZoneEntrance_OnFrame
-	.byte 0
+	end_map_scripts
 
 Route121_SafariZoneEntrance_OnFrame:
 	map_script_2 VAR_SAFARI_ZONE_STATE, 1, Route121_SafariZoneEntrance_EventScript_ExitSafariZone
-	.2byte 0
+	end_map_script_table
 
 Route121_SafariZoneEntrance_EventScript_ExitSafariZone::
 	lockall

--- a/data/maps/Route122/scripts.inc
+++ b/data/maps/Route122/scripts.inc
@@ -1,3 +1,3 @@
 Route122_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/Route123/scripts.inc
+++ b/data/maps/Route123/scripts.inc
@@ -1,6 +1,6 @@
 Route123_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route123_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route123_OnTransition:
 	special SetRoute123Weather

--- a/data/maps/Route123_BerryMastersHouse/scripts.inc
+++ b/data/maps/Route123_BerryMastersHouse/scripts.inc
@@ -1,6 +1,6 @@
 Route123_BerryMastersHouse_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route123_BerryMastersHouse_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route123_BerryMastersHouse_OnTransition:
 	setflag FLAG_LANDMARK_BERRY_MASTERS_HOUSE

--- a/data/maps/Route124/scripts.inc
+++ b/data/maps/Route124/scripts.inc
@@ -1,6 +1,6 @@
 Route124_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route124_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route124_OnTransition:
 	call_if_set FLAG_SYS_WEATHER_CTRL, Common_EventScript_SetAbnormalWeather

--- a/data/maps/Route124_DivingTreasureHuntersHouse/scripts.inc
+++ b/data/maps/Route124_DivingTreasureHuntersHouse/scripts.inc
@@ -1,6 +1,6 @@
 Route124_DivingTreasureHuntersHouse_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route124_DivingTreasureHuntersHouse_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route124_DivingTreasureHuntersHouse_OnTransition:
 	setflag FLAG_LANDMARK_HUNTERS_HOUSE

--- a/data/maps/Route125/scripts.inc
+++ b/data/maps/Route125/scripts.inc
@@ -2,7 +2,7 @@ Route125_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route125_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, Route125_OnLoad
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route125_OnFrame
-	.byte 0
+	end_map_scripts
 
 Route125_OnTransition:
 	call_if_set FLAG_SYS_WEATHER_CTRL, Common_EventScript_SetAbnormalWeather
@@ -18,7 +18,7 @@ Route125_OnLoad:
 
 Route125_OnFrame:
 	map_script_2 VAR_SHOULD_END_ABNORMAL_WEATHER, 1, AbnormalWeather_EventScript_EndEventAndCleanup_1
-	.2byte 0
+	end_map_script_table
 
 Route125_EventScript_Nolen::
 	trainerbattle_single TRAINER_NOLEN, Route125_Text_NolenIntro, Route125_Text_NolenDefeat

--- a/data/maps/Route126/scripts.inc
+++ b/data/maps/Route126/scripts.inc
@@ -1,6 +1,6 @@
 Route126_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route126_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route126_OnTransition:
 	call_if_set FLAG_SYS_WEATHER_CTRL, Common_EventScript_SetAbnormalWeather

--- a/data/maps/Route127/scripts.inc
+++ b/data/maps/Route127/scripts.inc
@@ -2,7 +2,7 @@ Route127_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route127_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, Route127_OnLoad
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route127_OnFrame
-	.byte 0
+	end_map_scripts
 
 Route127_OnTransition:
 	call_if_set FLAG_SYS_WEATHER_CTRL, Common_EventScript_SetAbnormalWeather
@@ -18,7 +18,7 @@ Route127_OnLoad:
 
 Route127_OnFrame:
 	map_script_2 VAR_SHOULD_END_ABNORMAL_WEATHER, 1, AbnormalWeather_EventScript_EndEventAndCleanup_1
-	.2byte 0
+	end_map_script_table
 
 Route127_EventScript_Camden::
 	trainerbattle_single TRAINER_CAMDEN, Route127_Text_CamdenIntro, Route127_Text_CamdenDefeat

--- a/data/maps/Route128/scripts.inc
+++ b/data/maps/Route128/scripts.inc
@@ -5,7 +5,7 @@
 Route128_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route128_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route128_OnFrame
-	.byte 0
+	end_map_scripts
 
 Route128_OnTransition:
 	call_if_set FLAG_SYS_WEATHER_CTRL, Common_EventScript_SetAbnormalWeather
@@ -13,7 +13,7 @@ Route128_OnTransition:
 
 Route128_OnFrame:
 	map_script_2 VAR_ROUTE128_STATE, 1, Route128_EventScript_KyogreAwakenedScene
-	.2byte 0
+	end_map_script_table
 
 Route128_EventScript_KyogreAwakenedScene::
 	lockall

--- a/data/maps/Route129/scripts.inc
+++ b/data/maps/Route129/scripts.inc
@@ -2,7 +2,7 @@ Route129_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route129_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, Route129_OnLoad
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, Route129_OnFrame
-	.byte 0
+	end_map_scripts
 
 Route129_OnLoad:
 	call_if_eq VAR_ABNORMAL_WEATHER_LOCATION, ABNORMAL_WEATHER_ROUTE_129_WEST, AbnormalWeather_EventScript_PlaceTilesRoute129West
@@ -22,7 +22,7 @@ Route129_EventScript_CheckSetAbnormalWeather::
 
 Route129_OnFrame:
 	map_script_2 VAR_SHOULD_END_ABNORMAL_WEATHER, 1, AbnormalWeather_EventScript_EndEventAndCleanup_1
-	.2byte 0
+	end_map_script_table
 
 Route129_EventScript_Chase::
 	trainerbattle_single TRAINER_CHASE, Route129_Text_ChaseIntro, Route129_Text_ChaseDefeat

--- a/data/maps/Route130/scripts.inc
+++ b/data/maps/Route130/scripts.inc
@@ -1,6 +1,6 @@
 Route130_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route130_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route130_OnTransition:
 	call_if_ge VAR_SOOTOPOLIS_CITY_STATE, 4, Route130_EventScript_CheckSetAbnormalWeather

--- a/data/maps/Route131/scripts.inc
+++ b/data/maps/Route131/scripts.inc
@@ -1,6 +1,6 @@
 Route131_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, Route131_OnTransition
-	.byte 0
+	end_map_scripts
 
 Route131_OnTransition:
 	call_if_ge VAR_SOOTOPOLIS_CITY_STATE, 4, Route131_EventScript_CheckSetAbnormalWeather

--- a/data/maps/Route132/scripts.inc
+++ b/data/maps/Route132/scripts.inc
@@ -1,5 +1,5 @@
 Route132_MapScripts::
-	.byte 0
+	end_map_scripts
 
 Route132_EventScript_Gilbert::
 	trainerbattle_single TRAINER_GILBERT, Route132_Text_GilbertIntro, Route132_Text_GilbertDefeat

--- a/data/maps/Route133/scripts.inc
+++ b/data/maps/Route133/scripts.inc
@@ -1,5 +1,5 @@
 Route133_MapScripts::
-	.byte 0
+	end_map_scripts
 
 Route133_EventScript_Franklin::
 	trainerbattle_single TRAINER_FRANKLIN, Route133_Text_FranklinIntro, Route133_Text_FranklinDefeat

--- a/data/maps/Route134/scripts.inc
+++ b/data/maps/Route134/scripts.inc
@@ -1,6 +1,6 @@
 Route134_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Route134_OnResume
-	.byte 0
+	end_map_scripts
 
 Route134_OnResume:
 	setdivewarp MAP_UNDERWATER_ROUTE134, 8, 6

--- a/data/maps/RustboroCity/scripts.inc
+++ b/data/maps/RustboroCity/scripts.inc
@@ -8,7 +8,7 @@
 RustboroCity_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, RustboroCity_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, RustboroCity_OnFrame
-	.byte 0
+	end_map_scripts
 
 RustboroCity_OnTransition:
 	setflag FLAG_VISITED_RUSTBORO_CITY
@@ -33,7 +33,7 @@ RustboroCity_EventScript_HideMapNamePopup::
 
 RustboroCity_OnFrame:
 	map_script_2 VAR_RUSTBORO_CITY_STATE, 6, RustboroCity_EventScript_ScientistAddMatchCall
-	.2byte 0
+	end_map_script_table
 
 RustboroCity_EventScript_ScientistAddMatchCall::
 	lockall

--- a/data/maps/RustboroCity_CuttersHouse/scripts.inc
+++ b/data/maps/RustboroCity_CuttersHouse/scripts.inc
@@ -1,5 +1,5 @@
 RustboroCity_CuttersHouse_MapScripts::
-	.byte 0
+	end_map_scripts
 
 RustboroCity_CuttersHouse_EventScript_Cutter::
 	lock

--- a/data/maps/RustboroCity_DevonCorp_1F/scripts.inc
+++ b/data/maps/RustboroCity_DevonCorp_1F/scripts.inc
@@ -2,7 +2,7 @@
 
 RustboroCity_DevonCorp_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, RustboroCity_DevonCorp_1F_OnTransition
-	.byte 0
+	end_map_scripts
 
 RustboroCity_DevonCorp_1F_OnTransition:
 	call_if_unset FLAG_RETURNED_DEVON_GOODS, RustboroCity_DevonCorp_1F_EventScript_BlockStairs

--- a/data/maps/RustboroCity_DevonCorp_2F/scripts.inc
+++ b/data/maps/RustboroCity_DevonCorp_2F/scripts.inc
@@ -2,7 +2,7 @@
 
 RustboroCity_DevonCorp_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, RustboroCity_DevonCorp_2F_OnTransition
-	.byte 0
+	end_map_scripts
 
 RustboroCity_DevonCorp_2F_OnTransition:
 	call_if_eq VAR_FOSSIL_RESURRECTION_STATE, 1, RustboroCity_DevonCorp_2F_EventScript_SetFossilReady

--- a/data/maps/RustboroCity_DevonCorp_3F/scripts.inc
+++ b/data/maps/RustboroCity_DevonCorp_3F/scripts.inc
@@ -4,7 +4,7 @@ RustboroCity_DevonCorp_3F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, RustboroCity_DevonCorp_3F_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, RustboroCity_DevonCorp_3F_OnWarp
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, RustboroCity_DevonCorp_3F_OnFrame
-	.byte 0
+	end_map_scripts
 
 RustboroCity_DevonCorp_3F_OnTransition:
 	call_if_eq VAR_DEVON_CORP_3F_STATE, 0, RustboroCity_DevonCorp_3F_EventScript_SetEmployeePos
@@ -17,7 +17,7 @@ RustboroCity_DevonCorp_3F_EventScript_SetEmployeePos::
 
 RustboroCity_DevonCorp_3F_OnWarp:
 	map_script_2 VAR_DEVON_CORP_3F_STATE, 0, RustboroCity_DevonCorp_3F_EventScript_PlayerFaceEast
-	.2byte 0
+	end_map_script_table
 
 RustboroCity_DevonCorp_3F_EventScript_PlayerFaceEast::
 	turnobject OBJ_EVENT_ID_PLAYER, DIR_EAST
@@ -25,7 +25,7 @@ RustboroCity_DevonCorp_3F_EventScript_PlayerFaceEast::
 
 RustboroCity_DevonCorp_3F_OnFrame:
 	map_script_2 VAR_DEVON_CORP_3F_STATE, 0, RustboroCity_DevonCorp_3F_EventScript_MeetPresident
-	.2byte 0
+	end_map_script_table
 
 RustboroCity_DevonCorp_3F_EventScript_MeetPresident::
 	lockall

--- a/data/maps/RustboroCity_Flat1_1F/scripts.inc
+++ b/data/maps/RustboroCity_Flat1_1F/scripts.inc
@@ -1,5 +1,5 @@
 RustboroCity_Flat1_1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 RustboroCity_Flat1_1F_EventScript_Man::
 	msgbox RustboroCity_Flat1_1F_Text_EveryPokemonHasAbility, MSGBOX_NPC

--- a/data/maps/RustboroCity_Flat1_2F/scripts.inc
+++ b/data/maps/RustboroCity_Flat1_2F/scripts.inc
@@ -1,7 +1,7 @@
 .set LOCALID_WALDAS_DAD, 6
 
 RustboroCity_Flat1_2F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 RustboroCity_Flat1_2F_EventScript_WaldasDad::
 	lock

--- a/data/maps/RustboroCity_Flat2_1F/scripts.inc
+++ b/data/maps/RustboroCity_Flat2_1F/scripts.inc
@@ -1,5 +1,5 @@
 RustboroCity_Flat2_1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 RustboroCity_Flat2_1F_EventScript_OldWoman::
 	msgbox RustboroCity_Flat2_1F_Text_DevonWorkersLiveHere, MSGBOX_NPC

--- a/data/maps/RustboroCity_Flat2_2F/scripts.inc
+++ b/data/maps/RustboroCity_Flat2_2F/scripts.inc
@@ -1,5 +1,5 @@
 RustboroCity_Flat2_2F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 RustboroCity_Flat2_2F_EventScript_OldMan::
 	msgbox RustboroCity_Flat2_2F_Text_DevonWasTinyInOldDays, MSGBOX_NPC

--- a/data/maps/RustboroCity_Flat2_3F/scripts.inc
+++ b/data/maps/RustboroCity_Flat2_3F/scripts.inc
@@ -1,5 +1,5 @@
 RustboroCity_Flat2_3F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 RustboroCity_Flat2_3F_EventScript_DevonEmployee::
 	msgbox RustboroCity_Flat2_3F_Text_PresidentCollectsRareStones, MSGBOX_NPC

--- a/data/maps/RustboroCity_Gym/scripts.inc
+++ b/data/maps/RustboroCity_Gym/scripts.inc
@@ -1,5 +1,5 @@
 RustboroCity_Gym_MapScripts::
-	.byte 0
+	end_map_scripts
 
 RustboroCity_Gym_EventScript_Roxanne::
 	trainerbattle_single TRAINER_ROXANNE_1, RustboroCity_Gym_Text_RoxanneIntro, RustboroCity_Gym_Text_RoxanneDefeat, RustboroCity_Gym_EventScript_RoxanneDefeated, NO_MUSIC

--- a/data/maps/RustboroCity_House1/scripts.inc
+++ b/data/maps/RustboroCity_House1/scripts.inc
@@ -1,5 +1,5 @@
 RustboroCity_House1_MapScripts::
-	.byte 0
+	end_map_scripts
 
 RustboroCity_House1_EventScript_Trader::
 	lock

--- a/data/maps/RustboroCity_House2/scripts.inc
+++ b/data/maps/RustboroCity_House2/scripts.inc
@@ -1,5 +1,5 @@
 RustboroCity_House2_MapScripts::
-	.byte 0
+	end_map_scripts
 
 RustboroCity_House2_EventScript_PokefanF::
 	msgbox RustboroCity_House2_Text_TrainerSchoolExcellent, MSGBOX_NPC

--- a/data/maps/RustboroCity_House3/scripts.inc
+++ b/data/maps/RustboroCity_House3/scripts.inc
@@ -1,5 +1,5 @@
 RustboroCity_House3_MapScripts::
-	.byte 0
+	end_map_scripts
 
 RustboroCity_House3_EventScript_OldMan::
 	msgbox RustboroCity_House3_Text_IGivePerfectlySuitedNicknames, MSGBOX_NPC

--- a/data/maps/RustboroCity_Mart/scripts.inc
+++ b/data/maps/RustboroCity_Mart/scripts.inc
@@ -1,5 +1,5 @@
 RustboroCity_Mart_MapScripts::
-	.byte 0
+	end_map_scripts
 
 RustboroCity_Mart_EventScript_Clerk::
 	lock

--- a/data/maps/RustboroCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/RustboroCity_PokemonCenter_1F/scripts.inc
@@ -3,7 +3,7 @@
 RustboroCity_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, RustboroCity_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 RustboroCity_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_RUSTBORO_CITY

--- a/data/maps/RustboroCity_PokemonCenter_2F/scripts.inc
+++ b/data/maps/RustboroCity_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ RustboroCity_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 RustboroCity_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/RustboroCity_PokemonSchool/scripts.inc
+++ b/data/maps/RustboroCity_PokemonSchool/scripts.inc
@@ -1,5 +1,5 @@
 RustboroCity_PokemonSchool_MapScripts::
-	.byte 0
+	end_map_scripts
 
 RustboroCity_PokemonSchool_EventScript_Blackboard::
 	lockall

--- a/data/maps/RusturfTunnel/scripts.inc
+++ b/data/maps/RusturfTunnel/scripts.inc
@@ -7,12 +7,12 @@
 RusturfTunnel_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, RusturfTunnel_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, RusturfTunnel_OnFrame
-	.byte 0
+	end_map_scripts
 
 RusturfTunnel_OnFrame:
 	map_script_2 VAR_RUSTURF_TUNNEL_STATE, 4, RusturfTunnel_EventScript_ClearTunnelScene
 	map_script_2 VAR_RUSTURF_TUNNEL_STATE, 5, RusturfTunnel_EventScript_ClearTunnelScene
-	.2byte 0
+	end_map_script_table
 
 RusturfTunnel_OnTransition:
 	call_if_eq VAR_RUSTURF_TUNNEL_STATE, 2, RusturfTunnel_EventScript_SetAquaGruntAndPeekoPos

--- a/data/maps/SSTidalCorridor/scripts.inc
+++ b/data/maps/SSTidalCorridor/scripts.inc
@@ -3,7 +3,7 @@
 
 SSTidalCorridor_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, SSTidalCorridor_OnFrame
-	.byte 0
+	end_map_scripts
 
 SSTidalCorridor_OnFrame:
 	map_script_2 VAR_SS_TIDAL_SCOTT_STATE, 0, SSTidalCorridor_EventScript_ScottScene
@@ -11,7 +11,7 @@ SSTidalCorridor_OnFrame:
 	map_script_2 VAR_SS_TIDAL_STATE, SS_TIDAL_BOARD_LILYCOVE, SSTidalCorridor_EventScript_DepartLilycoveForSlateport
 	map_script_2 VAR_SS_TIDAL_STATE, SS_TIDAL_EXIT_CURRENTS_RIGHT, SSTidalCorridor_EventScript_HalfwayToLilycove
 	map_script_2 VAR_SS_TIDAL_STATE, SS_TIDAL_EXIT_CURRENTS_LEFT, SSTidalCorridor_EventScript_ArrivedInSlateport
-	.2byte 0
+	end_map_script_table
 
 SSTidalCorridor_EventScript_DepartSlateportForLilycove::
 	special SetSSTidalFlag

--- a/data/maps/SSTidalLowerDeck/scripts.inc
+++ b/data/maps/SSTidalLowerDeck/scripts.inc
@@ -1,5 +1,5 @@
 SSTidalLowerDeck_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SSTidalLowerDeck_EventScript_Phillip::
 	trainerbattle_single TRAINER_PHILLIP, SSTidalLowerDeck_Text_PhillipIntro, SSTidalLowerDeck_Text_PhillipDefeat

--- a/data/maps/SSTidalRooms/scripts.inc
+++ b/data/maps/SSTidalRooms/scripts.inc
@@ -1,5 +1,5 @@
 SSTidalRooms_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SSTidalRooms_EventScript_SnatchGiver::
 	lock

--- a/data/maps/SafariZone_North/scripts.inc
+++ b/data/maps/SafariZone_North/scripts.inc
@@ -1,5 +1,5 @@
 SafariZone_North_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SafariZone_North_EventScript_Fisherman::
 	msgbox SafariZone_North_Text_Fisherman, MSGBOX_NPC

--- a/data/maps/SafariZone_Northeast/scripts.inc
+++ b/data/maps/SafariZone_Northeast/scripts.inc
@@ -1,4 +1,4 @@
 SafariZone_Northeast_MapScripts::
-	.byte 0
+	end_map_scripts
 
 @ Event scripts for SafariZone_Northeast are in SafariZone_South/scripts.inc

--- a/data/maps/SafariZone_Northwest/scripts.inc
+++ b/data/maps/SafariZone_Northwest/scripts.inc
@@ -1,5 +1,5 @@
 SafariZone_Northwest_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SafariZone_Northwest_EventScript_Man::
 	msgbox SafariZone_Northwest_Text_Man, MSGBOX_NPC

--- a/data/maps/SafariZone_RestHouse/scripts.inc
+++ b/data/maps/SafariZone_RestHouse/scripts.inc
@@ -1,5 +1,5 @@
 SafariZone_RestHouse_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SafariZone_RestHouse_EventScript_Youngster::
 	msgbox SafariZone_RestHouse_Text_Youngster, MSGBOX_NPC

--- a/data/maps/SafariZone_South/scripts.inc
+++ b/data/maps/SafariZone_South/scripts.inc
@@ -3,11 +3,11 @@
 SafariZone_South_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SafariZone_South_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, SafariZone_South_OnFrame
-	.byte 0
+	end_map_scripts
 
 SafariZone_South_OnFrame:
 	map_script_2 VAR_SAFARI_ZONE_STATE, 2, SafariZone_South_EventScript_EnterSafariZone
-	.2byte 0
+	end_map_script_table
 
 SafariZone_South_EventScript_EnterSafariZone::
 	lockall

--- a/data/maps/SafariZone_Southeast/scripts.inc
+++ b/data/maps/SafariZone_Southeast/scripts.inc
@@ -1,4 +1,4 @@
 SafariZone_Southeast_MapScripts::
-	.byte 0
+	end_map_scripts
 
 @ Event scripts for SafariZone_Southeast are in SafariZone_South/scripts.inc

--- a/data/maps/SafariZone_Southwest/scripts.inc
+++ b/data/maps/SafariZone_Southwest/scripts.inc
@@ -1,5 +1,5 @@
 SafariZone_Southwest_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SafariZone_Southwest_EventScript_Woman::
 	msgbox SafariZone_Southwest_Text_Woman, MSGBOX_NPC

--- a/data/maps/ScorchedSlab/scripts.inc
+++ b/data/maps/ScorchedSlab/scripts.inc
@@ -1,6 +1,6 @@
 ScorchedSlab_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, ScorchedSlab_OnTransition
-	.byte 0
+	end_map_scripts
 
 ScorchedSlab_OnTransition:
 	setflag FLAG_LANDMARK_SCORCHED_SLAB

--- a/data/maps/SeafloorCavern_Entrance/scripts.inc
+++ b/data/maps/SeafloorCavern_Entrance/scripts.inc
@@ -2,7 +2,7 @@
 
 SeafloorCavern_Entrance_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, SeafloorCavern_Entrance_OnResume
-	.byte 0
+	end_map_scripts
 
 SeafloorCavern_Entrance_OnResume:
 	setdivewarp MAP_UNDERWATER_SEAFLOOR_CAVERN, 6, 5

--- a/data/maps/SeafloorCavern_Room1/scripts.inc
+++ b/data/maps/SeafloorCavern_Room1/scripts.inc
@@ -1,5 +1,5 @@
 SeafloorCavern_Room1_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SeafloorCavern_Room1_EventScript_Grunt1::
 	trainerbattle_single TRAINER_GRUNT_SEAFLOOR_CAVERN_1, SeafloorCavern_Room1_Text_Grunt1Intro, SeafloorCavern_Room1_Text_Grunt1Defeat

--- a/data/maps/SeafloorCavern_Room2/scripts.inc
+++ b/data/maps/SeafloorCavern_Room2/scripts.inc
@@ -1,3 +1,3 @@
 SeafloorCavern_Room2_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/SeafloorCavern_Room3/scripts.inc
+++ b/data/maps/SeafloorCavern_Room3/scripts.inc
@@ -1,5 +1,5 @@
 SeafloorCavern_Room3_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SeafloorCavern_Room3_EventScript_Shelly::
 	trainerbattle_single TRAINER_SHELLY_SEAFLOOR_CAVERN, SeafloorCavern_Room3_Text_ShellyIntro, SeafloorCavern_Room3_Text_ShellyDefeat

--- a/data/maps/SeafloorCavern_Room4/scripts.inc
+++ b/data/maps/SeafloorCavern_Room4/scripts.inc
@@ -1,5 +1,5 @@
 SeafloorCavern_Room4_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SeafloorCavern_Room4_EventScript_Grunt3::
 	trainerbattle_single TRAINER_GRUNT_SEAFLOOR_CAVERN_3, SeafloorCavern_Room4_Text_Grunt3Intro, SeafloorCavern_Room4_Text_Grunt3Defeat

--- a/data/maps/SeafloorCavern_Room5/scripts.inc
+++ b/data/maps/SeafloorCavern_Room5/scripts.inc
@@ -1,3 +1,3 @@
 SeafloorCavern_Room5_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/SeafloorCavern_Room6/scripts.inc
+++ b/data/maps/SeafloorCavern_Room6/scripts.inc
@@ -1,3 +1,3 @@
 SeafloorCavern_Room6_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/SeafloorCavern_Room7/scripts.inc
+++ b/data/maps/SeafloorCavern_Room7/scripts.inc
@@ -1,3 +1,3 @@
 SeafloorCavern_Room7_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/SeafloorCavern_Room8/scripts.inc
+++ b/data/maps/SeafloorCavern_Room8/scripts.inc
@@ -1,3 +1,3 @@
 SeafloorCavern_Room8_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/SeafloorCavern_Room9/scripts.inc
+++ b/data/maps/SeafloorCavern_Room9/scripts.inc
@@ -6,7 +6,7 @@
 .set LOCALID_KYOGRE_SLEEPING, 7
 
 SeafloorCavern_Room9_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SeafloorCavern_Room9_EventScript_ArchieAwakenKyogre::
 	lockall

--- a/data/maps/SealedChamber_InnerRoom/scripts.inc
+++ b/data/maps/SealedChamber_InnerRoom/scripts.inc
@@ -1,5 +1,5 @@
 SealedChamber_InnerRoom_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SealedChamber_InnerRoom_EventScript_BrailleBackWall::
 	lockall

--- a/data/maps/SealedChamber_OuterRoom/scripts.inc
+++ b/data/maps/SealedChamber_OuterRoom/scripts.inc
@@ -2,7 +2,7 @@ SealedChamber_OuterRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, SealedChamber_OuterRoom_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, SealedChamber_OuterRoom_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, SealedChamber_OuterRoom_OnLoad
-	.byte 0
+	end_map_scripts
 
 SealedChamber_OuterRoom_OnResume:
 	setdivewarp MAP_UNDERWATER_SEALED_CHAMBER, 12, 44

--- a/data/maps/ShoalCave_HighTideEntranceRoom/scripts.inc
+++ b/data/maps/ShoalCave_HighTideEntranceRoom/scripts.inc
@@ -1,3 +1,3 @@
 ShoalCave_HighTideEntranceRoom_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/ShoalCave_HighTideInnerRoom/scripts.inc
+++ b/data/maps/ShoalCave_HighTideInnerRoom/scripts.inc
@@ -1,3 +1,3 @@
 ShoalCave_HighTideInnerRoom_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/ShoalCave_LowTideEntranceRoom/scripts.inc
+++ b/data/maps/ShoalCave_LowTideEntranceRoom/scripts.inc
@@ -1,6 +1,6 @@
 ShoalCave_LowTideEntranceRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, ShoalCave_LowTideEntranceRoom_OnTransition
-	.byte 0
+	end_map_scripts
 
 ShoalCave_LowTideEntranceRoom_OnTransition:
 	special UpdateShoalTideFlag

--- a/data/maps/ShoalCave_LowTideIceRoom/scripts.inc
+++ b/data/maps/ShoalCave_LowTideIceRoom/scripts.inc
@@ -1,3 +1,3 @@
 ShoalCave_LowTideIceRoom_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/ShoalCave_LowTideInnerRoom/scripts.inc
+++ b/data/maps/ShoalCave_LowTideInnerRoom/scripts.inc
@@ -1,7 +1,7 @@
 ShoalCave_LowTideInnerRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, ShoalCave_LowTideInnerRoom_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, ShoalCave_LowTideInnerRoom_OnTransition
-	.byte 0
+	end_map_scripts
 
 ShoalCave_LowTideInnerRoom_OnTransition:
 	goto_if_set FLAG_SYS_SHOAL_TIDE, ShoalCave_LowTideInnerRoom_EventScript_SetHighTide

--- a/data/maps/ShoalCave_LowTideLowerRoom/scripts.inc
+++ b/data/maps/ShoalCave_LowTideLowerRoom/scripts.inc
@@ -1,6 +1,6 @@
 ShoalCave_LowTideLowerRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, ShoalCave_LowTideLowerRoom_OnLoad
-	.byte 0
+	end_map_scripts
 
 ShoalCave_LowTideLowerRoom_OnLoad:
 	call ShoalCave_LowTideLowerRoom_EventScript_SetShoalItemMetatiles

--- a/data/maps/ShoalCave_LowTideStairsRoom/scripts.inc
+++ b/data/maps/ShoalCave_LowTideStairsRoom/scripts.inc
@@ -1,6 +1,6 @@
 ShoalCave_LowTideStairsRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_LOAD, ShoalCave_LowTideStairsRoom_OnLoad
-	.byte 0
+	end_map_scripts
 
 ShoalCave_LowTideStairsRoom_OnLoad:
 	call ShoalCave_LowTideStairsRoom_EventScript_SetShoalItemMetatiles

--- a/data/maps/SkyPillar_1F/scripts.inc
+++ b/data/maps/SkyPillar_1F/scripts.inc
@@ -1,6 +1,6 @@
 SkyPillar_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SkyPillar_1F_OnTransition
-	.byte 0
+	end_map_scripts
 
 SkyPillar_1F_OnTransition:
 	call_if_lt VAR_SKY_PILLAR_STATE, 2, SkyPillar_1F_EventScript_CleanFloor

--- a/data/maps/SkyPillar_2F/scripts.inc
+++ b/data/maps/SkyPillar_2F/scripts.inc
@@ -2,7 +2,7 @@ SkyPillar_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, CaveHole_CheckFallDownHole
 	map_script MAP_SCRIPT_ON_TRANSITION, SkyPillar_2F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, SkyPillar_2F_SetHoleWarp
-	.byte 0
+	end_map_scripts
 
 SkyPillar_2F_OnTransition:
 	call_if_lt VAR_SKY_PILLAR_STATE, 2, SkyPillar_2F_EventScript_CleanFloor

--- a/data/maps/SkyPillar_3F/scripts.inc
+++ b/data/maps/SkyPillar_3F/scripts.inc
@@ -1,6 +1,6 @@
 SkyPillar_3F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SkyPillar_3F_OnTransition
-	.byte 0
+	end_map_scripts
 
 SkyPillar_3F_OnTransition:
 	call_if_lt VAR_SKY_PILLAR_STATE, 2, SkyPillar_3F_EventScript_CleanFloor

--- a/data/maps/SkyPillar_4F/scripts.inc
+++ b/data/maps/SkyPillar_4F/scripts.inc
@@ -2,7 +2,7 @@ SkyPillar_4F_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, CaveHole_CheckFallDownHole
 	map_script MAP_SCRIPT_ON_TRANSITION, SkyPillar_4F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, SkyPillar_4F_SetHoleWarp
-	.byte 0
+	end_map_scripts
 
 SkyPillar_4F_OnTransition:
 	call_if_lt VAR_SKY_PILLAR_STATE, 2, SkyPillar_4F_EventScript_CleanFloor

--- a/data/maps/SkyPillar_5F/scripts.inc
+++ b/data/maps/SkyPillar_5F/scripts.inc
@@ -1,6 +1,6 @@
 SkyPillar_5F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SkyPillar_5F_OnTransition
-	.byte 0
+	end_map_scripts
 
 SkyPillar_5F_OnTransition:
 	call_if_lt VAR_SKY_PILLAR_STATE, 2, SkyPillar_5F_EventScript_CleanFloor

--- a/data/maps/SkyPillar_Entrance/scripts.inc
+++ b/data/maps/SkyPillar_Entrance/scripts.inc
@@ -1,6 +1,6 @@
 SkyPillar_Entrance_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SkyPillar_Entrance_OnTransition
-	.byte 0
+	end_map_scripts
 
 SkyPillar_Entrance_OnTransition:
 	setflag FLAG_LANDMARK_SKY_PILLAR

--- a/data/maps/SkyPillar_Outside/scripts.inc
+++ b/data/maps/SkyPillar_Outside/scripts.inc
@@ -4,7 +4,7 @@ SkyPillar_Outside_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SkyPillar_Outside_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, SkyPillar_Outside_OnLoad
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, SkyPillar_Outside_OnFrame
-	.byte 0
+	end_map_scripts
 
 SkyPillar_Outside_OnTransition:
 	call_if_eq VAR_SOOTOPOLIS_CITY_STATE, 3, SkyPillar_Outside_EventScript_HideMapNamePopup
@@ -30,7 +30,7 @@ SkyPillar_Outside_EventScript_OpenDoor::
 
 SkyPillar_Outside_OnFrame:
 	map_script_2 VAR_SOOTOPOLIS_CITY_STATE, 3, SkyPillar_Outside_EventScript_WallaceScene
-	.2byte 0
+	end_map_script_table
 
 SkyPillar_Outside_EventScript_WallaceScene::
 	lockall

--- a/data/maps/SkyPillar_Top/scripts.inc
+++ b/data/maps/SkyPillar_Top/scripts.inc
@@ -4,7 +4,7 @@ SkyPillar_Top_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, SkyPillar_Top_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, SkyPillar_Top_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, SkyPillar_Top_OnWarp
-	.byte 0
+	end_map_scripts
 
 SkyPillar_Top_OnResume:
 	call_if_set FLAG_SYS_CTRL_OBJ_DELETE, SkyPillar_Top_EventScript_TryRemoveRayquaza
@@ -36,7 +36,7 @@ SkyPillar_Top_EventScript_ShowRayquaza::
 
 SkyPillar_Top_OnWarp:
 	map_script_2 VAR_SKY_PILLAR_STATE, 0, SkyPillar_Top_EventScript_RayquazaFaceDown
-	.2byte 0
+	end_map_script_table
 
 SkyPillar_Top_EventScript_RayquazaFaceDown::
 	turnobject LOCALID_RAYQUAZA_SLEEPING, DIR_SOUTH

--- a/data/maps/SlateportCity/scripts.inc
+++ b/data/maps/SlateportCity/scripts.inc
@@ -24,7 +24,7 @@
 SlateportCity_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SlateportCity_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, SlateportCity_OnFrame
-	.byte 0
+	end_map_scripts
 
 SlateportCity_OnTransition:
 	setvar VAR_SLATEPORT_MUSEUM_1F_STATE, 0
@@ -71,7 +71,7 @@ SlateportCity_EventScript_MoveScottLeft::
 
 SlateportCity_OnFrame:
 	map_script_2 VAR_SLATEPORT_OUTSIDE_MUSEUM_STATE, 1, SlateportCity_EventScript_ScottScene
-	.2byte 0
+	end_map_script_table
 
 SlateportCity_EventScript_ScottScene::
 	lockall

--- a/data/maps/SlateportCity_BattleTentBattleRoom/scripts.inc
+++ b/data/maps/SlateportCity_BattleTentBattleRoom/scripts.inc
@@ -5,7 +5,7 @@ SlateportCity_BattleTentBattleRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SlateportCity_BattleTentBattleRoom_OnTransition
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, SlateportCity_BattleTentBattleRoom_OnWarp
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, SlateportCity_BattleTentBattleRoom_OnFrame
-	.byte 0
+	end_map_scripts
 
 	@ On this map the player (OBJ_EVENT_ID_PLAYER) is hidden
 	@ The player is represented instead by LOCALID_PLAYER, which has the gfx id VAR_OBJ_GFX_ID_1
@@ -30,7 +30,7 @@ SlateportCity_BattleTentBattleRoom_EventScript_SetPlayerGfxFemale::
 
 SlateportCity_BattleTentBattleRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, SlateportCity_BattleTentBattleRoom_EventScript_SetUpObjects
-	.2byte 0
+	end_map_script_table
 
 SlateportCity_BattleTentBattleRoom_EventScript_SetUpObjects::
 	setvar VAR_TEMP_1, 1
@@ -40,7 +40,7 @@ SlateportCity_BattleTentBattleRoom_EventScript_SetUpObjects::
 
 SlateportCity_BattleTentBattleRoom_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, SlateportCity_BattleTentBattleRoom_EventScript_EnterRoom
-	.2byte 0
+	end_map_script_table
 
 SlateportCity_BattleTentBattleRoom_EventScript_EnterRoom::
 	applymovement LOCALID_PLAYER, SlateportCity_BattleTentBattleRoom_Movement_PlayerEnter

--- a/data/maps/SlateportCity_BattleTentCorridor/scripts.inc
+++ b/data/maps/SlateportCity_BattleTentCorridor/scripts.inc
@@ -3,13 +3,13 @@
 SlateportCity_BattleTentCorridor_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, SlateportCity_BattleTentCorridor_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, SlateportCity_BattleTentCorridor_OnWarp
-	.byte 0
+	end_map_scripts
 
 	@ This is Slateport Tent's version of the Battle Factory Pre-Battle Room
 
 SlateportCity_BattleTentCorridor_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, SlateportCity_BattleTentCorridor_EventScript_SetUpObjects
-	.2byte 0
+	end_map_script_table
 
 SlateportCity_BattleTentCorridor_EventScript_SetUpObjects::
 	setvar VAR_TEMP_1, 1
@@ -22,7 +22,7 @@ SlateportCity_BattleTentCorridor_EventScript_TurnPlayerNorth::
 
 SlateportCity_BattleTentCorridor_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, SlateportCity_BattleTentCorridor_EventScript_EnterCorridor
-	.2byte 0
+	end_map_script_table
 
 SlateportCity_BattleTentCorridor_EventScript_EnterCorridor::
 	goto_if_eq VAR_0x8006, 1, SlateportCity_BattleTentCorridor_EventScript_ReturnToRoomFromBattle

--- a/data/maps/SlateportCity_BattleTentLobby/scripts.inc
+++ b/data/maps/SlateportCity_BattleTentLobby/scripts.inc
@@ -3,11 +3,11 @@
 SlateportCity_BattleTentLobby_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, SlateportCity_BattleTentLobby_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, SlateportCity_BattleTentLobby_OnWarp
-	.byte 0
+	end_map_scripts
 
 SlateportCity_BattleTentLobby_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, SlateportCity_BattleTentLobby_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 SlateportCity_BattleTentLobby_EventScript_TurnPlayerNorth::
 	setvar VAR_TEMP_1, 1
@@ -20,7 +20,7 @@ SlateportCity_BattleTentLobby_OnFrame:
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_PAUSED, SlateportCity_BattleTentLobby_EventScript_ResumeChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_WON, SlateportCity_BattleTentLobby_EventScript_WonChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_LOST, SlateportCity_BattleTentLobby_EventScript_LostChallenge
-	.2byte 0
+	end_map_script_table
 
 SlateportCity_BattleTentLobby_EventScript_GetChallengeStatus::
 	frontier_getstatus

--- a/data/maps/SlateportCity_Harbor/scripts.inc
+++ b/data/maps/SlateportCity_Harbor/scripts.inc
@@ -6,7 +6,7 @@
 
 SlateportCity_Harbor_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SlateportCity_Harbor_OnTransition
-	.byte 0
+	end_map_scripts
 
 SlateportCity_Harbor_OnTransition:
 	setescapewarp MAP_SLATEPORT_CITY, 28, 13

--- a/data/maps/SlateportCity_House/scripts.inc
+++ b/data/maps/SlateportCity_House/scripts.inc
@@ -1,5 +1,5 @@
 SlateportCity_House_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SlateportCity_House_EventScript_PokefanM::
 	msgbox SlateportCity_House_Text_NatureToDoWithStatGains, MSGBOX_NPC

--- a/data/maps/SlateportCity_Mart/scripts.inc
+++ b/data/maps/SlateportCity_Mart/scripts.inc
@@ -1,5 +1,5 @@
 SlateportCity_Mart_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SlateportCity_Mart_EventScript_Clerk::
 	lock

--- a/data/maps/SlateportCity_NameRatersHouse/scripts.inc
+++ b/data/maps/SlateportCity_NameRatersHouse/scripts.inc
@@ -1,5 +1,5 @@
 SlateportCity_NameRatersHouse_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SlateportCity_NameRatersHouse_EventScript_NameRater::
 	lock

--- a/data/maps/SlateportCity_OceanicMuseum_1F/scripts.inc
+++ b/data/maps/SlateportCity_OceanicMuseum_1F/scripts.inc
@@ -1,7 +1,7 @@
 .set LOCALID_FAMILIAR_GRUNT, 13
 
 SlateportCity_OceanicMuseum_1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SlateportCity_OceanicMuseum_1F_EventScript_EntranceAttendant::
 	msgbox SlateportCity_OceanicMuseum_1F_Text_PleaseEnjoyYourself, MSGBOX_NPC

--- a/data/maps/SlateportCity_OceanicMuseum_2F/scripts.inc
+++ b/data/maps/SlateportCity_OceanicMuseum_2F/scripts.inc
@@ -4,7 +4,7 @@
 .set LOCALID_GRUNT_2, 4
 
 SlateportCity_OceanicMuseum_2F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SlateportCity_OceanicMuseum_2F_EventScript_CaptStern::
 	lock

--- a/data/maps/SlateportCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/SlateportCity_PokemonCenter_1F/scripts.inc
@@ -3,7 +3,7 @@
 SlateportCity_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SlateportCity_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 SlateportCity_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_SLATEPORT_CITY

--- a/data/maps/SlateportCity_PokemonCenter_2F/scripts.inc
+++ b/data/maps/SlateportCity_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ SlateportCity_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 SlateportCity_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/SlateportCity_PokemonFanClub/scripts.inc
+++ b/data/maps/SlateportCity_PokemonFanClub/scripts.inc
@@ -1,5 +1,5 @@
 SlateportCity_PokemonFanClub_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SlateportCity_PokemonFanClub_EventScript_Chairman::
 	lock

--- a/data/maps/SlateportCity_SternsShipyard_1F/scripts.inc
+++ b/data/maps/SlateportCity_SternsShipyard_1F/scripts.inc
@@ -1,7 +1,7 @@
 .set LOCALID_DOCK, 1
 
 SlateportCity_SternsShipyard_1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SlateportCity_SternsShipyard_1F_EventScript_Dock::
 	lockall

--- a/data/maps/SlateportCity_SternsShipyard_2F/scripts.inc
+++ b/data/maps/SlateportCity_SternsShipyard_2F/scripts.inc
@@ -1,5 +1,5 @@
 SlateportCity_SternsShipyard_2F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SlateportCity_SternsShipyard_2F_EventScript_Scientist1::
 	msgbox SlateportCity_SternsShipyard_2F_Text_ShipDesignMoreLikeBuilding, MSGBOX_NPC

--- a/data/maps/SootopolisCity/scripts.inc
+++ b/data/maps/SootopolisCity/scripts.inc
@@ -22,7 +22,7 @@ SootopolisCity_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, SootopolisCity_OnResume
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, SootopolisCity_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, SootopolisCity_OnWarp
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_OnLoad:
 	call_if_unset FLAG_SOOTOPOLIS_ARCHIE_MAXIE_LEAVE, SootopolisCity_EventScript_LockGymDoor
@@ -160,7 +160,7 @@ SootopolisCity_EventScript_SetExpertBlockCaveEntrance::
 
 SootopolisCity_OnWarp:
 	map_script_2 VAR_SOOTOPOLIS_CITY_STATE, 5, SootopolisCity_EventScript_PlayerFaceLegendaries
-	.2byte 0
+	end_map_script_table
 
 SootopolisCity_EventScript_PlayerFaceLegendaries::
 	call_if_eq VAR_SKY_PILLAR_STATE, 1, SootopolisCity_EventScript_PlayerFaceLegendaries1
@@ -183,7 +183,7 @@ SootopolisCity_OnResume:
 SootopolisCity_OnFrame:
 	map_script_2 VAR_SOOTOPOLIS_CITY_STATE, 1, SootopolisCity_EventScript_StartLegendariesScene
 	map_script_2 VAR_SKY_PILLAR_STATE, 1, SootopolisCity_EventScript_StartRayquazaScene
-	.2byte 0
+	end_map_script_table
 
 @ If not at PokeCenter, assumed to have arrived via Dive
 SootopolisCity_EventScript_StartLegendariesScene::

--- a/data/maps/SootopolisCity_Gym_1F/scripts.inc
+++ b/data/maps/SootopolisCity_Gym_1F/scripts.inc
@@ -3,7 +3,7 @@ SootopolisCity_Gym_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, SootopolisCity_Gym_1F_OnResume
 	map_script MAP_SCRIPT_ON_LOAD, SootopolisCity_Gym_1F_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, SootopolisCity_Gym_1F_OnTransition
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_Gym_1F_OnTransition:
 	setvar VAR_ICE_STEP_COUNT, 1
@@ -38,7 +38,7 @@ SootopolisCity_Gym_1F_OnFrame:
 	map_script_2 VAR_ICE_STEP_COUNT, 28, SootopolisCity_Gym_1F_EventScript_UnlockSecondStairs
 	map_script_2 VAR_ICE_STEP_COUNT, 67, SootopolisCity_Gym_1F_EventScript_UnlockThirdStairs
 	map_script_2 VAR_ICE_STEP_COUNT, 0, SootopolisCity_Gym_1F_EventScript_FallThroughIce
-	.2byte 0
+	end_map_script_table
 
 SootopolisCity_Gym_1F_EventScript_UnlockFirstStairs::
 	addvar VAR_ICE_STEP_COUNT, 1

--- a/data/maps/SootopolisCity_Gym_B1F/scripts.inc
+++ b/data/maps/SootopolisCity_Gym_B1F/scripts.inc
@@ -1,5 +1,5 @@
 SootopolisCity_Gym_B1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_Gym_B1F_EventScript_Andrea::
 	trainerbattle_single TRAINER_ANDREA, SootopolisCity_Gym_B1F_Text_AndreaIntro, SootopolisCity_Gym_B1F_Text_AndreaDefeat

--- a/data/maps/SootopolisCity_House1/scripts.inc
+++ b/data/maps/SootopolisCity_House1/scripts.inc
@@ -1,5 +1,5 @@
 SootopolisCity_House1_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_House1_EventScript_BrickBreakBlackBelt::
 	lock

--- a/data/maps/SootopolisCity_House2/scripts.inc
+++ b/data/maps/SootopolisCity_House2/scripts.inc
@@ -1,5 +1,5 @@
 SootopolisCity_House2_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_House2_EventScript_ExpertF::
 	lock

--- a/data/maps/SootopolisCity_House3/scripts.inc
+++ b/data/maps/SootopolisCity_House3/scripts.inc
@@ -1,5 +1,5 @@
 SootopolisCity_House3_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_House3_EventScript_Woman::
 	lock

--- a/data/maps/SootopolisCity_House4/scripts.inc
+++ b/data/maps/SootopolisCity_House4/scripts.inc
@@ -1,5 +1,5 @@
 SootopolisCity_House4_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_House4_EventScript_Man::
 	msgbox SootopolisCity_House4_Text_AncientTreasuresWaitingInSea, MSGBOX_NPC

--- a/data/maps/SootopolisCity_House5/scripts.inc
+++ b/data/maps/SootopolisCity_House5/scripts.inc
@@ -1,5 +1,5 @@
 SootopolisCity_House5_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_House5_EventScript_Maniac::
 	msgbox SootopolisCity_House5_Text_SootopolisMtPyreConnection, MSGBOX_NPC

--- a/data/maps/SootopolisCity_House6/scripts.inc
+++ b/data/maps/SootopolisCity_House6/scripts.inc
@@ -1,5 +1,5 @@
 SootopolisCity_House6_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_House6_EventScript_Woman::
 	lock

--- a/data/maps/SootopolisCity_House7/scripts.inc
+++ b/data/maps/SootopolisCity_House7/scripts.inc
@@ -1,5 +1,5 @@
 SootopolisCity_House7_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_House7_EventScript_OldMan::
 	msgbox SootopolisCity_House7_Text_CityFromEruptedVolcano, MSGBOX_NPC

--- a/data/maps/SootopolisCity_LotadAndSeedotHouse/scripts.inc
+++ b/data/maps/SootopolisCity_LotadAndSeedotHouse/scripts.inc
@@ -1,5 +1,5 @@
 SootopolisCity_LotadAndSeedotHouse_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_LotadAndSeedotHouse_EventScript_SeedotBrother::
 	special GetSeedotSizeRecordInfo

--- a/data/maps/SootopolisCity_Mart/scripts.inc
+++ b/data/maps/SootopolisCity_Mart/scripts.inc
@@ -1,5 +1,5 @@
 SootopolisCity_Mart_MapScripts::
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_Mart_EventScript_Clerk::
 	lock

--- a/data/maps/SootopolisCity_MysteryEventsHouse_1F/scripts.inc
+++ b/data/maps/SootopolisCity_MysteryEventsHouse_1F/scripts.inc
@@ -3,7 +3,7 @@
 SootopolisCity_MysteryEventsHouse_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SootopolisCity_MysteryEventsHouse_1F_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, SootopolisCity_MysteryEventsHouse_1F_OnFrame
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_MysteryEventsHouse_1F_OnTransition:
 	frontier_checkvisittrainer
@@ -27,7 +27,7 @@ SootopolisCity_MysteryEventsHouse_1F_OnFrame:
 	map_script_2 VAR_SOOTOPOLIS_MYSTERY_EVENTS_STATE, 1, SootopolisCity_MysteryEventsHouse_1F_EventScript_OldManCommentOnBattle
 	map_script_2 VAR_SOOTOPOLIS_MYSTERY_EVENTS_STATE, 2, SootopolisCity_MysteryEventsHouse_1F_EventScript_OldManCommentOnBattle
 	map_script_2 VAR_SOOTOPOLIS_MYSTERY_EVENTS_STATE, 3, SootopolisCity_MysteryEventsHouse_1F_EventScript_OldManCommentOnBattle
-	.2byte 0
+	end_map_script_table
 
 SootopolisCity_MysteryEventsHouse_1F_EventScript_OldManCommentOnBattle::
 	lockall

--- a/data/maps/SootopolisCity_MysteryEventsHouse_B1F/scripts.inc
+++ b/data/maps/SootopolisCity_MysteryEventsHouse_B1F/scripts.inc
@@ -1,7 +1,7 @@
 SootopolisCity_MysteryEventsHouse_B1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SootopolisCity_MysteryEventsHouse_B1F_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, SootopolisCity_MysteryEventsHouse_B1F_OnFrame
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_MysteryEventsHouse_B1F_OnTransition:
 	special SetEReaderTrainerGfxId
@@ -9,7 +9,7 @@ SootopolisCity_MysteryEventsHouse_B1F_OnTransition:
 
 SootopolisCity_MysteryEventsHouse_B1F_OnFrame:
 	map_script_2 VAR_TEMP_1, 0, SootopolisCity_MysteryEventsHouse_B1F_EventScript_BattleVisitingTrainer
-	.2byte 0
+	end_map_script_table
 
 SootopolisCity_MysteryEventsHouse_B1F_EventScript_BattleVisitingTrainer::
 	lockall

--- a/data/maps/SootopolisCity_PokemonCenter_1F/scripts.inc
+++ b/data/maps/SootopolisCity_PokemonCenter_1F/scripts.inc
@@ -3,7 +3,7 @@
 SootopolisCity_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SootopolisCity_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 SootopolisCity_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_SOOTOPOLIS_CITY

--- a/data/maps/SootopolisCity_PokemonCenter_2F/scripts.inc
+++ b/data/maps/SootopolisCity_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ SootopolisCity_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 SootopolisCity_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/SouthernIsland_Exterior/scripts.inc
+++ b/data/maps/SouthernIsland_Exterior/scripts.inc
@@ -3,7 +3,7 @@
 
 SouthernIsland_Exterior_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SouthernIsland_Exterior_OnTransition
-	.byte 0
+	end_map_scripts
 
 SouthernIsland_Exterior_OnTransition:
 	setflag FLAG_LANDMARK_SOUTHERN_ISLAND

--- a/data/maps/SouthernIsland_Interior/scripts.inc
+++ b/data/maps/SouthernIsland_Interior/scripts.inc
@@ -3,7 +3,7 @@
 SouthernIsland_Interior_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, SouthernIsland_Interior_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, SouthernIsland_Interior_OnTransition
-	.byte 0
+	end_map_scripts
 
 SouthernIsland_Interior_OnResume:
 	call_if_set FLAG_SYS_CTRL_OBJ_DELETE, SouthernIsland_Interior_EventScript_TryRemoveLati

--- a/data/maps/TerraCave_End/scripts.inc
+++ b/data/maps/TerraCave_End/scripts.inc
@@ -3,7 +3,7 @@
 TerraCave_End_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, TerraCave_End_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, TerraCave_End_OnTransition
-	.byte 0
+	end_map_scripts
 
 TerraCave_End_OnResume:
 	call_if_set FLAG_SYS_CTRL_OBJ_DELETE, TerraCave_End_EventScript_TryRemoveGroudon

--- a/data/maps/TerraCave_Entrance/scripts.inc
+++ b/data/maps/TerraCave_Entrance/scripts.inc
@@ -1,6 +1,6 @@
 TerraCave_Entrance_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, TerraCave_Entrance_OnTransition
-	.byte 0
+	end_map_scripts
 
 TerraCave_Entrance_OnTransition:
 	setflag FLAG_ARRIVED_AT_TERRA_CAVE_ENTRANCE

--- a/data/maps/TradeCenter/scripts.inc
+++ b/data/maps/TradeCenter/scripts.inc
@@ -1,3 +1,3 @@
 TradeCenter_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/TrainerHill_1F/scripts.inc
+++ b/data/maps/TrainerHill_1F/scripts.inc
@@ -2,5 +2,5 @@ TrainerHill_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, TrainerHill_OnResume
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, TrainerHill_OnWarp
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, TrainerHill_OnFrame
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/TrainerHill_2F/scripts.inc
+++ b/data/maps/TrainerHill_2F/scripts.inc
@@ -2,5 +2,5 @@ TrainerHill_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, TrainerHill_OnResume
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, TrainerHill_OnWarp
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, TrainerHill_OnFrame
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/TrainerHill_3F/scripts.inc
+++ b/data/maps/TrainerHill_3F/scripts.inc
@@ -1,5 +1,5 @@
 TrainerHill_3F_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, TrainerHill_OnResume
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, TrainerHill_OnFrame
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/TrainerHill_4F/scripts.inc
+++ b/data/maps/TrainerHill_4F/scripts.inc
@@ -1,5 +1,5 @@
 TrainerHill_4F_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, TrainerHill_OnResume
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, TrainerHill_OnFrame
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/TrainerHill_Elevator/scripts.inc
+++ b/data/maps/TrainerHill_Elevator/scripts.inc
@@ -2,11 +2,11 @@
 
 TrainerHill_Elevator_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, TrainerHill_Elevator_OnFrame
-	.byte 0
+	end_map_scripts
 
 TrainerHill_Elevator_OnFrame:
 	map_script_2 VAR_TEMP_4, 0, TrainerHill_Elevator_EventScript_EnterElevator
-	.2byte 0
+	end_map_script_table
 
 TrainerHill_Elevator_EventScript_Attendant::
 	end

--- a/data/maps/TrainerHill_Entrance/scripts.inc
+++ b/data/maps/TrainerHill_Entrance/scripts.inc
@@ -9,7 +9,7 @@ TrainerHill_Entrance_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, TrainerHill_Entrance_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, TrainerHill_Entrance_OnLoad
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, TrainerHill_Entrance_OnFrame
-	.byte 0
+	end_map_scripts
 
 TrainerHill_Entrance_OnTransition:
 	setflag FLAG_LANDMARK_TRAINER_HILL
@@ -58,7 +58,7 @@ TrainerHill_Entrance_OnFrame:
 	map_script_2 VAR_TEMP_D, 17, TrainerHill_Entrance_EventScript_ExitElevator
 	map_script_2 VAR_TEMP_5, 1, TrainerHill_Entrance_EventScript_EntryTrigger
 	map_script_2 VAR_TEMP_1, 1, TrainerHill_EventScript_WarpToEntranceCounter
-	.2byte 0
+	end_map_script_table
 
 TrainerHill_Entrance_EventScript_ExitElevator::
 	lockall

--- a/data/maps/TrainerHill_Roof/scripts.inc
+++ b/data/maps/TrainerHill_Roof/scripts.inc
@@ -1,7 +1,7 @@
 TrainerHill_Roof_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, TrainerHill_OnResume
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, TrainerHill_OnFrame
-	.byte 0
+	end_map_scripts
 
 TrainerHill_Roof_EventScript_Owner::
 	trainerhill_settrainerflags

--- a/data/maps/Underwater_MarineCave/scripts.inc
+++ b/data/maps/Underwater_MarineCave/scripts.inc
@@ -1,7 +1,7 @@
 Underwater_MarineCave_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Underwater_MarineCave_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, Underwater_MarineCave_OnTransition
-	.byte 0
+	end_map_scripts
 
 Underwater_MarineCave_OnTransition:
 	setflag FLAG_ARRIVED_AT_MARINE_CAVE_EMERGE_SPOT

--- a/data/maps/Underwater_Route105/scripts.inc
+++ b/data/maps/Underwater_Route105/scripts.inc
@@ -1,6 +1,6 @@
 Underwater_Route105_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Underwater_Route105_OnResume
-	.byte 0
+	end_map_scripts
 
 Underwater_Route105_OnResume:
 	call AbnormalWeather_Underwater_SetupEscapeWarp

--- a/data/maps/Underwater_Route124/scripts.inc
+++ b/data/maps/Underwater_Route124/scripts.inc
@@ -1,3 +1,3 @@
 Underwater_Route124_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/Underwater_Route125/scripts.inc
+++ b/data/maps/Underwater_Route125/scripts.inc
@@ -1,6 +1,6 @@
 Underwater_Route125_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Underwater_Route125_OnResume
-	.byte 0
+	end_map_scripts
 
 Underwater_Route125_OnResume:
 	call AbnormalWeather_Underwater_SetupEscapeWarp

--- a/data/maps/Underwater_Route126/scripts.inc
+++ b/data/maps/Underwater_Route126/scripts.inc
@@ -1,3 +1,3 @@
 Underwater_Route126_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/Underwater_Route127/scripts.inc
+++ b/data/maps/Underwater_Route127/scripts.inc
@@ -1,6 +1,6 @@
 Underwater_Route127_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Underwater_Route127_OnResume
-	.byte 0
+	end_map_scripts
 
 Underwater_Route127_OnResume:
 	call AbnormalWeather_Underwater_SetupEscapeWarp

--- a/data/maps/Underwater_Route128/scripts.inc
+++ b/data/maps/Underwater_Route128/scripts.inc
@@ -1,3 +1,3 @@
 Underwater_Route128_MapScripts::
-	.byte 0
+	end_map_scripts
 

--- a/data/maps/Underwater_Route129/scripts.inc
+++ b/data/maps/Underwater_Route129/scripts.inc
@@ -1,6 +1,6 @@
 Underwater_Route129_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Underwater_Route129_OnResume
-	.byte 0
+	end_map_scripts
 
 Underwater_Route129_OnResume:
 	call AbnormalWeather_Underwater_SetupEscapeWarp

--- a/data/maps/Underwater_Route134/scripts.inc
+++ b/data/maps/Underwater_Route134/scripts.inc
@@ -1,6 +1,6 @@
 Underwater_Route134_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Underwater_Route134_OnResume
-	.byte 0
+	end_map_scripts
 
 Underwater_Route134_OnResume:
 	setdivewarp MAP_ROUTE134, 60, 31

--- a/data/maps/Underwater_SeafloorCavern/scripts.inc
+++ b/data/maps/Underwater_SeafloorCavern/scripts.inc
@@ -2,7 +2,7 @@ Underwater_SeafloorCavern_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Underwater_SeafloorCavern_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, Underwater_SeafloorCavern_OnTransition
 	map_script MAP_SCRIPT_ON_LOAD, Underwater_SeafloorCavern_OnLoad
-	.byte 0
+	end_map_scripts
 
 Underwater_SeafloorCavern_OnTransition:
 	setflag FLAG_LANDMARK_SEAFLOOR_CAVERN

--- a/data/maps/Underwater_SealedChamber/scripts.inc
+++ b/data/maps/Underwater_SealedChamber/scripts.inc
@@ -1,6 +1,6 @@
 Underwater_SealedChamber_MapScripts::
 	map_script MAP_SCRIPT_ON_DIVE_WARP, Underwater_SealedChamber_OnDive
-	.byte 0
+	end_map_scripts
 
 Underwater_SealedChamber_OnDive:
 	getplayerxy VAR_0x8004, VAR_0x8005

--- a/data/maps/Underwater_SootopolisCity/scripts.inc
+++ b/data/maps/Underwater_SootopolisCity/scripts.inc
@@ -1,6 +1,6 @@
 Underwater_SootopolisCity_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, Underwater_SootopolisCity_OnResume
-	.byte 0
+	end_map_scripts
 
 Underwater_SootopolisCity_OnResume:
 	setdivewarp MAP_SOOTOPOLIS_CITY, 29, 53

--- a/data/maps/UnionRoom/scripts.inc
+++ b/data/maps/UnionRoom/scripts.inc
@@ -3,7 +3,7 @@
 UnionRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_RESUME, UnionRoom_OnResume
 	map_script MAP_SCRIPT_ON_TRANSITION, UnionRoom_OnTransition
-	.byte 0
+	end_map_scripts
 
 UnionRoom_OnResume:
 	setflag FLAG_HIDE_UNION_ROOM_PLAYER_1

--- a/data/maps/VerdanturfTown/scripts.inc
+++ b/data/maps/VerdanturfTown/scripts.inc
@@ -2,7 +2,7 @@
 
 VerdanturfTown_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, VerdanturfTown_OnTransition
-	.byte 0
+	end_map_scripts
 
 VerdanturfTown_OnTransition:
 	setflag FLAG_VISITED_VERDANTURF_TOWN

--- a/data/maps/VerdanturfTown_BattleTentBattleRoom/scripts.inc
+++ b/data/maps/VerdanturfTown_BattleTentBattleRoom/scripts.inc
@@ -6,7 +6,7 @@ VerdanturfTown_BattleTentBattleRoom_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, VerdanturfTown_BattleTentBattleRoom_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, VerdanturfTown_BattleTentBattleRoom_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, VerdanturfTown_BattleTentBattleRoom_OnWarp
-	.byte 0
+	end_map_scripts
 
 	@ On this map the player (OBJ_EVENT_ID_PLAYER) is hidden
 	@ The player is represented instead by object event 1, which has the gfx id VAR_OBJ_GFX_ID_1
@@ -34,7 +34,7 @@ VerdanturfTown_BattleTentBattleRoom_EventScript_SetPlayerGfxFemale::
 
 VerdanturfTown_BattleTentBattleRoom_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, VerdanturfTown_BattleTentBattleRoom_EventScript_EnterRoom
-	.2byte 0
+	end_map_script_table
 
 VerdanturfTown_BattleTentBattleRoom_EventScript_EnterRoom::
 	showobjectat LOCALID_PLAYER, MAP_VERDANTURF_TOWN_BATTLE_TENT_BATTLE_ROOM
@@ -130,7 +130,7 @@ VerdanturfTown_BattleTentBattleRoom_EventScript_PauseChallenge::
 
 VerdanturfTown_BattleTentBattleRoom_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, VerdanturfTown_BattleTentBattleRoom_EventScript_SetUpObjects
-	.2byte 0
+	end_map_script_table
 
 VerdanturfTown_BattleTentBattleRoom_EventScript_SetUpObjects::
 	hideobjectat LOCALID_PLAYER, MAP_VERDANTURF_TOWN_BATTLE_TENT_BATTLE_ROOM

--- a/data/maps/VerdanturfTown_BattleTentCorridor/scripts.inc
+++ b/data/maps/VerdanturfTown_BattleTentCorridor/scripts.inc
@@ -2,11 +2,11 @@
 
 VerdanturfTown_BattleTentCorridor_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, VerdanturfTown_BattleTentCorridor_OnFrame
-	.byte 0
+	end_map_scripts
 
 VerdanturfTown_BattleTentCorridor_OnFrame:
 	map_script_2 VAR_TEMP_0, 0, VerdanturfTown_BattleTentCorridor_EventScript_EnterCorridor
-	.2byte 0
+	end_map_script_table
 
 VerdanturfTown_BattleTentCorridor_EventScript_EnterCorridor::
 	lockall

--- a/data/maps/VerdanturfTown_BattleTentLobby/scripts.inc
+++ b/data/maps/VerdanturfTown_BattleTentLobby/scripts.inc
@@ -3,11 +3,11 @@
 VerdanturfTown_BattleTentLobby_MapScripts::
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, VerdanturfTown_BattleTentLobby_OnFrame
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, VerdanturfTown_BattleTentLobby_OnWarp
-	.byte 0
+	end_map_scripts
 
 VerdanturfTown_BattleTentLobby_OnWarp:
 	map_script_2 VAR_TEMP_1, 0, VerdanturfTown_BattleTentLobby_EventScript_TurnPlayerNorth
-	.2byte 0
+	end_map_script_table
 
 VerdanturfTown_BattleTentLobby_EventScript_TurnPlayerNorth::
 	setvar VAR_TEMP_1, 1
@@ -20,7 +20,7 @@ VerdanturfTown_BattleTentLobby_OnFrame:
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_PAUSED, VerdanturfTown_BattleTentLobby_EventScript_ResumeChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_WON, VerdanturfTown_BattleTentLobby_EventScript_WonChallenge
 	map_script_2 VAR_TEMP_0, CHALLENGE_STATUS_LOST, VerdanturfTown_BattleTentLobby_EventScript_LostChallenge
-	.2byte 0
+	end_map_script_table
 
 VerdanturfTown_BattleTentLobby_EventScript_GetChallengeStatus::
 	frontier_getstatus

--- a/data/maps/VerdanturfTown_FriendshipRatersHouse/scripts.inc
+++ b/data/maps/VerdanturfTown_FriendshipRatersHouse/scripts.inc
@@ -1,5 +1,5 @@
 VerdanturfTown_FriendshipRatersHouse_MapScripts::
-	.byte 0
+	end_map_scripts
 
 VerdanturfTown_FriendshipRatersHouse_EventScript_FriendshipRater::
 	lock

--- a/data/maps/VerdanturfTown_House/scripts.inc
+++ b/data/maps/VerdanturfTown_House/scripts.inc
@@ -1,5 +1,5 @@
 VerdanturfTown_House_MapScripts::
-	.byte 0
+	end_map_scripts
 
 VerdanturfTown_House_EventScript_Woman1::
 	msgbox VerdanturfTown_House_Text_TrainersGatherAtPokemonLeague, MSGBOX_NPC

--- a/data/maps/VerdanturfTown_Mart/scripts.inc
+++ b/data/maps/VerdanturfTown_Mart/scripts.inc
@@ -1,5 +1,5 @@
 VerdanturfTown_Mart_MapScripts::
-	.byte 0
+	end_map_scripts
 
 VerdanturfTown_Mart_EventScript_Clerk::
 	lock

--- a/data/maps/VerdanturfTown_PokemonCenter_1F/scripts.inc
+++ b/data/maps/VerdanturfTown_PokemonCenter_1F/scripts.inc
@@ -3,7 +3,7 @@
 VerdanturfTown_PokemonCenter_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, VerdanturfTown_PokemonCenter_1F_OnTransition
 	map_script MAP_SCRIPT_ON_RESUME, CableClub_OnResume
-	.byte 0
+	end_map_scripts
 
 VerdanturfTown_PokemonCenter_1F_OnTransition:
 	setrespawn HEAL_LOCATION_VERDANTURF_TOWN

--- a/data/maps/VerdanturfTown_PokemonCenter_2F/scripts.inc
+++ b/data/maps/VerdanturfTown_PokemonCenter_2F/scripts.inc
@@ -3,7 +3,7 @@ VerdanturfTown_PokemonCenter_2F_MapScripts::
 	map_script MAP_SCRIPT_ON_WARP_INTO_MAP_TABLE, CableClub_OnWarp
 	map_script MAP_SCRIPT_ON_LOAD, CableClub_OnLoad
 	map_script MAP_SCRIPT_ON_TRANSITION, CableClub_OnTransition
-	.byte 0
+	end_map_scripts
 
 @ The below 3 are unused and leftover from RS
 VerdanturfTown_PokemonCenter_2F_EventScript_Colosseum::

--- a/data/maps/VerdanturfTown_WandasHouse/scripts.inc
+++ b/data/maps/VerdanturfTown_WandasHouse/scripts.inc
@@ -1,5 +1,5 @@
 VerdanturfTown_WandasHouse_MapScripts::
-	.byte 0
+	end_map_scripts
 
 VerdanturfTown_WandasHouse_EventScript_Wally::
 	lock

--- a/data/maps/VictoryRoad_1F/scripts.inc
+++ b/data/maps/VictoryRoad_1F/scripts.inc
@@ -2,7 +2,7 @@
 
 VictoryRoad_1F_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, VictoryRoad_1F_OnTransition
-	.byte 0
+	end_map_scripts
 
 VictoryRoad_1F_OnTransition:
 	call_if_eq VAR_VICTORY_ROAD_1F_STATE, 1, VictoryRoad_1F_EventScript_SetEntranceWallyPos1

--- a/data/maps/VictoryRoad_B1F/scripts.inc
+++ b/data/maps/VictoryRoad_B1F/scripts.inc
@@ -1,5 +1,5 @@
 VictoryRoad_B1F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 VictoryRoad_B1F_EventScript_Samuel::
 	trainerbattle_single TRAINER_SAMUEL, VictoryRoad_B1F_Text_SamuelIntro, VictoryRoad_B1F_Text_SamuelDefeat

--- a/data/maps/VictoryRoad_B2F/scripts.inc
+++ b/data/maps/VictoryRoad_B2F/scripts.inc
@@ -1,5 +1,5 @@
 VictoryRoad_B2F_MapScripts::
-	.byte 0
+	end_map_scripts
 
 VictoryRoad_B2F_EventScript_Vito::
 	trainerbattle_single TRAINER_VITO, VictoryRoad_B2F_Text_VitoIntro, VictoryRoad_B2F_Text_VitoDefeat

--- a/data/scripts/battle_pike.inc
+++ b/data/scripts/battle_pike.inc
@@ -44,7 +44,7 @@ BattleFrontier_BattlePikeRoomNormal_EventScript_SetBrainRoomObjPos::
 
 BattleFrontier_BattlePikeRoom_OnWarp:
 	map_script_2 VAR_TEMP_4, 0, BattleFrontier_BattlePikeRoomNormal_EventScript_InitRoomObjects
-	.2byte 0
+	end_map_script_table
 
 BattleFrontier_BattlePikeRoomNormal_EventScript_InitRoomObjects::
 	setvar VAR_OBJ_GFX_ID_1, OBJ_EVENT_GFX_LINK_RECEPTIONIST

--- a/data/scripts/cable_club.inc
+++ b/data/scripts/cable_club.inc
@@ -57,7 +57,7 @@ CableClub_OnWarp:
 	map_script_2 VAR_CABLE_CLUB_STATE, USING_UNION_ROOM, CableClub_EventScript_CheckTurnAttendant
 	map_script_2 VAR_CABLE_CLUB_STATE, USING_BERRY_CRUSH, CableClub_EventScript_CheckTurnAttendant
 	map_script_2 VAR_CABLE_CLUB_STATE, USING_MINIGAME, CableClub_EventScript_CheckTurnAttendant
-	.2byte 0
+	end_map_script_table
 
 CableClub_EventScript_CheckTurnAttendant::
 	goto_if_eq VAR_0x8007, 0, CableClub_EventScript_DontTurnAttendant
@@ -110,7 +110,7 @@ CableClub_OnFrame:
 	map_script_2 VAR_CABLE_CLUB_STATE, USING_UNION_ROOM, CableClub_EventScript_ExitUnionRoom
 	map_script_2 VAR_CABLE_CLUB_STATE, USING_BERRY_CRUSH, CableClub_EventScript_ExitLinkRoom
 	map_script_2 VAR_CABLE_CLUB_STATE, USING_MINIGAME, CableClub_EventScript_ExitMinigameRoom
-	.2byte 0
+	end_map_script_table
 
 CableClub_EventScript_ExitLinkRoom::
 	lockall

--- a/data/scripts/cave_hole.inc
+++ b/data/scripts/cave_hole.inc
@@ -1,6 +1,6 @@
 CaveHole_CheckFallDownHole:
 	map_script_2 VAR_ICE_STEP_COUNT, 0, EventScript_FallDownHole
-	.2byte 0
+	end_map_script_table
 
 CaveHole_FixCrackedGround:
 	copyvar VAR_ICE_STEP_COUNT, 1

--- a/data/scripts/shared_secret_base.inc
+++ b/data/scripts/shared_secret_base.inc
@@ -3,11 +3,11 @@ SecretBase_MapScripts::
 	map_script MAP_SCRIPT_ON_TRANSITION, SecretBase_OnTransition
 	map_script MAP_SCRIPT_ON_FRAME_TABLE, SecretBase_OnFrame
 	map_script MAP_SCRIPT_ON_RESUME, SecretBase_OnResume
-	.byte 0
+	end_map_scripts
 
 SecretBase_OnWarp:
 	map_script_2 VAR_SECRET_BASE_INITIALIZED, 0, SecretBase_EventScript_InitDecorations
-	.2byte 0
+	end_map_script_table
 
 SecretBase_OnTransition:
 	call SecretBase_EventScript_SetDecorationFlags
@@ -17,7 +17,7 @@ SecretBase_OnTransition:
 
 SecretBase_OnFrame:
 	map_script_2 VAR_INIT_SECRET_BASE, 0, SecretBase_EventScript_FirstEntrance
-	.2byte 0
+	end_map_script_table
 
 SecretBase_OnResume:
 	setstepcallback STEP_CB_SECRET_BASE

--- a/data/scripts/trainer_hill.inc
+++ b/data/scripts/trainer_hill.inc
@@ -9,7 +9,7 @@ TrainerHill_OnResume:
 
 TrainerHill_OnWarp:
 	map_script_2 VAR_TEMP_3, 0, TrainerHill_1F_EventScript_DummyOnWarp
-	.2byte 0
+	end_map_script_table
 
 TrainerHill_1F_EventScript_DummyOnWarp::
 	setvar VAR_TEMP_3, 1
@@ -20,7 +20,7 @@ TrainerHill_1F_EventScript_DummyOnWarp::
 TrainerHill_OnFrame:
 	map_script_2 VAR_TEMP_2, 0, TrainerHill_1F_EventScript_DummyWarpToEntranceCounter
 	map_script_2 VAR_TEMP_1, 1, TrainerHill_EventScript_WarpToEntranceCounter
-	.2byte 0
+	end_map_script_table
 
 EventScript_TrainerHillTimer::
 	lockall


### PR DESCRIPTION
This would be a reasonable time to rename `map_script_2` to something descriptive like `map_script_table`, but it might not be worth the conflicts.

This PR won't disrupt poryscript or any new map scripts downstream.