### PR TITLE
Updated the size of the struct InGameTrade's otName variable

### DIFF
--- a/src/trade.c
+++ b/src/trade.c
@@ -157,7 +157,7 @@ struct InGameTrade {
     u32 personality;
     u16 heldItem;
     u8 mailNum;
-    u8 otName[11];
+    u8 otName[TRAINER_NAME_LENGTH + 1];
     u8 otGender;
     u8 sheen;
     u16 requestedSpecies;


### PR DESCRIPTION
## Description
I spotted this a moment ago and decided to give it a quick update.
I imagine that it's better to use `TRAINER_NAME_LENGTH + 1` here like other parts of the code do.

## **Discord contact info**
lunos4026