### PR TITLE
Fix build on NixOS and add instructions to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -354,6 +354,13 @@ Then proceed to [Choosing where to store pokeemerald (Linux)](#choosing-where-to
 >   [install devkitARM on Arch Linux](#installing-devkitarm-on-arch-linux).
 </details>
 
+### NixOS
+Run the following command to start an interactive shell with the necessary packages:
+```bash
+nix-shell -p pkgsCross.arm-embedded.stdenv.cc git pkg-config libpng
+```
+Then proceed to [Choosing where to store pokeemerald Expansion (Linux)](#choosing-where-to-store-pokeemerald-expansion-linux).
+
 ### Other distributions
 _(Specific instructions for other distributions would be greatly appreciated!)_
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ MODERN_ELF_NAME := $(MODERN_ROM_NAME:.gba=.elf)
 MODERN_MAP_NAME := $(MODERN_ROM_NAME:.gba=.map)
 MODERN_OBJ_DIR_NAME := build/modern
 
-SHELL := /bin/bash -o pipefail
+SHELL := bash -o pipefail
 
 ELF = $(ROM:.gba=.elf)
 MAP = $(ROM:.gba=.map)

--- a/asmdiff.sh
+++ b/asmdiff.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ -d "$DEVKITARM/bin/" ]]; then
     OBJDUMP_BIN="$DEVKITARM/bin/arm-none-eabi-objdump"


### PR DESCRIPTION
## Description
This fixes a build error on NixOS caused by bash not being at /bin/bash, and adds instructions for building on NixOS to INSTALL.md. It does *not* include instructions for installing devkitARM, as devkitARM cannot be installed on NixOS without hacks that would almost certainly not be considered supported, but `make modern` works with the distribution's `arm-none-eabi` toolchain.

Also see https://github.com/pret/agbcc/pull/70.

## **Discord contact info**
leo60228