### PR TITLE
Fix Pokeblock script missing a releaseall

### DIFF
--- a/data/scripts/safari_zone.inc
+++ b/data/scripts/safari_zone.inc
@@ -53,6 +53,9 @@ SafariZone_EventScript_ChoosePokeblock::
 	special OpenPokeblockCaseOnFeeder
 	waitstate
 	goto_if_ne VAR_RESULT, 0xFFFF, SafariZone_EventScript_PokeblockPlaced
+#ifdef BUGFIX
+	releaseall  @ Only gets called from EventScript_PokeBlockFeeder which uses lockall.
+#endif
 	end
 
 SafariZone_EventScript_PokeblockPlaced::


### PR DESCRIPTION
## Description
That script will only get called from `SafariZone_EventScript_ChoosePokeblock` which uses a lockall.
I don't think this have any impact in vanilla, but fixes other systems that interact with that system.
In my current rom hack the poor follower was left behind once you cancelled using a PokeBlock.

![image](https://github.com/pret/pokeemerald/assets/18596778/4ee222d5-d502-4817-9deb-70c1ee8c8cce)


## **Discord contact info**
671gz
