### PR TITLE
Added POKEMART_LIST_END to avoid users accidentally removing it

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1108,6 +1108,13 @@
 	.4byte \products
 	.endm
 
+	@ Used as the endpoint for a Pokemart item list
+	.macro pokemartlistend
+	.2byte ITEM_NONE
+	release
+	end
+	.endm
+
 	@ Opens the Pokemart system and treats the list of items as decorations.
 	@ Products should be a list of .2byte decoration values preceded by an .align 2
 	.macro pokemartdecoration products:req

--- a/data/maps/BattleFrontier_Mart/scripts.inc
+++ b/data/maps/BattleFrontier_Mart/scripts.inc
@@ -28,7 +28,7 @@ BattleFrontier_Mart_Pokemart:
 	.2byte ITEM_ZINC
 	.2byte ITEM_CARBOS
 	.2byte ITEM_HP_UP
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/BattleFrontier_Mart/scripts.inc
+++ b/data/maps/BattleFrontier_Mart/scripts.inc
@@ -28,9 +28,7 @@ BattleFrontier_Mart_Pokemart:
 	.2byte ITEM_ZINC
 	.2byte ITEM_CARBOS
 	.2byte ITEM_HP_UP
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 BattleFrontier_Mart_EventScript_OldMan::
 	msgbox BattleFrontier_Mart_Text_ChaperonGrandson, MSGBOX_NPC

--- a/data/maps/EverGrandeCity_PokemonLeague_1F/scripts.inc
+++ b/data/maps/EverGrandeCity_PokemonLeague_1F/scripts.inc
@@ -45,7 +45,7 @@ EverGrandeCity_PokemonLeague_1F_Pokemart:
 	.2byte ITEM_FULL_HEAL
 	.2byte ITEM_REVIVE
 	.2byte ITEM_MAX_REPEL
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/EverGrandeCity_PokemonLeague_1F/scripts.inc
+++ b/data/maps/EverGrandeCity_PokemonLeague_1F/scripts.inc
@@ -45,9 +45,7 @@ EverGrandeCity_PokemonLeague_1F_Pokemart:
 	.2byte ITEM_FULL_HEAL
 	.2byte ITEM_REVIVE
 	.2byte ITEM_MAX_REPEL
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 @ The door guards only check for FLAG_BADGE06_GET because Winonas badge is the only one that can be skipped
 @ Its assumed the player has the remaining badges

--- a/data/maps/FallarborTown_Mart/scripts.inc
+++ b/data/maps/FallarborTown_Mart/scripts.inc
@@ -25,7 +25,7 @@ FallarborTown_Mart_Pokemart:
 	.2byte ITEM_X_DEFEND
 	.2byte ITEM_DIRE_HIT
 	.2byte ITEM_GUARD_SPEC
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/FallarborTown_Mart/scripts.inc
+++ b/data/maps/FallarborTown_Mart/scripts.inc
@@ -25,9 +25,7 @@ FallarborTown_Mart_Pokemart:
 	.2byte ITEM_X_DEFEND
 	.2byte ITEM_DIRE_HIT
 	.2byte ITEM_GUARD_SPEC
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 FallarborTown_Mart_EventScript_Woman::
 	msgbox FallarborTown_Mart_Text_DecidingSkittyEvolve, MSGBOX_NPC

--- a/data/maps/FortreeCity_DecorationShop/scripts.inc
+++ b/data/maps/FortreeCity_DecorationShop/scripts.inc
@@ -29,7 +29,7 @@ FortreeCity_DecorationShop_PokemartDecor_Desks:
 	.2byte DECOR_BRICK_DESK
 	.2byte DECOR_CAMP_DESK
 	.2byte DECOR_HARD_DESK
-	.2byte DECOR_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 
@@ -53,7 +53,7 @@ FortreeCity_DecorationShop_PokemartDecor_Chairs:
 	.2byte DECOR_BRICK_CHAIR
 	.2byte DECOR_CAMP_CHAIR
 	.2byte DECOR_HARD_CHAIR
-	.2byte DECOR_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/FortreeCity_DecorationShop/scripts.inc
+++ b/data/maps/FortreeCity_DecorationShop/scripts.inc
@@ -29,9 +29,7 @@ FortreeCity_DecorationShop_PokemartDecor_Desks:
 	.2byte DECOR_BRICK_DESK
 	.2byte DECOR_CAMP_DESK
 	.2byte DECOR_HARD_DESK
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 FortreeCity_DecorationShop_EventScript_ClerkChairs::
 	lock
@@ -53,9 +51,7 @@ FortreeCity_DecorationShop_PokemartDecor_Chairs:
 	.2byte DECOR_BRICK_CHAIR
 	.2byte DECOR_CAMP_CHAIR
 	.2byte DECOR_HARD_CHAIR
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 FortreeCity_DecorationShop_Text_MerchandiseSentToPC:
 	.string "Merchandise you buy here is sent to\n"

--- a/data/maps/FortreeCity_Mart/scripts.inc
+++ b/data/maps/FortreeCity_Mart/scripts.inc
@@ -23,7 +23,7 @@ FortreeCity_Mart_Pokemart:
 	.2byte ITEM_REVIVE
 	.2byte ITEM_SUPER_REPEL
 	.2byte ITEM_WOOD_MAIL
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/FortreeCity_Mart/scripts.inc
+++ b/data/maps/FortreeCity_Mart/scripts.inc
@@ -23,9 +23,7 @@ FortreeCity_Mart_Pokemart:
 	.2byte ITEM_REVIVE
 	.2byte ITEM_SUPER_REPEL
 	.2byte ITEM_WOOD_MAIL
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 FortreeCity_Mart_EventScript_Woman::
 	msgbox FortreeCity_Mart_Text_SuperRepelBetter, MSGBOX_NPC

--- a/data/maps/LavaridgeTown_HerbShop/scripts.inc
+++ b/data/maps/LavaridgeTown_HerbShop/scripts.inc
@@ -17,7 +17,7 @@ LavaridgeTown_HerbShop_Pokemart:
 	.2byte ITEM_ENERGY_ROOT
 	.2byte ITEM_HEAL_POWDER
 	.2byte ITEM_REVIVAL_HERB
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/LavaridgeTown_HerbShop/scripts.inc
+++ b/data/maps/LavaridgeTown_HerbShop/scripts.inc
@@ -17,9 +17,7 @@ LavaridgeTown_HerbShop_Pokemart:
 	.2byte ITEM_ENERGY_ROOT
 	.2byte ITEM_HEAL_POWDER
 	.2byte ITEM_REVIVAL_HERB
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 LavaridgeTown_HerbShop_EventScript_ExpertM::
 	msgbox LavaridgeTown_HerbShop_Text_HerbalMedicineWorksButMonWillDislike, MSGBOX_NPC

--- a/data/maps/LavaridgeTown_Mart/scripts.inc
+++ b/data/maps/LavaridgeTown_Mart/scripts.inc
@@ -22,7 +22,7 @@ LavaridgeTown_Mart_Pokemart:
 	.2byte ITEM_REVIVE
 	.2byte ITEM_SUPER_REPEL
 	.2byte ITEM_X_SPEED
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/LavaridgeTown_Mart/scripts.inc
+++ b/data/maps/LavaridgeTown_Mart/scripts.inc
@@ -22,9 +22,7 @@ LavaridgeTown_Mart_Pokemart:
 	.2byte ITEM_REVIVE
 	.2byte ITEM_SUPER_REPEL
 	.2byte ITEM_X_SPEED
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 LavaridgeTown_Mart_EventScript_ExpertM::
 	msgbox LavaridgeTown_Mart_Text_XSpeedFirstStrike, MSGBOX_NPC

--- a/data/maps/LilycoveCity_DepartmentStore_2F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_2F/scripts.inc
@@ -36,7 +36,7 @@ LilycoveCity_DepartmentStore_2F_Pokemart1:
 	.2byte ITEM_ICE_HEAL
 	.2byte ITEM_AWAKENING
 	.2byte ITEM_FLUFFY_TAIL
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 
@@ -62,7 +62,7 @@ LilycoveCity_DepartmentStore_2F_Pokemart2:
 	.2byte ITEM_MAX_REPEL
 	.2byte ITEM_WAVE_MAIL
 	.2byte ITEM_MECH_MAIL
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/LilycoveCity_DepartmentStore_2F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_2F/scripts.inc
@@ -36,9 +36,7 @@ LilycoveCity_DepartmentStore_2F_Pokemart1:
 	.2byte ITEM_ICE_HEAL
 	.2byte ITEM_AWAKENING
 	.2byte ITEM_FLUFFY_TAIL
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 LilycoveCity_DepartmentStore_2F_EventScript_ClerkRight::
 	lock
@@ -62,9 +60,7 @@ LilycoveCity_DepartmentStore_2F_Pokemart2:
 	.2byte ITEM_MAX_REPEL
 	.2byte ITEM_WAVE_MAIL
 	.2byte ITEM_MECH_MAIL
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 LilycoveCity_DepartmentStore_2F_Text_LearnToUseItemsProperly:
 	.string "Learn to use items properly.\n"

--- a/data/maps/LilycoveCity_DepartmentStore_3F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_3F/scripts.inc
@@ -19,7 +19,7 @@ LilycoveCity_DepartmentStore_3F_Pokemart_Vitamins:
 	.2byte ITEM_ZINC
 	.2byte ITEM_CARBOS
 	.2byte ITEM_HP_UP
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 
@@ -42,7 +42,7 @@ LilycoveCity_DepartmentStore_3F_Pokemart_StatBoosters:
 	.2byte ITEM_DIRE_HIT
 	.2byte ITEM_GUARD_SPEC
 	.2byte ITEM_X_ACCURACY
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/LilycoveCity_DepartmentStore_3F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_3F/scripts.inc
@@ -19,9 +19,7 @@ LilycoveCity_DepartmentStore_3F_Pokemart_Vitamins:
 	.2byte ITEM_ZINC
 	.2byte ITEM_CARBOS
 	.2byte ITEM_HP_UP
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 LilycoveCity_DepartmentStore_3F_EventScript_ClerkRight::
 	lock
@@ -42,9 +40,7 @@ LilycoveCity_DepartmentStore_3F_Pokemart_StatBoosters:
 	.2byte ITEM_DIRE_HIT
 	.2byte ITEM_GUARD_SPEC
 	.2byte ITEM_X_ACCURACY
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 LilycoveCity_DepartmentStore_3F_EventScript_TriathleteM::
 	msgbox LilycoveCity_DepartmentStore_3F_Text_ItemsBestForTougheningPokemon, MSGBOX_NPC

--- a/data/maps/LilycoveCity_DepartmentStore_4F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_4F/scripts.inc
@@ -29,7 +29,7 @@ LilycoveCity_DepartmentStore_4F_Pokemart_AttackTMs:
 	.2byte ITEM_TM_THUNDER
 	.2byte ITEM_TM_BLIZZARD
 	.2byte ITEM_TM_HYPER_BEAM
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 
@@ -49,7 +49,7 @@ LilycoveCity_DepartmentStore_4F_Pokemart_DefenseTMs:
 	.2byte ITEM_TM_SAFEGUARD
 	.2byte ITEM_TM_REFLECT
 	.2byte ITEM_TM_LIGHT_SCREEN
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/LilycoveCity_DepartmentStore_4F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_4F/scripts.inc
@@ -29,9 +29,7 @@ LilycoveCity_DepartmentStore_4F_Pokemart_AttackTMs:
 	.2byte ITEM_TM_THUNDER
 	.2byte ITEM_TM_BLIZZARD
 	.2byte ITEM_TM_HYPER_BEAM
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 LilycoveCity_DepartmentStore_4F_EventScript_ClerkRight::
 	lock
@@ -49,9 +47,7 @@ LilycoveCity_DepartmentStore_4F_Pokemart_DefenseTMs:
 	.2byte ITEM_TM_SAFEGUARD
 	.2byte ITEM_TM_REFLECT
 	.2byte ITEM_TM_LIGHT_SCREEN
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 LilycoveCity_DepartmentStore_4F_Text_AttackOrDefenseTM:
 	.string "Hmm…\p"

--- a/data/maps/LilycoveCity_DepartmentStore_5F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_5F/scripts.inc
@@ -41,7 +41,7 @@ LilycoveCity_DepartmentStore_5F_Pokemart_Dolls:
 	.2byte DECOR_SKITTY_DOLL
 	.2byte DECOR_SWABLU_DOLL
 	.2byte DECOR_GULPIN_DOLL
-	.2byte DECOR_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 
@@ -66,7 +66,7 @@ LilycoveCity_DepartmentStore_5F_Pokemart_Cushions:
 	.2byte DECOR_GRASS_CUSHION
 	.2byte DECOR_FIRE_CUSHION
 	.2byte DECOR_WATER_CUSHION
-	.2byte DECOR_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 
@@ -91,7 +91,7 @@ LilycoveCity_DepartmentStore_5F_Pokemart_Posters:
 	.2byte DECOR_LONG_POSTER
 	.2byte DECOR_SEA_POSTER
 	.2byte DECOR_SKY_POSTER
-	.2byte DECOR_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 
@@ -117,7 +117,7 @@ LilycoveCity_DepartmentStore_5F_Pokemart_Mats:
 	.2byte DECOR_GLITTER_MAT
 	.2byte DECOR_JUMP_MAT
 	.2byte DECOR_SPIN_MAT
-	.2byte DECOR_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/LilycoveCity_DepartmentStore_5F/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStore_5F/scripts.inc
@@ -41,9 +41,7 @@ LilycoveCity_DepartmentStore_5F_Pokemart_Dolls:
 	.2byte DECOR_SKITTY_DOLL
 	.2byte DECOR_SWABLU_DOLL
 	.2byte DECOR_GULPIN_DOLL
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 LilycoveCity_DepartmentStore_5F_EventScript_ClerkMidLeft::
 	lock
@@ -66,9 +64,7 @@ LilycoveCity_DepartmentStore_5F_Pokemart_Cushions:
 	.2byte DECOR_GRASS_CUSHION
 	.2byte DECOR_FIRE_CUSHION
 	.2byte DECOR_WATER_CUSHION
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 LilycoveCity_DepartmentStore_5F_EventScript_ClerkMidRight::
 	lock
@@ -91,9 +87,7 @@ LilycoveCity_DepartmentStore_5F_Pokemart_Posters:
 	.2byte DECOR_LONG_POSTER
 	.2byte DECOR_SEA_POSTER
 	.2byte DECOR_SKY_POSTER
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 LilycoveCity_DepartmentStore_5F_EventScript_ClerkFarRight::
 	lock
@@ -117,9 +111,7 @@ LilycoveCity_DepartmentStore_5F_Pokemart_Mats:
 	.2byte DECOR_GLITTER_MAT
 	.2byte DECOR_JUMP_MAT
 	.2byte DECOR_SPIN_MAT
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 LilycoveCity_DepartmentStore_5F_EventScript_PokefanF::
 	msgbox LilycoveCity_DepartmentStore_5F_Text_PlaceFullOfCuteDolls, MSGBOX_NPC

--- a/data/maps/MauvilleCity_Mart/scripts.inc
+++ b/data/maps/MauvilleCity_Mart/scripts.inc
@@ -25,7 +25,7 @@ MauvilleCity_Mart_Pokemart:
 	.2byte ITEM_GUARD_SPEC
 	.2byte ITEM_DIRE_HIT
 	.2byte ITEM_X_ACCURACY
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/MauvilleCity_Mart/scripts.inc
+++ b/data/maps/MauvilleCity_Mart/scripts.inc
@@ -25,9 +25,7 @@ MauvilleCity_Mart_Pokemart:
 	.2byte ITEM_GUARD_SPEC
 	.2byte ITEM_DIRE_HIT
 	.2byte ITEM_X_ACCURACY
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 MauvilleCity_Mart_EventScript_ExpertM::
 	msgbox MauvilleCity_Mart_Text_ItemsToTemporarilyElevateStats, MSGBOX_NPC

--- a/data/maps/MossdeepCity_Mart/scripts.inc
+++ b/data/maps/MossdeepCity_Mart/scripts.inc
@@ -22,7 +22,7 @@ MossdeepCity_Mart_Pokemart:
 	.2byte ITEM_MAX_REPEL
 	.2byte ITEM_X_ATTACK
 	.2byte ITEM_X_DEFEND
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/MossdeepCity_Mart/scripts.inc
+++ b/data/maps/MossdeepCity_Mart/scripts.inc
@@ -22,9 +22,7 @@ MossdeepCity_Mart_Pokemart:
 	.2byte ITEM_MAX_REPEL
 	.2byte ITEM_X_ATTACK
 	.2byte ITEM_X_DEFEND
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 MossdeepCity_Mart_EventScript_Woman::
 	msgbox MossdeepCity_Mart_Text_ReviveIsFantastic, MSGBOX_NPC

--- a/data/maps/OldaleTown_Mart/scripts.inc
+++ b/data/maps/OldaleTown_Mart/scripts.inc
@@ -18,7 +18,7 @@ OldaleTown_Mart_Pokemart_Basic:
 	.2byte ITEM_ANTIDOTE
 	.2byte ITEM_PARALYZE_HEAL
 	.2byte ITEM_AWAKENING
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 
@@ -35,7 +35,7 @@ OldaleTown_Mart_Pokemart_Expanded:
 	.2byte ITEM_ANTIDOTE
 	.2byte ITEM_PARALYZE_HEAL
 	.2byte ITEM_AWAKENING
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/OldaleTown_Mart/scripts.inc
+++ b/data/maps/OldaleTown_Mart/scripts.inc
@@ -18,9 +18,7 @@ OldaleTown_Mart_Pokemart_Basic:
 	.2byte ITEM_ANTIDOTE
 	.2byte ITEM_PARALYZE_HEAL
 	.2byte ITEM_AWAKENING
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 OldaleTown_Mart_ExpandedItems::
 	pokemart OldaleTown_Mart_Pokemart_Expanded
@@ -35,9 +33,7 @@ OldaleTown_Mart_Pokemart_Expanded:
 	.2byte ITEM_ANTIDOTE
 	.2byte ITEM_PARALYZE_HEAL
 	.2byte ITEM_AWAKENING
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 OldaleTown_Mart_EventScript_Woman::
 	lock

--- a/data/maps/PetalburgCity_Mart/scripts.inc
+++ b/data/maps/PetalburgCity_Mart/scripts.inc
@@ -25,7 +25,7 @@ PetalburgCity_Mart_Pokemart_Basic:
 	.2byte ITEM_X_ATTACK
 	.2byte ITEM_X_DEFEND
 	.2byte ITEM_ORANGE_MAIL
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 
@@ -50,7 +50,7 @@ PetalburgCity_Mart_Pokemart_Expanded:
 	.2byte ITEM_X_ATTACK
 	.2byte ITEM_X_DEFEND
 	.2byte ITEM_ORANGE_MAIL
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/PetalburgCity_Mart/scripts.inc
+++ b/data/maps/PetalburgCity_Mart/scripts.inc
@@ -25,9 +25,7 @@ PetalburgCity_Mart_Pokemart_Basic:
 	.2byte ITEM_X_ATTACK
 	.2byte ITEM_X_DEFEND
 	.2byte ITEM_ORANGE_MAIL
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 PetalburgCity_Mart_EventScript_ExpandedItems::
 	pokemart PetalburgCity_Mart_Pokemart_Expanded
@@ -50,9 +48,7 @@ PetalburgCity_Mart_Pokemart_Expanded:
 	.2byte ITEM_X_ATTACK
 	.2byte ITEM_X_DEFEND
 	.2byte ITEM_ORANGE_MAIL
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 PetalburgCity_Mart_EventScript_Woman::
 	msgbox PetalburgCity_Mart_Text_WeakWillGrowStronger, MSGBOX_NPC

--- a/data/maps/Route104_PrettyPetalFlowerShop/scripts.inc
+++ b/data/maps/Route104_PrettyPetalFlowerShop/scripts.inc
@@ -59,7 +59,7 @@ Route104_PrettyPetalFlowerShop_Pokemart_Plants:
 	.2byte DECOR_COLORFUL_PLANT
 	.2byte DECOR_BIG_PLANT
 	.2byte DECOR_GORGEOUS_PLANT
-	.2byte DECOR_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/Route104_PrettyPetalFlowerShop/scripts.inc
+++ b/data/maps/Route104_PrettyPetalFlowerShop/scripts.inc
@@ -59,9 +59,7 @@ Route104_PrettyPetalFlowerShop_Pokemart_Plants:
 	.2byte DECOR_COLORFUL_PLANT
 	.2byte DECOR_BIG_PLANT
 	.2byte DECOR_GORGEOUS_PLANT
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 Route104_PrettyPetalFlowerShop_EventScript_WailmerPailGirl::
 	lock

--- a/data/maps/RustboroCity_Mart/scripts.inc
+++ b/data/maps/RustboroCity_Mart/scripts.inc
@@ -28,7 +28,7 @@ RustboroCity_Mart_Pokemart_Basic:
 	.2byte ITEM_X_SPEED
 	.2byte ITEM_X_ATTACK
 	.2byte ITEM_X_DEFEND
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 
@@ -52,7 +52,7 @@ RustboroCity_Mart_Pokemart_Expanded:
 	.2byte ITEM_X_SPEED
 	.2byte ITEM_X_ATTACK
 	.2byte ITEM_X_DEFEND
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/RustboroCity_Mart/scripts.inc
+++ b/data/maps/RustboroCity_Mart/scripts.inc
@@ -28,9 +28,7 @@ RustboroCity_Mart_Pokemart_Basic:
 	.2byte ITEM_X_SPEED
 	.2byte ITEM_X_ATTACK
 	.2byte ITEM_X_DEFEND
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 RustboroCity_Mart_EventScript_PokemartExpanded::
 	pokemart RustboroCity_Mart_Pokemart_Expanded
@@ -52,9 +50,7 @@ RustboroCity_Mart_Pokemart_Expanded:
 	.2byte ITEM_X_SPEED
 	.2byte ITEM_X_ATTACK
 	.2byte ITEM_X_DEFEND
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 RustboroCity_Mart_EventScript_PokefanF::
 	msgbox RustboroCity_Mart_Text_BuyingHealsInCaseOfShroomish, MSGBOX_NPC

--- a/data/maps/SlateportCity/scripts.inc
+++ b/data/maps/SlateportCity/scripts.inc
@@ -514,7 +514,7 @@ SlateportCity_PokemartDecor_Dolls:
 	.2byte DECOR_AZURILL_DOLL
 	.2byte DECOR_MARILL_DOLL
 	.2byte DECOR_SKITTY_DOLL
-	.2byte DECOR_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 
@@ -550,7 +550,7 @@ SlateportCity_PokemartDecor:
 	.2byte DECOR_A_NOTE_MAT
 	.2byte DECOR_B_NOTE_MAT
 	.2byte DECOR_C_HIGH_NOTE_MAT
-	.2byte DECOR_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/SlateportCity/scripts.inc
+++ b/data/maps/SlateportCity/scripts.inc
@@ -154,7 +154,7 @@ SlateportCity_Pokemart_EnergyGuru:
 	.2byte ITEM_ZINC
 	.2byte ITEM_CALCIUM
 	.2byte ITEM_HP_UP
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 
@@ -568,7 +568,7 @@ SlateportCity_EventScript_PowerTMClerk::
 SlateportCity_Pokemart_PowerTMs:
 	.2byte ITEM_TM_HIDDEN_POWER
 	.2byte ITEM_TM_SECRET_POWER
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/SlateportCity/scripts.inc
+++ b/data/maps/SlateportCity/scripts.inc
@@ -154,9 +154,7 @@ SlateportCity_Pokemart_EnergyGuru:
 	.2byte ITEM_ZINC
 	.2byte ITEM_CALCIUM
 	.2byte ITEM_HP_UP
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 SlateportCity_EventScript_EffortRibbonWoman::
 	lock
@@ -514,9 +512,7 @@ SlateportCity_PokemartDecor_Dolls:
 	.2byte DECOR_AZURILL_DOLL
 	.2byte DECOR_MARILL_DOLL
 	.2byte DECOR_SKITTY_DOLL
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 SlateportCity_EventScript_ComeBackWithSecretPower::
 	msgbox gText_ComeBackWithSecretPower, MSGBOX_DEFAULT
@@ -550,9 +546,7 @@ SlateportCity_PokemartDecor:
 	.2byte DECOR_A_NOTE_MAT
 	.2byte DECOR_B_NOTE_MAT
 	.2byte DECOR_C_HIGH_NOTE_MAT
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 SlateportCity_EventScript_PowerTMClerk::
 	lock
@@ -568,9 +562,7 @@ SlateportCity_EventScript_PowerTMClerk::
 SlateportCity_Pokemart_PowerTMs:
 	.2byte ITEM_TM_HIDDEN_POWER
 	.2byte ITEM_TM_SECRET_POWER
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 @ Scene with Capt Sterns interview and Team Aqua announcing plans to steal Submarine
 SlateportCity_EventScript_CaptStern::

--- a/data/maps/SlateportCity_Mart/scripts.inc
+++ b/data/maps/SlateportCity_Mart/scripts.inc
@@ -22,7 +22,7 @@ SlateportCity_Mart_Pokemart:
 	.2byte ITEM_ESCAPE_ROPE
 	.2byte ITEM_REPEL
 	.2byte ITEM_HARBOR_MAIL
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/SlateportCity_Mart/scripts.inc
+++ b/data/maps/SlateportCity_Mart/scripts.inc
@@ -22,9 +22,7 @@ SlateportCity_Mart_Pokemart:
 	.2byte ITEM_ESCAPE_ROPE
 	.2byte ITEM_REPEL
 	.2byte ITEM_HARBOR_MAIL
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 SlateportCity_Mart_EventScript_BlackBelt::
 	msgbox SlateportCity_Mart_Text_SomeItemsOnlyAtMart, MSGBOX_NPC

--- a/data/maps/SootopolisCity_Mart/scripts.inc
+++ b/data/maps/SootopolisCity_Mart/scripts.inc
@@ -22,7 +22,7 @@ SootopolisCity_Mart_Pokemart:
 	.2byte ITEM_X_ATTACK
 	.2byte ITEM_X_DEFEND
 	.2byte ITEM_SHADOW_MAIL
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/SootopolisCity_Mart/scripts.inc
+++ b/data/maps/SootopolisCity_Mart/scripts.inc
@@ -22,9 +22,7 @@ SootopolisCity_Mart_Pokemart:
 	.2byte ITEM_X_ATTACK
 	.2byte ITEM_X_DEFEND
 	.2byte ITEM_SHADOW_MAIL
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 SootopolisCity_Mart_EventScript_FatMan::
 	lock

--- a/data/maps/TrainerHill_Entrance/scripts.inc
+++ b/data/maps/TrainerHill_Entrance/scripts.inc
@@ -265,7 +265,7 @@ TrainerHill_Entrance_Pokemart_Basic:
 	.2byte ITEM_DIRE_HIT
 	.2byte ITEM_GUARD_SPEC
 	.2byte ITEM_X_ACCURACY
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 
@@ -289,7 +289,7 @@ TrainerHill_Entrance_Pokemart_Expanded:
 	.2byte ITEM_DIRE_HIT
 	.2byte ITEM_GUARD_SPEC
 	.2byte ITEM_X_ACCURACY
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/TrainerHill_Entrance/scripts.inc
+++ b/data/maps/TrainerHill_Entrance/scripts.inc
@@ -265,9 +265,7 @@ TrainerHill_Entrance_Pokemart_Basic:
 	.2byte ITEM_DIRE_HIT
 	.2byte ITEM_GUARD_SPEC
 	.2byte ITEM_X_ACCURACY
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 TrainerHill_Entrance_EventScript_ExpandedPokemart::
 	pokemart TrainerHill_Entrance_Pokemart_Expanded
@@ -289,9 +287,7 @@ TrainerHill_Entrance_Pokemart_Expanded:
 	.2byte ITEM_DIRE_HIT
 	.2byte ITEM_GUARD_SPEC
 	.2byte ITEM_X_ACCURACY
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 TrainerHill_Entrance_Text_StillGettingReady:
 	.string "This is the TRAINER HILL where\n"

--- a/data/maps/VerdanturfTown_Mart/scripts.inc
+++ b/data/maps/VerdanturfTown_Mart/scripts.inc
@@ -24,7 +24,7 @@ VerdanturfTown_Mart_Pokemart:
 	.2byte ITEM_REPEL
 	.2byte ITEM_X_SPECIAL
 	.2byte ITEM_FLUFFY_TAIL
-	.2byte ITEM_NONE
+	.2byte POKEMART_LIST_END
 	release
 	end
 

--- a/data/maps/VerdanturfTown_Mart/scripts.inc
+++ b/data/maps/VerdanturfTown_Mart/scripts.inc
@@ -24,9 +24,7 @@ VerdanturfTown_Mart_Pokemart:
 	.2byte ITEM_REPEL
 	.2byte ITEM_X_SPECIAL
 	.2byte ITEM_FLUFFY_TAIL
-	.2byte POKEMART_LIST_END
-	release
-	end
+	pokemartlistend
 
 VerdanturfTown_Mart_EventScript_Boy::
 	msgbox VerdanturfTown_Mart_Text_XSpecialIsCrucial, MSGBOX_NPC

--- a/include/constants/items.h
+++ b/include/constants/items.h
@@ -423,6 +423,9 @@
 // Its icon is defined at ITEMS_COUNT as the "return to field" arrow
 #define ITEM_LIST_END 0xFFFF
 
+// List terminator for PokéMarts.
+#define POKEMART_LIST_END 0
+
 // Range of berries given out by various NPCS
 #define FIRST_BERRY_MASTER_BERRY      ITEM_POMEG_BERRY
 #define LAST_BERRY_MASTER_BERRY       ITEM_NOMEL_BERRY

--- a/include/constants/items.h
+++ b/include/constants/items.h
@@ -423,9 +423,6 @@
 // Its icon is defined at ITEMS_COUNT as the "return to field" arrow
 #define ITEM_LIST_END 0xFFFF
 
-// List terminator for PokéMarts.
-#define POKEMART_LIST_END 0
-
 // Range of berries given out by various NPCS
 #define FIRST_BERRY_MASTER_BERRY      ITEM_POMEG_BERRY
 #define LAST_BERRY_MASTER_BERRY       ITEM_NOMEL_BERRY

--- a/src/shop.c
+++ b/src/shop.c
@@ -381,8 +381,8 @@ static void SetShopItemsForSale(const u16 *items)
     sMartInfo.itemList = items;
     sMartInfo.itemCount = 0;
 
-    // Read items until ITEM_NONE / DECOR_NONE is reached
-    while (sMartInfo.itemList[i])
+    // Read items until POKEMART_LIST_END is reached
+    while (sMartInfo.itemList[i] != POKEMART_LIST_END)
     {
         sMartInfo.itemCount++;
         i++;

--- a/src/shop.c
+++ b/src/shop.c
@@ -381,8 +381,8 @@ static void SetShopItemsForSale(const u16 *items)
     sMartInfo.itemList = items;
     sMartInfo.itemCount = 0;
 
-    // Read items until POKEMART_LIST_END is reached
-    while (sMartInfo.itemList[i] != POKEMART_LIST_END)
+    // Read items until ITEM_NONE / DECOR_NONE is reached
+    while (sMartInfo.itemList[i])
     {
         sMartInfo.itemCount++;
         i++;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously, because it had the `ITEM_`/`DECOR_` prefix, users would mistakenly remove it from their custom mart lists.
This should hopefully aleviate the issue.

## **Discord contact info**
AsparagusEduardo