### PR TITLE
Simplify weirdly matching division/substraction code

### DIFF
--- a/src/battle_anim_effects_2.c
+++ b/src/battle_anim_effects_2.c
@@ -3673,7 +3673,6 @@ static void AnimTask_UproarDistortion_Step(u8 taskId)
 
 static void AnimJaggedMusicNote(struct Sprite *sprite)
 {
-    int var1;
     u8 battler = !gBattleAnimArgs[0] ? gBattleAnimAttacker : gBattleAnimTarget;
 
     if (GetBattlerSide(battler) == B_SIDE_OPPONENT)
@@ -3684,16 +3683,8 @@ static void AnimJaggedMusicNote(struct Sprite *sprite)
     sprite->data[0] = 0;
     sprite->data[1] = (u16)sprite->x << 3;
     sprite->data[2] = (u16)sprite->y << 3;
-
-    var1 = gBattleAnimArgs[1] << 3;
-    if (var1 < 0)
-        var1 += 7;
-    sprite->data[3] = var1 >> 3;
-
-    var1 = gBattleAnimArgs[2] << 3;
-    if (var1 < 0)
-        var1 += 7;
-    sprite->data[4] = var1 >> 3;
+    sprite->data[3] = (gBattleAnimArgs[1] << 3) / 8;
+    sprite->data[4] = (gBattleAnimArgs[2] << 3) / 8;
 
     sprite->oam.tileNum += gBattleAnimArgs[3] * 16;
     sprite->callback = AnimJaggedMusicNote_Step;

--- a/src/battle_anim_fight.c
+++ b/src/battle_anim_fight.c
@@ -493,7 +493,7 @@ static void AnimFistOrFootRandomPos(struct Sprite *sprite)
         y *= -1;
 
     if (GET_BATTLER_SIDE2(battler) == B_SIDE_PLAYER)
-        y += 0xFFF0;
+        y -= 16;
 
     sprite->x += x;
     sprite->y += y;

--- a/src/battle_anim_rock.c
+++ b/src/battle_anim_rock.c
@@ -558,7 +558,6 @@ void AnimTask_Rollout(u8 taskId)
 {
     u16 var0, var1, var2, var3;
     u8 rolloutCounter;
-    int var5;
     s16 pan1, pan2;
     struct Task *task;
 
@@ -582,13 +581,7 @@ void AnimTask_Rollout(u8 taskId)
     task->data[11] = 0;
     task->data[9] = 0;
     task->data[12] = 1;
-
-    var5 = task->data[8];
-    if (var5 < 0)
-        var5 += 7;
-
-    task->data[10] = (var5 >> 3) - 1;
-
+    task->data[10] = (task->data[8] / 8) - 1;
     task->data[2] = var0 * 8;
     task->data[3] = var1 * 8;
     task->data[4] = ((var2 - var0) * 8) / task->data[8];

--- a/src/battle_intro.c
+++ b/src/battle_intro.c
@@ -196,12 +196,12 @@ static void BattleIntroSlide1(u8 taskId)
         {
             if (gTasks[taskId].tTerrain == BATTLE_TERRAIN_LONG_GRASS)
             {
-                if (gBattle_BG1_Y != 0xFFB0)
+                if (gBattle_BG1_Y != (u16)(-80))
                     gBattle_BG1_Y -= 2;
             }
             else
             {
-                if (gBattle_BG1_Y != 0xFFC8)
+                if (gBattle_BG1_Y != (u16)(-56))
                     gBattle_BG1_Y -= 1;
             }
         }

--- a/src/berry_crush.c
+++ b/src/berry_crush.c
@@ -1373,7 +1373,6 @@ static void CreateBerrySprites(struct BerryCrushGame *game, struct BerryCrushGam
     u8 spriteId;
     s16 distance, var1;
     s16 *data;
-    s32 amplitude;
     s16 speed;
     u32 var2;
 
@@ -1395,11 +1394,7 @@ static void CreateBerrySprites(struct BerryCrushGame *game, struct BerryCrushGam
         sYAccel = 32;
         sBitfield = 112; // Setting bits in MASK_TARGET_Y
         distance = gfx->playerCoords[i]->berryXDest - gfx->playerCoords[i]->berryXOffset;
-        amplitude = distance;
-        if (distance < 0)
-            amplitude += 3;
-
-        sAmplitude = amplitude >> 2;
+        sAmplitude = distance / 4;
         distance *= 128;
         var2 = speed + 32;
         var2 = var2 / 2;

--- a/src/field_weather.c
+++ b/src/field_weather.c
@@ -277,7 +277,6 @@ static void BuildColorMaps(void)
     u16 brightnessDelta;
     u16 colorMapIndex;
     u16 baseBrightness;
-    u32 remainingBrightness;
     s16 diff;
 
     sPaletteColorMapTypes = sBasePaletteColorMapTypes;
@@ -305,11 +304,7 @@ static void BuildColorMaps(void)
             }
 
             baseBrightness = curBrightness;
-            remainingBrightness = 0x1f00 - curBrightness;
-            if ((0x1f00 - curBrightness) < 0)
-                remainingBrightness += 0xf;
-
-            brightnessDelta = remainingBrightness / (NUM_WEATHER_COLOR_MAPS - 3);
+            brightnessDelta = (0x1f00 - curBrightness) / (NUM_WEATHER_COLOR_MAPS - 3);
             if (colorVal < 12)
             {
                 // For shadows (color values < 12), the remaining color mappings are

--- a/src/international_string_util.c
+++ b/src/international_string_util.c
@@ -76,10 +76,7 @@ int Intl_GetListMenuWidth(const struct ListMenuTemplate *listMenu)
     }
 
     finalWidth = maxWidth + listMenu->item_X + 9;
-    if (finalWidth < 0)
-        finalWidth += 7;
-
-    finalWidth >>= 3;
+    finalWidth /= 8;
     if (finalWidth > 28)
         finalWidth = 28;
 

--- a/src/pokemon_animation.c
+++ b/src/pokemon_animation.c
@@ -4969,29 +4969,24 @@ static void ShrinkGrowVibrate(struct Sprite *sprite)
     }
     else
     {
-        u8 posY_unsigned;
-        s8 posY_signed;
-        s32 posY;
-        s16 index = (u16)(sprite->data[2] % sprite->data[6] * 256) / sprite->data[6] % 256;
+        s8 sinY;
+        u16 y;
+        s16 index = ((u16)(sprite->data[2] % sprite->data[6] * 256) / sprite->data[6]) % 256;
         if (sprite->data[2] % 2 == 0)
         {
             sprite->data[4] = Sin(index, 32) + 256;
             sprite->data[5] = Sin(index, 32) + 256;
-            posY_unsigned = Sin(index, 32);
-            posY_signed = posY_unsigned;
+            sinY = Sin(index, 32);
         }
         else
         {
             sprite->data[4] = Sin(index, 8) + 256;
             sprite->data[5] = Sin(index, 8) + 256;
-            posY_unsigned = Sin(index, 8);
-            posY_signed = posY_unsigned;
+            sinY = Sin(index, 8);
         }
 
-        posY = posY_signed;
-        if (posY < 0)
-            posY += 7;
-        sprite->y2 = (u32)(posY) >> 3;
+        y = sinY / 8;
+        sprite->y2 = y;
         HandleSetAffineData(sprite, sprite->data[4], sprite->data[5], 0);
     }
 


### PR DESCRIPTION
There were some cases, where instead of a simple division by 8, the code was needlessly confusing to match compiler generated code.