### PR TITLE
Missing Constant in Dex Cry Screen

### DIFF
--- a/src/pokedex_cry_screen.c
+++ b/src/pokedex_cry_screen.c
@@ -362,7 +362,7 @@ static void BufferCryWaveformSegment(void)
     else
         baseBuffer = gSoundInfo.pcmBuffer + (gSoundInfo.pcmDmaPeriod + 1 - gPcmDmaCounter) * gSoundInfo.pcmSamplesPerVBlank;
 
-    buffer = baseBuffer + 0x630;
+    buffer = baseBuffer + PCM_DMA_BUF_SIZE;
     for (i = 0; i < ARRAY_COUNT(sDexCryScreen->cryWaveformBuffer); i++)
         sDexCryScreen->cryWaveformBuffer[i] = buffer[i * 2] * 2;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
0x630 (1584) is the size of the PCM buffer, so we should be using the define for this.

## **Discord contact info**
kurausukun