### PR TITLE
Make sure gHeap is always aligned

### DIFF
--- a/gflib/malloc.c
+++ b/gflib/malloc.c
@@ -4,7 +4,7 @@
 static void *sHeapStart;
 static u32 sHeapSize;
 
-EWRAM_DATA u8 gHeap[HEAP_SIZE] = {0};
+ALIGNED(4) EWRAM_DATA u8 gHeap[HEAP_SIZE] = {0};
 
 #define MALLOC_SYSTEM_ID 0xA3A3
 


### PR DESCRIPTION
When building with `-Os` compiler flag, there is a chance(not always) that `gHeap` ends up not aligned, which breaks the game.