### PR TITLE
Safeguard SQUARE and CUBE Macro Arguments in Parentheses

### DIFF
--- a/src/data/pokemon/experience_tables.h
+++ b/src/data/pokemon/experience_tables.h
@@ -1,5 +1,5 @@
-#define SQUARE(n)(n * n)
-#define CUBE(n)(n * n * n)
+#define SQUARE(n)((n) * (n))
+#define CUBE(n)((n) * (n) * (n))
 
 #define EXP_SLOW(n)((5 * CUBE(n)) / 4) // (5 * (n)^3) / 4
 #define EXP_FAST(n)((4 * CUBE(n)) / 5) // (4 * (n)^3) / 5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently these macros are only used in this file and are only ever used with single numbers, so having the terms be naked was not an issue. However, just in case for some reason someone tries to use expressions with more than 1 term, it would be a good idea to use parentheses properly here.

## **Discord contact info**
kurausukun