### PR TITLE
Fix mapjson misreporting errors when processing map_groups.json

### DIFF
--- a/tools/mapjson/mapjson.cpp
+++ b/tools/mapjson/mapjson.cpp
@@ -75,6 +75,9 @@ string json_to_string(const Json &data, const string &field = "", bool silent = 
         case Json::Type::BOOL:
             output = value.bool_value() ? "TRUE" : "FALSE";
             break;
+        case Json::Type::NUL:
+            output = "";
+            break;
         default:{
             if (!silent) {
                 string s = !field.empty() ? ("Value for '" + field + "'") : "JSON field";
@@ -459,23 +462,24 @@ string generate_map_constants_text(string groups_filepath, Json groups_data) {
     for (auto &group : groups_data["group_order"].array_items()) {
         string groupName = json_to_string(group);
         text << "// " << groupName << "\n";
-        vector<Json> map_ids;
+        vector<string> map_ids;
         size_t max_length = 0;
 
         for (auto &map_name : groups_data[groupName].array_items()) {
-            string header_filepath = file_dir + json_to_string(map_name) + dir_separator + "map.json";
+            string map_filepath = file_dir + json_to_string(map_name) + dir_separator + "map.json";
             string err_str;
-            Json map_data = Json::parse(read_text_file(header_filepath), err_str);
-            map_ids.push_back(map_data["id"]);
-            string id = json_to_string(map_data, "id");
+            Json map_data = Json::parse(read_text_file(map_filepath), err_str);
+            if (map_data == Json())
+                FATAL_ERROR("%s: %s\n", map_filepath.c_str(), err_str.c_str());
+            string id = json_to_string(map_data, "id", true);
+            map_ids.push_back(id);
             if (id.length() > max_length)
                 max_length = id.length();
         }
 
         int map_id_num = 0;
-        for (Json map_id : map_ids) {
-            string id = json_to_string(map_id);
-            text << "#define " << id << string((max_length - id.length() + 1), ' ')
+        for (string map_id : map_ids) {
+            text << "#define " << map_id << string((max_length - map_id.length() + 1), ' ')
                  << "(" << map_id_num++ << " | (" << group_num << " << 8))\n";
         }
         text << "\n";


### PR DESCRIPTION
In mapjson, if `Json::parse` encounters an error reading a `map.json` file while processing `map_groups.json` it will return an empty Json object. This isn't checked, so mapjson will continue until it errors because it can't find the `id` field, with this unhelpful error message:
```
tools/mapjson/mapjson groups emerald data/maps/map_groups.json
Value for 'id' is unexpected type; expected string, number, or bool.
make: *** [map_data_rules.mk:22: data/maps/groups.inc] Error 1
```
Now mapjson will stop and report the actual error instead. (Additionally, if `id` *was* actually missing the message above is slightly misleading. This was also fixed)