### PR TITLE
Fix compilation for modern under certain circumstances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ LD := $(PREFIX)ld
 # note: the makefile must be set up so MODERNCC is never called
 # if MODERN=0
 MODERNCC := $(PREFIX)gcc
-PATH_MODERNCC := PATH=$(TOOLCHAIN)/bin:PATH $(MODERNCC)
+PATH_MODERNCC := PATH="$(PATH)" $(MODERNCC)
 
 ifeq ($(OS),Windows_NT)
 EXE := .exe


### PR DESCRIPTION
When prepending something to PATH, we should use PATH=/foo/bar:$PATH and not PATH=/foo/bar:PATH. Because your shell won't certainly find something under the literal name PATH.

If one is not using devkitarm, TOOLCHAIN will resolve to an empty string. If TOOLCHAIN is an empty string the only search path for the modern gcc will be /bin which may work on some installations but is probably not what was originally intended with this line. So let's just search the standard search path if nothing can be found under $(TOOLCHAIN).