### PR TITLE
Detect potential misalignment in modern

### DIFF
--- a/include/decompress.h
+++ b/include/decompress.h
@@ -3,7 +3,7 @@
 
 #include "sprite.h"
 
-extern u8 gDecompressionBuffer[0x4000];
+extern u8 ALIGNED(4) gDecompressionBuffer[0x4000];
 
 void LZDecompressWram(const u32 *src, void *dest);
 void LZDecompressVram(const u32 *src, void *dest);

--- a/include/gba/m4a_internal.h
+++ b/include/gba/m4a_internal.h
@@ -213,7 +213,7 @@ struct SoundInfo
     ExtVolPitFunc ExtVolPit;
     u8 gap2[16];
     struct SoundChannel chans[MAX_DIRECTSOUND_CHANNELS];
-    s8 pcmBuffer[PCM_DMA_BUF_SIZE * 2];
+    s8 ALIGNED(4) pcmBuffer[PCM_DMA_BUF_SIZE * 2];
 };
 
 struct SongHeader

--- a/include/gba/syscall.h
+++ b/include/gba/syscall.h
@@ -27,9 +27,31 @@ u16 ArcTan2(s16 x, s16 y);
 
 void CpuSet(const void *src, void *dest, u32 control);
 
+#if MODERN
+// NOTE: Assumes 16-bit CpuSets unless control is a constant and has
+// CPU_SET_32BIT set.
+#define CpuSet(src, dest, control) \
+    do \
+    { \
+        _Static_assert(_Alignof(src) >= __builtin_choose_expr(__builtin_constant_p(control), ((control) & CPU_SET_32BIT) ? 4 : 2, 2), "source potentially unaligned"); \
+        _Static_assert(_Alignof(dest) >= __builtin_choose_expr(__builtin_constant_p(control), ((control) & CPU_SET_32BIT) ? 4 : 2, 2), "destination potentially unaligned"); \
+        CpuSet(src, dest, control); \
+    } while (0)
+#endif
+
 #define CPU_FAST_SET_SRC_FIXED 0x01000000
 
 void CpuFastSet(const void *src, void *dest, u32 control);
+
+#if MODERN
+#define CpuFastSet(src, dest, control) \
+    do \
+    { \
+        _Static_assert(_Alignof(src) >= 4, "source potentially unaligned"); \
+        _Static_assert(_Alignof(dest) >= 4, "destination potentially unaligned"); \
+        CpuFastSet(src, dest, control); \
+    } while (0)
+#endif
 
 void BgAffineSet(struct BgAffineSrcData *src, struct BgAffineDstData *dest, s32 count);
 

--- a/include/global.h
+++ b/include/global.h
@@ -845,7 +845,7 @@ struct WaldaPhrase
 struct TrainerNameRecord
 {
     u32 trainerId;
-    u8 trainerName[PLAYER_NAME_LENGTH + 1];
+    u8 ALIGNED(2) trainerName[PLAYER_NAME_LENGTH + 1];
 };
 
 struct TrainerHillSave

--- a/include/graphics.h
+++ b/include/graphics.h
@@ -3893,7 +3893,7 @@ extern const u32 gIntroGroudon_Gfx[];
 extern const u32 gIntroGroudon_Tilemap[];
 extern const u32 gIntroLegendBg_Gfx[];
 extern const u32 gIntroGroudonBg_Tilemap[];
-extern const u8 gIntro3Bg_Pal[0x200];
+extern const u8 ALIGNED(2) gIntro3Bg_Pal[0x200];
 extern const u32 gIntroKyogre_Gfx[];
 extern const u32 gIntroKyogre_Tilemap[];
 extern const u32 gIntroKyogreBg_Tilemap[];
@@ -5018,8 +5018,8 @@ extern const u32 gPokenavOptions_Gfx[];
 extern const u16 gPokenavOptions_Pal[];
 
 // Battle Factory Screen
-extern const u8 gFrontierFactorySelectMenu_Gfx[];
-extern const u8 gFrontierFactorySelectMenu_Tilemap[];
+extern const u16 gFrontierFactorySelectMenu_Gfx[];
+extern const u16 gFrontierFactorySelectMenu_Tilemap[];
 extern const u16 gFrontierFactorySelectMenu_Pal[];
 
 // Object event pals

--- a/include/item_menu.h
+++ b/include/item_menu.h
@@ -78,7 +78,7 @@ struct BagMenu
     u8 numShownItems[POCKETS_COUNT];
     s16 graphicsLoadState;
     u8 unused2[14];
-    u8 pocketNameBuffer[32][32];
+    u8 ALIGNED(4) pocketNameBuffer[32][32];
     u8 unused3[4];
 };
 

--- a/include/librfu.h
+++ b/include/librfu.h
@@ -329,7 +329,7 @@ struct RfuIntrStruct
 {
     union RfuPacket rxPacketAlloc;
     union RfuPacket txPacketAlloc;
-    u8 block1[0x960]; // size of librfu_intr.s binary
+    u8 ALIGNED(2) block1[0x960]; // size of librfu_intr.s binary
     struct STWIStatus block2;
 };
 

--- a/include/link.h
+++ b/include/link.h
@@ -238,7 +238,7 @@ struct BlockRequest
 };
 
 extern struct Link gLink;
-extern u16 gRecvCmds[MAX_RFU_PLAYERS][CMD_LENGTH];
+extern u16 ALIGNED(4) gRecvCmds[MAX_RFU_PLAYERS][CMD_LENGTH];
 extern u8 gBlockSendBuffer[BLOCK_BUFFER_SIZE];
 extern u16 gLinkType;
 extern u32 gLinkStatus;

--- a/include/mon_markings.h
+++ b/include/mon_markings.h
@@ -18,7 +18,7 @@ struct MonMarkingsMenu
     struct Sprite *textSprite;
     const u8 *frameTiles;
     const u16 *framePalette;
-    u8 windowSpriteTiles[0x1000];
+    u8 ALIGNED(2) windowSpriteTiles[0x1000];
     u8 unused[0x80];
     u8 tileLoadState;
 };

--- a/include/palette.h
+++ b/include/palette.h
@@ -54,9 +54,9 @@ struct PaletteFadeControl
 
 extern struct PaletteFadeControl gPaletteFade;
 extern u32 gPlttBufferTransferPending;
-extern u8 gPaletteDecompressionBuffer[];
-extern u16 gPlttBufferUnfaded[PLTT_BUFFER_SIZE];
-extern u16 gPlttBufferFaded[PLTT_BUFFER_SIZE];
+extern u8 ALIGNED(4) gPaletteDecompressionBuffer[];
+extern u16 ALIGNED(4) gPlttBufferUnfaded[PLTT_BUFFER_SIZE];
+extern u16 ALIGNED(4) gPlttBufferFaded[PLTT_BUFFER_SIZE];
 
 void LoadCompressedPalette(const u32 *src, u16 offset, u16 size);
 void LoadPalette(const void *src, u16 offset, u16 size);

--- a/include/scanline_effect.h
+++ b/include/scanline_effect.h
@@ -37,7 +37,7 @@ struct ScanlineEffect
 
 extern struct ScanlineEffect gScanlineEffect;
 
-extern u16 gScanlineEffectRegBuffers[2][0x3C0];
+extern u16 ALIGNED(4) gScanlineEffectRegBuffers[2][0x3C0];
 
 void ScanlineEffect_Stop(void);
 void ScanlineEffect_Clear(void);

--- a/src/battle_factory_screen.c
+++ b/src/battle_factory_screen.c
@@ -268,7 +268,7 @@ static const u8 sActionHighlightMiddle_Gfx[] = INCBIN_U8( "graphics/battle_front
 static const u8 sActionHighlightRight_Gfx[]  = INCBIN_U8( "graphics/battle_frontier/factory_screen/action_highlight_right.4bpp");
 static const u8 sMonPicBgAnim_Gfx[]          = INCBIN_U8( "graphics/battle_frontier/factory_screen/mon_pic_bg_anim.4bpp");
 static const u8 sMonPicBg_Tilemap[]          = INCBIN_U8( "graphics/battle_frontier/factory_screen/mon_pic_bg.bin");
-static const u8 sMonPicBg_Gfx[]              = INCBIN_U8( "graphics/battle_frontier/factory_screen/mon_pic_bg.4bpp");
+static const u16 sMonPicBg_Gfx[]             = INCBIN_U16("graphics/battle_frontier/factory_screen/mon_pic_bg.4bpp");
 static const u16 sMonPicBg_Pal[]             = INCBIN_U16("graphics/battle_frontier/factory_screen/mon_pic_bg.gbapal");
 
 static const struct SpriteSheet sSelect_SpriteSheets[] =

--- a/src/berry_fix_program.c
+++ b/src/berry_fix_program.c
@@ -117,7 +117,7 @@ static const struct WindowTemplate sBerryFixWindowTemplates[] = {
     DUMMY_WIN_TEMPLATE
 };
 
-static const u16 sBerryFixPalColors[] = {
+static const u16 ALIGNED(4) sBerryFixPalColors[] = {
     RGB_WHITE,       RGB_WHITE,       RGB(12, 12, 12), RGB(26, 26, 25),
     RGB(28, 1, 1),   RGB(31, 23, 14), RGB(4, 19, 1),   RGB(18, 30, 18),
     RGB(6, 10, 25),  RGB(20, 24, 30), RGB_WHITE,       RGB(12, 12, 12),

--- a/src/contest.c
+++ b/src/contest.c
@@ -1301,8 +1301,8 @@ static void Task_ReadyStartLinkContest(u8 taskId)
 
 static bool8 SetupContestGraphics(u8 *stateVar)
 {
-    u16 tempPalette1[16];
-    u16 tempPalette2[16];
+    u16 ALIGNED(4) tempPalette1[16];
+    u16 ALIGNED(4) tempPalette2[16];
 
     switch (*stateVar)
     {

--- a/src/decoration.c
+++ b/src/decoration.c
@@ -1916,7 +1916,7 @@ static void CopyPalette(u16 *dest, u16 pal)
 
 static void CopyTile(u8 *dest, u16 tile)
 {
-    u8 buffer[TILE_SIZE_4BPP];
+    u8 ALIGNED(4) buffer[TILE_SIZE_4BPP];
     u16 mode;
     u16 i;
 

--- a/src/field_weather.c
+++ b/src/field_weather.c
@@ -61,7 +61,7 @@ static void None_Main(void);
 static u8 None_Finish(void);
 
 EWRAM_DATA struct Weather gWeather = {0};
-EWRAM_DATA static u8 sFieldEffectPaletteColorMapTypes[32] = {0};
+EWRAM_DATA static u8 ALIGNED(2) sFieldEffectPaletteColorMapTypes[32] = {0};
 
 static const u8 *sPaletteColorMapTypes;
 
@@ -111,7 +111,7 @@ void (*const gWeatherPalStateFuncs[])(void) =
 
 // This table specifies which of the color maps should be
 // applied to each of the background and sprite palettes.
-static const u8 sBasePaletteColorMapTypes[32] =
+static const u8 ALIGNED(2) sBasePaletteColorMapTypes[32] =
 {
     // background palettes
     COLOR_MAP_DARK_CONTRAST,
@@ -149,7 +149,7 @@ static const u8 sBasePaletteColorMapTypes[32] =
     COLOR_MAP_DARK_CONTRAST,
 };
 
-const u16 gFogPalette[] = INCBIN_U16("graphics/weather/fog.gbapal");
+const u16 ALIGNED(4) gFogPalette[] = INCBIN_U16("graphics/weather/fog.gbapal");
 
 void StartWeather(void)
 {

--- a/src/fieldmap.c
+++ b/src/fieldmap.c
@@ -25,7 +25,7 @@ struct ConnectionFlags
     u8 east:1;
 };
 
-EWRAM_DATA static u16 sBackupMapData[MAX_MAP_DATA_SIZE] = {0};
+EWRAM_DATA static u16 ALIGNED(4) sBackupMapData[MAX_MAP_DATA_SIZE] = {0};
 EWRAM_DATA struct MapHeader gMapHeader = {0};
 EWRAM_DATA struct Camera gCamera = {0};
 EWRAM_DATA static struct ConnectionFlags sMapConnectionFlags = {0};

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -1219,8 +1219,8 @@ const u32 gRouletteMultiplier_Gfx[] = INCBIN_U32("graphics/roulette/multiplier.4
 const u16 gFrontierFactorySelectMenu_Pal[] = INCBIN_U16("graphics/battle_frontier/factory_menu1.gbapal");
 const u16 gFrontierFactorySelectMenu_Pal2[] = INCBIN_U16("graphics/battle_frontier/factory_menu2.gbapal");
 
-const u8 gFrontierFactorySelectMenu_Gfx[] = INCBIN_U8("graphics/battle_frontier/factory_menu1.4bpp");
-const u8 gFrontierFactorySelectMenu_Gfx2[] = INCBIN_U8("graphics/battle_frontier/factory_menu2.4bpp");
+const u16 gFrontierFactorySelectMenu_Gfx[] = INCBIN_U16("graphics/battle_frontier/factory_menu1.4bpp");
+const u16 gFrontierFactorySelectMenu_Gfx2[] = INCBIN_U16("graphics/battle_frontier/factory_menu2.4bpp");
 
 const u16 gFrontierFactorySelectMenu_Tilemap[] = INCBIN_U16("graphics/battle_frontier/factory_menu.bin");
 

--- a/src/item_menu.c
+++ b/src/item_menu.c
@@ -2429,16 +2429,16 @@ static void PrintPocketNames(const u8 *pocketName1, const u8 *pocketName2)
 
 static void CopyPocketNameToWindow(u32 a)
 {
-    u8 (* tileDataBuffer)[32][32];
+    u8 (*tileDataBuffer)[32][32];
     u8 *windowTileData;
     int b;
     if (a > 8)
         a = 8;
     tileDataBuffer = &gBagMenu->pocketNameBuffer;
     windowTileData = (u8 *)GetWindowAttribute(2, WINDOW_TILE_DATA);
-    CpuCopy32(tileDataBuffer[0][a], windowTileData, 0x100); // Top half of pocket name
+    CpuCopy32(&tileDataBuffer[0][a], windowTileData, 0x100); // Top half of pocket name
     b = a + 16;
-    CpuCopy32(tileDataBuffer[0][b], windowTileData + 0x100, 0x100); // Bottom half of pocket name
+    CpuCopy32(&tileDataBuffer[0][b], windowTileData + 0x100, 0x100); // Bottom half of pocket name
     CopyWindowToVram(WIN_POCKET_NAME, COPYWIN_GFX);
 }
 

--- a/src/link.c
+++ b/src/link.c
@@ -78,7 +78,7 @@ bool8 gRemoteLinkPlayersNotReceived[MAX_LINK_PLAYERS];
 u8 gBlockReceivedStatus[MAX_LINK_PLAYERS];
 u32 gLinkFiller2;
 u16 gLinkHeldKeys;
-u16 gRecvCmds[MAX_RFU_PLAYERS][CMD_LENGTH];
+u16 ALIGNED(4) gRecvCmds[MAX_RFU_PLAYERS][CMD_LENGTH];
 u32 gLinkStatus;
 bool8 gLinkDummy1; // Never read
 bool8 gLinkDummy2; // Never read

--- a/src/mirage_tower.c
+++ b/src/mirage_tower.c
@@ -75,7 +75,7 @@ static void Task_FossilFallAndSink(u8);
 static void SpriteCB_FallingFossil(struct Sprite *);
 static void UpdateDisintegrationEffect(u8 *, u16, u8, u8, u8);
 
-static const u8 sBlankTile_Gfx[32] = {0};
+static const u8 ALIGNED(2) sBlankTile_Gfx[32] = {0};
 static const u8 sMirageTower_Gfx[] = INCBIN_U8("graphics/misc/mirage_tower.4bpp");
 static const u16 sMirageTowerTilemap[] = INCBIN_U16("graphics/misc/mirage_tower.bin");
 static const u16 sFossil_Pal[] = INCBIN_U16("graphics/object_events/pics/misc/fossil.gbapal"); // Unused

--- a/src/palette.c
+++ b/src/palette.c
@@ -64,7 +64,7 @@ static EWRAM_DATA struct PaletteStruct sPaletteStructs[NUM_PALETTE_STRUCTS] = {0
 EWRAM_DATA struct PaletteFadeControl gPaletteFade = {0};
 static EWRAM_DATA u32 sFiller = 0;
 static EWRAM_DATA u32 sPlttBufferTransferPending = 0;
-EWRAM_DATA u8 gPaletteDecompressionBuffer[PLTT_SIZE] = {0};
+EWRAM_DATA u8 ALIGNED(2) gPaletteDecompressionBuffer[PLTT_SIZE] = {0};
 
 static const struct PaletteStructTemplate sDummyPaletteStructTemplate = {
     .id = 0xFFFF,

--- a/src/pokedex_area_region_map.c
+++ b/src/pokedex_area_region_map.c
@@ -8,7 +8,7 @@
 
 static EWRAM_DATA u8 *sPokedexAreaMapBgNum = NULL;
 
-static const u16 sPokedexAreaMap_Pal[] = INCBIN_U16("graphics/pokedex/region_map.gbapal");
+static const u16 ALIGNED(4) sPokedexAreaMap_Pal[] = INCBIN_U16("graphics/pokedex/region_map.gbapal");
 static const u32 sPokedexAreaMap_Gfx[] = INCBIN_U32("graphics/pokedex/region_map.8bpp.lz");
 static const u32 sPokedexAreaMap_Tilemap[] = INCBIN_U32("graphics/pokedex/region_map.bin.lz");
 static const u32 sPokedexAreaMapAffine_Gfx[] = INCBIN_U32("graphics/pokedex/region_map_affine.8bpp.lz");

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -550,8 +550,8 @@ struct PokemonStorageSystemData
     u16 *displayMonTilePtr;
     struct Sprite *displayMonSprite;
     u16 displayMonPalBuffer[0x40];
-    u8 tileBuffer[MON_PIC_SIZE * MAX_MON_PIC_FRAMES];
-    u8 itemIconBuffer[0x800];
+    u8 ALIGNED(4) tileBuffer[MON_PIC_SIZE * MAX_MON_PIC_FRAMES];
+    u8 ALIGNED(4) itemIconBuffer[0x800];
     u8 wallpaperBgTilemapBuffer[0x1000];
     u8 displayMenuTilemapBuffer[0x800];
 };

--- a/src/pokenav_conditions_gfx.c
+++ b/src/pokenav_conditions_gfx.c
@@ -116,10 +116,12 @@ static const LoopedTask sLoopedTaskFuncs[] =
     [CONDITION_FUNC_CLOSE_MARKINGS] = LoopedTask_CloseMonMarkingsWindow
 };
 
+typedef u8 ALIGNED(4) TilemapBuffer[BG_SCREEN_SIZE];
+
 struct Pokenav_ConditionMenuGfx
 {
     u32 loopedTaskId;
-    u8 tilemapBuffers[3][BG_SCREEN_SIZE];
+    TilemapBuffer tilemapBuffers[3];
     u8 filler[2];
     u8 partyPokeballSpriteIds[PARTY_SIZE + 1];
     u32 (*callback)(void);

--- a/src/pokenav_region_map.c
+++ b/src/pokenav_region_map.c
@@ -35,7 +35,7 @@ struct Pokenav_RegionMapGfx
     u32 loopTaskId;
     u16 infoWindowId;
     struct Sprite *cityZoomTextSprites[3];
-    u8 tilemapBuffer[BG_SCREEN_SIZE];
+    u8 ALIGNED(2) tilemapBuffer[BG_SCREEN_SIZE];
     u8 cityZoomPics[NUM_CITY_MAPS][200];
 };
 

--- a/src/rayquaza_scene.c
+++ b/src/rayquaza_scene.c
@@ -60,10 +60,12 @@ enum
 
 #define MAX_SMOKE 10
 
+typedef u8 ALIGNED(4) TilemapBuffer[BG_SCREEN_SIZE];
+
 struct RayquazaScene
 {
     MainCallback exitCallback;
-    u8 tilemapBuffers[4][BG_SCREEN_SIZE];
+    TilemapBuffer tilemapBuffers[4];
     u16 unk; // never read
     u8 animId;
     bool8 endEarly;

--- a/src/scanline_effect.c
+++ b/src/scanline_effect.c
@@ -13,7 +13,7 @@ static void CopyValue32Bit(void);
 // Per-scanline register values.
 // This is double buffered so that it can be safely written to at any time
 // without overwriting the buffer that the DMA is currently reading
-EWRAM_DATA u16 gScanlineEffectRegBuffers[2][0x3C0] = {0};
+EWRAM_DATA u16 ALIGNED(4) gScanlineEffectRegBuffers[2][0x3C0] = {0};
 
 EWRAM_DATA struct ScanlineEffect gScanlineEffect = {0};
 EWRAM_DATA static bool8 sShouldStopWaveTask = FALSE;

--- a/src/util.c
+++ b/src/util.c
@@ -158,7 +158,7 @@ void CopySpriteTiles(u8 shape, u8 size, u8 *tiles, u16 *tilemap, u8 *output)
 {
     u8 x, y;
     s8 i, j;
-    u8 xflip[32];
+    u8 ALIGNED(4) xflip[32];
     u8 h = sSpriteDimensions[shape][size][1];
     u8 w = sSpriteDimensions[shape][size][0];
 


### PR DESCRIPTION
Wraps `CPU_FILL`, `CPU_COPY`, `DmaSet`, `DMA_FILL`, `DMA_CLEAR`, `DMA_COPY`, `CpuSet`, and `CpuFastSet` with a static assert which checks the source and destination arguments are appropriately aligned to either 16 or 32 bits, depending (in the sense of `alignof`, rather than the looser sense of "has an address with the bottom X bits clear").

I would have liked to be able to switch between the strict `alignof` behavior and the looser one, but I haven't yet been able to work out a way to make GCC give me that information, assuming such a way even exists.

Also adds `ALIGNMENT(x)` attributes to all variables/members which were flagged as potentially misaligned, or in a few places changed the types of `INCBIN`s. Note none of these variables are actually misaligned currently, but changes to the surrounding code can cause them to become misaligned, e.g. deleting unused members of `struct`s.