### PR TITLE
Include gba/defines.h in gba/types.h

### DIFF
--- a/include/gba/types.h
+++ b/include/gba/types.h
@@ -2,6 +2,7 @@
 #define GUARD_GBA_TYPES_H
 
 #include <stdint.h>
+#include "gba/defines.h"
 
 typedef uint8_t   u8;
 typedef uint16_t u16;


### PR DESCRIPTION
If `gba/types.h` is included before `gba/defines.h`, it ends up declaring a variable named `PACKED` rather than specifying that `BgCnt` should be packed.

This occurs in `src/mini_printf.c`, and also apparently in a feature branch which is how this situation was detected (a multiple definition error at link time).