### PR TITLE
Add FRONTIER_REPEAT_CHALLENGES_START_HARDEST_RANGE constant

### DIFF
--- a/include/constants/battle_frontier.h
+++ b/include/constants/battle_frontier.h
@@ -56,6 +56,11 @@
 // There are 2 facilities that differ: Battle Dome (DOME_ROUNDS_COUNT) and Battle Pike (NUM_PIKE_ROOMS).
 #define FRONTIER_STAGES_PER_CHALLENGE 7
 
+// Every time you complete 7 battles, the Battle Frontier challenge repeats. After 7 repeats, the Battle
+// Frontier uses trainer IDs that always come from the last, hardest range, which is the same for both
+// trainer ID tables.
+#define FRONTIER_REPEAT_CHALLENGES_START_HARDEST_RANGE 7
+
 // These sets of facility ids would be redundant if the order was consistent
 // The order is important for this set so that all the non-link records can be continuous
 #define RANKING_HALL_TOWER_SINGLES   0

--- a/src/battle_tower.c
+++ b/src/battle_tower.c
@@ -1105,7 +1105,7 @@ u16 GetRandomScaledFrontierTrainerId(u8 challengeNum, u8 battleNum)
 {
     u16 trainerId;
 
-    if (challengeNum <= 7)
+    if (challengeNum <= FRONTIER_REPEAT_CHALLENGES_START_HARDEST_RANGE)
     {
         if (battleNum == FRONTIER_STAGES_PER_CHALLENGE - 1)
         {
@@ -1122,8 +1122,8 @@ u16 GetRandomScaledFrontierTrainerId(u8 challengeNum, u8 battleNum)
     else
     {
         // After challenge 7, trainer IDs always come from the last, hardest range, which is the same for both trainer ID tables
-        trainerId = (sFrontierTrainerIdRanges[7][1] - sFrontierTrainerIdRanges[7][0]) + 1;
-        trainerId = sFrontierTrainerIdRanges[7][0] + (Random() % trainerId);
+        trainerId = (sFrontierTrainerIdRanges[FRONTIER_REPEAT_CHALLENGES_START_HARDEST_RANGE][1] - sFrontierTrainerIdRanges[FRONTIER_REPEAT_CHALLENGES_START_HARDEST_RANGE][0]) + 1;
+        trainerId = sFrontierTrainerIdRanges[FRONTIER_REPEAT_CHALLENGES_START_HARDEST_RANGE][0] + (Random() % trainerId);
     }
 
     return trainerId;
@@ -1134,7 +1134,7 @@ static void GetRandomScaledFrontierTrainerIdRange(u8 challengeNum, u8 battleNum,
 {
     u16 trainerId, range;
 
-    if (challengeNum <= 7)
+    if (challengeNum <= FRONTIER_REPEAT_CHALLENGES_START_HARDEST_RANGE)
     {
         if (battleNum == FRONTIER_STAGES_PER_CHALLENGE - 1)
         {
@@ -1151,8 +1151,8 @@ static void GetRandomScaledFrontierTrainerIdRange(u8 challengeNum, u8 battleNum,
     else
     {
         // After challenge 7, trainer IDs always come from the last, hardest range, which is the same for both trainer ID tables
-        range = (sFrontierTrainerIdRanges[7][1] - sFrontierTrainerIdRanges[7][0]) + 1;
-        trainerId = sFrontierTrainerIdRanges[7][0];
+        range = (sFrontierTrainerIdRanges[FRONTIER_REPEAT_CHALLENGES_START_HARDEST_RANGE][1] - sFrontierTrainerIdRanges[FRONTIER_REPEAT_CHALLENGES_START_HARDEST_RANGE][0]) + 1;
+        trainerId = sFrontierTrainerIdRanges[FRONTIER_REPEAT_CHALLENGES_START_HARDEST_RANGE][0];
     }
 
     *trainerIdPtr = trainerId;


### PR DESCRIPTION
Add FRONTIER_REPEAT_CHALLENGES_START_HARDEST_RANGE constant
## Description
Every time you complete 7 battles, the Battle Frontier challenge repeats. After 7 repeats, the Battle Frontier uses trainer IDs that always come from the last, hardest range, which is the same for both trainer ID tables. This constant addresses that.
## **Discord contact info**
Yak Attack#9182