### PR TITLE
Change Safe Div to explicitly check b != 0

### DIFF
--- a/include/global.h
+++ b/include/global.h
@@ -80,7 +80,7 @@
 // Used in cases where division by 0 can occur in the retail version.
 // Avoids invalid opcodes on some emulators, and the otherwise UB.
 #ifdef UBFIX
-#define SAFE_DIV(a, b) ((b) ? (a) / (b) : 0)
+#define SAFE_DIV(a, b) (((b) != 0) ? (a) / (b) : 0)
 #else
 #define SAFE_DIV(a, b) ((a) / (b))
 #endif


### PR DESCRIPTION
This is so that compilers on modern don't cry about 
`-Werror=int-in-bool-context`