### PR TITLE
Added BUGFIX for "dual non-immunity" glitch. 

### DIFF
--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -1484,7 +1484,13 @@ static void Cmd_get_highest_type_effectiveness(void)
 
         if (gCurrentMove != MOVE_NONE)
         {
+            // TypeCalc does not assign to gMoveResultFlags, Cmd_TypeCalc does
+            // This makes the check for gMoveResultFlags below always fail
+#ifdef BUGFIX
+            gMoveResultFlags = TypeCalc(gCurrentMove, sBattler_AI, gBattlerTarget);
+#else
             TypeCalc(gCurrentMove, sBattler_AI, gBattlerTarget);
+#endif
 
             if (gBattleMoveDamage == 120) // Super effective STAB.
                 gBattleMoveDamage = AI_EFFECTIVENESS_x2;
@@ -1519,7 +1525,16 @@ static void Cmd_if_type_effectiveness(void)
     gBattleMoveDamage = AI_EFFECTIVENESS_x1;
     gCurrentMove = AI_THINKING_STRUCT->moveConsidered;
 
+    // TypeCalc does not assign to gMoveResultFlags, Cmd_TypeCalc does
+    // This makes the check for gMoveResultFlags below always fail
+    // This is how you get the "dual non-immunity" glitch, where AI 
+    // will use ineffective moves on immune pokémon if the second type
+    // has a non-neutral, non-immune effectiveness
+#ifdef BUGFIX
+    gMoveResultFlags = TypeCalc(gCurrentMove, sBattler_AI, gBattlerTarget);
+#else
     TypeCalc(gCurrentMove, sBattler_AI, gBattlerTarget);
+#endif
 
     if (gBattleMoveDamage == 120) // Super effective STAB.
         gBattleMoveDamage = AI_EFFECTIVENESS_x2;

--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -1484,7 +1484,7 @@ static void Cmd_get_highest_type_effectiveness(void)
 
         if (gCurrentMove != MOVE_NONE)
         {
-            // TypeCalc does not assign to gMoveResultFlags, Cmd_TypeCalc does
+            // TypeCalc does not assign to gMoveResultFlags, Cmd_typecalc does
             // This makes the check for gMoveResultFlags below always fail
 #ifdef BUGFIX
             gMoveResultFlags = TypeCalc(gCurrentMove, sBattler_AI, gBattlerTarget);
@@ -1525,7 +1525,7 @@ static void Cmd_if_type_effectiveness(void)
     gBattleMoveDamage = AI_EFFECTIVENESS_x1;
     gCurrentMove = AI_THINKING_STRUCT->moveConsidered;
 
-    // TypeCalc does not assign to gMoveResultFlags, Cmd_TypeCalc does
+    // TypeCalc does not assign to gMoveResultFlags, Cmd_typecalc does
     // This makes the check for gMoveResultFlags below always fail
     // This is how you get the "dual non-immunity" glitch, where AI 
     // will use ineffective moves on immune pokémon if the second type


### PR DESCRIPTION
In certain AI script commands, the call to TypeCalc does not assign effectiveness flags properly, resulting in the check for immunity always failing. 

The name of the glitch comes from the Emerald Kaizo "AI Move Choice Analysis" document

----------------------------
![image](https://github.com/pret/pokeemerald/assets/5789925/412e0055-e6cf-4ef8-99d0-9a0a261b7e7a)
----------------------------

## Description
I assign the result of `TypeCalc` to `gMoveResultFlags` in the BUGFIX config.

## **Discord contact info**
@KABoissonneault 