### PR TITLE
jsonproc: filter out every non-alphanumeric character

### DIFF
--- a/tools/jsonproc/jsonproc.cpp
+++ b/tools/jsonproc/jsonproc.cpp
@@ -105,10 +105,13 @@ int main(int argc, char *argv[])
     });
 
     env.add_callback("cleanString", 1, [](Arguments& args) {
-        string badChars = ".'{} \n\t-\u00e9";
         string str = args.at(0)->get<string>();
         for (unsigned int i = 0; i < str.length(); i++) {
-            if (badChars.find(str[i]) != std::string::npos) {
+            // This code is not Unicode aware, so UTF-8 is not easily parsable without introducing
+            // another library. Just filter out any non-alphanumeric characters for now.
+            // TODO: proper Unicode string normalization
+            if ((i == 0 && isdigit(str[i]))
+             || !isalnum(str[i])) {
                 str[i] = '_';
             }
         }


### PR DESCRIPTION
## Description
Instead of filtering out specific characters, filter out anything that isn't alphanumeric (and prevent digits from being the first character too).
A more proper fix would be decomposing characters with diacritics and using their "base letter" but that would take a proper Unicode library as the current code is not Unicode aware.
Fixes #1963 .

## **Discord contact info**
Sierraffinity