### PR TITLE
Have pokeemerald use OFast, aapcs, and ftoplevel-reorder for MODERN by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ $(C_BUILDDIR)/librfu_intr.o: CFLAGS := -O2 -mthumb-interwork -quiet
 else
 $(C_BUILDDIR)/librfu_intr.o: CFLAGS := -mthumb-interwork -Ofast -mabi=aapcs -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
 $(C_BUILDDIR)/m4a.o: CFLAGS := -mthumb -mthumb-interwork -Ofast -mabi=aapcs -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
-
+$(C_BUILDDIR)/agb_flash.o: CFLAGS := -mthumb -mthumb-interwork -Ofast -mabi=aapcs -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
 endif
 
 ifeq ($(DINFO),1)

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ LIBPATH := -L ../../tools/agbcc/lib
 LIB := $(LIBPATH) -lgcc -lc -L../../libagbsyscall -lagbsyscall
 else
 CC1              = $(shell $(PATH_MODERNCC) --print-prog-name=cc1) -quiet
-override CFLAGS += -mthumb -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
+override CFLAGS += -mthumb -mthumb-interwork -Ofast -mabi=aapcs -mtune=arm7tdmi -march=armv4t -Wno-pointer-to-int-cast
 ROM := $(MODERN_ROM_NAME)
 OBJ_DIR := $(MODERN_OBJ_DIR_NAME)
 LIBPATH := -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libgcc.a))" -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libnosys.a))" -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libc.a))"
@@ -297,7 +297,9 @@ $(C_BUILDDIR)/record_mixing.o: CFLAGS += -ffreestanding
 $(C_BUILDDIR)/librfu_intr.o: CC1 := tools/agbcc/bin/agbcc_arm$(EXE)
 $(C_BUILDDIR)/librfu_intr.o: CFLAGS := -O2 -mthumb-interwork -quiet
 else
-$(C_BUILDDIR)/librfu_intr.o: CFLAGS := -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
+$(C_BUILDDIR)/librfu_intr.o: CFLAGS := -mthumb-interwork -Ofast -mabi=aapcs -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
+$(C_BUILDDIR)/m4a.o: CFLAGS := -mthumb -mthumb-interwork -Ofast -mabi=aapcs -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
+
 endif
 
 ifeq ($(DINFO),1)


### PR DESCRIPTION
The big question is: why make these changes?

Let's take a look:
OFast is a compiler flag that allows for some standard-breaking optimizations, mostly in the floating point category. Pokeemerald rarely uses floating points and where it does, it does not require extreme accuracy. In addition, OFast optimizes for speed, not space, of which there is always 32 MB of anyway.

AAPCS is the ABI that supports arm7tdmi chips and up. It mostly mandated how functions start and end in order to interwork with thumb code. apcs-gnu was back when pokeemerald was still being decompiled.

Finally, ftoplevel-reorder, it is not able to be disabled on clang, and without disabling top-level reordering, the game does not boot. Or rather, it doesn't boot because only one file, m4a.c, does not play nicely with the compiler, causing the game to crash when initializing the sound. For this reason, m4a.c gets its own exception in the Makefile.

These changes should be beneficial to anyone compiling on MODERN and there does not seem to be any downsides. These changes were thoroughly tested for weeks on my end, to ensure no side effects happened. I hope you enjoy this!

Signed-off-by: Arven