### PR TITLE
Replace NUM_TEXT_PRINTERS with WINDOWS_MAX

### DIFF
--- a/gflib/text.c
+++ b/gflib/text.c
@@ -36,7 +36,7 @@ static u32 GetGlyphWidth_Narrow(u16, bool32);
 static u32 GetGlyphWidth_SmallNarrow(u16, bool32);
 
 static EWRAM_DATA struct TextPrinter sTempTextPrinter = {0};
-static EWRAM_DATA struct TextPrinter sTextPrinters[NUM_TEXT_PRINTERS] = {0};
+static EWRAM_DATA struct TextPrinter sTextPrinters[WINDOWS_MAX] = {0};
 
 static u16 sFontHalfRowLookupTable[0x51];
 static u16 sLastTextBgColor;
@@ -244,7 +244,7 @@ static void SetFontsPointer(const struct FontInfo *fonts)
 void DeactivateAllTextPrinters(void)
 {
     int printer;
-    for (printer = 0; printer < NUM_TEXT_PRINTERS; ++printer)
+    for (printer = 0; printer < WINDOWS_MAX; ++printer)
         sTextPrinters[printer].active = FALSE;
 }
 
@@ -322,7 +322,7 @@ void RunTextPrinters(void)
 
     if (!gDisableTextPrinters)
     {
-        for (i = 0; i < NUM_TEXT_PRINTERS; ++i)
+        for (i = 0; i < WINDOWS_MAX; ++i)
         {
             if (sTextPrinters[i].active)
             {

--- a/gflib/text.h
+++ b/gflib/text.h
@@ -3,8 +3,6 @@
 
 #include "characters.h"
 
-#define NUM_TEXT_PRINTERS 32
-
 // Given as a text speed when all the text should be
 // loaded at once but not copied to vram yet.
 #define TEXT_SKIP_DRAW 0xFF

--- a/gflib/window.c
+++ b/gflib/window.c
@@ -9,8 +9,6 @@ u8 gTransparentTileNumber;
 void *gWindowBgTilemapBuffers[NUM_BACKGROUNDS];
 extern u32 gWindowTileAutoAllocEnabled;
 
-#define WINDOWS_MAX  32
-
 EWRAM_DATA struct Window gWindows[WINDOWS_MAX] = {0};
 EWRAM_DATA static struct Window* sWindowPtr = NULL;
 EWRAM_DATA static u16 sWindowSize = 0;

--- a/gflib/window.h
+++ b/gflib/window.h
@@ -1,6 +1,8 @@
 #ifndef GUARD_WINDOW_H
 #define GUARD_WINDOW_H
 
+#define WINDOWS_MAX  32
+
 #define PIXEL_FILL(num) ((num) | ((num) << 4))
 
 enum {

--- a/src/contest.c
+++ b/src/contest.c
@@ -5503,7 +5503,7 @@ static void ContestBG_FillBoxWithTile(u8 bg, u16 firstTileNum, u8 x, u8 y, u8 wi
 static bool32 Contest_RunTextPrinters(void)
 {
     RunTextPrinters();
-    return IsTextPrinterActive(4);
+    return IsTextPrinterActive(WIN_GENERAL_TEXT);
 }
 
 static void Contest_SetBgCopyFlags(u32 flagIndex)


### PR DESCRIPTION
`sTextPrinters` takes a window ID for an index, so these constants represented the same thing.