### PR TITLE
[leak-informed] Remove fakematch in NewGameInitPCItems

### DIFF
--- a/src/player_pc.c
+++ b/src/player_pc.c
@@ -362,9 +362,9 @@ void NewGameInitPCItems(void)
 
     while (TRUE)
     {
-        if (sNewGamePCItems[i].itemId == ITEM_NONE || sNewGamePCItems[i].quantity == 0)
+        if (sNewGamePCItems[i][0] == ITEM_NONE || sNewGamePCItems[i][1] == 0)
             break;
-        if (AddPCItem(sNewGamePCItems[i].itemId, sNewGamePCItems[i].quantity) != TRUE)
+        if (AddPCItem(sNewGamePCItems[i][0], sNewGamePCItems[i][1]) != TRUE)
             break;
         i++;
     }

--- a/src/player_pc.c
+++ b/src/player_pc.c
@@ -224,8 +224,8 @@ static const struct MenuAction sItemStorage_MenuActions[] =
 
 static const u16 sNewGamePCItems[][2] =
 {
-    [ITEM_POTION, 1],
-    [ITEM_NONE, 0]
+    { ITEM_POTION, 1 },
+    { ITEM_NONE, 0 }
 };
 
 const struct MenuAction gMailboxMailOptions[] =

--- a/src/player_pc.c
+++ b/src/player_pc.c
@@ -355,16 +355,20 @@ static const struct WindowTemplate sWindowTemplates_ItemStorage[ITEMPC_WIN_COUNT
 
 static const u8 sSwapArrowTextColors[] = {TEXT_COLOR_WHITE, TEXT_COLOR_LIGHT_GRAY, TEXT_COLOR_DARK_GRAY};
 
-// Macro below is likely a fakematch, equivalent to sNewGamePCItems[i].quantity
-#define GET_QUANTITY(i) ((u16)((u16 *)sNewGamePCItems + 1)[i * 2])
 void NewGameInitPCItems(void)
 {
     u8 i = 0;
     ClearItemSlots(gSaveBlock1Ptr->pcItems, PC_ITEMS_COUNT);
-    for(; sNewGamePCItems[i].itemId != ITEM_NONE && GET_QUANTITY(i) &&
-        AddPCItem(sNewGamePCItems[i].itemId, GET_QUANTITY(i)) == TRUE; i++);
+
+    while (TRUE)
+    {
+        if (sNewGamePCItems[i].itemId == ITEM_NONE || sNewGamePCItems[i].quantity == 0)
+            break;
+        if (AddPCItem(sNewGamePCItems[i].itemId, sNewGamePCItems[i].quantity) != TRUE)
+            break;
+        i++;
+    }
 }
-#undef GET_QUANTITY
 
 void BedroomPC(void)
 {

--- a/src/player_pc.c
+++ b/src/player_pc.c
@@ -222,10 +222,10 @@ static const struct MenuAction sItemStorage_MenuActions[] =
     [MENU_EXIT]     = { gText_Cancel,       {ItemStorage_Exit} }
 };
 
-static const struct ItemSlot sNewGamePCItems[] =
+static const u16 sNewGamePCItems[][2] =
 {
-    { ITEM_POTION, 1 },
-    { ITEM_NONE, 0 }
+    [ITEM_POTION, 1],
+    [ITEM_NONE, 0]
 };
 
 const struct MenuAction gMailboxMailOptions[] =


### PR DESCRIPTION
I cheated and found the original function in the leaked source, but I am confident someone who knows C better than me could have figured this out if they'd looked at it; I think it went under the radar because everyone collectively gave up on finding and fixing fakematches.

## **Discord contact info**
I am *.ketsuban* on Discord.