### PR TITLE
Fix poison projectile array being incorrectly combined into three separate arrays

### DIFF
--- a/src/battle_anim_poison.c
+++ b/src/battle_anim_poison.c
@@ -59,15 +59,7 @@ static const union AnimCmd sAnim_SludgeBombHit[] =
 static const union AnimCmd *const sAnims_PoisonProjectile[] =
 {
     sAnim_PoisonProjectile,
-};
-
-static const union AnimCmd *const sAnims_AcidPoisonDroplet[] =
-{
     sAnim_AcidPoisonDroplet,
-};
-
-static const union AnimCmd *const sAnims_SludgeBombHit[] =
-{
     sAnim_SludgeBombHit,
 };
 
@@ -122,7 +114,7 @@ const struct SpriteTemplate gSludgeBombHitParticleSpriteTemplate =
     .tileTag = ANIM_TAG_POISON_BUBBLE,
     .paletteTag = ANIM_TAG_POISON_BUBBLE,
     .oam = &gOamData_AffineNormal_ObjNormal_16x16,
-    .anims = sAnims_SludgeBombHit,
+    .anims = &sAnims_PoisonProjectile[2],
     .images = NULL,
     .affineAnims = sAffineAnims_SludgeBombHit,
     .callback = AnimSludgeBombHitParticle,
@@ -145,7 +137,7 @@ const struct SpriteTemplate gAcidPoisonDropletSpriteTemplate =
     .tileTag = ANIM_TAG_POISON_BUBBLE,
     .paletteTag = ANIM_TAG_POISON_BUBBLE,
     .oam = &gOamData_AffineDouble_ObjNormal_16x16,
-    .anims = sAnims_AcidPoisonDroplet,
+    .anims = &sAnims_PoisonProjectile[1],
     .images = NULL,
     .affineAnims = gAffineAnims_Droplet,
     .callback = AnimAcidPoisonDroplet,


### PR DESCRIPTION
## Description
It combines three incorrectly separated arrays into a single array, the separated array causes issues if compiler reorders array offsets e.g. this causes a crash in PC port when the move sludge is used with animations on because the arrays are compiled in different offsets which causes unmapped memory access.

## **Discord contact info**
nt_x86