### PR TITLE
Renamed ScrCmd_setmonmodernfatefulencounter and ScrCmd_checkmonmodernfatefulencounter for consistency reasons

### DIFF
--- a/data/script_cmd_table.inc
+++ b/data/script_cmd_table.inc
@@ -205,8 +205,8 @@ gScriptCmdTable::
 	.4byte ScrCmd_nop1                              @ 0xca
 	.4byte ScrCmd_nop1                              @ 0xcb
 	.4byte ScrCmd_nop1                              @ 0xcc
-	.4byte ScrCmd_setmonmodernfatefulencounter      @ 0xcd
-	.4byte ScrCmd_checkmonmodernfatefulencounter    @ 0xce
+	.4byte ScrCmd_setmodernfatefulencounter         @ 0xcd
+	.4byte ScrCmd_checkmodernfatefulencounter       @ 0xce
 	.4byte ScrCmd_trywondercardscript               @ 0xcf
 	.4byte ScrCmd_nop1                              @ 0xd0
 	.4byte ScrCmd_warpspinenter                     @ 0xd1

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -2207,7 +2207,7 @@ bool8 ScrCmd_lockfortrainer(struct ScriptContext *ctx)
 }
 
 // This command will set a Pokémon's modernFatefulEncounter bit; there is no similar command to clear it.
-bool8 ScrCmd_setmonmodernfatefulencounter(struct ScriptContext *ctx)
+bool8 ScrCmd_setmodernfatefulencounter(struct ScriptContext *ctx)
 {
     bool8 isModernFatefulEncounter = TRUE;
     u16 partyIndex = VarGet(ScriptReadHalfword(ctx));
@@ -2216,7 +2216,7 @@ bool8 ScrCmd_setmonmodernfatefulencounter(struct ScriptContext *ctx)
     return FALSE;
 }
 
-bool8 ScrCmd_checkmonmodernfatefulencounter(struct ScriptContext *ctx)
+bool8 ScrCmd_checkmodernfatefulencounter(struct ScriptContext *ctx)
 {
     u16 partyIndex = VarGet(ScriptReadHalfword(ctx));
 


### PR DESCRIPTION
## Description
I just realized that the labels of the functions of code linked to the `setmodernfatefulencounter` and `checkmodernfatefulencounter` scripting macros didn't match said macros and decided to correct it.

Alternative to the changes in this PR, the `setmodernfatefulencounter` and `checkmodernfatefulencounter` macros could be renamed to `setmonmodernfatefulencounter` and `checkmonmodernfatefulencounter`.
I don't know which would be more preferable of the 2.

## **Discord contact info**
lunos4026