### PR TITLE
added a bugfix for the interaction between Curse and Pressure

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1221,7 +1221,18 @@ static void Cmd_ppreduce(void)
             ppToDeduct += AbilityBattleEffects(ABILITYEFFECT_COUNT_OTHER_SIDE, gBattlerAttacker, ABILITY_PRESSURE, 0, 0);
             break;
         default:
-            if (gBattlerAttacker != gBattlerTarget && gBattleMons[gBattlerTarget].ability == ABILITY_PRESSURE)
+#ifdef BUGFIX
+			//There is an issue with asymmetrical interaction between non-ghost curse and pressure,
+			//since the player controller changes the target of non-ghost curse to the user,
+			//but the opponent controller doesn't, so the player's non-ghost curse loses 1 PP
+			//against and opponent with pressure, but an opponent's non-ghost curse loses 2 PP
+			//against a player with pressure.
+			//This bugfix ensures that non-ghost curse always only deducts 1 PP against pressure,
+			//regardless of used by the player or opponent.
+            if (gBattlerAttacker != gBattlerTarget && gBattleMons[gBattlerTarget].ability == ABILITY_PRESSURE && !(gBattleMoves[gCurrentMove].effect == EFFECT_CURSE && gBattleMons[gBattlerAttacker].type1 != TYPE_GHOST && gBattleMons[gBattlerAttacker].type2 != TYPE_GHOST))
+#else
+			if (gBattlerAttacker != gBattlerTarget && gBattleMons[gBattlerTarget].ability == ABILITY_PRESSURE)
+#endif
                 ppToDeduct++;
             break;
         }


### PR DESCRIPTION
## Description
It was recently discovered by LRXC that Pokémon Emerald has a bug where if the player has a Pokémon with Pressure and the opposing non-ghost Pokémon uses Curse, two PP are deducted instead of just one. Since a non-ghost Curse only affects the user, I believe that it should not interact with Pressure. This is the case when the player's non-ghost Pokémon uses Curse against the opponent's Pressure Pokémon - there, only one PP is deducted. This asymmetric interaction indicates that this is a bug. I believe that the reason is that when the player uses Curse, there is a check in battle_controller_player.c (line 486) that makes the user the target of the move when it not a ghost type, but there is no corresponding check in player_controller_opponent.c, so presumably when the AI uses Curse the target always remains (one of) the player's Pokémon, since in battle_moves.h, the target is defined as "MOVE_TARGET_SELECTED".
To make sure that non-ghost Curse never interacts with Pressure as was most likely intended, I added a bugfix in battle_script_commands.c, Cmd_ppreduce(), starting line 1224, where ppToDeduct doesn't increase if the move is Curse and the user is not a ghost type.
I have tested this myself in Emerald where my Torkoal's Curse against a wild Absol with Pressure on Route 120 only deducted 1 PP, but without the bugfix, the wild Regice's Curse against my Absol with Pressure deducted 2 PP (I caught it with a Master Ball right after it used the move to check.) After my bugfix, Regice's Curse now only deducted 1 PP.

## **Discord contact info**
rogerwrightshoe