### PR TITLE
Added fix to Keep the Camera from Making Waves

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -8070,7 +8070,11 @@ static void DoGroundEffects_OnSpawn(struct ObjectEvent *objEvent, struct Sprite 
 {
     u32 flags;
 
+#ifdef BUGFIX
+    if (objEvent->triggerGroundEffectsOnMove && objEvent->localId != OBJ_EVENT_ID_CAMERA)
+#else
     if (objEvent->triggerGroundEffectsOnMove)
+#endif
     {
         flags = 0;
         UpdateObjectEventElevationAndPriority(objEvent, sprite);
@@ -8086,7 +8090,11 @@ static void DoGroundEffects_OnBeginStep(struct ObjectEvent *objEvent, struct Spr
 {
     u32 flags;
 
+#ifdef BUGFIX
+    if (objEvent->triggerGroundEffectsOnMove && objEvent->localId != OBJ_EVENT_ID_CAMERA)
+#else
     if (objEvent->triggerGroundEffectsOnMove)
+#endif
     {
         flags = 0;
         UpdateObjectEventElevationAndPriority(objEvent, sprite);
@@ -8103,7 +8111,11 @@ static void DoGroundEffects_OnFinishStep(struct ObjectEvent *objEvent, struct Sp
 {
     u32 flags;
 
+#ifdef BUGFIX
+    if (objEvent->triggerGroundEffectsOnStop && objEvent->localId != OBJ_EVENT_ID_CAMERA)
+#else
     if (objEvent->triggerGroundEffectsOnStop)
+#endif
     {
         flags = 0;
         UpdateObjectEventElevationAndPriority(objEvent, sprite);


### PR DESCRIPTION
Implements https://github.com/pret/pokeemerald/wiki/Keep-the-Camera-from-Making-Waves as a `BUGFIX`, stolen from @tustin2121 with permission. I opted against the invisible option as the camera seems like the more applicable version.

## Description
| `BUGFIX` On | `BUGFIX` Off|
| --- | --- |
|![on](https://github.com/pret/pokeemerald/assets/77138753/685cfac3-11df-4c25-83cd-234fd9123f32) | ![off](https://github.com/pret/pokeemerald/assets/77138753/cb7457af-3ced-406d-84cf-944d4857cb36) |

## Testing
```diff

// data/maps/InsideOfTruck/scripts.inc
InsideOfTruck_EventScript_MovingBox::
+    warp MAP_PETALBURG_CITY,0
	msgbox InsideOfTruck_Text_BoxPrintedWithMonLogo, MSGBOX_SIGN
	end

// data/maps/PetalburgCity/scripts.inc
PetalburgCity_EventScript_Boy::
+    special SpawnCameraObject
+    applymovement OBJ_EVENT_ID_CAMERA, WalkAway
	lock
	faceplayer
	msgbox PetalburgCity_Text_WaterReflection, MSGBOX_DEFAULT
	closemessage
	applymovement LOCALID_BOY, Common_Movement_FaceOriginalDirection
	waitmovement 0
	release
	end

+ WalkAway:
+    walk_down
+    walk_down
+    walk_down
+    walk_left
+    walk_left
+    walk_left
+    step_end
```

## **Discord contact info**
I am pkmnsnfrn.