### PR TITLE
Replaced decomp list with pret.github.io link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,4 @@ It builds the following ROM:
 
 To set up the repository, see [INSTALL.md](INSTALL.md).
 
-
-## See also
-
-Other disassembly and/or decompilation projects:
-* [**Pokémon Red and Blue**](https://github.com/pret/pokered)
-* [**Pokémon Gold and Silver (Space World '97 demo)**](https://github.com/pret/pokegold-spaceworld)
-* [**Pokémon Yellow**](https://github.com/pret/pokeyellow)
-* [**Pokémon Trading Card Game**](https://github.com/pret/poketcg)
-* [**Pokémon Pinball**](https://github.com/pret/pokepinball)
-* [**Pokémon Stadium**](https://github.com/pret/pokestadium)
-* [**Pokémon Gold and Silver**](https://github.com/pret/pokegold)
-* [**Pokémon Crystal**](https://github.com/pret/pokecrystal)
-* [**Pokémon Ruby and Sapphire**](https://github.com/pret/pokeruby)
-* [**Pokémon Pinball: Ruby & Sapphire**](https://github.com/pret/pokepinballrs)
-* [**Pokémon FireRed and LeafGreen**](https://github.com/pret/pokefirered)
-* [**Pokémon Mystery Dungeon: Red Rescue Team**](https://github.com/pret/pmd-red)
-* [**Pokémon Diamond and Pearl**](https://github.com/pret/pokediamond)
-* [**Pokémon Platinum**](https://github.com/pret/pokeplatinum) 
-* [**Pokémon HeartGold and SoulSilver**](https://github.com/pret/pokeheartgold)
-* [**Pokémon Mystery Dungeon: Explorers of Sky**](https://github.com/pret/pmd-sky)
-
-## Contacts
-
-You can find us on:
-
-* [Discord (PRET, #pokeemerald)](https://discord.gg/d5dubZ3)
-* [IRC](https://web.libera.chat/?#pret)
+For contacts and other pret projects, see [pret.github.io](https://pret.github.io/).


### PR DESCRIPTION
## Description
Per discussions on Discord/GitHub last week, there is now a decomp list at [pret.github.io](https://pret.github.io/) to avoid having to copy/paste the list every time something changes.

## **Discord contact info**
Some Body (anonymousrandom)