### PR TITLE
Updated value of gMain.inBattle at OpponentHandleEndLinkBattle

### DIFF
--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -2007,7 +2007,7 @@ static void OpponentHandleEndLinkBattle(void)
 {
     if (gBattleTypeFlags & BATTLE_TYPE_LINK && !(gBattleTypeFlags & BATTLE_TYPE_IS_MASTER))
     {
-        gMain.inBattle = 0;
+        gMain.inBattle = FALSE;
         gMain.callback1 = gPreBattleCallback1;
         SetMainCallback2(gMain.savedCallback);
     }


### PR DESCRIPTION
## Description
The function `OpponentHandleEndLinkBattle` sets `gMain.inBattle` to 0 instead of using the constant `FALSE`.
This PR fixes that. Very useful. Lot of work involved. Brain tired from lotsa thinking.

## **Discord contact info**
lunos4026