### PR TITLE
[Build System Rewrite] Linkerscript now tracks RAM/ROM usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ sound/**/*.bin
 sound/songs/midi/*.s
 tools/agbcc
 *.map
-*.ld
 *.bat
 *.dump
 *.sa*

--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,6 @@ ifneq ($(MODERN),1)
 CPPFLAGS += -I tools/agbcc/include -I tools/agbcc -nostdinc -undef
 endif
 
-LDFLAGS = -Map ../../$(MAP)
-
 SHA1 := $(shell { command -v sha1sum || command -v shasum; } 2>/dev/null) -c
 GFX := tools/gbagfx/gbagfx$(EXE)
 AIF := tools/aif2pcm/aif2pcm$(EXE)
@@ -406,19 +404,20 @@ $(OBJ_DIR)/sym_ewram.ld: sym_ewram.txt
 	$(RAMSCRGEN) ewram_data $< ENGLISH > $@
 
 ifeq ($(MODERN),0)
-LD_SCRIPT := ld_script.txt
+LD_SCRIPT := ld_script.ld
 LD_SCRIPT_DEPS := $(OBJ_DIR)/sym_bss.ld $(OBJ_DIR)/sym_common.ld $(OBJ_DIR)/sym_ewram.ld
 else
-LD_SCRIPT := ld_script_modern.txt
+LD_SCRIPT := ld_script_modern.ld
 LD_SCRIPT_DEPS :=
 endif
 
 $(OBJ_DIR)/ld_script.ld: $(LD_SCRIPT) $(LD_SCRIPT_DEPS)
 	cd $(OBJ_DIR) && sed "s#tools/#../../tools/#g" ../../$(LD_SCRIPT) > ld_script.ld
 
+LDFLAGS = -Map ../../$(MAP)
 $(ELF): $(OBJ_DIR)/ld_script.ld $(OBJS) libagbsyscall
 	@echo "cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ld_script.ld -o ../../$@ <objects> <lib>"
-	@cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ld_script.ld -o ../../$@ $(OBJS_REL) $(LIB)
+	@cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ld_script.ld --print-memory-usage -o ../../$@ $(OBJS_REL) $(LIB) | cat
 	$(FIX) $@ -t"$(TITLE)" -c$(GAME_CODE) -m$(MAKER_CODE) -r$(REVISION) --silent
 
 $(ROM): $(ELF)

--- a/gflib/malloc.c
+++ b/gflib/malloc.c
@@ -4,7 +4,7 @@
 static void *sHeapStart;
 static u32 sHeapSize;
 
-__attribute__((section("__EWRAM_HEAP"))) u8 gHeap[HEAP_SIZE] = {0};
+EWRAM_DATA u8 gHeap[HEAP_SIZE] = {0};
 
 #define MALLOC_SYSTEM_ID 0xA3A3
 

--- a/gflib/malloc.c
+++ b/gflib/malloc.c
@@ -1,7 +1,10 @@
 #include "global.h"
+#include "malloc.h"
 
 static void *sHeapStart;
 static u32 sHeapSize;
+
+__attribute__((section("__EWRAM_HEAP"))) u8 gHeap[HEAP_SIZE] = {0};
 
 #define MALLOC_SYSTEM_ID 0xA3A3
 

--- a/gflib/malloc.h
+++ b/gflib/malloc.h
@@ -1,7 +1,6 @@
 #ifndef GUARD_ALLOC_H
 #define GUARD_ALLOC_H
 
-#define HEAP_SIZE 0x1C000
 
 #define FREE_AND_SET_NULL(ptr)          \
 {                                       \
@@ -11,6 +10,8 @@
 
 #define TRY_FREE_AND_SET_NULL(ptr) if (ptr != NULL) FREE_AND_SET_NULL(ptr)
 
+// 122 KB. Max size of the heap without running into other data
+#define HEAP_SIZE 0x1C000
 extern u8 gHeap[];
 
 void *Alloc(u32 size);

--- a/gflib/malloc.h
+++ b/gflib/malloc.h
@@ -10,9 +10,8 @@
 
 #define TRY_FREE_AND_SET_NULL(ptr) if (ptr != NULL) FREE_AND_SET_NULL(ptr)
 
-// 122 KB. Max size of the heap without running into other data
 #define HEAP_SIZE 0x1C000
-extern u8 gHeap[];
+extern u8 gHeap[HEAP_SIZE];
 
 void *Alloc(u32 size);
 void *AllocZeroed(u32 size);

--- a/ld_script.ld
+++ b/ld_script.ld
@@ -3,6 +3,13 @@ ENTRY(Start)
 gNumMusicPlayers = 4;
 gMaxLines = 0;
 
+MEMORY
+{
+    EWRAM (rwx) : ORIGIN = 0x2000000, LENGTH = 256K
+    IWRAM (rwx) : ORIGIN = 0x3000000, LENGTH = 32K
+    ROM    (rx) : ORIGIN = 0x8000000, LENGTH = 16M
+}
+
 /* Modify the following load addresses as needed to make more room. Alternately, delete both the
    declarations below and their references further down to get rid of the gaps.                  */
 
@@ -10,28 +17,22 @@ __anim_mon_load_address = 0x8b00000;
 __gfx_load_address = 0x8c00000;
 
 SECTIONS {
-    . = 0x2000000;
 
-    ewram (NOLOAD) :
+    ewram 0x2000000 (NOLOAD) :
     ALIGN(4)
     {
-        gHeap = .;
-
-        . = 0x1C000;
+        *(__EWRAM_HEAP);
 
         INCLUDE "sym_ewram.ld"
-        src/*.o(ewram_data);
-        gflib/*.o(ewram_data);
+        src/*.o(ewram_data);        /**/
+        gflib/*.o(ewram_data);      /**/
 
         *libc.a:impure.o(.data);
         *libc.a:locale.o(.data);
         *libc.a:mallocr.o(.data);
-        . = 0x40000;
-    }
+    } > EWRAM
 
-    . = 0x3000000;
-
-    iwram (NOLOAD) :
+    iwram 0x3000000 (NOLOAD) :
     ALIGN(4)
     {
         /* .bss starts at 0x3000000 */
@@ -46,10 +47,9 @@ SECTIONS {
         /* COMMON starts at 0x30022A8 */
         INCLUDE "sym_common.ld"
         *libc.a:sbrkr.o(COMMON);
-        end = .;
-        . = 0x8000;
-    }
+    } > IWRAM
 
+    /* BEGIN ROM DATA */
     . = 0x8000000;
 
     .text :
@@ -343,7 +343,7 @@ SECTIONS {
         src/gym_leader_rematch.o(.text);
         src/battle_transition_frontier.o(.text);
         src/international_string_util.o(.text);
-    } =0
+    } > ROM =0
 
     script_data :
     ALIGN(4)
@@ -356,7 +356,7 @@ SECTIONS {
         data/battle_ai_scripts.o(script_data);
         data/contest_ai_scripts.o(script_data);
         data/mystery_event_script_cmd_table.o(script_data);
-    } =0
+    } > ROM =0
 
     lib_text :
     ALIGN(4)
@@ -440,7 +440,7 @@ SECTIONS {
         *libc.a:libcfunc.o(.text);
         *libc.a:lseekr.o(.text);
         *libc.a:readr.o(.text);
-    } =0
+    } > ROM =0
 
     .rodata :
     ALIGN(4)
@@ -705,7 +705,7 @@ SECTIONS {
         data/mystery_gift.o(.rodata);
         src/m4a_tables.o(.rodata);
         data/sound_data.o(.rodata);
-    } =0
+    } > ROM =0
 
     song_data :
     ALIGN(4)
@@ -1240,7 +1240,7 @@ SECTIONS {
         sound/songs/midi/ph_nurse_blend.o(.rodata);
         sound/songs/midi/ph_nurse_held.o(.rodata);
         sound/songs/midi/ph_nurse_solo.o(.rodata);
-    } =0
+    } > ROM =0
 
     lib_rodata :
     SUBALIGN(4)
@@ -1293,7 +1293,7 @@ SECTIONS {
         *libc.a:lseekr.o(.rodata);
         *libc.a:readr.o(.rodata);
         src/libisagbprn.o(.rodata);
-    } =0
+    } > ROM =0
 
     multiboot_data :
     ALIGN(4)
@@ -1301,19 +1301,19 @@ SECTIONS {
         data/multiboot_ereader.o(.rodata);
         data/multiboot_berry_glitch_fix.o(.rodata);
         data/multiboot_pokemon_colosseum.o(.rodata);
-    } =0
+    } > ROM =0
 
     anim_mon_front_pic_data __anim_mon_load_address :
     ALIGN(4)
     {
         src/anim_mon_front_pics.o(.rodata);
-    } =0
+    } > ROM =0
 
     gfx_data __gfx_load_address :
     ALIGN(4)
     {
         src/graphics.o(.rodata);
-    } =0
+    } > ROM =0
 
     extra :
     ALIGN(4)
@@ -1323,7 +1323,7 @@ SECTIONS {
         src/*.o(.rodata);
         gflib/*.o(.rodata);
         data/*.o(.rodata);
-    } = 0
+    } > ROM = 0
 
     /* DWARF debug sections.
        Symbols in the DWARF debugging sections are relative to the beginning

--- a/ld_script.ld
+++ b/ld_script.ld
@@ -7,7 +7,7 @@ MEMORY
 {
     EWRAM (rwx) : ORIGIN = 0x2000000, LENGTH = 256K
     IWRAM (rwx) : ORIGIN = 0x3000000, LENGTH = 32K
-    ROM    (rx) : ORIGIN = 0x8000000, LENGTH = 16M
+    ROM    (rx) : ORIGIN = 0x8000000, LENGTH = 32M
 }
 
 /* Modify the following load addresses as needed to make more room. Alternately, delete both the
@@ -21,11 +21,9 @@ SECTIONS {
     ewram 0x2000000 (NOLOAD) :
     ALIGN(4)
     {
-        *(__EWRAM_HEAP);
-
         INCLUDE "sym_ewram.ld"
-        src/*.o(ewram_data);        /**/
-        gflib/*.o(ewram_data);      /**/
+        src/*.o(ewram_data);
+        gflib/*.o(ewram_data);
 
         *libc.a:impure.o(.data);
         *libc.a:locale.o(.data);

--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -3,12 +3,11 @@ ENTRY(Start)
 gNumMusicPlayers = 4;
 gMaxLines = 0;
 
-/* Memory Spaces */
 MEMORY
 {
     EWRAM (rwx) : ORIGIN = 0x2000000, LENGTH = 256K
     IWRAM (rwx) : ORIGIN = 0x3000000, LENGTH = 32K
-    ROM    (rx) : ORIGIN = 0x8000000, LENGTH = 16M
+    ROM    (rx) : ORIGIN = 0x8000000, LENGTH = 32M
 }
 
 SECTIONS {
@@ -16,10 +15,8 @@ SECTIONS {
     ewram 0x2000000 (NOLOAD) :
     ALIGN(4)
     {
-        *(__EWRAM_HEAP);
-
-        src/*.o(ewram_data);    /**/
-        gflib/*.o(ewram_data);  /**/
+        src/*.o(ewram_data);
+        gflib/*.o(ewram_data);
     } > EWRAM
 
     iwram 0x3000000 (NOLOAD) :
@@ -31,13 +28,11 @@ SECTIONS {
         *libc.a:*.o(.bss*);
         *libnosys.a:*.o(.bss*);
 
-        /* .bss.code starts at 0x3001AA8 */
         src/m4a.o(.bss.code);
 
-        /* COMMON starts at 0x30022A8 */
-        src/*.o(COMMON);            /**/
-        gflib/*.o(COMMON);          /**/
-        *libc.a:*.o(COMMON);        
+        src/*.o(COMMON);
+        gflib/*.o(COMMON);
+        *libc.a:*.o(COMMON);
         *libnosys.a:*.o(COMMON);
     } > IWRAM
 

--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -3,28 +3,28 @@ ENTRY(Start)
 gNumMusicPlayers = 4;
 gMaxLines = 0;
 
-SECTIONS {
-    . = 0x2000000;
-
-    ewram (NOLOAD) :
-    ALIGN(4)
-    {
-        gHeap = .;
-
-        . = 0x1C000;
-
-        src/*.o(ewram_data);
-        gflib/*.o(ewram_data);
-
-        . = 0x40000;
+/* Memory Spaces */
+MEMORY
+{
+    EWRAM (rwx) : ORIGIN = 0x2000000, LENGTH = 256K
+    IWRAM (rwx) : ORIGIN = 0x3000000, LENGTH = 32K
+    ROM    (rx) : ORIGIN = 0x8000000, LENGTH = 16M
 }
 
-    . = 0x3000000;
+SECTIONS {
 
-    iwram (NOLOAD) :
+    ewram 0x2000000 (NOLOAD) :
     ALIGN(4)
     {
-        /* .bss starts at 0x3000000 */
+        *(__EWRAM_HEAP);
+
+        src/*.o(ewram_data);    /**/
+        gflib/*.o(ewram_data);  /**/
+    } > EWRAM
+
+    iwram 0x3000000 (NOLOAD) :
+    ALIGN(4)
+    {
         src/*.o(.bss);
         gflib/*.o(.bss);
         data/*.o(.bss);
@@ -35,14 +35,13 @@ SECTIONS {
         src/m4a.o(.bss.code);
 
         /* COMMON starts at 0x30022A8 */
-        src/*.o(COMMON);
-        gflib/*.o(COMMON);
-        *libc.a:*.o(COMMON);
+        src/*.o(COMMON);            /**/
+        gflib/*.o(COMMON);          /**/
+        *libc.a:*.o(COMMON);        
         *libnosys.a:*.o(COMMON);
-        end = .;
-        . = 0x8000;
-    }
+    } > IWRAM
 
+    /* BEGIN ROM DATA */
     . = 0x8000000;
 
     .text :
@@ -55,13 +54,13 @@ SECTIONS {
         gflib/*.o(.text*);
         src/*.o(.text*);
         asm/*.o(.text*);
-    } =0
+    } > ROM =0
 
     script_data :
     ALIGN(4)
     {
 		data/*.o(script_data);
-    } =0
+    } > ROM =0
 
     lib_text :
     ALIGN(4)
@@ -82,7 +81,7 @@ SECTIONS {
         *libc.a:*.o(.text*);
         *libnosys.a:*.o(.text*);
         src/libisagbprn.o(.text);
-    } =0
+    } > ROM =0
 
     .rodata :
     ALIGN(4)
@@ -90,13 +89,13 @@ SECTIONS {
         src/*.o(.rodata*);
         gflib/*.o(.rodata*);
         data/*.o(.rodata*);
-    } =0
+    } > ROM =0
 
     song_data :
     ALIGN(4)
     {
         sound/songs/*.o(.rodata);
-    } =0
+    } > ROM =0
 
     lib_rodata :
     SUBALIGN(4)
@@ -121,19 +120,19 @@ SECTIONS {
         data/multiboot_ereader.o(.rodata);
         data/multiboot_berry_glitch_fix.o(.rodata);
         data/multiboot_pokemon_colosseum.o(.rodata);
-    } =0
+    } > ROM =0
 
     anim_mon_front_pic_data :
     ALIGN(4)
     {
         src/anim_mon_front_pics.o(.rodata);
-    } =0
+    } > ROM =0
 
     gfx_data :
     ALIGN(4)
     {
         src/graphics.o(.rodata);
-    } =0
+    } > ROM =0
 
     /* DWARF debug sections.
        Symbols in the DWARF debugging sections are relative to the beginning

--- a/sym_ewram.txt
+++ b/sym_ewram.txt
@@ -1,3 +1,4 @@
+	.include "gflib/malloc.o"
 	.include "src/decompress.o"
 	.include "src/main.o"
 	.include "gflib/window.o"


### PR DESCRIPTION
No dependencies on any other PRs

## Description
- The master linkerscripts now use `.ld` as their extension
- The linkerscript no longer sets the EWRAM heap size, the macro `HEAP_SIZE` does.
- The linkerscript should warn if memory bounds are exceeded.
- Running `make` now prints memory usages (note that on non-modern ROM's free space is fragmented due to `__anim_mon_load_address`)

Example output:
![image](https://github.com/pret/pokeemerald/assets/34080011/5e7e34bb-5481-4cf0-8474-3648476bef5f)

#### **Discord contact info**
icedude907