### PR TITLE
gbagfx to respect user CC setting

### DIFF
--- a/tools/gbagfx/Makefile
+++ b/tools/gbagfx/Makefile
@@ -1,4 +1,4 @@
-CC = gcc
+CC ?= gcc
 
 CFLAGS = -Wall -Wextra -Werror -Wno-sign-compare -std=c11 -O2 -DPNG_SKIP_SETJMP_CHECK
 CFLAGS += $(shell pkg-config --cflags libpng)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `gbagfx` Makefile did not respect the user setting for the `CC` variable. Now it does.

## **Discord contact info**
lucas#7562
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->