### PR TITLE
Rename GAME_STAT_FISHING_CAPTURES to GAME_STAT_FISHING_ENCOUNTERS

### DIFF
--- a/include/constants/game_stat.h
+++ b/include/constants/game_stat.h
@@ -13,7 +13,7 @@
 #define GAME_STAT_TRAINER_BATTLES              9
 #define GAME_STAT_ENTERED_HOF                 10
 #define GAME_STAT_POKEMON_CAPTURES            11
-#define GAME_STAT_FISHING_CAPTURES            12
+#define GAME_STAT_FISHING_ENCOUNTERS          12
 #define GAME_STAT_HATCHED_EGGS                13
 #define GAME_STAT_EVOLVED_POKEMON             14
 #define GAME_STAT_USED_POKECENTER             15

--- a/src/mauville_old_man.c
+++ b/src/mauville_old_man.c
@@ -969,7 +969,7 @@ static const struct Story sStorytellerStories[] = {
         MauvilleCity_PokemonCenter_1F_Text_PokemonCaughtStory
     },
     {
-        GAME_STAT_FISHING_CAPTURES, 1,
+        GAME_STAT_FISHING_ENCOUNTERS, 1,
         MauvilleCity_PokemonCenter_1F_Text_FishingPokemonCaughtTitle,
         MauvilleCity_PokemonCenter_1F_Text_FishingPokemonCaughtAction,
         MauvilleCity_PokemonCenter_1F_Text_FishingPokemonCaughtStory

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -783,7 +783,7 @@ void FishingWildEncounter(u8 rod)
     {
         species = GenerateFishingWildMon(gWildMonHeaders[GetCurrentMapWildMonHeaderId()].fishingMonsInfo, rod);
     }
-    IncrementGameStat(GAME_STAT_FISHING_CAPTURES);
+    IncrementGameStat(GAME_STAT_FISHING_ENCOUNTERS);
     SetPokemonAnglerSpecies(species);
     BattleSetup_StartWildBattle();
 }


### PR DESCRIPTION
Renames the game stat GAME_STAT_FISHING_CAPTURES to GAME_STAT_FISHING_ENCOUNTERS.

## Description
Unlike the game stat GAME_STAT_POKEMON_CAPTURES, which is increased in value every time you successfully catch a Pokémon, GAME_STAT_FISHING_CAPTURES is increased in value every time you start a battle with a Pokémon you encountered by fishing and has nothing to do with successfully catching said Pokémon. This PR renames said game stat to GAME_STAT_FISHING_ENCOUNTERS to reflect this difference and to prevent confusion.

## **Discord contact info**
Jasper#5206