### PR TITLE
Added bugfix for SaveBeforeLinkMultisChallenge to remove extra incrementgamestat

### DIFF
--- a/data/maps/BattleFrontier_BattleTowerLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerLobby/scripts.inc
@@ -421,7 +421,12 @@ BattleFrontier_BattleTowerLobby_EventScript_SaveBeforeLinkMultisChallenge::
 	call Common_EventScript_SaveGame
 	setvar VAR_TEMP_0, 255
 	goto_if_eq VAR_RESULT, 0, BattleFrontier_BattleTowerLobby_EventScript_CancelChallengeSaveFailed
+@ GAME_STAT_ENTERED_BATTLE_TOWER should not be incremented here, for two reasons:
+@ 1. It is incremented again in BattleFrontier_BattleTowerLobby_EventScript_CableLinkSuccessful or BattleFrontier_BattleTowerLobby_EventScript_WirelessLinkSuccessful
+@ 2. If the player tries to save, but fails, the counter will still be incremented even if the player never enters the tower.
+.ifndef BUGFIX
 	incrementgamestat GAME_STAT_ENTERED_BATTLE_TOWER
+.endif
 	specialvar VAR_RESULT, IsWirelessAdapterConnected
 	goto_if_eq VAR_RESULT, TRUE, BattleFrontier_BattleTowerLobby_EventScript_TryWirelessLink
 	goto BattleFrontier_BattleTowerLobby_EventScript_TryCableLink


### PR DESCRIPTION
## Description
`BattleFrontier_BattleTowerLobby_EventScript_SaveBeforeLinkMultisChallenge` runs after talking to the far right attendant, and initiating a Link Multi Battle Tower run. Before checking if wireless capabilities are functioning, the game runs `incrementgamestat GAME_STAT_ENTERED_BATTLE_TOWER`.

Assuming the player goes through and successfully connects, they end up in either `BattleFrontier_BattleTowerLobby_EventScript_CableLinkSuccessful` or `BattleFrontier_BattleTowerLobby_EventScript_WirelessLinkSuccessful`. The first thing both of those scripts do is `incrementgamestat GAME_STAT_ENTERED_BATTLE_TOWER`.

That means entering a Link Multi challenge will add 2 to the counter, as opposed to one. 

This PR adds a `BUGFIX` to remove `incrementgamestat` in `BattleFrontier_BattleTowerLobby_EventScript_SaveBeforeLinkMultisChallenge`.

## Testing

<details>
  <summary><a href="https://github.com/pret/pokeemerald/blob/fce97dc39798c9294374490f043375f2037d9c1c/src/field_specials.c"><h3>src/field_specials.c</h3></a></summary>

  ```diff
u16 GetBattleTowerSinglesStreak(void)
{
-    return GetGameStat(GAME_STAT_BATTLE_TOWER_SINGLES_STREAK);
+    return GetGameStat(GAME_STAT_ENTERED_BATTLE_TOWER);
}
```
</details>


<details>
  <summary><a href="https://github.com/pret/pokeemerald/blob/fce97dc39798c9294374490f043375f2037d9c1c/data/maps/BattleFrontier_BattleTowerLobby/scripts.inc"><h3>data/maps/BattleFrontier_BattleTowerLobby/scripts.inc</h3></a></summary>

  ```diff
BattleFrontier_BattleTowerLobby_EventScript_SaveBeforeLinkMultisChallenge::
    // all code here is unchanged

    call Common_EventScript_SaveGame
    setvar VAR_TEMP_0, 255
    goto_if_eq VAR_RESULT, 0, BattleFrontier_BattleTowerLobby_EventScript_CancelChallengeSaveFailed
+ .ifndef BUGFIX
+    incrementgamestat GAME_STAT_ENTERED_BATTLE_TOWER
+ .endif
+   call GetValue
    specialvar VAR_RESULT, IsWirelessAdapterConnected
    goto_if_eq VAR_RESULT, TRUE, BattleFrontier_BattleTowerLobby_EventScript_TryWirelessLink
    goto BattleFrontier_BattleTowerLobby_EventScript_TryCableLink
    end

+ GetValue::
+    specialvar VAR_0x8006,GetBattleTowerSinglesStreak
+    buffernumberstring STR_VAR_1, VAR_0x8006
+    msgbox WhatIsTheValue,MSGBOX_DEFAULT
+    closemessage
+    return
+    end
+
+ WhatIsTheValue::
+    .string "GAME-STAT-ENTERED-BATTLE-TOWER is\ncurrently at {STR_VAR_1}.$"

BattleFrontier_BattleTowerLobby_EventScript_EnterElevator::
+   call GetValue
    special SavePlayerParty
    setvar VAR_0x8004, FRONTIER_UTIL_FUNC_SET_PARTY_ORDER
    // all code here is unchanged

BattleFrontier_BattleTowerLobby_EventScript_LinkMultisAttendant::
    lock
    faceplayer
    setvar VAR_FRONTIER_FACILITY, FRONTIER_FACILITY_TOWER
    special SavePlayerParty
+    call GetValue
    msgbox BattleFrontier_BattleTowerLobby_Text_WelcomeLinkMultiBattle, MSGBOX_DEFAULT
// all code here is unchanged
```
</details>

### Video
<details>
  <summary><h4>Bugfix</h4></summary>

https://github.com/pret/pokeemerald/assets/77138753/e83f9fea-2add-45ff-ac7c-8392f5e524bd

</details>

<details>
  <summary><h4>No Bugfix</h4></summary>

https://github.com/pret/pokeemerald/assets/77138753/e8dabb11-9567-4676-9f5f-a2316483374b

</details>

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
pkmnsnfrn
<!--- Contributors must join https://discord.gg/d5dubZ3 -->