### PR TITLE
Fixed bottom half of Mt. Pyre not being labeled in PokeNav

### DIFF
--- a/src/landmark.c
+++ b/src/landmark.c
@@ -369,8 +369,13 @@ static const struct LandmarkList sLandmarkLists[] =
     {MAPSEC_ROUTE_120, 2, Landmarks_Route120_2},
     {MAPSEC_ROUTE_121, 2, Landmarks_Route121_2},
     {MAPSEC_ROUTE_122, 0, Landmarks_Route122_0},
+#ifdef BUGFIX
+    {MAPSEC_ROUTE_122, 1, Landmarks_Route122_0},
+    {MAPSEC_ROUTE_123, 0, Landmarks_Route123_0},
+#else
     {MAPSEC_ROUTE_123, 0, Landmarks_Route123_0},
     {MAPSEC_ROUTE_122, 1, Landmarks_Route122_0},
+#endif
     {MAPSEC_ROUTE_124, 7, Landmarks_Route124_7},
     {MAPSEC_ROUTE_125, 2, Landmarks_Route125_2},
     {MAPSEC_ROUTE_128, 1, Landmarks_Route128_1},


### PR DESCRIPTION
## Description
When zoomed in on the PokeNav, only the top half of Mt. Pyre gets labeled. This PR fixes that for anyone who defines BUGFIX

## **Discord contact info**
Frankfurter