### PR TITLE
[jsonproc] Workaround to handle basic special characters

### DIFF
--- a/tools/jsonproc/jsonproc.cpp
+++ b/tools/jsonproc/jsonproc.cpp
@@ -105,11 +105,76 @@ int main(int argc, char *argv[])
     });
 
     env.add_callback("cleanString", 1, [](Arguments& args) {
-        string badChars = ".'{} \n\t-\u00e9";
+        string badChars = ".'{} \n\t-&¿?";
+        string aChars = "áàâä";
+        string AChars = "ÁÀÂÄ";
+        string eChars = "éèêë";
+        string EChars = "ÉÈÊË";
+        string iChars = "íìîï";
+        string IChars = "ÍÌÎÏ";
+        string oChars = "óòôöœ";
+        string OChars = "ÓÒÔÖŒ";
+        string uChars = "úùûü";
+        string UChars = "ÚÙÛÜ";
+        string nChars = "ñ";
+        string NChars = "Ñ";
+        string dummyChars = "";
         string str = args.at(0)->get<string>();
         for (unsigned int i = 0; i < str.length(); i++) {
             if (badChars.find(str[i]) != std::string::npos) {
                 str[i] = '_';
+            }
+            if (nChars.find(str[i]) != std::string::npos)
+            {
+                str[i] = '_';
+            }
+            if (nChars.find(str[i]) != std::string::npos)
+            {
+                str[i] = 'n';
+            }
+            if (NChars.find(str[i]) != std::string::npos)
+            {
+                str[i] = 'N';
+            }
+            if (AChars.find(str[i]) != std::string::npos)
+            {
+                str[i] = 'A';
+            }
+            if (EChars.find(str[i]) != std::string::npos)
+            {
+                str[i] = 'E';
+            }
+            if (IChars.find(str[i]) != std::string::npos)
+            {
+                str[i] = 'I';
+            }
+            if (OChars.find(str[i]) != std::string::npos)
+            {
+                str[i] = 'O';
+            }
+            if (UChars.find(str[i]) != std::string::npos)
+            {
+                str[i] = 'U';
+            }
+            if (aChars.find(str[i]) != std::string::npos)
+            {
+                str[i] = 'a';
+            }
+            if (eChars.find(str[i]) != std::string::npos)
+            {
+                str[i] = 'e';
+            }
+            if (iChars.find(str[i]) != std::string::npos)
+            {
+                str[i] = 'i';
+            }
+            if (oChars.find(str[i]) != std::string::npos)
+            {
+                str[i] = 'o';
+            }
+            if (uChars.find(str[i]) != std::string::npos)
+            {
+                str[i] = 'u';
             }
         }
         return str;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a workaround to avoid compilation fails when including special characters in map names #1963 .
`pokeemerald/tools/jsonproc` was modified to include some special characters in the list of "bad characters" and implemented some commands to replace them with the better ascii aproximation:
```
aChars = "áàâä";
AChars = "ÁÀÂÄ";
eChars = "éèêë";
EChars = "ÉÈÊË";
iChars = "íìîï";
IChars = "ÍÌÎÏ";
oChars = "óòôöœ";
OChars = "ÓÒÔÖŒ";
uChars = "úùûü";
UChars = "ÚÙÛÜ";
nChars = "ñ";
NChars = "Ñ";
```

This makes that *it won't break anymore*, although it doesn't grants the correct result yet. It changes `Villa Raíz` for `Villa Ra_iz` i.e. however, I run out of ideas. My guess is that the first try to replace a _bad character_ also inserts the character even not having to replace it, but I don't know how to fix it.

## **Discord contact info**
Discord: excmojack
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->