### PR TITLE
Fixed out-of-bounds access in GetFactoryMonFixedIV for BUGFIX

### DIFF
--- a/src/battle_factory.c
+++ b/src/battle_factory.c
@@ -745,11 +745,11 @@ u8 GetFactoryMonFixedIV(u8 challengeNum, bool8 isLastBattle)
 // or the "elevated" rentals from round 8 (challengeNum+1==8)
 // This happens to land on a number higher than 31, which is interpreted as "random IVs"
 #ifdef BUGFIX
-    if (challengeNum > 7)
+    if (challengeNum >= ARRAY_COUNT(sFixedIVTable))
 #else
-    if (challengeNum > 8)
+    if (challengeNum > ARRAY_COUNT(sFixedIVTable))
 #endif
-        ivSet = 7;
+        ivSet = ARRAY_COUNT(sFixedIVTable) - 1;
     else
         ivSet = challengeNum;
 

--- a/src/battle_factory.c
+++ b/src/battle_factory.c
@@ -741,7 +741,14 @@ u8 GetFactoryMonFixedIV(u8 challengeNum, bool8 isLastBattle)
     u8 ivSet;
     bool8 useHigherIV = isLastBattle ? TRUE : FALSE;
 
+// The Factory has an out-of-bounds access when generating the rental draft for round 9 (challengeNum==8), 
+// or the "elevated" rentals from round 8 (challengeNum+1==8)
+// This happens to land on a number higher than 31, which is interpreted as "random IVs"
+#ifdef BUGFIX
+    if (challengeNum > 7)
+#else
     if (challengeNum > 8)
+#endif
         ivSet = 7;
     else
         ivSet = challengeNum;


### PR DESCRIPTION
## Description
It's well known that Pokémon rentals in the Battle Factory have a bug where IVs might sometimes be random instead of following a linear progression based on which round you're on.

From this guide: [https://pastebin.com/khTDyatY](https://pastebin.com/khTDyatY)
> Round 8: 31 IV (first slot RANDOM IVs if 15+ swaps, second slot random if 22+, third slot random if 29+, fourth random if 36+, fifth random if 43+)
> Round 9: RANDOM IVs (first slot 31 if 15+ swaps, second slot 31 if 22+, third slot 31 if 29+, fourth random if 36+, fifth random if 43+, sixth random if 50+)

Following the code in `battle_factory_screen.c` at `CreateFrontierFactorySelectableMons`:
```
u8 challengeNum = gSaveBlock2Ptr->frontier.factoryWinStreaks[battleMode][lvlMode] / 7;
u8 rentalRank = GetNumPastRentalsRank(battleMode, lvlMode);
...
if (i < rentalRank)
    ivs = GetFactoryMonFixedIV(challengeNum + 1, FALSE);
else
    ivs = GetFactoryMonFixedIV(challengeNum, FALSE);
CreateMonWithEVSpreadNatureOTID(....);
```

When the player has 15+ swaps, the first slots are elevated to the next round. So given a `challengeNum` of 7 on round 8, the IVs would be based on `challengeNum+1==8`. For round 9, non-elevated rentals now have a challenge rating of `8`, and elevated ones `9`.

As seen in the change, `8` is a problematic value for `GetFactoryMonFixedIV`, as it is not covered properly by the overflow check. As a result, the function returns `sFixedIVTable[8][useHigherIV]`, while `sFixedIVTable` only has 8 entries. The overflow probably reaches the first value in `sInitialRentalMonRanges`, `FRONTIER_MON_GRIMER` (aka `110`). This value is greater than 31, and is interpreted as "random IV" by `CreateBoxMon`.

Elevated rentals from round 9 and rentals from round 10 and beyond are properly capped to entry 7, and have IVs or 31.

This fix properly caps the IV entry index to `7` for `challengeNum==8`, for the BUGFIX config only. I've tested on round 9 with no swaps, and all Pokémons had 31 IVs, as originally intended.

## **Discord contact info**
@kaboissonneault

