### PR TITLE
Use BUGFIX in assembly files

### DIFF
--- a/data/battle_ai_scripts.s
+++ b/data/battle_ai_scripts.s
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "constants/battle.h"
 #include "constants/battle_ai.h"
 #include "constants/abilities.h"
@@ -1926,19 +1927,19 @@ AI_CV_Protect_End:
 @ BUG: Foresight is only encouraged if the user is Ghost type or
 @      has high evasion, but should check target instead
 AI_CV_Foresight:
-.ifdef BUGFIX
+#ifdef BUGFIX
 	get_target_type1
 	if_equal TYPE_GHOST, AI_CV_Foresight2
 	get_target_type2
 	if_equal TYPE_GHOST, AI_CV_Foresight2
 	if_stat_level_more_than AI_TARGET, STAT_EVASION, 8, AI_CV_Foresight3
-.else
+#else
 	get_user_type1
 	if_equal TYPE_GHOST, AI_CV_Foresight2
 	get_user_type2
 	if_equal TYPE_GHOST, AI_CV_Foresight2
 	if_stat_level_more_than AI_USER, STAT_EVASION, 8, AI_CV_Foresight3
-.endif
+#endif
 	score -2
 	goto AI_CV_Foresight_End
 
@@ -2183,13 +2184,13 @@ AI_CV_SemiInvulnerable2:
 	if_status2 AI_TARGET, STATUS2_CURSED, AI_CV_SemiInvulnerable_TryEncourage
 	if_status3 AI_TARGET, STATUS3_LEECHSEED, AI_CV_SemiInvulnerable_TryEncourage
 	get_weather
-.ifdef BUGFIX
+#ifdef BUGFIX
 	if_equal AI_WEATHER_HAIL, AI_CV_SemiInvulnerable_CheckIceType
 	if_equal AI_WEATHER_SANDSTORM, AI_CV_SemiInvulnerable_CheckSandstormTypes
-.else
+#else
 	if_equal AI_WEATHER_HAIL, AI_CV_SemiInvulnerable_CheckSandstormTypes
 	if_equal AI_WEATHER_SANDSTORM, AI_CV_SemiInvulnerable_CheckIceType
-.endif
+#endif
 	goto AI_CV_SemiInvulnerable5
 
 AI_CV_SemiInvulnerable_CheckSandstormTypes:
@@ -2254,11 +2255,11 @@ AI_CV_Hail_End:
 
 @ BUG: Facade score is increased if the target is statused, but should be if the user is
 AI_CV_Facade:
-.ifdef BUGFIX
+#ifdef BUGFIX
 	if_not_status AI_USER, STATUS1_POISON | STATUS1_BURN | STATUS1_PARALYSIS | STATUS1_TOXIC_POISON, AI_CV_Facade_End
-.else
+#else
 	if_not_status AI_TARGET, STATUS1_POISON | STATUS1_BURN | STATUS1_PARALYSIS | STATUS1_TOXIC_POISON, AI_CV_Facade_End
-.endif
+#endif
 	score +1
 AI_CV_Facade_End:
 	end
@@ -3176,9 +3177,9 @@ AI_HPAware_DiscouragedEffectsWhenTargetLowHP:
 AI_TrySunnyDayStart:
 	if_target_is_ally AI_TryOnAlly
 	if_not_effect EFFECT_SUNNY_DAY, AI_TrySunnyDayStart_End
-.ifndef BUGFIX  @ funcResult has not been set in this script yet, below call is nonsense
+#ifndef BUGFIX  @ funcResult has not been set in this script yet, below call is nonsense
 	if_equal FALSE, AI_TrySunnyDayStart_End
-.endif
+#endif
 	is_first_turn_for AI_USER
 	if_equal FALSE, AI_TrySunnyDayStart_End
 	score +5

--- a/data/contest_ai_scripts.s
+++ b/data/contest_ai_scripts.s
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "constants/global.h"
 #include "constants/contest.h"
 	.include "asm/macros.inc"
@@ -435,11 +436,11 @@ AI_CGM_BetterWhenAudienceExcited:
 AI_CGM_BetterWhenAudienceExcited_1stUp:
 	@ BUG: Should be if_appeal_num_eq 0
 	@ 1st up on 1st appeal excitement will always be 0
-.ifdef BUGFIX
+#ifdef BUGFIX
 	if_appeal_num_eq 0, AI_CGM_BetterWhenAudienceExcited_1stAppeal
-.else
+#else
 	if_appeal_num_not_eq 0, AI_CGM_BetterWhenAudienceExcited_1stAppeal
-.endif
+#endif
 	if_excitement_eq 4, AI_CGM_BetterWhenAudienceExcited_1AwayFromMax
 	if_excitement_eq 3, AI_CGM_BetterWhenAudienceExcited_2AwayFromMax
 	end
@@ -546,11 +547,11 @@ AI_CGM_TargetMonWithJudgesAttention:
 	end
 AI_CGM_TargetMonWithJudgesAttention_CheckMon1:
 	if_cannot_participate MON_1, AI_CGM_TargetMonWithJudgesAttention_CheckMon2
-.ifdef BUGFIX
+#ifdef BUGFIX
 	if_not_used_combo_starter MON_1, AI_CGM_TargetMonWithJudgesAttention_CheckMon2
-.else
+#else
 	if_used_combo_starter MON_1, AI_CGM_TargetMonWithJudgesAttention_CheckMon2
-.endif
+#endif
 	if_random_less_than 125, AI_CGM_TargetMonWithJudgesAttention_CheckMon2
 	score +2
 	if_not_completed_combo MON_1, AI_CGM_TargetMonWithJudgesAttention_CheckMon2
@@ -559,11 +560,11 @@ AI_CGM_TargetMonWithJudgesAttention_CheckMon1:
 AI_CGM_TargetMonWithJudgesAttention_CheckMon2:
 	if_user_order_eq MON_2, AI_CGM_End
 	if_cannot_participate MON_2, AI_CGM_TargetMonWithJudgesAttention_CheckMon3
-.ifdef BUGFIX
+#ifdef BUGFIX
 	if_not_used_combo_starter MON_2, AI_CGM_TargetMonWithJudgesAttention_CheckMon3
-.else
+#else
 	if_used_combo_starter MON_2, AI_CGM_TargetMonWithJudgesAttention_CheckMon3
-.endif
+#endif
 	if_random_less_than 125, AI_CGM_TargetMonWithJudgesAttention_CheckMon3
 	score +2
 	if_not_completed_combo MON_2, AI_CGM_TargetMonWithJudgesAttention_CheckMon3
@@ -572,11 +573,11 @@ AI_CGM_TargetMonWithJudgesAttention_CheckMon2:
 AI_CGM_TargetMonWithJudgesAttention_CheckMon3:
 	if_user_order_eq MON_3, AI_CGM_End
 	if_cannot_participate MON_3, AI_CGM_End
-.ifdef BUGFIX
+#ifdef BUGFIX
 	if_not_used_combo_starter MON_3, AI_CGM_End
-.else
+#else
 	if_used_combo_starter MON_3, AI_CGM_End
-.endif
+#endif
 	if_random_less_than 125, AI_CGM_End
 	score +2
 	if_not_completed_combo MON_3, AI_CGM_End

--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "constants/global.h"
 #include "constants/apprentice.h"
 #include "constants/battle.h"

--- a/data/maps/BattleFrontier_BattleTowerLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerLobby/scripts.inc
@@ -415,18 +415,18 @@ BattleFrontier_BattleTowerLobby_EventScript_SaveBeforeLinkMultisChallenge::
 @ to the flash, but not data in PokemonStorage. The SaveGame script that follows asks the player to do a full save,
 @ which they can opt out of. As a result the player can save their party and quit without having saved the PC.
 @ This allows players to clone pokemon and their held items by withdrawing them (or erase them by despositing).
-.ifndef BUGFIX
+#ifndef BUGFIX
 	tower_save 0
-.endif
+#endif
 	call Common_EventScript_SaveGame
 	setvar VAR_TEMP_CHALLENGE_STATUS, 255
 	goto_if_eq VAR_RESULT, 0, BattleFrontier_BattleTowerLobby_EventScript_CancelChallengeSaveFailed
 @ GAME_STAT_ENTERED_BATTLE_TOWER should not be incremented here, for two reasons:
 @ 1. It is incremented again in BattleFrontier_BattleTowerLobby_EventScript_CableLinkSuccessful or BattleFrontier_BattleTowerLobby_EventScript_WirelessLinkSuccessful
-@ 2. If the player tries to save, but fails, the counter will still be incremented even if the player never enters the tower.
-.ifndef BUGFIX
+@ 2. If the player tries to connect, but fails, the counter will still be incremented even if the player never enters the tower.
+#ifndef BUGFIX
 	incrementgamestat GAME_STAT_ENTERED_BATTLE_TOWER
-.endif
+#endif
 	specialvar VAR_RESULT, IsWirelessAdapterConnected
 	goto_if_eq VAR_RESULT, TRUE, BattleFrontier_BattleTowerLobby_EventScript_TryWirelessLink
 	goto BattleFrontier_BattleTowerLobby_EventScript_TryCableLink

--- a/data/maps/MossdeepCity_SpaceCenter_1F/scripts.inc
+++ b/data/maps/MossdeepCity_SpaceCenter_1F/scripts.inc
@@ -229,11 +229,11 @@ MossdeepCity_SpaceCenter_1F_EventScript_Grunt2::
 	copyobjectxytoperm LOCALID_STAIR_GRUNT
 	switch VAR_FACING
 	case DIR_WEST, MossdeepCity_SpaceCenter_1F_EventScript_MoveGruntFromStairsWest
-	#ifdef BUGFIX
+#ifdef BUGFIX
 	case DIR_EAST, MossdeepCity_SpaceCenter_1F_EventScript_MoveGruntFromStairsEast
-	#else
+#else
 	case DIR_WEST, MossdeepCity_SpaceCenter_1F_EventScript_MoveGruntFromStairsEast
-	#endif
+#endif
 	applymovement LOCALID_STAIR_GRUNT, MossdeepCity_SpaceCenter_1F_Movement_MoveGruntFromStairs
 	waitmovement 0
 	setvar VAR_MOSSDEEP_SPACE_CENTER_STAIR_GUARD_STATE, 2

--- a/data/scripts/trainer_hill.inc
+++ b/data/scripts/trainer_hill.inc
@@ -13,9 +13,9 @@ TrainerHill_OnWarp:
 
 TrainerHill_1F_EventScript_DummyOnWarp::
 	setvar VAR_TEMP_3, 1
-.ifdef BUGFIX
+#ifdef BUGFIX
 	end  @ Missing end. By chance, the next byte (0x02 of VAR_TEMP_2) is also the id for the end cmd
-.endif
+#endif
 
 TrainerHill_OnFrame:
 	map_script_2 VAR_TEMP_2, 0, TrainerHill_1F_EventScript_DummyWarpToEntranceCounter


### PR DESCRIPTION
`BUGFIX` (and the other defines in `config.h`) aren't currently being passed to assembly files. Of the possible solutions this seemed the least likely to interfere with `BUGFIX` use downstream.