### PR TITLE
Modern Optimization: Compile math_util as ARM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,6 +299,7 @@ $(C_BUILDDIR)/librfu_intr.o: CC1 := tools/agbcc/bin/agbcc_arm$(EXE)
 $(C_BUILDDIR)/librfu_intr.o: CFLAGS := -O2 -mthumb-interwork -quiet
 else
 $(C_BUILDDIR)/librfu_intr.o: CFLAGS := -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
+$(C_BUILDDIR)/math_util.o: CFLAGS := -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -Wno-pointer-to-int-cast
 endif
 
 ifeq ($(DINFO),1)


### PR DESCRIPTION
Because math_util does not branch or write to memory, instead using register, using ARM code instead of THUMB works here for modern compilers. Also no need for -fno-toplevel-reorder because this optimization is safe for this too.

Here is an example:
<img width="905" alt="Screenshot 2023-10-10 at 10 27 47 AM" src="https://github.com/pret/pokeemerald/assets/122058867/899aa8c8-1ee7-4508-bdad-dc55f165bf88">
