### PR TITLE
Renamed SendMonToPC to CopyMonToPC instead

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -70,7 +70,7 @@ static void Task_PlayMapChosenOrBattleBGM(u8 taskId);
 static bool8 ShouldGetStatBadgeBoost(u16 flagId, u8 battlerId);
 static u16 GiveMoveToBoxMon(struct BoxPokemon *boxMon, u16 move);
 static bool8 ShouldSkipFriendshipChange(void);
-static u8 SendMonToPC(struct Pokemon *mon);
+static u8 CopyMonToPC(struct Pokemon *mon);
 
 EWRAM_DATA static u8 sLearningMoveTableID = 0;
 EWRAM_DATA u8 gPlayerPartyCount = 0;
@@ -4405,14 +4405,14 @@ u8 GiveMonToPlayer(struct Pokemon *mon)
     }
 
     if (i >= PARTY_SIZE)
-        return SendMonToPC(mon);
+        return CopyMonToPC(mon);
 
     CopyMon(&gPlayerParty[i], mon, sizeof(*mon));
     gPlayerPartyCount = i + 1;
     return MON_GIVEN_TO_PARTY;
 }
 
-static u8 SendMonToPC(struct Pokemon *mon)
+static u8 CopyMonToPC(struct Pokemon *mon)
 {
     s32 boxNo, boxPos;
 


### PR DESCRIPTION
## Description
"SendMonToPC" implies that the Pokémon affected is actually sent over to the PC, but in reality the function simply copies the data of the Pokémon and then pastes it in the first available slot of the Pokémon Storage System.
~~I totally wasn't misled by the label, nuh uh.~~
This PR corrects that by renaming the function to "CopyMonToPC" instead.

## **Discord contact info**
lunos4026