### PR TITLE
ALIGNED(2) The boxTitleTiles in storage

### DIFF
--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -431,7 +431,7 @@ struct PokemonStorageSystemData
     u16 scrollUnused5; // Never read
     u16 scrollUnused6; // Never read
     u8 filler1[22];
-    u8 boxTitleTiles[1024];
+    ALIGNED(2) u8 boxTitleTiles[1024];
     u8 boxTitleCycleId;
     u8 wallpaperLoadState; // Written to, but never read.
     u8 wallpaperLoadBoxId;


### PR DESCRIPTION
This bug was found by removing unused fields, only to find the graphics were corrupted because CpuCopy16 expects an aligned-2 pointer.