### PR TITLE
Fix HideMapNamePopUpWindow possible overflow

### DIFF
--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -15,11 +15,6 @@ SECTIONS {
     ewram 0x2000000 (NOLOAD) :
     ALIGN(4)
     {
-        /* 
-           We link malloc.o here to prevent `gHeap` from landing in the middle of EWRAM.
-           Otherwise this causes corruption issues on some ld versions
-        */
-        gflib/malloc.o(ewram_data);
         src/*.o(ewram_data);
         gflib/*.o(ewram_data);
     } > EWRAM

--- a/src/map_name_popup.c
+++ b/src/map_name_popup.c
@@ -317,8 +317,13 @@ void HideMapNamePopUpWindow(void)
 {
     if (FuncIsActiveTask(Task_MapNamePopUpWindow))
     {
-        ClearStdWindowAndFrame(GetMapNamePopUpWindowId(), TRUE);
-        RemoveMapNamePopUpWindow();
+    #ifdef UBFIX
+        if (GetMapNamePopUpWindowId() != WINDOW_NONE)
+    #endif // UBFIX
+        {
+            ClearStdWindowAndFrame(GetMapNamePopUpWindowId(), TRUE);
+            RemoveMapNamePopUpWindow();
+        }
         SetGpuReg_ForcedBlank(REG_OFFSET_BG0VOFS, 0);
         DestroyTask(sPopupTaskId);
     }


### PR DESCRIPTION
Followup to #1976

We found the cause of the glitching map graphics. It was `GetMapNamePopUpWindowId` passing 0xFF as valid windowId, which in turn modifies the data directly below `gWindows`, which happened to be `gHeap` on some compiler/linker versions. In vanilla this goes unnoticed.