### PR TITLE
fix(linking): link gflib/malloc.c at top of EWRAM in ld_script_modern.ld

### DIFF
--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -15,6 +15,11 @@ SECTIONS {
     ewram 0x2000000 (NOLOAD) :
     ALIGN(4)
     {
+        /* 
+           We link malloc.o here to prevent `gHeap` from landing in the middle of EWRAM.
+           Otherwise this causes corruption issues on some ld versions
+        */
+        gflib/malloc.o(ewram_data);
         src/*.o(ewram_data);
         gflib/*.o(ewram_data);
     } > EWRAM


### PR DESCRIPTION
## Description

Linking malloc.c in the middle of EWRAM breaks on some specific linker versions manifesting in a corrupted scene when transitioning from littleroot town to the first route.

NOTE: This mitigates the bug, but probably does not fix the underlying issue. However I would suggest merging this in order to prevent errors like that on downstream projects like mods or the hideout/expansion project. It is probably fair game to revert this change if we can fix the underlying issue.

## **Discord contact info**
karathan