### PR TITLE
Renamed AllocZeroed to Calloc

### DIFF
--- a/gflib/malloc.c
+++ b/gflib/malloc.c
@@ -128,7 +128,7 @@ void FreeInternal(void *heapStart, void *pointer)
     }
 }
 
-void *AllocZeroedInternal(void *heapStart, u32 size)
+void *CallocInternal(void *heapStart, u32 size)
 {
     void *mem = AllocInternal(heapStart, size);
 
@@ -180,9 +180,9 @@ void *Alloc(u32 size)
     return AllocInternal(sHeapStart, size);
 }
 
-void *AllocZeroed(u32 size)
+void *Calloc(u32 size)
 {
-    return AllocZeroedInternal(sHeapStart, size);
+    return CallocInternal(sHeapStart, size);
 }
 
 void Free(void *pointer)

--- a/gflib/malloc.h
+++ b/gflib/malloc.h
@@ -14,7 +14,7 @@
 extern u8 gHeap[];
 
 void *Alloc(u32 size);
-void *AllocZeroed(u32 size);
+void *Calloc(u32 size);
 void Free(void *pointer);
 void InitHeap(void *pointer, u32 size);
 

--- a/gflib/window.c
+++ b/gflib/window.c
@@ -65,7 +65,7 @@ bool16 InitWindows(const struct WindowTemplate *templates)
 
             if (attrib != 0xFFFF)
             {
-                allocatedTilemapBuffer = AllocZeroed(attrib);
+                allocatedTilemapBuffer = Calloc(attrib);
 
                 if (allocatedTilemapBuffer == NULL)
                 {
@@ -81,7 +81,7 @@ bool16 InitWindows(const struct WindowTemplate *templates)
             }
         }
 
-        allocatedTilemapBuffer = AllocZeroed((u16)(32 * (templates[i].width * templates[i].height)));
+        allocatedTilemapBuffer = Calloc((u16)(32 * (templates[i].width * templates[i].height)));
 
         if (allocatedTilemapBuffer == NULL)
         {
@@ -143,7 +143,7 @@ u16 AddWindow(const struct WindowTemplate *template)
 
         if (attrib != 0xFFFF)
         {
-            allocatedTilemapBuffer = AllocZeroed(attrib);
+            allocatedTilemapBuffer = Calloc(attrib);
 
             if (allocatedTilemapBuffer == NULL)
                 return WINDOW_NONE;
@@ -156,7 +156,7 @@ u16 AddWindow(const struct WindowTemplate *template)
         }
     }
 
-    allocatedTilemapBuffer = AllocZeroed((u16)(32 * (template->width * template->height)));
+    allocatedTilemapBuffer = Calloc((u16)(32 * (template->width * template->height)));
 
     if (allocatedTilemapBuffer == NULL)
     {
@@ -622,7 +622,7 @@ u16 AddWindow8Bit(const struct WindowTemplate *template)
             memAddress = Alloc(attribute);
             if (memAddress == NULL)
                 return WINDOW_NONE;
-            for (i = 0; i < attribute; i++) // if we're going to zero out the memory anyway, why not call AllocZeroed?
+            for (i = 0; i < attribute; i++) // if we're going to zero out the memory anyway, why not call Calloc?
                 memAddress[i] = 0;
             gWindowBgTilemapBuffers[bgLayer] = memAddress;
             SetBgTilemapBuffer(bgLayer, memAddress);

--- a/src/apprentice.c
+++ b/src/apprentice.c
@@ -282,7 +282,7 @@ static void SetRandomQuestionData(void)
         SWAP(questionOrder[rand1], questionOrder[rand2], temp);
     }
 
-    gApprenticePartyMovesData = AllocZeroed(sizeof(*gApprenticePartyMovesData));
+    gApprenticePartyMovesData = Calloc(sizeof(*gApprenticePartyMovesData));
     gApprenticePartyMovesData->moveCounter = 0;
     for (i = 0; i < NUM_WHICH_MOVE_QUESTIONS; i++)
     {
@@ -980,7 +980,7 @@ static void InitQuestionData(void)
     for (i = 0; i < APPRENTICE_MAX_QUESTIONS && (PLAYER_APPRENTICE.questions[i].questionId != QUESTION_ID_WIN_SPEECH); count++, i++)
         ;
 
-    gApprenticeQuestionData = AllocZeroed(sizeof(*gApprenticeQuestionData));
+    gApprenticeQuestionData = Calloc(sizeof(*gApprenticeQuestionData));
     if (gSpecialVar_0x8005 == APPRENTICE_QUESTION_WHICH_MON)
     {
         if (PLAYER_APPRENTICE.questionsAnswered < NUM_WHICH_MON_QUESTIONS)

--- a/src/battle_anim_effects_2.c
+++ b/src/battle_anim_effects_2.c
@@ -3023,7 +3023,7 @@ void AnimTask_LoadMusicNotesPals(u8 taskId)
     for (i = 1; i < NUM_MUSIC_NOTE_PAL_TAGS; i++)
         paletteNums[i] = AllocSpritePalette(ANIM_SPRITES_START - i);
 
-    gMonSpritesGfxPtr->buffer = AllocZeroed(MON_PIC_SIZE * MAX_MON_PIC_FRAMES);
+    gMonSpritesGfxPtr->buffer = Calloc(MON_PIC_SIZE * MAX_MON_PIC_FRAMES);
     LZDecompressWram(gBattleAnimSpritePal_MusicNotes2, gMonSpritesGfxPtr->buffer);
     for (i = 0; i < NUM_MUSIC_NOTE_PAL_TAGS; i++)
         LoadPalette(&gMonSpritesGfxPtr->buffer[i * 32], (u16)(OBJ_PLTT_ID(paletteNums[i])), PLTT_SIZE_4BPP);

--- a/src/battle_anim_mons.c
+++ b/src/battle_anim_mons.c
@@ -2101,7 +2101,7 @@ u8 CreateAdditionalMonSpriteForMoveAnim(u16 species, bool8 isBackpic, u8 id, s16
     u16 palette = AllocSpritePalette(sSpriteTemplates_MoveEffectMons[id].paletteTag);
 
     if (gMonSpritesGfxPtr != NULL && gMonSpritesGfxPtr->buffer == NULL)
-        gMonSpritesGfxPtr->buffer = AllocZeroed(MON_PIC_SIZE * MAX_MON_PIC_FRAMES);
+        gMonSpritesGfxPtr->buffer = Calloc(MON_PIC_SIZE * MAX_MON_PIC_FRAMES);
     if (!isBackpic)
     {
         LoadCompressedPalette(GetMonSpritePalFromSpeciesAndPersonality(species, trainerId, personality), OBJ_PLTT_ID(palette), PLTT_SIZE_4BPP);

--- a/src/battle_anim_utility_funcs.c
+++ b/src/battle_anim_utility_funcs.c
@@ -392,7 +392,7 @@ void InitStatsChangeAnimation(u8 taskId)
 {
     u8 i;
 
-    sAnimStatsChangeData = AllocZeroed(sizeof(struct AnimStatsChangeData));
+    sAnimStatsChangeData = Calloc(sizeof(struct AnimStatsChangeData));
     for (i = 0; i < 8; i++)
         sAnimStatsChangeData->data[i] = gBattleAnimArgs[i];
 
@@ -899,7 +899,7 @@ void AnimTask_GetBattleTerrain(u8 taskId)
 
 void AnimTask_AllocBackupPalBuffer(u8 taskId)
 {
-    gMonSpritesGfxPtr->buffer = AllocZeroed(MON_PIC_SIZE * MAX_MON_PIC_FRAMES);
+    gMonSpritesGfxPtr->buffer = Calloc(MON_PIC_SIZE * MAX_MON_PIC_FRAMES);
     DestroyAnimVisualTask(taskId);
 }
 

--- a/src/battle_dome.c
+++ b/src/battle_dome.c
@@ -2279,8 +2279,8 @@ static void InitDomeTrainers(void)
     species[0] = 0;
     species[1] = 0;
     species[2] = 0;
-    rankingScores = AllocZeroed(sizeof(u16) * DOME_TOURNAMENT_TRAINERS_COUNT);
-    statValues = AllocZeroed(sizeof(int) * NUM_STATS);
+    rankingScores = Calloc(sizeof(u16) * DOME_TOURNAMENT_TRAINERS_COUNT);
+    statValues = Calloc(sizeof(int) * NUM_STATS);
 
     gSaveBlock2Ptr->frontier.domeLvlMode = gSaveBlock2Ptr->frontier.lvlMode + 1;
     gSaveBlock2Ptr->frontier.domeBattleMode = VarGet(VAR_FRONTIER_BATTLE_MODE) + 1;
@@ -3089,7 +3089,7 @@ static void Task_ShowTourneyInfoCard(u8 taskId)
         break;
     case 3:
         SetVBlankCallback(VblankCb_TourneyInfoCard);
-        sInfoCard = AllocZeroed(sizeof(*sInfoCard));
+        sInfoCard = Calloc(sizeof(*sInfoCard));
         for (i = 0; i < NUM_INFOCARD_SPRITES; i++)
             sInfoCard->spriteIds[i] = SPRITE_NONE;
         LoadMonIconPalettes();
@@ -4293,7 +4293,7 @@ static void DisplayTrainerInfoOnCard(u8 flags, u8 trainerTourneyId)
     int windowId = WIN_TRAINER_NAME;
     int x = 0, y = 0;
     u8 palSlot = 0;
-    s16 *allocatedArray = AllocZeroed(sizeof(s16) * ALLOC_ARRAY_SIZE);
+    s16 *allocatedArray = Calloc(sizeof(s16) * ALLOC_ARRAY_SIZE);
     trainerId = DOME_TRAINERS[trainerTourneyId].trainerId;
 
     if (flags & CARD_ALTERNATE_SLOT)
@@ -5346,7 +5346,7 @@ static void Task_ShowTourneyTree(u8 taskId)
         gTasks[taskId].tState++;
         break;
     case 2:
-        sTilemapBuffer = AllocZeroed(BG_SCREEN_SIZE);
+        sTilemapBuffer = Calloc(BG_SCREEN_SIZE);
         LZDecompressWram(gDomeTourneyTree_Tilemap, sTilemapBuffer);
         SetBgTilemapBuffer(1, sTilemapBuffer);
         CopyBgTilemapBufferToVram(1);
@@ -5836,8 +5836,8 @@ static void InitRandomTourneyTreeResults(void)
     if ((gSaveBlock2Ptr->frontier.domeLvlMode != -gSaveBlock2Ptr->frontier.domeBattleMode) && gSaveBlock2Ptr->frontier.challengeStatus != CHALLENGE_STATUS_SAVING)
         return;
 
-    statSums = AllocZeroed(sizeof(u16) * DOME_TOURNAMENT_TRAINERS_COUNT);
-    statValues = AllocZeroed(sizeof(int) * NUM_STATS);
+    statSums = Calloc(sizeof(u16) * DOME_TOURNAMENT_TRAINERS_COUNT);
+    statValues = Calloc(sizeof(int) * NUM_STATS);
     lvlMode = gSaveBlock2Ptr->frontier.lvlMode;
     gSaveBlock2Ptr->frontier.lvlMode = FRONTIER_LVL_50;
     zero1 = 0;

--- a/src/battle_factory_screen.c
+++ b/src/battle_factory_screen.c
@@ -1143,9 +1143,9 @@ static void CB2_InitSelectScreen(void)
         break;
     case 1:
         sSelectMenuTilesetBuffer = Alloc(0x440);
-        sSelectMonPicBgTilesetBuffer = AllocZeroed(0x440);
+        sSelectMonPicBgTilesetBuffer = Calloc(0x440);
         sSelectMenuTilemapBuffer = Alloc(BG_SCREEN_SIZE);
-        sSelectMonPicBgTilemapBuffer = AllocZeroed(BG_SCREEN_SIZE);
+        sSelectMonPicBgTilemapBuffer = Calloc(BG_SCREEN_SIZE);
         ChangeBgX(0, 0, BG_COORD_SET);
         ChangeBgY(0, 0, BG_COORD_SET);
         ChangeBgX(1, 0, BG_COORD_SET);
@@ -1281,7 +1281,7 @@ static void Select_InitMonsData(void)
     if (sFactorySelectScreen != NULL)
         return;
 
-    sFactorySelectScreen = AllocZeroed(sizeof(*sFactorySelectScreen));
+    sFactorySelectScreen = Calloc(sizeof(*sFactorySelectScreen));
     sFactorySelectScreen->cursorPos = 0;
     sFactorySelectScreen->selectingMonsState = 1;
     sFactorySelectScreen->fromSummaryScreen = FALSE;
@@ -1472,7 +1472,7 @@ static void Select_Task_OpenSummaryScreen(u8 taskId)
         DestroyTask(taskId);
         sFactorySelectScreen->fromSummaryScreen = TRUE;
         currMonId = sFactorySelectScreen->cursorPos;
-        sFactorySelectMons = AllocZeroed(sizeof(struct Pokemon) * SELECTABLE_MONS_COUNT);
+        sFactorySelectMons = Calloc(sizeof(struct Pokemon) * SELECTABLE_MONS_COUNT);
         for (i = 0; i < SELECTABLE_MONS_COUNT; i++)
             sFactorySelectMons[i] = sFactorySelectScreen->mons[i].monData;
         ShowPokemonSummaryScreen(SUMMARY_MODE_LOCK_MOVES, sFactorySelectMons, currMonId, SELECTABLE_MONS_COUNT - 1, CB2_InitSelectScreen);
@@ -3245,7 +3245,7 @@ static void Swap_InitStruct(void)
 {
     if (sFactorySwapScreen == NULL)
     {
-        sFactorySwapScreen = AllocZeroed(sizeof(*sFactorySwapScreen));
+        sFactorySwapScreen = Calloc(sizeof(*sFactorySwapScreen));
         sFactorySwapScreen->cursorPos = 0;
         sFactorySwapScreen->monPicAnimating = FALSE;
         sFactorySwapScreen->fromSummaryScreen = FALSE;
@@ -3276,9 +3276,9 @@ static void CB2_InitSwapScreen(void)
         break;
     case 1:
         sSwapMenuTilesetBuffer = Alloc(0x440);
-        sSwapMonPicBgTilesetBuffer = AllocZeroed(0x440);
+        sSwapMonPicBgTilesetBuffer = Calloc(0x440);
         sSwapMenuTilemapBuffer = Alloc(BG_SCREEN_SIZE);
-        sSwapMonPicBgTilemapBuffer = AllocZeroed(BG_SCREEN_SIZE);
+        sSwapMonPicBgTilemapBuffer = Calloc(BG_SCREEN_SIZE);
         ChangeBgX(0, 0, BG_COORD_SET);
         ChangeBgY(0, 0, BG_COORD_SET);
         ChangeBgX(1, 0, BG_COORD_SET);

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -86,11 +86,11 @@ static const struct SpritePalette sSpritePalettes_HealthBoxHealthBar[2] =
 // code
 void AllocateBattleSpritesData(void)
 {
-    gBattleSpritesDataPtr = AllocZeroed(sizeof(struct BattleSpriteData));
-    gBattleSpritesDataPtr->battlerData = AllocZeroed(sizeof(struct BattleSpriteInfo) * MAX_BATTLERS_COUNT);
-    gBattleSpritesDataPtr->healthBoxesData = AllocZeroed(sizeof(struct BattleHealthboxInfo) * MAX_BATTLERS_COUNT);
-    gBattleSpritesDataPtr->animationData = AllocZeroed(sizeof(struct BattleAnimationInfo));
-    gBattleSpritesDataPtr->battleBars = AllocZeroed(sizeof(struct BattleBarInfo) * MAX_BATTLERS_COUNT);
+    gBattleSpritesDataPtr = Calloc(sizeof(struct BattleSpriteData));
+    gBattleSpritesDataPtr->battlerData = Calloc(sizeof(struct BattleSpriteInfo) * MAX_BATTLERS_COUNT);
+    gBattleSpritesDataPtr->healthBoxesData = Calloc(sizeof(struct BattleHealthboxInfo) * MAX_BATTLERS_COUNT);
+    gBattleSpritesDataPtr->animationData = Calloc(sizeof(struct BattleAnimationInfo));
+    gBattleSpritesDataPtr->battleBars = Calloc(sizeof(struct BattleBarInfo) * MAX_BATTLERS_COUNT);
 }
 
 void FreeBattleSpritesData(void)
@@ -1253,8 +1253,8 @@ void AllocateMonSpritesGfx(void)
     u8 i = 0, j;
 
     gMonSpritesGfxPtr = NULL;
-    gMonSpritesGfxPtr = AllocZeroed(sizeof(*gMonSpritesGfxPtr));
-    gMonSpritesGfxPtr->firstDecompressed = AllocZeroed(MON_PIC_SIZE * 4 * MAX_BATTLERS_COUNT);
+    gMonSpritesGfxPtr = Calloc(sizeof(*gMonSpritesGfxPtr));
+    gMonSpritesGfxPtr->firstDecompressed = Calloc(MON_PIC_SIZE * 4 * MAX_BATTLERS_COUNT);
 
     for (i = 0; i < MAX_BATTLERS_COUNT; i++)
     {
@@ -1270,7 +1270,7 @@ void AllocateMonSpritesGfx(void)
         gMonSpritesGfxPtr->templates[i].images = gMonSpritesGfxPtr->frameImages[i];
     }
 
-    gMonSpritesGfxPtr->barFontGfx = AllocZeroed(0x1000);
+    gMonSpritesGfxPtr->barFontGfx = Calloc(0x1000);
 }
 
 void FreeMonSpritesGfx(void)

--- a/src/battle_pike.c
+++ b/src/battle_pike.c
@@ -1075,7 +1075,7 @@ static u8 GetNextRoomType(void)
         }
     }
 
-    roomCandidates = AllocZeroed(numRoomCandidates);
+    roomCandidates = Calloc(numRoomCandidates);
     id = 0;
     for (i = 0; i < ARRAY_COUNT(roomTypesDisabled); i++)
     {
@@ -1348,7 +1348,7 @@ static void SetHintedRoom(void)
         else
             count = NUM_PIKE_ROOM_TYPES - 1; // exclude Brain room
 
-        roomCandidates = AllocZeroed(count);
+        roomCandidates = Calloc(count);
         for (i = 0, id = 0; i < count; i++)
         {
             if (gSaveBlock2Ptr->frontier.pikeHealingRoomsDisabled)

--- a/src/battle_pyramid.c
+++ b/src/battle_pyramid.c
@@ -1523,7 +1523,7 @@ void GenerateBattlePyramidFloorLayout(u16 *backupMapData, bool8 setPlayerPositio
     int y, x;
     int i;
     u8 entranceSquareId, exitSquareId;
-    u8 *floorLayoutOffsets = AllocZeroed(NUM_PYRAMID_FLOOR_SQUARES);
+    u8 *floorLayoutOffsets = Calloc(NUM_PYRAMID_FLOOR_SQUARES);
 
     GetPyramidFloorLayoutOffsets(floorLayoutOffsets);
     GetPyramidEntranceAndExitSquareIds(&entranceSquareId, &exitSquareId);
@@ -1651,7 +1651,7 @@ static void SetPyramidObjectPositionsUniformly(u8 objType)
     int squareId;
     u32 bits = 0;
     u8 id = GetPyramidFloorTemplateId();
-    u8 *floorLayoutOffsets = AllocZeroed(NUM_PYRAMID_FLOOR_SQUARES);
+    u8 *floorLayoutOffsets = Calloc(NUM_PYRAMID_FLOOR_SQUARES);
 
     GetPyramidFloorLayoutOffsets(floorLayoutOffsets);
     squareId = gSaveBlock2Ptr->frontier.pyramidRandoms[2] % NUM_PYRAMID_FLOOR_SQUARES;
@@ -1709,7 +1709,7 @@ static bool8 SetPyramidObjectPositionsInAndNearSquare(u8 objType, u8 squareId)
     int numPlacedObjects = 0;
     int numObjects;
     u8 id = GetPyramidFloorTemplateId();
-    u8 *floorLayoutOffsets = AllocZeroed(NUM_PYRAMID_FLOOR_SQUARES);
+    u8 *floorLayoutOffsets = Calloc(NUM_PYRAMID_FLOOR_SQUARES);
 
     GetPyramidFloorLayoutOffsets(floorLayoutOffsets);
     if (objType == OBJ_TRAINERS)
@@ -1775,7 +1775,7 @@ static bool8 SetPyramidObjectPositionsNearSquare(u8 objType, u8 squareId)
     int r8 = 0;
     int numObjects;
     u8 id = GetPyramidFloorTemplateId();
-    u8 *floorLayoutOffsets = AllocZeroed(NUM_PYRAMID_FLOOR_SQUARES);
+    u8 *floorLayoutOffsets = Calloc(NUM_PYRAMID_FLOOR_SQUARES);
 
     GetPyramidFloorLayoutOffsets(floorLayoutOffsets);
     if (objType == OBJ_TRAINERS)

--- a/src/battle_pyramid_bag.c
+++ b/src/battle_pyramid_bag.c
@@ -416,7 +416,7 @@ void CB2_ReturnToPyramidBagMenu(void)
 
 void GoToBattlePyramidBagMenu(u8 location, void (*exitCallback)(void))
 {
-    gPyramidBagMenu = AllocZeroed(sizeof(*gPyramidBagMenu));
+    gPyramidBagMenu = Calloc(sizeof(*gPyramidBagMenu));
 
     if (location != PYRAMIDBAG_LOC_PREV)
         gPyramidBagMenuState.location = location;

--- a/src/battle_records.c
+++ b/src/battle_records.c
@@ -482,7 +482,7 @@ static void CB2_ShowTrainerHillRecords(void)
         gMain.state++;
         break;
     case 2:
-        sTilemapBuffer = AllocZeroed(BG_SCREEN_SIZE);
+        sTilemapBuffer = Calloc(BG_SCREEN_SIZE);
         ResetBgsAndClearDma3BusyFlags(0);
         InitBgsFromTemplates(0, sTrainerHillRecordsBgTemplates, ARRAY_COUNT(sTrainerHillRecordsBgTemplates));
         SetBgTilemapBuffer(3, sTilemapBuffer);

--- a/src/battle_transition.c
+++ b/src/battle_transition.c
@@ -1058,7 +1058,7 @@ static void LaunchBattleTransitionTask(u8 transitionId)
 {
     u8 taskId = CreateTask(Task_BattleTransition, 2);
     gTasks[taskId].tTransitionId = transitionId;
-    sTransitionData = AllocZeroed(sizeof(*sTransitionData));
+    sTransitionData = Calloc(sizeof(*sTransitionData));
 }
 
 static void Task_BattleTransition(u8 taskId)

--- a/src/battle_util2.c
+++ b/src/battle_util2.c
@@ -19,23 +19,23 @@ void AllocateBattleResources(void)
     if (gBattleTypeFlags & BATTLE_TYPE_TRAINER_HILL)
         InitTrainerHillBattleStruct();
 
-    gBattleStruct = AllocZeroed(sizeof(*gBattleStruct));
+    gBattleStruct = Calloc(sizeof(*gBattleStruct));
 
-    gBattleResources = AllocZeroed(sizeof(*gBattleResources));
-    gBattleResources->secretBase = AllocZeroed(sizeof(*gBattleResources->secretBase));
-    gBattleResources->flags = AllocZeroed(sizeof(*gBattleResources->flags));
-    gBattleResources->battleScriptsStack = AllocZeroed(sizeof(*gBattleResources->battleScriptsStack));
-    gBattleResources->battleCallbackStack = AllocZeroed(sizeof(*gBattleResources->battleCallbackStack));
-    gBattleResources->beforeLvlUp = AllocZeroed(sizeof(*gBattleResources->beforeLvlUp));
-    gBattleResources->ai = AllocZeroed(sizeof(*gBattleResources->ai));
-    gBattleResources->battleHistory = AllocZeroed(sizeof(*gBattleResources->battleHistory));
-    gBattleResources->AI_ScriptsStack = AllocZeroed(sizeof(*gBattleResources->AI_ScriptsStack));
+    gBattleResources = Calloc(sizeof(*gBattleResources));
+    gBattleResources->secretBase = Calloc(sizeof(*gBattleResources->secretBase));
+    gBattleResources->flags = Calloc(sizeof(*gBattleResources->flags));
+    gBattleResources->battleScriptsStack = Calloc(sizeof(*gBattleResources->battleScriptsStack));
+    gBattleResources->battleCallbackStack = Calloc(sizeof(*gBattleResources->battleCallbackStack));
+    gBattleResources->beforeLvlUp = Calloc(sizeof(*gBattleResources->beforeLvlUp));
+    gBattleResources->ai = Calloc(sizeof(*gBattleResources->ai));
+    gBattleResources->battleHistory = Calloc(sizeof(*gBattleResources->battleHistory));
+    gBattleResources->AI_ScriptsStack = Calloc(sizeof(*gBattleResources->AI_ScriptsStack));
 
-    gLinkBattleSendBuffer = AllocZeroed(BATTLE_BUFFER_LINK_SIZE);
-    gLinkBattleRecvBuffer = AllocZeroed(BATTLE_BUFFER_LINK_SIZE);
+    gLinkBattleSendBuffer = Calloc(BATTLE_BUFFER_LINK_SIZE);
+    gLinkBattleRecvBuffer = Calloc(BATTLE_BUFFER_LINK_SIZE);
 
-    gBattleAnimBgTileBuffer = AllocZeroed(0x2000);
-    gBattleAnimBgTilemapBuffer = AllocZeroed(0x1000);
+    gBattleAnimBgTileBuffer = Calloc(0x2000);
+    gBattleAnimBgTilemapBuffer = Calloc(0x1000);
 
     if (gBattleTypeFlags & BATTLE_TYPE_SECRET_BASE)
     {

--- a/src/berry_blender.c
+++ b/src/berry_blender.c
@@ -959,7 +959,7 @@ static bool8 LoadBerryBlenderGfx(void)
     switch (sBerryBlender->loadGfxState)
     {
     case 0:
-        sBerryBlender->tilesBuffer = AllocZeroed(GetDecompressedDataSize(gBerryBlenderCenter_Gfx) + 100);
+        sBerryBlender->tilesBuffer = Calloc(GetDecompressedDataSize(gBerryBlenderCenter_Gfx) + 100);
         LZDecompressWram(gBerryBlenderCenter_Gfx, sBerryBlender->tilesBuffer);
         sBerryBlender->loadGfxState++;
         break;
@@ -1046,7 +1046,7 @@ static void InitBerryBlenderWindows(void)
 void DoBerryBlending(void)
 {
     if (sBerryBlender == NULL)
-        sBerryBlender = AllocZeroed(sizeof(*sBerryBlender));
+        sBerryBlender = Calloc(sizeof(*sBerryBlender));
 
     sBerryBlender->gameEndState = 0;
     sBerryBlender->mainState = 0;
@@ -1273,7 +1273,7 @@ static void StartBlender(void)
 
     SetGpuReg(REG_OFFSET_DISPCNT, 0);
     if (sBerryBlender == NULL)
-        sBerryBlender = AllocZeroed(sizeof(*sBerryBlender));
+        sBerryBlender = Calloc(sizeof(*sBerryBlender));
 
     sBerryBlender->mainState = 0;
     sBerryBlender->unk1 = 0;

--- a/src/berry_crush.c
+++ b/src/berry_crush.c
@@ -1013,7 +1013,7 @@ void StartBerryCrush(MainCallback exitCallback)
         return;
     }
 
-    sGame = AllocZeroed(sizeof(*sGame));
+    sGame = Calloc(sizeof(*sGame));
     if (!sGame)
     {
         // Alloc failed

--- a/src/berry_fix_program.c
+++ b/src/berry_fix_program.c
@@ -207,7 +207,7 @@ void CB2_InitBerryFixProgram(void)
     ResetTasks();
     ScanlineEffect_Stop();
     SetGpuReg(REG_OFFSET_DISPCNT, 0);
-    sBerryFix = AllocZeroed(sizeof(*sBerryFix));
+    sBerryFix = Calloc(sizeof(*sBerryFix));
     sBerryFix->state = MAINSTATE_INIT;
     sBerryFix->curScene = SCENE_NONE;
     SetMainCallback2(BerryFix_Main);

--- a/src/berry_tag_screen.c
+++ b/src/berry_tag_screen.c
@@ -175,7 +175,7 @@ static void HandleBagCursorPositionChange(s8 toMove);
 // code
 void DoBerryTagScreen(void)
 {
-    sBerryTag = AllocZeroed(sizeof(*sBerryTag));
+    sBerryTag = Calloc(sizeof(*sBerryTag));
     sBerryTag->berryId = ItemIdToBerryType(gSpecialVar_ItemId);
     SetMainCallback2(CB2_InitBerryTagScreen);
 }

--- a/src/cable_car.c
+++ b/src/cable_car.c
@@ -267,7 +267,7 @@ static void CB2_LoadCableCar(void)
         DmaFillLarge16(3, 0, (void *)VRAM, VRAM_SIZE, 0x1000);
         DmaFill32Defvars(3, 0, (void *)OAM, OAM_SIZE);
         DmaFill16Defvars(3, 0, (void *)PLTT, PLTT_SIZE);
-        sCableCar = AllocZeroed(sizeof(*sCableCar));
+        sCableCar = Calloc(sizeof(*sCableCar));
         gMain.state++;
         break;
     case 1:

--- a/src/confetti_util.c
+++ b/src/confetti_util.c
@@ -19,10 +19,10 @@ bool32 ConfettiUtil_Init(u8 count)
     if (count > 64)
         count = 64;
 
-    sWork = AllocZeroed(sizeof(*sWork));
+    sWork = Calloc(sizeof(*sWork));
     if (sWork == NULL)
         return FALSE;
-    sWork->array = AllocZeroed(count * sizeof(struct ConfettiUtil));
+    sWork->array = Calloc(count * sizeof(struct ConfettiUtil));
     if (sWork->array == NULL)
     {
         FREE_AND_SET_NULL(sWork);

--- a/src/contest.c
+++ b/src/contest.c
@@ -1123,23 +1123,23 @@ static void InitContestResources(void)
 
 static void AllocContestResources(void)
 {
-    gContestResources = AllocZeroed(sizeof(struct ContestResources));
-    gContestResources->contest = AllocZeroed(sizeof(struct Contest));
-    gContestResources->status = AllocZeroed(sizeof(struct ContestantStatus) * CONTESTANT_COUNT);
-    gContestResources->appealResults = AllocZeroed(sizeof(struct ContestAppealMoveResults));
-    gContestResources->aiData = AllocZeroed(sizeof(struct ContestAIInfo));
-    gContestResources->excitement = AllocZeroed(sizeof(struct ContestExcitement) * CONTESTANT_COUNT);
-    gContestResources->gfxState = AllocZeroed(sizeof(struct ContestGraphicsState) * CONTESTANT_COUNT);
-    gContestResources->moveAnim = AllocZeroed(sizeof(struct ContestMoveAnimData));
-    gContestResources->tv = AllocZeroed(sizeof(struct ContestTV) * CONTESTANT_COUNT);
-    gContestResources->unused = AllocZeroed(sizeof(struct ContestUnused));
-    gContestResources->contestBgTilemaps[0] = AllocZeroed(0x1000);
-    gContestResources->contestBgTilemaps[1] = AllocZeroed(0x1000);
-    gContestResources->contestBgTilemaps[2] = AllocZeroed(0x1000);
-    gContestResources->contestBgTilemaps[3] = AllocZeroed(0x1000);
-    gContestResources->boxBlinkTiles1 = AllocZeroed(0x800);
-    gContestResources->boxBlinkTiles2 = AllocZeroed(0x800);
-    gContestResources->animBgTileBuffer = AllocZeroed(0x2000);
+    gContestResources = Calloc(sizeof(struct ContestResources));
+    gContestResources->contest = Calloc(sizeof(struct Contest));
+    gContestResources->status = Calloc(sizeof(struct ContestantStatus) * CONTESTANT_COUNT);
+    gContestResources->appealResults = Calloc(sizeof(struct ContestAppealMoveResults));
+    gContestResources->aiData = Calloc(sizeof(struct ContestAIInfo));
+    gContestResources->excitement = Calloc(sizeof(struct ContestExcitement) * CONTESTANT_COUNT);
+    gContestResources->gfxState = Calloc(sizeof(struct ContestGraphicsState) * CONTESTANT_COUNT);
+    gContestResources->moveAnim = Calloc(sizeof(struct ContestMoveAnimData));
+    gContestResources->tv = Calloc(sizeof(struct ContestTV) * CONTESTANT_COUNT);
+    gContestResources->unused = Calloc(sizeof(struct ContestUnused));
+    gContestResources->contestBgTilemaps[0] = Calloc(0x1000);
+    gContestResources->contestBgTilemaps[1] = Calloc(0x1000);
+    gContestResources->contestBgTilemaps[2] = Calloc(0x1000);
+    gContestResources->contestBgTilemaps[3] = Calloc(0x1000);
+    gContestResources->boxBlinkTiles1 = Calloc(0x800);
+    gContestResources->boxBlinkTiles2 = Calloc(0x800);
+    gContestResources->animBgTileBuffer = Calloc(0x2000);
     gBattleAnimBgTileBuffer = gContestResources->animBgTileBuffer;
     gBattleAnimBgTilemapBuffer = gContestResources->contestBgTilemaps[1];
 }
@@ -1176,7 +1176,7 @@ void CB2_StartContest(void)
         AllocContestResources();
         AllocateMonSpritesGfx();
         FREE_AND_SET_NULL(gMonSpritesGfxPtr->firstDecompressed);
-        gMonSpritesGfxPtr->firstDecompressed = AllocZeroed(0x4000);
+        gMonSpritesGfxPtr->firstDecompressed = Calloc(0x4000);
         SetVBlankCallback(NULL);
         InitContestInfoBgs();
         InitContestWindows();

--- a/src/contest_painting.c
+++ b/src/contest_painting.c
@@ -269,7 +269,7 @@ static void InitContestPaintingWindow(void)
     InitBgsFromTemplates(0, sBgTemplates, ARRAY_COUNT(sBgTemplates));
     ChangeBgX(1, 0, BG_COORD_SET);
     ChangeBgY(1, 0, BG_COORD_SET);
-    SetBgTilemapBuffer(1, AllocZeroed(BG_SCREEN_SIZE));
+    SetBgTilemapBuffer(1, Calloc(BG_SCREEN_SIZE));
     sWindowId = AddWindow(&sWindowTemplate);
     DeactivateAllTextPrinters();
     FillWindowPixelBuffer(sWindowId, PIXEL_FILL(0));
@@ -548,8 +548,8 @@ static u8 GetImageEffectForContestWinner(u8 contestWinnerId)
 
 static void AllocPaintingResources(void)
 {
-    gContestPaintingMonPalette = AllocZeroed(OBJ_PLTT_SIZE);
-    gContestMonPixels = AllocZeroed(0x2000);
+    gContestPaintingMonPalette = Calloc(OBJ_PLTT_SIZE);
+    gContestMonPixels = Calloc(0x2000);
 }
 
 static void DoContestPaintingImageProcessing(u8 imageEffect)

--- a/src/contest_util.c
+++ b/src/contest_util.c
@@ -1909,15 +1909,15 @@ static void Task_UpdateContestResultBar(u8 taskId)
 
 static void AllocContestResults(void)
 {
-    sContestResults = AllocZeroed(sizeof(*sContestResults));
-    sContestResults->data = AllocZeroed(sizeof(*sContestResults->data));
-    sContestResults->monResults = AllocZeroed(sizeof(*sContestResults->monResults));
-    sContestResults->unusedBg = AllocZeroed(BG_SCREEN_SIZE);
-    sContestResults->tilemapBuffers[0] = AllocZeroed(BG_SCREEN_SIZE);
-    sContestResults->tilemapBuffers[1] = AllocZeroed(BG_SCREEN_SIZE);
-    sContestResults->tilemapBuffers[2] = AllocZeroed(BG_SCREEN_SIZE);
-    sContestResults->tilemapBuffers[3] = AllocZeroed(BG_SCREEN_SIZE);
-    sContestResults->unused = AllocZeroed(0x1000);
+    sContestResults = Calloc(sizeof(*sContestResults));
+    sContestResults->data = Calloc(sizeof(*sContestResults->data));
+    sContestResults->monResults = Calloc(sizeof(*sContestResults->monResults));
+    sContestResults->unusedBg = Calloc(BG_SCREEN_SIZE);
+    sContestResults->tilemapBuffers[0] = Calloc(BG_SCREEN_SIZE);
+    sContestResults->tilemapBuffers[1] = Calloc(BG_SCREEN_SIZE);
+    sContestResults->tilemapBuffers[2] = Calloc(BG_SCREEN_SIZE);
+    sContestResults->tilemapBuffers[3] = Calloc(BG_SCREEN_SIZE);
+    sContestResults->unused = Calloc(0x1000);
     AllocateMonSpritesGfx();
 }
 

--- a/src/credits.c
+++ b/src/credits.c
@@ -364,7 +364,7 @@ static void InitCreditsBgsAndWindows(void)
 {
     ResetBgsAndClearDma3BusyFlags(0);
     InitBgsFromTemplates(0, sBackgroundTemplates, ARRAY_COUNT(sBackgroundTemplates));
-    SetBgTilemapBuffer(0, AllocZeroed(BG_SCREEN_SIZE));
+    SetBgTilemapBuffer(0, Calloc(BG_SCREEN_SIZE));
     LoadPalette(sCredits_Pal, BG_PLTT_ID(8), 2 * PLTT_SIZE_4BPP);
     InitWindows(sWindowTemplates);
     DeactivateAllTextPrinters();
@@ -448,7 +448,7 @@ void CB2_StartCreditsSequence(void)
     m4aSongNumStart(MUS_CREDITS);
     SetMainCallback2(CB2_Credits);
     sUsedSpeedUp = FALSE;
-    sCreditsData = AllocZeroed(sizeof(struct CreditsData));
+    sCreditsData = Calloc(sizeof(struct CreditsData));
 
     DeterminePokemonToShow();
 

--- a/src/decompress.c
+++ b/src/decompress.c
@@ -268,7 +268,7 @@ bool8 LoadCompressedSpriteSheetUsingHeap(const struct CompressedSpriteSheet *src
     struct SpriteSheet dest;
     void *buffer;
 
-    buffer = AllocZeroed(src->data[0] >> 8);
+    buffer = Calloc(src->data[0] >> 8);
     LZ77UnCompWram(src->data, buffer);
 
     dest.data = buffer;
@@ -285,7 +285,7 @@ bool8 LoadCompressedSpritePaletteUsingHeap(const struct CompressedSpritePalette 
     struct SpritePalette dest;
     void *buffer;
 
-    buffer = AllocZeroed(src->data[0] >> 8);
+    buffer = Calloc(src->data[0] >> 8);
     LZ77UnCompWram(src->data, buffer);
     dest.data = buffer;
     dest.tag = src->tag;

--- a/src/decoration.c
+++ b/src/decoration.c
@@ -960,7 +960,7 @@ static void InitDecorationItemsWindow(u8 taskId)
     s16 *data = gTasks[taskId].data;
     AddDecorationWindow(WINDOW_DECORATION_CATEGORY_ITEMS);
     ShowDecorationCategorySummaryWindow(sCurDecorationCategory);
-    sDecorationItemsMenu = AllocZeroed(sizeof(*sDecorationItemsMenu));
+    sDecorationItemsMenu = Calloc(sizeof(*sDecorationItemsMenu));
     sDecorationItemsMenu->scrollIndicatorsTaskId = TASK_NONE;
     InitDecorationItemsMenuLimits();
     InitDecorationItemsMenuScrollAndCursor();

--- a/src/dodrio_berry_picking.c
+++ b/src/dodrio_berry_picking.c
@@ -665,7 +665,7 @@ void StartDodrioBerryPicking(u16 partyId, void (*exitCallback)(void))
 {
     sExitingGame = FALSE;
 
-    if (gReceivedRemoteLinkPlayers && (sGame = AllocZeroed(sizeof(*sGame))))
+    if (gReceivedRemoteLinkPlayers && (sGame = Calloc(sizeof(*sGame))))
     {
         ResetTasksAndSprites();
         InitDodrioGame(sGame);
@@ -3820,7 +3820,7 @@ static const union AnimCmd *const sAnims_Cloud[] =
 
 static void LoadDodrioGfx(void)
 {
-    void *ptr = AllocZeroed(0x3000);
+    void *ptr = Calloc(0x3000);
     struct SpritePalette normal = {sDodrioNormal_Pal, PALTAG_DODRIO_NORMAL};
     struct SpritePalette shiny = {sDodrioShiny_Pal, PALTAG_DODRIO_SHINY};
 
@@ -3848,7 +3848,7 @@ static void CreateDodrioSprite(struct DodrioGame_MonInfo * monInfo, u8 playerId,
         .callback = SpriteCB_Dodrio,
     };
 
-    sDodrioSpriteIds[id] = AllocZeroed(4);
+    sDodrioSpriteIds[id] = Calloc(4);
     *sDodrioSpriteIds[id] = CreateSprite(&template, GetDodrioXPos(playerId, numPlayers), 136, 3);
     SetDodrioInvisibility(TRUE, id);
 }
@@ -4004,7 +4004,7 @@ static void InitStatusBarPos(void)
 static void CreateStatusBarSprites(void)
 {
     u8 i;
-    void *ptr = AllocZeroed(0x180);
+    void *ptr = Calloc(0x180);
     struct SpritePalette pal = {sStatus_Pal, PALTAG_STATUS};
 
     LZ77UnCompWram(sStatus_Gfx, ptr);
@@ -4023,7 +4023,7 @@ static void CreateStatusBarSprites(void)
             .callback = SpriteCB_Status,
         };
 
-        sStatusBar = AllocZeroed(sizeof(*sStatusBar));
+        sStatusBar = Calloc(sizeof(*sStatusBar));
         LoadSpriteSheet(&sheet);
         LoadSpritePalette(&pal);
         for (i = 0; i < NUM_STATUS_SQUARES; i++)
@@ -4146,7 +4146,7 @@ static const u8 sUnusedSounds[] = {
 
 static void LoadBerryGfx(void)
 {
-    void *ptr = AllocZeroed(0x480);
+    void *ptr = Calloc(0x480);
     struct SpritePalette pal = {sBerries_Pal, PALTAG_BERRIES};
 
     LZ77UnCompWram(sBerries_Gfx, ptr);
@@ -4191,7 +4191,7 @@ static void CreateBerrySprites(void)
     // Create berry sprites that fall during gameplay
     for (i = 0; i < NUM_BERRY_COLUMNS; i++)
     {
-        sBerrySpriteIds[i] = AllocZeroed(4);
+        sBerrySpriteIds[i] = Calloc(4);
         x = i * 16;
         *sBerrySpriteIds[i] = CreateSprite(&berry, x + (i * 8), 8, 1);
         SetBerryInvisibility(i, TRUE);
@@ -4200,7 +4200,7 @@ static void CreateBerrySprites(void)
     // Create berry icon sprites for results screen
     for (i = 0; i < NUM_BERRY_TYPES; i++)
     {
-        sBerryIconSpriteIds[i] = AllocZeroed(4);
+        sBerryIconSpriteIds[i] = Calloc(4);
         if (i == BERRY_MISSED)
             *sBerryIconSpriteIds[i] = CreateSprite(&berryIcon, sBerryIconXCoords[i], 49, 0);
         else
@@ -4295,7 +4295,7 @@ static const s16 sCloudStartCoords[NUM_CLOUDS][2] =
 static void CreateCloudSprites(void)
 {
     u8 i;
-    void *ptr = AllocZeroed(0x400);
+    void *ptr = Calloc(0x400);
     struct SpritePalette pal = {sCloud_Pal, PALTAG_CLOUD};
 
     LZ77UnCompWram(sCloud_Gfx, ptr);
@@ -4317,7 +4317,7 @@ static void CreateCloudSprites(void)
         LoadSpritePalette(&pal);
         for (i = 0; i < NUM_CLOUDS; i++)
         {
-            sCloudSpriteIds[i] = AllocZeroed(4);
+            sCloudSpriteIds[i] = Calloc(4);
             *sCloudSpriteIds[i] = CreateSprite(&template, sCloudStartCoords[i][0], sCloudStartCoords[i][1], 4);
         }
     }

--- a/src/ereader_helpers.c
+++ b/src/ereader_helpers.c
@@ -467,7 +467,7 @@ static bool32 TryWriteTrainerHill_Internal(struct EReaderTrainerHillSet * hillSe
 
 bool32 TryWriteTrainerHill(struct EReaderTrainerHillSet * hillSet)
 {
-    void *buffer = AllocZeroed(SECTOR_SIZE);
+    void *buffer = Calloc(SECTOR_SIZE);
     bool32 result = TryWriteTrainerHill_Internal(hillSet, buffer);
     Free(buffer);
     return result;
@@ -487,7 +487,7 @@ static bool32 TryReadTrainerHill_Internal(struct EReaderTrainerHillSet * dest, u
 
 static bool32 TryReadTrainerHill(struct EReaderTrainerHillSet * hillSet)
 {
-    u8 *buffer = AllocZeroed(SECTOR_SIZE);
+    u8 *buffer = Calloc(SECTOR_SIZE);
     bool32 result = TryReadTrainerHill_Internal(hillSet, buffer);
     Free(buffer);
     return result;
@@ -495,7 +495,7 @@ static bool32 TryReadTrainerHill(struct EReaderTrainerHillSet * hillSet)
 
 bool32 ReadTrainerHillAndValidate(void)
 {
-    struct EReaderTrainerHillSet *hillSet = AllocZeroed(SECTOR_SIZE);
+    struct EReaderTrainerHillSet *hillSet = Calloc(SECTOR_SIZE);
     bool32 result = TryReadTrainerHill(hillSet);
     Free(hillSet);
     return result;

--- a/src/ereader_screen.c
+++ b/src/ereader_screen.c
@@ -260,7 +260,7 @@ void CreateEReaderTask(void)
     data->unused2 = 0;
     data->unused3 = 0;
     data->status = 0;
-    data->unusedBuffer = AllocZeroed(CLIENT_MAX_MSG_SIZE);
+    data->unusedBuffer = Calloc(CLIENT_MAX_MSG_SIZE);
 }
 
 static void ResetTimer(u16 *timer)

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -8797,7 +8797,7 @@ u8 MovementAction_LockAnim_Step0(struct ObjectEvent *objectEvent, struct Sprite 
     bool32 ableToStore = FALSE;
     if (sLockedAnimObjectEvents == NULL)
     {
-        sLockedAnimObjectEvents = AllocZeroed(sizeof(struct LockedAnimObjectEvents));
+        sLockedAnimObjectEvents = Calloc(sizeof(struct LockedAnimObjectEvents));
         sLockedAnimObjectEvents->localIds[0] = objectEvent->localId;
         sLockedAnimObjectEvents->count = 1;
         ableToStore = TRUE;

--- a/src/evolution_scene.c
+++ b/src/evolution_scene.c
@@ -248,7 +248,7 @@ void EvolutionScene(struct Pokemon *mon, u16 postEvoSpecies, bool8 canStopEvo, u
 
     gReservedSpritePaletteCount = 4;
 
-    sEvoStructPtr = AllocZeroed(sizeof(struct EvoInfo));
+    sEvoStructPtr = Calloc(sizeof(struct EvoInfo));
     AllocateMonSpritesGfx();
 
     GetMonData(mon, MON_DATA_NICKNAME, name);
@@ -484,7 +484,7 @@ void TradeEvolutionScene(struct Pokemon *mon, u16 postEvoSpecies, u8 preEvoSprit
     personality = GetMonData(mon, MON_DATA_PERSONALITY);
     trainerId = GetMonData(mon, MON_DATA_OT_ID);
 
-    sEvoStructPtr = AllocZeroed(sizeof(struct EvoInfo));
+    sEvoStructPtr = Calloc(sizeof(struct EvoInfo));
     sEvoStructPtr->preEvoSpriteId = preEvoSpriteId;
 
     DecompressPicFromTable_2(&gMonFrontPicTable[postEvoSpecies],
@@ -1597,7 +1597,7 @@ static void StartBgAnimation(bool8 isLink)
 {
     u8 innerBgId, outerBgId;
 
-    sBgAnimPal = AllocZeroed(0x640);
+    sBgAnimPal = Calloc(0x640);
     InitMovingBgPalette(sBgAnimPal);
 
     if (!isLink)

--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -2556,7 +2556,7 @@ static void Task_ShowScrollableMultichoice(u8 taskId)
     sScrollableMultichoice_ItemSpriteId = MAX_SPRITES;
     FillFrontierExchangeCornerWindowAndItemIcon(task->tScrollMultiId, 0);
     ShowBattleFrontierTutorWindow(task->tScrollMultiId, 0);
-    sScrollableMultichoice_ListMenuItem = AllocZeroed(task->tNumItems * 8);
+    sScrollableMultichoice_ListMenuItem = Calloc(task->tNumItems * 8);
     sFrontierExchangeCorner_NeverRead = 0;
     InitScrollableMultichoice();
 

--- a/src/fldeff_cut.c
+++ b/src/fldeff_cut.c
@@ -337,7 +337,7 @@ bool8 FldEff_CutGrass(void)
 
     SetCutGrassMetatiles(gPlayerFacingPosition.x - sTileCountFromPlayer_X, gPlayerFacingPosition.y - (1 + sTileCountFromPlayer_Y));
     DrawWholeMapView();
-    sCutGrassSpriteArrayPtr = AllocZeroed(CUT_SPRITE_ARRAY_COUNT);
+    sCutGrassSpriteArrayPtr = Calloc(CUT_SPRITE_ARRAY_COUNT);
 
     // populate sprite ID array
     for (i = 0; i < CUT_SPRITE_ARRAY_COUNT; i++)

--- a/src/frontier_pass.c
+++ b/src/frontier_pass.c
@@ -611,7 +611,7 @@ static u32 AllocateFrontierPassData(void (*callback)(void))
     if (sPassData != NULL)
         return ERR_ALREADY_DONE;
 
-    sPassData = AllocZeroed(sizeof(*sPassData));
+    sPassData = Calloc(sizeof(*sPassData));
     if (sPassData == NULL)
         return ERR_ALLOC_FAILED;
 
@@ -662,7 +662,7 @@ static u32 AllocateFrontierPassGfx(void)
     if (sPassGfx != NULL)
         return ERR_ALREADY_DONE;
 
-    sPassGfx = AllocZeroed(sizeof(*sPassGfx));
+    sPassGfx = Calloc(sizeof(*sPassGfx));
     if (sPassGfx == NULL)
         return ERR_ALLOC_FAILED;
 
@@ -1368,7 +1368,7 @@ static void ShowFrontierMap(void (*callback)(void))
     if (sMapData != NULL)
         SetMainCallback2(callback); // This line doesn't make sense at all, since it gets overwritten later anyway.
 
-    sMapData = AllocZeroed(sizeof(*sMapData));
+    sMapData = Calloc(sizeof(*sMapData));
     sMapData->callback = callback;
     ResetTasks();
     CreateTask(Task_HandleFrontierMap, 0);

--- a/src/frontier_util.c
+++ b/src/frontier_util.c
@@ -2271,7 +2271,7 @@ static void Fill1PRecords(struct RankingHall1P *dst, s32 hallFacilityId, s32 lvl
 {
     s32 i, j;
     struct RankingHall1P record1P[HALL_RECORDS_COUNT + 1];
-    struct PlayerHallRecords *playerHallRecords = AllocZeroed(sizeof(struct PlayerHallRecords));
+    struct PlayerHallRecords *playerHallRecords = Calloc(sizeof(struct PlayerHallRecords));
     GetPlayerHallRecords(playerHallRecords);
 
     for (i = 0; i < HALL_RECORDS_COUNT; i++)
@@ -2305,7 +2305,7 @@ static void Fill2PRecords(struct RankingHall2P *dst, s32 lvlMode)
 {
     s32 i, j;
     struct RankingHall2P record2P[HALL_RECORDS_COUNT + 1];
-    struct PlayerHallRecords *playerHallRecords = AllocZeroed(sizeof(struct PlayerHallRecords));
+    struct PlayerHallRecords *playerHallRecords = Calloc(sizeof(struct PlayerHallRecords));
     GetPlayerHallRecords(playerHallRecords);
 
     for (i = 0; i < HALL_RECORDS_COUNT; i++)
@@ -2421,7 +2421,7 @@ void ClearRankingHallRecords(void)
 void SaveGameFrontier(void)
 {
     s32 i;
-    struct Pokemon *monsParty = AllocZeroed(sizeof(struct Pokemon) * PARTY_SIZE);
+    struct Pokemon *monsParty = Calloc(sizeof(struct Pokemon) * PARTY_SIZE);
 
     for (i = 0; i < PARTY_SIZE; i++)
         monsParty[i] = gPlayerParty[i];

--- a/src/hall_of_fame.c
+++ b/src/hall_of_fame.c
@@ -371,7 +371,7 @@ static bool8 InitHallOfFameScreen(void)
     case 0:
         SetVBlankCallback(NULL);
         ClearVramOamPltt_LoadHofPal();
-        sHofGfxPtr = AllocZeroed(sizeof(*sHofGfxPtr));
+        sHofGfxPtr = Calloc(sizeof(*sHofGfxPtr));
         gMain.state = 1;
         break;
     case 1:
@@ -420,7 +420,7 @@ void CB2_DoHallOfFameScreen(void)
     {
         u8 taskId = CreateTask(Task_Hof_InitMonData, 0);
         gTasks[taskId].tDontSaveData = FALSE;
-        sHofMonPtr = AllocZeroed(sizeof(*sHofMonPtr));
+        sHofMonPtr = Calloc(sizeof(*sHofMonPtr));
     }
 }
 
@@ -430,7 +430,7 @@ void CB2_DoHallOfFameScreenDontSaveData(void)
     {
         u8 taskId = CreateTask(Task_Hof_InitMonData, 0);
         gTasks[taskId].tDontSaveData = TRUE;
-        sHofMonPtr = AllocZeroed(sizeof(*sHofMonPtr));
+        sHofMonPtr = Calloc(sizeof(*sHofMonPtr));
     }
 }
 
@@ -804,7 +804,7 @@ void CB2_DoHallOfFamePC(void)
     default:
         SetVBlankCallback(NULL);
         ClearVramOamPltt_LoadHofPal();
-        sHofGfxPtr = AllocZeroed(sizeof(*sHofGfxPtr));
+        sHofGfxPtr = Calloc(sizeof(*sHofGfxPtr));
         gMain.state = 1;
         break;
     case 1:
@@ -850,7 +850,7 @@ void CB2_DoHallOfFamePC(void)
                 gTasks[taskId].tMonSpriteId(i) = SPRITE_NONE;
             }
 
-            sHofMonPtr = AllocZeroed(SECTOR_SIZE * NUM_HOF_SECTORS);
+            sHofMonPtr = Calloc(SECTOR_SIZE * NUM_HOF_SECTORS);
             SetMainCallback2(CB2_HallOfFame);
         }
         break;

--- a/src/item.c
+++ b/src/item.c
@@ -256,7 +256,7 @@ bool8 AddBagItem(u16 itemId, u16 count)
         u8 pocket = ItemId_GetPocket(itemId) - 1;
 
         itemPocket = &gBagPockets[pocket];
-        newItems = AllocZeroed(itemPocket->capacity * sizeof(struct ItemSlot));
+        newItems = Calloc(itemPocket->capacity * sizeof(struct ItemSlot));
         memcpy(newItems, itemPocket->itemSlots, itemPocket->capacity * sizeof(struct ItemSlot));
 
         if (pocket != BERRIES_POCKET)
@@ -491,7 +491,7 @@ bool8 AddPCItem(u16 itemId, u16 count)
     struct ItemSlot *newItems;
 
     // Copy PC items
-    newItems = AllocZeroed(sizeof(gSaveBlock1Ptr->pcItems));
+    newItems = Calloc(sizeof(gSaveBlock1Ptr->pcItems));
     memcpy(newItems, gSaveBlock1Ptr->pcItems, sizeof(gSaveBlock1Ptr->pcItems));
 
     // Use any item slots that already contain this item

--- a/src/item_icon.c
+++ b/src/item_icon.c
@@ -59,7 +59,7 @@ bool8 AllocItemIconTemporaryBuffers(void)
     if (gItemIconDecompressionBuffer == NULL)
         return FALSE;
 
-    gItemIcon4x4Buffer = AllocZeroed(0x200);
+    gItemIcon4x4Buffer = Calloc(0x200);
     if (gItemIcon4x4Buffer == NULL)
     {
         Free(gItemIconDecompressionBuffer);

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -614,7 +614,7 @@ void QuizLadyOpenBagMenu(void)
 
 void GoToBagMenu(u8 location, u8 pocket, void ( *exitCallback)())
 {
-    gBagMenu = AllocZeroed(sizeof(*gBagMenu));
+    gBagMenu = Calloc(sizeof(*gBagMenu));
     if (gBagMenu == NULL)
     {
         // Alloc failed, exit
@@ -2285,7 +2285,7 @@ static void PrepareBagForWallyTutorial(void)
 {
     u32 i;
 
-    sTempWallyBag = AllocZeroed(sizeof(*sTempWallyBag));
+    sTempWallyBag = Calloc(sizeof(*sTempWallyBag));
     memcpy(sTempWallyBag->bagPocket_Items, gSaveBlock1Ptr->bagPocket_Items, sizeof(gSaveBlock1Ptr->bagPocket_Items));
     memcpy(sTempWallyBag->bagPocket_PokeBalls, gSaveBlock1Ptr->bagPocket_PokeBalls, sizeof(gSaveBlock1Ptr->bagPocket_PokeBalls));
     sTempWallyBag->pocket = gBagPosition.pocket;

--- a/src/link_rfu_3.c
+++ b/src/link_rfu_3.c
@@ -913,7 +913,7 @@ void SaveLinkTrainerNames(void)
         s32 j;
         s32 nextSpace;
         s32 connectedTrainerRecordIndices[MAX_RFU_PLAYERS];
-        struct TrainerNameRecord *newRecords = AllocZeroed(sizeof(gSaveBlock1Ptr->trainerNameRecords));
+        struct TrainerNameRecord *newRecords = Calloc(sizeof(gSaveBlock1Ptr->trainerNameRecords));
 
         // Check if we already have a record saved for connected trainers.
         for (i = 0; i < GetLinkPlayerCount(); i++)

--- a/src/mail.c
+++ b/src/mail.c
@@ -448,7 +448,7 @@ void ReadMail(struct Mail *mail, void (*exitCallback)(void), bool8 hasText)
     u16 buffer[2];
     u16 species;
 
-    sMailRead = AllocZeroed(sizeof(*sMailRead));
+    sMailRead = Calloc(sizeof(*sMailRead));
     sMailRead->language = GAME_LANGUAGE;
     sMailRead->international = TRUE;
     sMailRead->parserSingle = CopyEasyChatWord;

--- a/src/mirage_tower.c
+++ b/src/mirage_tower.c
@@ -292,7 +292,7 @@ void TryStartMirageTowerPulseBlendEffect(void)
      || !FlagGet(FLAG_MIRAGE_TOWER_VISIBLE))
         return;
 
-    sMirageTowerPulseBlend = AllocZeroed(sizeof(*sMirageTowerPulseBlend));
+    sMirageTowerPulseBlend = Calloc(sizeof(*sMirageTowerPulseBlend));
     InitPulseBlend(&sMirageTowerPulseBlend->pulseBlend);
     InitPulseBlendPaletteSettings(&sMirageTowerPulseBlend->pulseBlend, &gMirageTowerPulseBlendSettings);
     MarkUsedPulseBlendPalettes(&sMirageTowerPulseBlend->pulseBlend, 0x1, TRUE);
@@ -535,8 +535,8 @@ static void InitMirageTowerShake(u8 taskId)
         gTasks[taskId].tState++;
         break;
     case 1:
-        sMirageTowerGfxBuffer = (u8 *)AllocZeroed(MIRAGE_TOWER_GFX_LENGTH);
-        sMirageTowerTilemapBuffer = (u8 *)AllocZeroed(BG_SCREEN_SIZE);
+        sMirageTowerGfxBuffer = (u8 *)Calloc(MIRAGE_TOWER_GFX_LENGTH);
+        sMirageTowerTilemapBuffer = (u8 *)Calloc(BG_SCREEN_SIZE);
         ChangeBgX(0, 0, BG_COORD_SET);
         ChangeBgY(0, 0, BG_COORD_SET);
         gTasks[taskId].tState++;
@@ -583,7 +583,7 @@ static void DoMirageTowerDisintegration(u8 taskId)
     switch (gTasks[taskId].tState)
     {
     case 1:
-        sFallingTower = AllocZeroed(OUTER_BUFFER_LENGTH * sizeof(struct FallAnim_Tower));
+        sFallingTower = Calloc(OUTER_BUFFER_LENGTH * sizeof(struct FallAnim_Tower));
         break;
     case 3:
         if (gTasks[taskId].data[3] <= (OUTER_BUFFER_LENGTH - 1))
@@ -670,10 +670,10 @@ static void Task_FossilFallAndSink(u8 taskId)
     switch (gTasks[taskId].tState)
     {
     case 1:
-        sFallingFossil = AllocZeroed(sizeof(*sFallingFossil));
-        sFallingFossil->frameImageTiles = AllocZeroed(sizeof(sFossil_Gfx));
-        sFallingFossil->frameImage = AllocZeroed(sizeof(*sFallingFossil->frameImage));
-        sFallingFossil->disintegrateRand = AllocZeroed(FOSSIL_DISINTEGRATE_LENGTH * sizeof(u16));
+        sFallingFossil = Calloc(sizeof(*sFallingFossil));
+        sFallingFossil->frameImageTiles = Calloc(sizeof(sFossil_Gfx));
+        sFallingFossil->frameImage = Calloc(sizeof(*sFallingFossil->frameImage));
+        sFallingFossil->disintegrateRand = Calloc(FOSSIL_DISINTEGRATE_LENGTH * sizeof(u16));
         sFallingFossil->disintegrateIdx = 0;
         break;
     case 2:

--- a/src/move_relearner.c
+++ b/src/move_relearner.c
@@ -394,7 +394,7 @@ static void CB2_InitLearnMove(void)
     FreeAllSpritePalettes();
     ResetTasks();
     ClearScheduledBgCopiesToVram();
-    sMoveRelearnerStruct = AllocZeroed(sizeof(*sMoveRelearnerStruct));
+    sMoveRelearnerStruct = Calloc(sizeof(*sMoveRelearnerStruct));
     sMoveRelearnerStruct->partyMon = gSpecialVar_0x8004;
     SetVBlankCallback(VBlankCB_MoveRelearner);
 
@@ -422,7 +422,7 @@ static void CB2_InitLearnMoveReturnFromSelectMove(void)
     FreeAllSpritePalettes();
     ResetTasks();
     ClearScheduledBgCopiesToVram();
-    sMoveRelearnerStruct = AllocZeroed(sizeof(*sMoveRelearnerStruct));
+    sMoveRelearnerStruct = Calloc(sizeof(*sMoveRelearnerStruct));
     sMoveRelearnerStruct->state = MENU_STATE_FADE_FROM_SUMMARY_SCREEN;
     sMoveRelearnerStruct->partyMon = gSpecialVar_0x8004;
     sMoveRelearnerStruct->moveSlot = gSpecialVar_0x8005;

--- a/src/mystery_gift_client.c
+++ b/src/mystery_gift_client.c
@@ -29,7 +29,7 @@ extern const struct MysteryGiftClientCmd gMysteryGiftClientScript_Init[];
 
 void MysteryGiftClient_Create(bool32 isWonderNews)
 {
-    sClient = AllocZeroed(sizeof(*sClient));
+    sClient = Calloc(sizeof(*sClient));
     MysteryGiftClient_Init(sClient, 1, 0);
     sClient->isWonderNews = isWonderNews;
 }
@@ -69,10 +69,10 @@ static void MysteryGiftClient_Init(struct MysteryGiftClient * client, u32 sendPl
     client->unused = 0;
     client->funcId = FUNC_INIT;
     client->funcState = 0;
-    client->sendBuffer = AllocZeroed(MG_LINK_BUFFER_SIZE);
-    client->recvBuffer = AllocZeroed(MG_LINK_BUFFER_SIZE);
-    client->script = AllocZeroed(MG_LINK_BUFFER_SIZE);
-    client->msg = AllocZeroed(CLIENT_MAX_MSG_SIZE);
+    client->sendBuffer = Calloc(MG_LINK_BUFFER_SIZE);
+    client->recvBuffer = Calloc(MG_LINK_BUFFER_SIZE);
+    client->script = Calloc(MG_LINK_BUFFER_SIZE);
+    client->msg = Calloc(CLIENT_MAX_MSG_SIZE);
     MysteryGiftLink_Init(&client->link, sendPlayerId, recvPlayerId);
 }
 

--- a/src/mystery_gift_menu.c
+++ b/src/mystery_gift_menu.c
@@ -1124,7 +1124,7 @@ static void CreateMysteryGiftTask(void)
     data->unused2 = 0;
     data->unused3 = 0;
     data->msgId = 0;
-    data->clientMsg = AllocZeroed(CLIENT_MAX_MSG_SIZE);
+    data->clientMsg = Calloc(CLIENT_MAX_MSG_SIZE);
 }
 
 static void Task_MysteryGift(u8 taskId)

--- a/src/mystery_gift_server.c
+++ b/src/mystery_gift_server.c
@@ -24,13 +24,13 @@ extern const struct MysteryGiftServerCmd gMysteryGiftServerScript_SendWonderCard
 
 void MysterGiftServer_CreateForNews(void)
 {
-    sServer = AllocZeroed(sizeof(*sServer));
+    sServer = Calloc(sizeof(*sServer));
     MysteryGiftServer_Init(sServer, gMysteryGiftServerScript_SendWonderNews, 0, 1);
 }
 
 void MysterGiftServer_CreateForCard(void)
 {
-    sServer = AllocZeroed(sizeof(*sServer));
+    sServer = Calloc(sizeof(*sServer));
     MysteryGiftServer_Init(sServer, gMysteryGiftServerScript_SendWonderCard, 0, 1);
 }
 
@@ -53,10 +53,10 @@ static void MysteryGiftServer_Init(struct MysteryGiftServer * svr, const void * 
 {
     svr->unused = 0;
     svr->funcId = FUNC_INIT;
-    svr->card = AllocZeroed(sizeof(*svr->card));
-    svr->news = AllocZeroed(sizeof(*svr->news));
-    svr->recvBuffer = AllocZeroed(MG_LINK_BUFFER_SIZE);
-    svr->linkGameData = AllocZeroed(sizeof(*svr->linkGameData));
+    svr->card = Calloc(sizeof(*svr->card));
+    svr->news = Calloc(sizeof(*svr->news));
+    svr->recvBuffer = Calloc(MG_LINK_BUFFER_SIZE);
+    svr->linkGameData = Calloc(sizeof(*svr->linkGameData));
     svr->script = script;
     svr->cmdidx = 0;
     MysteryGiftLink_Init(&svr->link, sendPlayerId, recvPlayerId);

--- a/src/mystery_gift_view.c
+++ b/src/mystery_gift_view.c
@@ -188,7 +188,7 @@ bool32 WonderCard_Init(struct WonderCard * card, struct WonderCardMetadata * met
 {
     if (card == NULL || metadata == NULL)
         return FALSE;
-    sWonderCardData = AllocZeroed(sizeof(*sWonderCardData));
+    sWonderCardData = Calloc(sizeof(*sWonderCardData));
     if (sWonderCardData == NULL)
         return FALSE;
     sWonderCardData->card = *card;
@@ -644,7 +644,7 @@ bool32 WonderNews_Init(const struct WonderNews * news)
 {
     if (news == NULL)
         return FALSE;
-    sWonderNewsData = AllocZeroed(sizeof(*sWonderNewsData));
+    sWonderNewsData = Calloc(sizeof(*sWonderNewsData));
     if (sWonderNewsData == NULL)
         return FALSE;
     sWonderNewsData->news = *news;

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1394,9 +1394,9 @@ static void InitOverworldBgs(void)
     SetBgAttribute(1, BG_ATTR_MOSAIC, 1);
     SetBgAttribute(2, BG_ATTR_MOSAIC, 1);
     SetBgAttribute(3, BG_ATTR_MOSAIC, 1);
-    gOverworldTilemapBuffer_Bg1 = AllocZeroed(BG_SCREEN_SIZE);
-    gOverworldTilemapBuffer_Bg2 = AllocZeroed(BG_SCREEN_SIZE);
-    gOverworldTilemapBuffer_Bg3 = AllocZeroed(BG_SCREEN_SIZE);
+    gOverworldTilemapBuffer_Bg1 = Calloc(BG_SCREEN_SIZE);
+    gOverworldTilemapBuffer_Bg2 = Calloc(BG_SCREEN_SIZE);
+    gOverworldTilemapBuffer_Bg3 = Calloc(BG_SCREEN_SIZE);
     SetBgTilemapBuffer(1, gOverworldTilemapBuffer_Bg1);
     SetBgTilemapBuffer(2, gOverworldTilemapBuffer_Bg2);
     SetBgTilemapBuffer(3, gOverworldTilemapBuffer_Bg3);

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -2149,7 +2149,7 @@ static u16 *GetPartyMenuPalBufferPtr(u8 paletteId)
 
 static void BlitBitmapToPartyWindow(u8 windowId, const u8 *b, u8 c, u8 x, u8 y, u8 width, u8 height)
 {
-    u8 *pixels = AllocZeroed(height * width * 32);
+    u8 *pixels = Calloc(height * width * 32);
     u8 i, j;
 
     if (pixels != NULL)

--- a/src/player_pc.c
+++ b/src/player_pc.c
@@ -937,7 +937,7 @@ static void Mailbox_Cancel(u8 taskId)
 
 static void ItemStorage_Init(void)
 {
-    sItemStorageMenu = AllocZeroed(sizeof(*sItemStorageMenu));
+    sItemStorageMenu = Calloc(sizeof(*sItemStorageMenu));
     memset(sItemStorageMenu->windowIds, WINDOW_NONE, ITEMPC_WIN_COUNT);
     sItemStorageMenu->toSwapPos = NOT_SWAPPING;
     sItemStorageMenu->spriteId = SPRITE_NONE;

--- a/src/pokeblock_feed.c
+++ b/src/pokeblock_feed.c
@@ -617,7 +617,7 @@ static bool8 LoadPokeblockFeedScene(void)
     switch (gMain.state)
     {
     case 0:
-        sPokeblockFeed = AllocZeroed(sizeof(*sPokeblockFeed));
+        sPokeblockFeed = Calloc(sizeof(*sPokeblockFeed));
         SetVBlankHBlankCallbacksToNull();
         ClearScheduledBgCopiesToVram();
         gMain.state++;

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -1610,7 +1610,7 @@ void CB2_OpenPokedex(void)
         gMain.state++;
         break;
     case 2:
-        sPokedexView = AllocZeroed(sizeof(struct PokedexView));
+        sPokedexView = Calloc(sizeof(struct PokedexView));
         ResetPokedexView(sPokedexView);
         CreateTask(Task_OpenPokedexMainPage, 0);
         sPokedexView->dexMode = gSaveBlock2Ptr->pokedex.mode;
@@ -2062,10 +2062,10 @@ static bool8 LoadPokedexListPage(u8 page)
         SetGpuReg(REG_OFFSET_BG2VOFS, sPokedexView->initialVOffset);
         ResetBgsAndClearDma3BusyFlags(0);
         InitBgsFromTemplates(0, sPokedex_BgTemplate, ARRAY_COUNT(sPokedex_BgTemplate));
-        SetBgTilemapBuffer(3, AllocZeroed(BG_SCREEN_SIZE));
-        SetBgTilemapBuffer(2, AllocZeroed(BG_SCREEN_SIZE));
-        SetBgTilemapBuffer(1, AllocZeroed(BG_SCREEN_SIZE));
-        SetBgTilemapBuffer(0, AllocZeroed(BG_SCREEN_SIZE));
+        SetBgTilemapBuffer(3, Calloc(BG_SCREEN_SIZE));
+        SetBgTilemapBuffer(2, Calloc(BG_SCREEN_SIZE));
+        SetBgTilemapBuffer(1, Calloc(BG_SCREEN_SIZE));
+        SetBgTilemapBuffer(0, Calloc(BG_SCREEN_SIZE));
         DecompressAndLoadBgGfxUsingHeap(3, gPokedexMenu_Gfx, 0x2000, 0, 0);
         CopyToBgTilemapBuffer(1, gPokedexList_Tilemap, 0, 0);
         CopyToBgTilemapBuffer(3, gPokedexListUnderlay_Tilemap, 0, 0);
@@ -3192,10 +3192,10 @@ static u8 LoadInfoScreen(struct PokedexListItem *item, u8 monSpriteId)
     gTasks[taskId].tTrainerSpriteId = SPRITE_NONE;
     ResetBgsAndClearDma3BusyFlags(0);
     InitBgsFromTemplates(0, sInfoScreen_BgTemplate, ARRAY_COUNT(sInfoScreen_BgTemplate));
-    SetBgTilemapBuffer(3, AllocZeroed(BG_SCREEN_SIZE));
-    SetBgTilemapBuffer(2, AllocZeroed(BG_SCREEN_SIZE));
-    SetBgTilemapBuffer(1, AllocZeroed(BG_SCREEN_SIZE));
-    SetBgTilemapBuffer(0, AllocZeroed(BG_SCREEN_SIZE));
+    SetBgTilemapBuffer(3, Calloc(BG_SCREEN_SIZE));
+    SetBgTilemapBuffer(2, Calloc(BG_SCREEN_SIZE));
+    SetBgTilemapBuffer(1, Calloc(BG_SCREEN_SIZE));
+    SetBgTilemapBuffer(0, Calloc(BG_SCREEN_SIZE));
     InitWindows(sInfoScreen_WindowTemplates);
     DeactivateAllTextPrinters();
 
@@ -3962,8 +3962,8 @@ static void Task_DisplayCaughtMonDexPage(u8 taskId)
             ResetOtherVideoRegisters(DISPCNT_BG0_ON);
             ResetBgsAndClearDma3BusyFlags(0);
             InitBgsFromTemplates(0, sNewEntryInfoScreen_BgTemplate, ARRAY_COUNT(sNewEntryInfoScreen_BgTemplate));
-            SetBgTilemapBuffer(3, AllocZeroed(BG_SCREEN_SIZE));
-            SetBgTilemapBuffer(2, AllocZeroed(BG_SCREEN_SIZE));
+            SetBgTilemapBuffer(3, Calloc(BG_SCREEN_SIZE));
+            SetBgTilemapBuffer(2, Calloc(BG_SCREEN_SIZE));
             InitWindows(sNewEntryInfoScreen_WindowTemplates);
             DeactivateAllTextPrinters();
             gTasks[taskId].tState = 1;
@@ -4823,10 +4823,10 @@ static void Task_LoadSearchMenu(u8 taskId)
             ResetOtherVideoRegisters(0);
             ResetBgsAndClearDma3BusyFlags(0);
             InitBgsFromTemplates(0, sSearchMenu_BgTemplate, ARRAY_COUNT(sSearchMenu_BgTemplate));
-            SetBgTilemapBuffer(3, AllocZeroed(BG_SCREEN_SIZE));
-            SetBgTilemapBuffer(2, AllocZeroed(BG_SCREEN_SIZE));
-            SetBgTilemapBuffer(1, AllocZeroed(BG_SCREEN_SIZE));
-            SetBgTilemapBuffer(0, AllocZeroed(BG_SCREEN_SIZE));
+            SetBgTilemapBuffer(3, Calloc(BG_SCREEN_SIZE));
+            SetBgTilemapBuffer(2, Calloc(BG_SCREEN_SIZE));
+            SetBgTilemapBuffer(1, Calloc(BG_SCREEN_SIZE));
+            SetBgTilemapBuffer(0, Calloc(BG_SCREEN_SIZE));
             InitWindows(sSearchMenu_WindowTemplate);
             DeactivateAllTextPrinters();
             PutWindowTilemap(0);

--- a/src/pokedex_area_screen.c
+++ b/src/pokedex_area_screen.c
@@ -584,7 +584,7 @@ void ShowPokedexAreaScreen(u16 species, u8 *screenSwitchState)
 {
     u8 taskId;
 
-    sPokedexAreaScreen = AllocZeroed(sizeof(*sPokedexAreaScreen));
+    sPokedexAreaScreen = Calloc(sizeof(*sPokedexAreaScreen));
     sPokedexAreaScreen->species = species;
     sPokedexAreaScreen->screenSwitchState = screenSwitchState;
     screenSwitchState[0] = 0;

--- a/src/pokedex_cry_screen.c
+++ b/src/pokedex_cry_screen.c
@@ -235,7 +235,7 @@ bool8 LoadCryWaveformWindow(struct CryScreenWindow *window, u8 windowId)
     case 0:
         if (!sDexCryScreen)
         {
-            sDexCryScreen = AllocZeroed(sizeof(*sDexCryScreen));
+            sDexCryScreen = Calloc(sizeof(*sDexCryScreen));
             sCryWaveformWindowTiledata = (u8 *)GetWindowAttribute(windowId, WINDOW_TILE_DATA);
         }
 
@@ -457,7 +457,7 @@ bool8 LoadCryMeter(struct CryScreenWindow *window, u8 windowId)
     {
     case 0:
         if (!sCryMeterNeedle)
-            sCryMeterNeedle = AllocZeroed(sizeof(*sCryMeterNeedle));
+            sCryMeterNeedle = Calloc(sizeof(*sCryMeterNeedle));
 
         CopyToWindowPixelBuffer(windowId, sCryMeter_Gfx, 0, 0);
         LoadPalette(sCryMeter_Pal, BG_PLTT_ID(window->paletteNo), PLTT_SIZE_4BPP);

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6964,7 +6964,7 @@ struct MonSpritesGfxManager *CreateMonSpritesGfxManager(u8 managerId, u8 mode)
 
     failureFlags = 0;
     managerId %= MON_SPR_GFX_MANAGERS_COUNT;
-    gfx = AllocZeroed(sizeof(*gfx));
+    gfx = Calloc(sizeof(*gfx));
     if (gfx == NULL)
         return NULL;
 
@@ -6989,8 +6989,8 @@ struct MonSpritesGfxManager *CreateMonSpritesGfxManager(u8 managerId, u8 mode)
     }
 
     // Set up sprite / sprite pointer buffers
-    gfx->spriteBuffer = AllocZeroed(gfx->dataSize * MON_PIC_SIZE * MAX_MON_PIC_FRAMES * gfx->numSprites);
-    gfx->spritePointers = AllocZeroed(gfx->numSprites * 32); // ? Only * 4 is necessary, perhaps they were thinking bits.
+    gfx->spriteBuffer = Calloc(gfx->dataSize * MON_PIC_SIZE * MAX_MON_PIC_FRAMES * gfx->numSprites);
+    gfx->spritePointers = Calloc(gfx->numSprites * 32); // ? Only * 4 is necessary, perhaps they were thinking bits.
     if (gfx->spriteBuffer == NULL || gfx->spritePointers == NULL)
     {
         failureFlags |= ALLOC_FAIL_BUFFER;
@@ -7002,8 +7002,8 @@ struct MonSpritesGfxManager *CreateMonSpritesGfxManager(u8 managerId, u8 mode)
     }
 
     // Set up sprite structs
-    gfx->templates = AllocZeroed(sizeof(struct SpriteTemplate) * gfx->numSprites);
-    gfx->frameImages = AllocZeroed(sizeof(struct SpriteFrameImage) * gfx->numSprites * gfx->numFrames);
+    gfx->templates = Calloc(sizeof(struct SpriteTemplate) * gfx->numSprites);
+    gfx->frameImages = Calloc(sizeof(struct SpriteFrameImage) * gfx->numSprites * gfx->numFrames);
     if (gfx->templates == NULL || gfx->frameImages == NULL)
     {
         failureFlags |= ALLOC_FAIL_STRUCT;

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -1077,7 +1077,7 @@ static const u16 sMarkings_Pal[] = INCBIN_U16("graphics/summary_screen/markings.
 // code
 void ShowPokemonSummaryScreen(u8 mode, void *mons, u8 monIndex, u8 maxMonIndex, void (*callback)(void))
 {
-    sMonSummaryScreen = AllocZeroed(sizeof(*sMonSummaryScreen));
+    sMonSummaryScreen = Calloc(sizeof(*sMonSummaryScreen));
     sMonSummaryScreen->mode = mode;
     sMonSummaryScreen->monList.mons = mons;
     sMonSummaryScreen->curMonIndex = monIndex;

--- a/src/rayquaza_scene.c
+++ b/src/rayquaza_scene.c
@@ -1285,7 +1285,7 @@ static const struct BgTemplate sBgTemplates_ChasesAway[] =
 
 void DoRayquazaScene(u8 animId, bool8 endEarly, void (*exitCallback)(void))
 {
-    sRayScene = AllocZeroed(sizeof(*sRayScene));
+    sRayScene = Calloc(sizeof(*sRayScene));
     sRayScene->animId = animId;
     sRayScene->exitCallback = exitCallback;
     sRayScene->endEarly = endEarly;

--- a/src/record_mixing.c
+++ b/src/record_mixing.c
@@ -1355,7 +1355,7 @@ static void SaveHighestWinStreakRecords(struct RecordMixingHallRecords *mixHallR
 static void ReceiveRankingHallRecords(struct PlayerHallRecords *records, size_t recordSize, u32 multiplayerId)
 {
     u8 linkPlayerCount = GetLinkPlayerCount();
-    struct RecordMixingHallRecords *mixHallRecords = AllocZeroed(sizeof(*mixHallRecords));
+    struct RecordMixingHallRecords *mixHallRecords = Calloc(sizeof(*mixHallRecords));
 
     GetNewHallRecords(mixHallRecords, records, recordSize, multiplayerId, linkPlayerCount);
     SaveHighestWinStreakRecords(mixHallRecords);

--- a/src/recorded_battle.c
+++ b/src/recorded_battle.c
@@ -286,7 +286,7 @@ static u8 GetNextRecordedDataByte(u8 *data, u8 *idx, u8 *size)
 
 bool32 CanCopyRecordedBattleSaveData(void)
 {
-    struct RecordedBattleSave *dst = AllocZeroed(sizeof(struct RecordedBattleSave));
+    struct RecordedBattleSave *dst = Calloc(sizeof(struct RecordedBattleSave));
     bool32 ret = CopyRecordedBattleFromSave(dst);
     Free(dst);
     return ret;
@@ -325,8 +325,8 @@ bool32 MoveRecordedBattleToSaveData(void)
     u8 saveAttempts;
 
     saveAttempts = 0;
-    battleSave = AllocZeroed(sizeof(struct RecordedBattleSave));
-    savSection = AllocZeroed(SECTOR_SIZE);
+    battleSave = Calloc(sizeof(struct RecordedBattleSave));
+    savSection = Calloc(SECTOR_SIZE);
 
     for (i = 0; i < PARTY_SIZE; i++)
     {
@@ -490,7 +490,7 @@ static bool32 TryCopyRecordedBattleSaveData(struct RecordedBattleSave *dst, stru
 
 static bool32 CopyRecordedBattleFromSave(struct RecordedBattleSave *dst)
 {
-    struct SaveSector *savBuffer = AllocZeroed(SECTOR_SIZE);
+    struct SaveSector *savBuffer = Calloc(SECTOR_SIZE);
     bool32 ret = TryCopyRecordedBattleSaveData(dst, savBuffer);
     Free(savBuffer);
 
@@ -586,7 +586,7 @@ static void SetVariablesForRecordedBattle(struct RecordedBattleSave *src)
 
 void PlayRecordedBattle(void (*CB2_After)(void))
 {
-    struct RecordedBattleSave *battleSave = AllocZeroed(sizeof(struct RecordedBattleSave));
+    struct RecordedBattleSave *battleSave = Calloc(sizeof(struct RecordedBattleSave));
     if (CopyRecordedBattleFromSave(battleSave) == TRUE)
     {
         u8 taskId;

--- a/src/rotating_tile_puzzle.c
+++ b/src/rotating_tile_puzzle.c
@@ -89,7 +89,7 @@ EWRAM_DATA static struct RotatingTilePuzzle *sRotatingTilePuzzle = NULL;
 void InitRotatingTilePuzzle(bool8 isTrickHouse)
 {
     if (sRotatingTilePuzzle == NULL)
-        sRotatingTilePuzzle = AllocZeroed(sizeof(*sRotatingTilePuzzle));
+        sRotatingTilePuzzle = Calloc(sizeof(*sRotatingTilePuzzle));
 
     sRotatingTilePuzzle->isTrickHouse = isTrickHouse;
 }

--- a/src/roulette.c
+++ b/src/roulette.c
@@ -1088,7 +1088,7 @@ static void InitRouletteBgAndWindows(void)
 {
     u32 size = 0;
 
-    sRoulette = AllocZeroed(sizeof(*sRoulette));
+    sRoulette = Calloc(sizeof(*sRoulette));
     ResetBgsAndClearDma3BusyFlags(0);
     InitBgsFromTemplates(1, sBgTemplates, ARRAY_COUNT(sBgTemplates));
     SetBgTilemapBuffer(0, sRoulette->tilemapBuffers[0]);

--- a/src/secret_base.c
+++ b/src/secret_base.c
@@ -921,7 +921,7 @@ static void Task_ShowSecretBaseRegistryMenu(u8 taskId)
         tSelectedRow = 0;
         tScrollOffset = 0;
         ClearDialogWindowAndFrame(0, FALSE);
-        sRegistryMenu = AllocZeroed(sizeof(*sRegistryMenu));
+        sRegistryMenu = Calloc(sizeof(*sRegistryMenu));
         tMainWindowId = AddWindow(&sRegistryWindowTemplates[0]);
         BuildRegistryMenuItems(taskId);
         FinalizeRegistryMenu(taskId);

--- a/src/shop.c
+++ b/src/shop.c
@@ -513,7 +513,7 @@ static void CB2_InitBuyMenu(void)
         ResetSpriteData();
         ResetTasks();
         ClearScheduledBgCopiesToVram();
-        sShopData = AllocZeroed(sizeof(struct ShopData));
+        sShopData = Calloc(sizeof(struct ShopData));
         sShopData->scrollIndicatorsTaskId = TASK_NONE;
         sShopData->itemSpriteIds[0] = SPRITE_NONE;
         sShopData->itemSpriteIds[1] = SPRITE_NONE;

--- a/src/slot_machine.c
+++ b/src/slot_machine.c
@@ -1021,7 +1021,7 @@ void PlaySlotMachine(u8 machineId, MainCallback exitCallback)
 {
     u8 taskId;
 
-    sSlotMachine = AllocZeroed(sizeof(*sSlotMachine));
+    sSlotMachine = Calloc(sizeof(*sSlotMachine));
     PlaySlotMachine_Internal(machineId, exitCallback);
     taskId = CreateTask(Task_FadeToSlotMachine, 0);
     gTasks[taskId].tState = 0;
@@ -1229,8 +1229,8 @@ static void SlotMachineSetup_InitPalsSpritesTasks(void)
 static void SlotMachineSetup_InitTilemaps(void)
 {
     sSelectedPikaPowerTile = Alloc(8);
-    sReelOverlay_Tilemap = AllocZeroed(14);
-    sReelButtonPress_Tilemap = AllocZeroed(8);
+    sReelOverlay_Tilemap = Calloc(14);
+    sReelButtonPress_Tilemap = Calloc(8);
 
     // several of these are 1 bit off from each other
     sReelOverlay_Tilemap[0] = 0x2051;
@@ -4156,7 +4156,7 @@ static void CreateReelTimePikachuSprite(void)
     struct SpriteTemplate spriteTemplate;
     u8 spriteId;
     if (sImageTable_ReelTimePikachu == NULL)
-        sImageTable_ReelTimePikachu = AllocZeroed(sizeof(struct SpriteFrameImage) * 5);
+        sImageTable_ReelTimePikachu = Calloc(sizeof(struct SpriteFrameImage) * 5);
 
     sImageTable_ReelTimePikachu[0].data = sReelTimeGfxPtr + (0 * 0x800);
     sImageTable_ReelTimePikachu[0].size = 0x800;
@@ -4201,7 +4201,7 @@ static void CreateReelTimeMachineSprites(void)
     struct Sprite *sprite;
 
     if (sImageTable_ReelTimeMachineAntennae == NULL)
-        sImageTable_ReelTimeMachineAntennae = AllocZeroed(sizeof(struct SpriteFrameImage) * 1);
+        sImageTable_ReelTimeMachineAntennae = Calloc(sizeof(struct SpriteFrameImage) * 1);
 
     sImageTable_ReelTimeMachineAntennae[0].data = sReelTimeGfxPtr + 0x2800;
     sImageTable_ReelTimeMachineAntennae[0].size = 0x300;
@@ -4215,7 +4215,7 @@ static void CreateReelTimeMachineSprites(void)
     sSlotMachine->reelTimeMachineSpriteIds[0] = spriteId;
 
     if (sImageTable_ReelTimeMachine == NULL)
-        sImageTable_ReelTimeMachine = AllocZeroed(sizeof(struct SpriteFrameImage) * 1);
+        sImageTable_ReelTimeMachine = Calloc(sizeof(struct SpriteFrameImage) * 1);
 
     sImageTable_ReelTimeMachine[0].data = sReelTimeGfxPtr + 0x2800 + 0x300;
     sImageTable_ReelTimeMachine[0].size = 0x500;
@@ -4236,7 +4236,7 @@ static void CreateBrokenReelTimeMachineSprite(void)
     struct Sprite *sprite;
 
     if (sImageTable_BrokenReelTimeMachine == NULL)
-        sImageTable_BrokenReelTimeMachine = AllocZeroed(sizeof(struct SpriteFrameImage) * 1);
+        sImageTable_BrokenReelTimeMachine = Calloc(sizeof(struct SpriteFrameImage) * 1);
 
     sImageTable_BrokenReelTimeMachine[0].data = sReelTimeGfxPtr + 0x3000;
     sImageTable_BrokenReelTimeMachine[0].size = 0x600;
@@ -5015,7 +5015,7 @@ static void LoadSlotMachineGfx(void)
     LZDecompressWram(gSlotMachineDigitalDisplay_Gfx, sDigitalDisplayGfxPtr);
     sReelTimeGfxPtr = Alloc(0x3600);
     LZDecompressWram(sReelTimeGfx, sReelTimeGfxPtr);
-    sSlotMachineSpritesheetsPtr = AllocZeroed(sizeof(struct SpriteSheet) * ARRAY_COUNT(sSlotMachineSpriteSheets));
+    sSlotMachineSpritesheetsPtr = Calloc(sizeof(struct SpriteSheet) * ARRAY_COUNT(sSlotMachineSpriteSheets));
     for (i = 0; i < ARRAY_COUNT(sSlotMachineSpriteSheets); i++)
     {
         sSlotMachineSpritesheetsPtr[i].data = sSlotMachineSpriteSheets[i].data;
@@ -5035,8 +5035,8 @@ static void LoadReelBackground(void)
     u8 *dest;
     u8 i, j;
 
-    sReelBackgroundSpriteSheet = AllocZeroed(sizeof(struct SpriteSheet));
-    sReelBackground_Gfx = AllocZeroed(0x2000); // Background is plain white
+    sReelBackgroundSpriteSheet = Calloc(sizeof(struct SpriteSheet));
+    sReelBackground_Gfx = Calloc(0x2000); // Background is plain white
     dest = sReelBackground_Gfx;
     for (i = 0; i < 0x40; i++)
     {
@@ -5143,53 +5143,53 @@ static void SetDigitalDisplayImagePtrs(void)
 
 static void AllocDigitalDisplayGfx(void)
 {
-    sImageTable_DigitalDisplay_Reel = AllocZeroed(sizeof(struct SpriteFrameImage) * 1);
+    sImageTable_DigitalDisplay_Reel = Calloc(sizeof(struct SpriteFrameImage) * 1);
     sImageTable_DigitalDisplay_Reel[0].data = sDigitalDisplayGfxPtr;
     sImageTable_DigitalDisplay_Reel[0].size = 0x600;
 
-    sImageTable_DigitalDisplay_Time = AllocZeroed(sizeof(struct SpriteFrameImage) * 1);
+    sImageTable_DigitalDisplay_Time = Calloc(sizeof(struct SpriteFrameImage) * 1);
     sImageTable_DigitalDisplay_Time[0].data = sDigitalDisplayGfxPtr + 0x600;
     sImageTable_DigitalDisplay_Time[0].size = 0x200;
 
-    sImageTable_DigitalDisplay_Insert = AllocZeroed(sizeof(struct SpriteFrameImage) * 1);
+    sImageTable_DigitalDisplay_Insert = Calloc(sizeof(struct SpriteFrameImage) * 1);
     sImageTable_DigitalDisplay_Insert[0].data = sDigitalDisplayGfxPtr + 0x800;
     sImageTable_DigitalDisplay_Insert[0].size = 0x200;
 
-    sImageTable_DigitalDisplay_Stop = AllocZeroed(sizeof(struct SpriteFrameImage) * 1);
+    sImageTable_DigitalDisplay_Stop = Calloc(sizeof(struct SpriteFrameImage) * 1);
     sImageTable_DigitalDisplay_Stop[0].data = sDigitalDisplayGfxPtr + 0xA00;
     sImageTable_DigitalDisplay_Stop[0].size = 0x200;
 
-    sImageTable_DigitalDisplay_Win = AllocZeroed(sizeof(struct SpriteFrameImage) * 1);
+    sImageTable_DigitalDisplay_Win = Calloc(sizeof(struct SpriteFrameImage) * 1);
     sImageTable_DigitalDisplay_Win[0].data = sDigitalDisplayGfxPtr + 0xC00;
     sImageTable_DigitalDisplay_Win[0].size = 0x300;
 
-    sImageTable_DigitalDisplay_Lose = AllocZeroed(sizeof(struct SpriteFrameImage) * 1);
+    sImageTable_DigitalDisplay_Lose = Calloc(sizeof(struct SpriteFrameImage) * 1);
     sImageTable_DigitalDisplay_Lose[0].data = sDigitalDisplayGfxPtr + 0x1000;
     sImageTable_DigitalDisplay_Lose[0].size = 0x400;
 
-    sImageTable_DigitalDisplay_Bonus = AllocZeroed(sizeof(struct SpriteFrameImage) * 1);
+    sImageTable_DigitalDisplay_Bonus = Calloc(sizeof(struct SpriteFrameImage) * 1);
     sImageTable_DigitalDisplay_Bonus[0].data = sDigitalDisplayGfxPtr + 0x1400;
     sImageTable_DigitalDisplay_Bonus[0].size = 0x200;
 
-    sImageTable_DigitalDisplay_Big = AllocZeroed(sizeof(struct SpriteFrameImage) * 1);
+    sImageTable_DigitalDisplay_Big = Calloc(sizeof(struct SpriteFrameImage) * 1);
     sImageTable_DigitalDisplay_Big[0].data = sDigitalDisplayGfxPtr + 0x1600;
     sImageTable_DigitalDisplay_Big[0].size = 0x300;
 
-    sImageTable_DigitalDisplay_Reg = AllocZeroed(sizeof(struct SpriteFrameImage) * 1);
+    sImageTable_DigitalDisplay_Reg = Calloc(sizeof(struct SpriteFrameImage) * 1);
     sImageTable_DigitalDisplay_Reg[0].data = sDigitalDisplayGfxPtr + 0x1900;
     sImageTable_DigitalDisplay_Reg[0].size = 0x300;
 
-    sImageTable_DigitalDisplay_AButton = AllocZeroed(sizeof(struct SpriteFrameImage) * 2);
+    sImageTable_DigitalDisplay_AButton = Calloc(sizeof(struct SpriteFrameImage) * 2);
     sImageTable_DigitalDisplay_AButton[0].data = sDigitalDisplayGfxPtr + 0x1C00;
     sImageTable_DigitalDisplay_AButton[0].size = 0x200;
     sImageTable_DigitalDisplay_AButton[1].data = sDigitalDisplayGfxPtr + 0x1E00;
     sImageTable_DigitalDisplay_AButton[1].size = 0x200;
 
-    sImageTable_DigitalDisplay_Smoke = AllocZeroed(sizeof(struct SpriteFrameImage) * 1);
+    sImageTable_DigitalDisplay_Smoke = Calloc(sizeof(struct SpriteFrameImage) * 1);
     sImageTable_DigitalDisplay_Smoke[0].data = sDigitalDisplayGfxPtr + 0x2000;
     sImageTable_DigitalDisplay_Smoke[0].size = 640;
 
-    sImageTable_DigitalDisplay_Number = AllocZeroed(sizeof(struct SpriteFrameImage) * 5);
+    sImageTable_DigitalDisplay_Number = Calloc(sizeof(struct SpriteFrameImage) * 5);
     sImageTable_DigitalDisplay_Number[0].data = sDigitalDisplayGfxPtr + 0x2280;
     sImageTable_DigitalDisplay_Number[0].size = 0x80;
     sImageTable_DigitalDisplay_Number[1].data = sDigitalDisplayGfxPtr + 0x2300;
@@ -5201,13 +5201,13 @@ static void AllocDigitalDisplayGfx(void)
     sImageTable_DigitalDisplay_Number[4].data = sDigitalDisplayGfxPtr + 0x2480;
     sImageTable_DigitalDisplay_Number[4].size = 0x80;
 
-    sImageTable_DigitalDisplay_Pokeball = AllocZeroed(sizeof(struct SpriteFrameImage) * 2);
+    sImageTable_DigitalDisplay_Pokeball = Calloc(sizeof(struct SpriteFrameImage) * 2);
     sImageTable_DigitalDisplay_Pokeball[0].data = sDigitalDisplayGfxPtr + 0x2600;
     sImageTable_DigitalDisplay_Pokeball[0].size = 0x480;
     sImageTable_DigitalDisplay_Pokeball[1].data = sDigitalDisplayGfxPtr + 10880;
     sImageTable_DigitalDisplay_Pokeball[1].size = 0x480;
 
-    sImageTable_DigitalDisplay_DPad = AllocZeroed(sizeof(struct SpriteFrameImage) * 2);
+    sImageTable_DigitalDisplay_DPad = Calloc(sizeof(struct SpriteFrameImage) * 2);
     sImageTable_DigitalDisplay_DPad[0].data = sDigitalDisplayGfxPtr + 0x2F00;
     sImageTable_DigitalDisplay_DPad[0].size = 0x180;
     sImageTable_DigitalDisplay_DPad[1].data = sDigitalDisplayGfxPtr + 0x3080;

--- a/src/trade.c
+++ b/src/trade.c
@@ -452,9 +452,9 @@ static void CB2_CreateTradeMenu(void)
     switch (gMain.state)
     {
     case 0:
-        sTradeMenu = AllocZeroed(sizeof(*sTradeMenu));
+        sTradeMenu = Calloc(sizeof(*sTradeMenu));
         InitTradeMenu();
-        sMenuTextTileBuffer = AllocZeroed(NUM_MENU_TEXT_SPRITES * 256);
+        sMenuTextTileBuffer = Calloc(NUM_MENU_TEXT_SPRITES * 256);
 
         for (i = 0; i < NUM_MENU_TEXT_SPRITES; i++)
             sMenuTextTileBuffers[i] = &sMenuTextTileBuffer[i * 256];
@@ -2834,7 +2834,7 @@ void CB2_LinkTrade(void)
             gLinkType = LINKTYPE_TRADE_DISCONNECTED;
             CloseLink();
         }
-        sTradeAnim = AllocZeroed(sizeof(*sTradeAnim));
+        sTradeAnim = Calloc(sizeof(*sTradeAnim));
         AllocateMonSpritesGfx();
         ResetTasks();
         ResetSpriteData();
@@ -3007,7 +3007,7 @@ static void CB2_InitInGameTrade(void)
         StringCopy(gLinkPlayers[1].name, otName);
         gLinkPlayers[0].language = GAME_LANGUAGE;
         gLinkPlayers[1].language = GetMonData(&gEnemyParty[0], MON_DATA_LANGUAGE);
-        sTradeAnim = AllocZeroed(sizeof(*sTradeAnim));
+        sTradeAnim = Calloc(sizeof(*sTradeAnim));
         AllocateMonSpritesGfx();
         ResetTasks();
         ResetSpriteData();

--- a/src/trainer_card.c
+++ b/src/trainer_card.c
@@ -1797,7 +1797,7 @@ static bool8 Task_EndCardFlip(struct Task *task)
 
 void ShowPlayerTrainerCard(void (*callback)(void))
 {
-    sData = AllocZeroed(sizeof(*sData));
+    sData = Calloc(sizeof(*sData));
     sData->callback2 = callback;
     if (callback == CB2_ReshowFrontierPass)
         sData->blendColor = RGB_WHITE;
@@ -1816,7 +1816,7 @@ void ShowPlayerTrainerCard(void (*callback)(void))
 
 void ShowTrainerCardInLink(u8 cardId, void (*callback)(void))
 {
-    sData = AllocZeroed(sizeof(*sData));
+    sData = Calloc(sizeof(*sData));
     sData->callback2 = callback;
     sData->isLink = TRUE;
     sData->trainerCard = gTrainerCards[cardId];

--- a/src/trainer_hill.c
+++ b/src/trainer_hill.c
@@ -326,7 +326,7 @@ void InitTrainerHillBattleStruct(void)
     s32 i, j;
 
     SetUpDataStruct();
-    sFloorTrainers = AllocZeroed(sizeof(*sFloorTrainers));
+    sFloorTrainers = Calloc(sizeof(*sFloorTrainers));
 
     for (i = 0; i < HILL_TRAINERS_PER_FLOOR; i++)
     {
@@ -348,7 +348,7 @@ static void SetUpDataStruct(void)
 {
     if (sHillData == NULL)
     {
-        sHillData = AllocZeroed(sizeof(*sHillData));
+        sHillData = Calloc(sizeof(*sHillData));
         sHillData->floorId = gMapHeader.mapLayoutId - LAYOUT_TRAINER_HILL_1F;
 
         // This copy depends on the floor data for each challenge being directly after the

--- a/src/tv.c
+++ b/src/tv.c
@@ -3966,7 +3966,7 @@ static void TranslateShowNames(TVShow *show, u32 language)
     int i;
     TVShow **shows;
 
-    shows = AllocZeroed(sizeof(TVShow *) * 11);
+    shows = Calloc(sizeof(TVShow *) * 11);
     for (i = 0; i < LAST_TVSHOW_IDX; i++)
     {
         switch (show[i].common.kind)

--- a/src/union_room.c
+++ b/src/union_room.c
@@ -405,9 +405,9 @@ static void Task_TryBecomeLinkLeader(u8 taskId)
         data->state = LL_STATE_INIT2;
         break;
     case LL_STATE_INIT2:
-        data->incomingPlayerList = AllocZeroed(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
-        data->playerList = AllocZeroed(MAX_RFU_PLAYERS * sizeof(struct RfuPlayer));
-        data->playerListBackup = AllocZeroed(MAX_RFU_PLAYERS * sizeof(struct RfuPlayer));
+        data->incomingPlayerList = Calloc(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
+        data->playerList = Calloc(MAX_RFU_PLAYERS * sizeof(struct RfuPlayer));
+        data->playerListBackup = Calloc(MAX_RFU_PLAYERS * sizeof(struct RfuPlayer));
         ClearIncomingPlayerList(data->incomingPlayerList, RFU_CHILD_MAX);
         ClearRfuPlayerList(data->playerList->players, MAX_RFU_PLAYERS);
         CopyHostRfuGameDataAndUsername(&data->playerList->players[0].rfu.data, data->playerList->players[0].rfu.name);
@@ -996,8 +996,8 @@ static void Task_TryJoinLinkGroup(u8 taskId)
         SetWirelessCommType1();
         OpenLink();
         InitializeRfuLinkManager_JoinGroup();
-        data->incomingPlayerList = AllocZeroed(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
-        data->playerList = AllocZeroed(MAX_RFU_PLAYER_LIST_SIZE * sizeof(struct RfuPlayer));
+        data->incomingPlayerList = Calloc(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
+        data->playerList = Calloc(MAX_RFU_PLAYER_LIST_SIZE * sizeof(struct RfuPlayer));
         data->state = LG_STATE_CHOOSE_LEADER_MSG;
         break;
     case LG_STATE_CHOOSE_LEADER_MSG:
@@ -1321,8 +1321,8 @@ static void Task_ListenToWireless(u8 taskId)
         OpenLink();
         InitializeRfuLinkManager_JoinGroup();
         RfuSetIgnoreError(TRUE);
-        data->incomingPlayerList = AllocZeroed(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
-        data->playerList = AllocZeroed(MAX_RFU_PLAYER_LIST_SIZE * sizeof(struct RfuPlayer));
+        data->incomingPlayerList = Calloc(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
+        data->playerList = Calloc(MAX_RFU_PLAYER_LIST_SIZE * sizeof(struct RfuPlayer));
         data->state = 2;
         break;
     case 2:
@@ -1896,9 +1896,9 @@ static void Task_SendMysteryGift(u8 taskId)
         data->state = 1;
         break;
     case 1:
-        data->incomingPlayerList = AllocZeroed(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
-        data->playerList = AllocZeroed(MAX_RFU_PLAYERS * sizeof(struct RfuPlayer));
-        data->playerListBackup = AllocZeroed(MAX_RFU_PLAYERS * sizeof(struct RfuPlayer));
+        data->incomingPlayerList = Calloc(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
+        data->playerList = Calloc(MAX_RFU_PLAYERS * sizeof(struct RfuPlayer));
+        data->playerListBackup = Calloc(MAX_RFU_PLAYERS * sizeof(struct RfuPlayer));
         ClearIncomingPlayerList(data->incomingPlayerList, RFU_CHILD_MAX);
         ClearRfuPlayerList(data->playerList->players, MAX_RFU_PLAYERS);
         CopyHostRfuGameDataAndUsername(&data->playerList->players[0].rfu.data, data->playerList->players[0].rfu.name);
@@ -2099,8 +2099,8 @@ static void Task_CardOrNewsWithFriend(u8 taskId)
         SetWirelessCommType1();
         OpenLink();
         InitializeRfuLinkManager_JoinGroup();
-        data->incomingPlayerList = AllocZeroed(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
-        data->playerList = AllocZeroed(MAX_RFU_PLAYER_LIST_SIZE * sizeof(struct RfuPlayer));
+        data->incomingPlayerList = Calloc(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
+        data->playerList = Calloc(MAX_RFU_PLAYER_LIST_SIZE * sizeof(struct RfuPlayer));
         data->state = 1;
         break;
     case 1:
@@ -2267,8 +2267,8 @@ static void Task_CardOrNewsOverWireless(u8 taskId)
         SetWirelessCommType1();
         OpenLink();
         InitializeRfuLinkManager_JoinGroup();
-        data->incomingPlayerList = AllocZeroed(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
-        data->playerList = AllocZeroed(MAX_RFU_PLAYER_LIST_SIZE * sizeof(struct RfuPlayer));
+        data->incomingPlayerList = Calloc(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
+        data->playerList = Calloc(MAX_RFU_PLAYER_LIST_SIZE * sizeof(struct RfuPlayer));
         data->state = 1;
         break;
     case 1:
@@ -2428,7 +2428,7 @@ void RunUnionRoom(void)
     // dumb line needed to match
     sWirelessLinkMain.uRoom = sWirelessLinkMain.uRoom;
 
-    uroom = AllocZeroed(sizeof(*sWirelessLinkMain.uRoom));
+    uroom = Calloc(sizeof(*sWirelessLinkMain.uRoom));
     sWirelessLinkMain.uRoom = uroom;
     sURoom = uroom;
 
@@ -2490,10 +2490,10 @@ static void Task_RunUnionRoom(u8 taskId)
     switch (uroom->state)
     {
     case UR_STATE_INIT:
-        uroom->incomingChildList = AllocZeroed(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
-        uroom->incomingParentList = AllocZeroed(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
-        uroom->playerList = AllocZeroed(MAX_UNION_ROOM_LEADERS * sizeof(struct RfuPlayer));
-        uroom->spawnPlayer = AllocZeroed(sizeof(struct RfuPlayer));
+        uroom->incomingChildList = Calloc(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
+        uroom->incomingParentList = Calloc(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
+        uroom->playerList = Calloc(MAX_UNION_ROOM_LEADERS * sizeof(struct RfuPlayer));
+        uroom->spawnPlayer = Calloc(sizeof(struct RfuPlayer));
         ClearRfuPlayerList(uroom->playerList->players, MAX_UNION_ROOM_LEADERS);
         gPlayerCurrActivity = IN_UNION_ROOM;
         uroom->searchTaskId = CreateTask_SearchForChildOrParent(uroom->incomingParentList, uroom->incomingChildList, LINK_GROUP_UNION_ROOM_RESUME);
@@ -3298,7 +3298,7 @@ void InitUnionRoom(void)
     sUnionRoomPlayerName[0] = EOS;
     CreateTask(Task_InitUnionRoom, 0);
     sWirelessLinkMain.uRoom = sWirelessLinkMain.uRoom; // Needed to match.
-    sWirelessLinkMain.uRoom = data = AllocZeroed(sizeof(struct WirelessLink_URoom));
+    sWirelessLinkMain.uRoom = data = Calloc(sizeof(struct WirelessLink_URoom));
     sURoom = sWirelessLinkMain.uRoom;
     data->state = 0;
     data->textState = 0;
@@ -3327,13 +3327,13 @@ static void Task_InitUnionRoom(u8 taskId)
         data->state = 2;
         break;
     case 2:
-        data->incomingChildList = AllocZeroed(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
+        data->incomingChildList = Calloc(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
         ClearIncomingPlayerList(data->incomingChildList, RFU_CHILD_MAX);
-        data->incomingParentList = AllocZeroed(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
+        data->incomingParentList = Calloc(RFU_CHILD_MAX * sizeof(struct RfuIncomingPlayer));
         ClearIncomingPlayerList(data->incomingParentList, RFU_CHILD_MAX);
-        data->playerList = AllocZeroed(MAX_UNION_ROOM_LEADERS * sizeof(struct RfuPlayer));
+        data->playerList = Calloc(MAX_UNION_ROOM_LEADERS * sizeof(struct RfuPlayer));
         ClearRfuPlayerList(data->playerList->players, MAX_UNION_ROOM_LEADERS);
-        data->spawnPlayer = AllocZeroed(sizeof(struct RfuPlayer));
+        data->spawnPlayer = Calloc(sizeof(struct RfuPlayer));
         ClearRfuPlayerList(&data->spawnPlayer->players[0], 1);
         data->searchTaskId = CreateTask_SearchForChildOrParent(data->incomingParentList, data->incomingChildList, LINK_GROUP_UNION_ROOM_INIT);
         data->state = 3;

--- a/src/union_room_battle.c
+++ b/src/union_room_battle.c
@@ -116,7 +116,7 @@ void CB2_UnionRoomBattle(void)
     {
     case 0:
         SetGpuReg(REG_OFFSET_DISPCNT, 0x0000);
-        sBattle = AllocZeroed(sizeof(struct UnionRoomBattle));
+        sBattle = Calloc(sizeof(struct UnionRoomBattle));
         ResetSpriteData();
         FreeAllSpritePalettes();
         ResetTasks();

--- a/src/use_pokeblock.c
+++ b/src/use_pokeblock.c
@@ -415,7 +415,7 @@ static const struct SpritePalette sSpritePalette_Condition =
 // When first opening the selection screen
 void ChooseMonToGivePokeblock(struct Pokeblock *pokeblock, void (*callback)(void))
 {
-    sMenu = AllocZeroed(sizeof(*sMenu));
+    sMenu = Calloc(sizeof(*sMenu));
     sInfo = &sMenu->info;
     sInfo->pokeblock = pokeblock;
     sInfo->exitCallback = callback;
@@ -426,7 +426,7 @@ void ChooseMonToGivePokeblock(struct Pokeblock *pokeblock, void (*callback)(void
 // When returning to the selection screen after feeding a pokeblock to a mon
 static void CB2_ReturnAndChooseMonToGivePokeblock(void)
 {
-    sMenu = AllocZeroed(sizeof(*sMenu));
+    sMenu = Calloc(sizeof(*sMenu));
     sInfo = &sMenu->info;
     sInfo->pokeblock = sPokeblock;
     sInfo->exitCallback = sExitCallback;

--- a/src/wireless_communication_status_screen.c
+++ b/src/wireless_communication_status_screen.c
@@ -198,7 +198,7 @@ void ShowWirelessCommunicationScreen(void)
 static void CB2_InitWirelessCommunicationScreen(void)
 {
     SetGpuReg(REG_OFFSET_DISPCNT, 0);
-    sStatusScreen = AllocZeroed(sizeof(struct WirelessCommunicationStatusScreen));
+    sStatusScreen = Calloc(sizeof(struct WirelessCommunicationStatusScreen));
     SetVBlankCallback(NULL);
     ResetBgsAndClearDma3BusyFlags(0);
     InitBgsFromTemplates(0, sBgTemplates, ARRAY_COUNT(sBgTemplates));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This came up in a pokeplatinum review. Since `Alloc` exists as a GF equivalent to `alloc`, it makes sense that `AllocZeroed` should be called `Calloc` instead.

## **Discord contact info**
AsparagusEduardo#6051