### PR TITLE
Fix Bravo Trainer Tower member names

### DIFF
--- a/include/global.tv.h
+++ b/include/global.tv.h
@@ -113,17 +113,17 @@ typedef union // size = 0x24
     struct {
         /*0x00*/ u8 kind;
         /*0x01*/ bool8 active;
-        /*0x02*/ u8 trainerName[PLAYER_NAME_LENGTH + 1];
+        /*0x02*/ u8 playerName[PLAYER_NAME_LENGTH + 1];
         /*0x0A*/ u16 species;
-        /*0x0C*/ u8 pokemonName[8];
+        /*0x0C*/ u8 opponentName[PLAYER_NAME_LENGTH + 1];
         /*0x14*/ u16 defeatedSpecies;
         /*0x16*/ u16 numFights;
         /*0x18*/ u16 words[1];
         /*0x1A*/ u8 btLevel;
         /*0x1B*/ u8 interviewResponse;
         /*0x1C*/ bool8 wonTheChallenge;
-        /*0x1D*/ u8 language;
-        /*0x1E*/ u8 pokemonNameLanguage;
+        /*0x1D*/ u8 playerLanguage;
+        /*0x1E*/ u8 opponentLanguage;
         /*0x1F*/ //u8 padding;
     } bravoTrainerTower;
 

--- a/src/tv.c
+++ b/src/tv.c
@@ -1483,8 +1483,8 @@ static void InterviewAfter_BravoTrainerBattleTowerProfile(void)
     TVShow *show = &gSaveBlock1Ptr->tvShows[sCurTVShowSlot];
     show->bravoTrainerTower.kind = TVSHOW_BRAVO_TRAINER_BATTLE_TOWER_PROFILE;
     show->bravoTrainerTower.active = TRUE;
-    StringCopy(show->bravoTrainerTower.trainerName, gSaveBlock2Ptr->playerName);
-    StringCopy(show->bravoTrainerTower.pokemonName, gSaveBlock2Ptr->frontier.towerInterview.opponentName);
+    StringCopy(show->bravoTrainerTower.playerName, gSaveBlock2Ptr->playerName);
+    StringCopy(show->bravoTrainerTower.opponentName, gSaveBlock2Ptr->frontier.towerInterview.opponentName);
     show->bravoTrainerTower.species = gSaveBlock2Ptr->frontier.towerInterview.playerSpecies;
     show->bravoTrainerTower.defeatedSpecies = gSaveBlock2Ptr->frontier.towerInterview.opponentSpecies;
     show->bravoTrainerTower.numFights = GetCurrentBattleTowerWinStreak(gSaveBlock2Ptr->frontier.towerLvlMode, 0);
@@ -1495,11 +1495,11 @@ static void InterviewAfter_BravoTrainerBattleTowerProfile(void)
         show->bravoTrainerTower.btLevel = FRONTIER_MAX_LEVEL_OPEN;
     show->bravoTrainerTower.interviewResponse = gSpecialVar_0x8004;
     StorePlayerIdInNormalShow(show);
-    show->bravoTrainerTower.language = gGameLanguage;
-    if (show->bravoTrainerTower.language == LANGUAGE_JAPANESE || gSaveBlock2Ptr->frontier.towerInterview.opponentLanguage == LANGUAGE_JAPANESE)
-        show->bravoTrainerTower.pokemonNameLanguage = LANGUAGE_JAPANESE;
+    show->bravoTrainerTower.playerLanguage = gGameLanguage;
+    if (show->bravoTrainerTower.playerLanguage == LANGUAGE_JAPANESE || gSaveBlock2Ptr->frontier.towerInterview.opponentLanguage == LANGUAGE_JAPANESE)
+        show->bravoTrainerTower.opponentLanguage = LANGUAGE_JAPANESE;
     else
-        show->bravoTrainerTower.pokemonNameLanguage = gSaveBlock2Ptr->frontier.towerInterview.opponentLanguage;
+        show->bravoTrainerTower.opponentLanguage = gSaveBlock2Ptr->frontier.towerInterview.opponentLanguage;
 }
 
 void TryPutSmartShopperOnAir(void)
@@ -3992,8 +3992,8 @@ static void TranslateShowNames(TVShow *show, u32 language)
             break;
         case TVSHOW_BRAVO_TRAINER_BATTLE_TOWER_PROFILE:
             shows[5] = &show[i];
-            SetStrLanguage(shows[5]->bravoTrainerTower.trainerName, shows[5]->bravoTrainerTower.language, language);
-            SetStrLanguage(shows[5]->bravoTrainerTower.pokemonName, shows[5]->bravoTrainerTower.pokemonNameLanguage, language);
+            SetStrLanguage(shows[5]->bravoTrainerTower.playerName, shows[5]->bravoTrainerTower.playerLanguage, language);
+            SetStrLanguage(shows[5]->bravoTrainerTower.opponentName, shows[5]->bravoTrainerTower.opponentLanguage, language);
             break;
         case TVSHOW_BRAVO_TRAINER_POKEMON_PROFILE:
             shows[4] = &show[i];
@@ -4035,8 +4035,8 @@ void SanitizeTVShowsForRuby(TVShow *shows)
     {
         if (curShow->bravoTrainerTower.kind == TVSHOW_BRAVO_TRAINER_BATTLE_TOWER_PROFILE)
         {
-            if ((curShow->bravoTrainerTower.language == LANGUAGE_JAPANESE && curShow->bravoTrainerTower.pokemonNameLanguage != LANGUAGE_JAPANESE)
-             || (curShow->bravoTrainerTower.language != LANGUAGE_JAPANESE && curShow->bravoTrainerTower.pokemonNameLanguage == LANGUAGE_JAPANESE))
+            if ((curShow->bravoTrainerTower.playerLanguage == LANGUAGE_JAPANESE && curShow->bravoTrainerTower.opponentLanguage != LANGUAGE_JAPANESE)
+             || (curShow->bravoTrainerTower.playerLanguage != LANGUAGE_JAPANESE && curShow->bravoTrainerTower.opponentLanguage == LANGUAGE_JAPANESE))
                 memset(curShow, 0, sizeof(TVShow));
         }
     }
@@ -4050,10 +4050,10 @@ static void TranslateRubyShows(TVShow *shows)
     {
         if (curShow->bravoTrainerTower.kind == TVSHOW_BRAVO_TRAINER_BATTLE_TOWER_PROFILE)
         {
-            if (IsStringJapanese(curShow->bravoTrainerTower.pokemonName))
-                curShow->bravoTrainerTower.pokemonNameLanguage = LANGUAGE_JAPANESE;
+            if (IsStringJapanese(curShow->bravoTrainerTower.opponentName))
+                curShow->bravoTrainerTower.opponentLanguage = LANGUAGE_JAPANESE;
             else
-                curShow->bravoTrainerTower.pokemonNameLanguage = GAME_LANGUAGE;
+                curShow->bravoTrainerTower.opponentLanguage = GAME_LANGUAGE;
         }
     }
 }
@@ -4093,8 +4093,8 @@ static void TranslateJapaneseEmeraldShows(TVShow *shows)
             curShow->bravoTrainer.pokemonNameLanguage = GetStringLanguage(curShow->bravoTrainer.pokemonNickname);
             break;
         case TVSHOW_BRAVO_TRAINER_BATTLE_TOWER_PROFILE:
-            curShow->bravoTrainerTower.language = GetStringLanguage(curShow->bravoTrainerTower.trainerName);
-            curShow->bravoTrainerTower.pokemonNameLanguage = GetStringLanguage(curShow->bravoTrainerTower.pokemonName);
+            curShow->bravoTrainerTower.playerLanguage = GetStringLanguage(curShow->bravoTrainerTower.playerName);
+            curShow->bravoTrainerTower.opponentLanguage = GetStringLanguage(curShow->bravoTrainerTower.opponentName);
             break;
         case TVSHOW_CONTEST_LIVE_UPDATES:
             curShow->contestLiveUpdates.winningTrainerLanguage = GetStringLanguage(curShow->contestLiveUpdates.winningTrainerName);
@@ -4385,7 +4385,7 @@ static void DoTVShowBravoTrainerBattleTower(void)
     switch(state)
     {
     case BRAVOTOWER_STATE_INTRO:
-        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.trainerName, show->bravoTrainerTower.language);
+        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.playerName, show->bravoTrainerTower.playerLanguage);
         StringCopy(gStringVar2, gSpeciesNames[show->bravoTrainerTower.species]);
         if (show->bravoTrainerTower.numFights >= FRONTIER_STAGES_PER_CHALLENGE)
             sTVShowState = BRAVOTOWER_STATE_NEW_RECORD;
@@ -4406,7 +4406,7 @@ static void DoTVShowBravoTrainerBattleTower(void)
             sTVShowState = BRAVOTOWER_STATE_LOST_FINAL;
         break;
     case BRAVOTOWER_STATE_LOST:
-        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.pokemonName, show->bravoTrainerTower.pokemonNameLanguage);
+        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.opponentName, show->bravoTrainerTower.opponentLanguage);
         ConvertIntToDecimalString(1, show->bravoTrainerTower.numFights + 1);
         if (show->bravoTrainerTower.interviewResponse == 0)
             sTVShowState = BRAVOTOWER_STATE_SATISFIED;
@@ -4414,7 +4414,7 @@ static void DoTVShowBravoTrainerBattleTower(void)
             sTVShowState = BRAVOTOWER_STATE_UNSATISFIED;
         break;
     case BRAVOTOWER_STATE_WON:
-        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.pokemonName, show->bravoTrainerTower.pokemonNameLanguage);
+        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.opponentName, show->bravoTrainerTower.opponentLanguage);
         StringCopy(gStringVar2, gSpeciesNames[show->bravoTrainerTower.defeatedSpecies]);
         if (show->bravoTrainerTower.interviewResponse == 0)
             sTVShowState = BRAVOTOWER_STATE_SATISFIED;
@@ -4422,7 +4422,7 @@ static void DoTVShowBravoTrainerBattleTower(void)
             sTVShowState = BRAVOTOWER_STATE_UNSATISFIED;
         break;
     case BRAVOTOWER_STATE_LOST_FINAL:
-        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.pokemonName, show->bravoTrainerTower.pokemonNameLanguage);
+        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.opponentName, show->bravoTrainerTower.opponentLanguage);
         StringCopy(gStringVar2, gSpeciesNames[show->bravoTrainerTower.defeatedSpecies]);
         if (show->bravoTrainerTower.interviewResponse == 0)
             sTVShowState = BRAVOTOWER_STATE_SATISFIED;
@@ -4430,11 +4430,11 @@ static void DoTVShowBravoTrainerBattleTower(void)
             sTVShowState = BRAVOTOWER_STATE_UNSATISFIED;
         break;
     case BRAVOTOWER_STATE_SATISFIED:
-        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.pokemonName, show->bravoTrainerTower.pokemonNameLanguage);
+        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.opponentName, show->bravoTrainerTower.opponentLanguage);
         sTVShowState = BRAVOTOWER_STATE_RESPONSE;
         break;
     case BRAVOTOWER_STATE_UNSATISFIED:
-        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.pokemonName, show->bravoTrainerTower.pokemonNameLanguage);
+        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.opponentName, show->bravoTrainerTower.opponentLanguage);
         sTVShowState = BRAVOTOWER_STATE_RESPONSE;
         break;
     case BRAVOTOWER_STATE_UNUSED_1:
@@ -4443,7 +4443,7 @@ static void DoTVShowBravoTrainerBattleTower(void)
     case BRAVOTOWER_STATE_UNUSED_2:
     case BRAVOTOWER_STATE_UNUSED_3:
     case BRAVOTOWER_STATE_UNUSED_4:
-        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.trainerName, show->bravoTrainerTower.language);
+        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.playerName, show->bravoTrainerTower.playerLanguage);
         sTVShowState = BRAVOTOWER_STATE_RESPONSE;
         break;
     case BRAVOTOWER_STATE_RESPONSE:
@@ -4456,12 +4456,12 @@ static void DoTVShowBravoTrainerBattleTower(void)
     case BRAVOTOWER_STATE_RESPONSE_SATISFIED:
     case BRAVOTOWER_STATE_RESPONSE_UNSATISFIED:
         CopyEasyChatWord(gStringVar1, show->bravoTrainerTower.words[0]);
-        TVShowConvertInternationalString(gStringVar2, show->bravoTrainerTower.trainerName, show->bravoTrainerTower.language);
-        TVShowConvertInternationalString(gStringVar3, show->bravoTrainerTower.pokemonName, show->bravoTrainerTower.pokemonNameLanguage);
+        TVShowConvertInternationalString(gStringVar2, show->bravoTrainerTower.playerName, show->bravoTrainerTower.playerLanguage);
+        TVShowConvertInternationalString(gStringVar3, show->bravoTrainerTower.opponentName, show->bravoTrainerTower.opponentLanguage);
         sTVShowState = BRAVOTOWER_STATE_OUTRO;
         break;
     case BRAVOTOWER_STATE_OUTRO:
-        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.trainerName, show->bravoTrainerTower.language);
+        TVShowConvertInternationalString(gStringVar1, show->bravoTrainerTower.playerName, show->bravoTrainerTower.playerLanguage);
         StringCopy(gStringVar2, gSpeciesNames[show->bravoTrainerTower.species]);
         TVShowDone();
         break;


### PR DESCRIPTION
Fixes a couple of names that incorrectly refer to a pokemon instead of a trainer.