### PR TITLE
preproc: support arbitrary expressions in enums

### DIFF
--- a/tools/preproc/asm_file.cpp
+++ b/tools/preproc/asm_file.cpp
@@ -520,6 +520,7 @@ bool AsmFile::ParseEnum()
     long currentHeaderLine = SkipWhitespaceAndEol();
     std::string enumName = ReadIdentifier();
     currentHeaderLine += SkipWhitespaceAndEol();
+    std::string enumBase = "0";
     long enumCounter = 0;
     long symbolCount = 0;
 
@@ -542,11 +543,28 @@ bool AsmFile::ParseEnum()
             if (m_buffer[m_pos] == '=')
             {
                 m_pos++;
-                currentHeaderLine += SkipWhitespaceAndEol();
-                enumCounter = ReadInteger(headerFilename, currentHeaderLine);
-                currentHeaderLine += SkipWhitespaceAndEol();
+                SkipWhitespace();
+                enumBase.clear();
+                for (;;)
+                {
+                    if (m_pos == m_size)
+                        RaiseError("unexpected EOF");
+                    if (m_buffer[m_pos] == ',')
+                        break;
+                    if (m_buffer[m_pos] == '\n')
+                    {
+                        currentHeaderLine++;
+                        enumBase.push_back(' ');
+                    }
+                    else
+                    {
+                        enumBase.push_back(m_buffer[m_pos]);
+                    }
+                    m_pos++;
+                }
+                enumCounter = 0;
             }
-            std::printf(".equiv %s, %ld\n", currentIdentName.c_str(), enumCounter);
+            std::printf(".equiv %s, (%s) + %ld\n", currentIdentName.c_str(), enumBase.c_str(), enumCounter);
             enumCounter++;
             symbolCount++;
         }


### PR DESCRIPTION
Fixes #2019 

There are probably still cases that don't work. Anything involving `sizeof` comes to mind, or any expressions which are handled differently by `as` than `gcc`... But this hopefully should fix most—if not all—of the realistic examples?

Tested with SBird's example:
```c
enum Bar {
    BAR_0 = 0,
    BAR_1 = 1,
};

enum {
    VALUE_0 = 0,
    VALUE_1, // 1
    VALUE_2, // 2
    VALUE_2a = BAR_1,
    VALUE_3
};
```
```sh
$ tools/preproc/preproc example.s charmap.txt | cpp -I include - | tools/preproc/preproc -ie example.s charmap.txt
# 1 "example.s"
# 0 "<stdin>"
# 0 "<built-in>"
# 0 "<command-line>"
# 1 "/nix/store/0c5jp9d9h9818arr6s21xibgjl1ybql0-glibc-2.39-52-dev/include/stdc-predef.h" 1 3 4
# 0 "<command-line>" 2
# 1 "<stdin>"
# 1 "example.s"
# 2 "example.s"
.equiv BAR_0, (0) + 0
# 3 "example.s"
.equiv BAR_1, (1) + 0

# 7 "example.s"
.equiv VALUE_0, (0) + 0
# 8 "example.s"
.equiv VALUE_1, (0) + 1
# 9 "example.s"
.equiv VALUE_2, (0) + 2
# 10 "example.s"
.equiv VALUE_2a, (BAR_1) + 0
# 11 "example.s"
.equiv VALUE_3, (BAR_1) + 1

$ tools/preproc/preproc example.s charmap.txt | cpp -I include - | tools/preproc/preproc -ie example.s charmap.txt | arm-none-eabi-as
$ readelf -s a.out

Symbol table '.symtab' contains 12 entries:
   Num:    Value  Size Type    Bind   Vis      Ndx Name
     0: 00000000     0 NOTYPE  LOCAL  DEFAULT  UND 
     1: 00000000     0 SECTION LOCAL  DEFAULT    1 .text
     2: 00000000     0 SECTION LOCAL  DEFAULT    2 .data
     3: 00000000     0 SECTION LOCAL  DEFAULT    3 .bss
     4: 00000000     0 NOTYPE  LOCAL  DEFAULT  ABS BAR_0
     5: 00000001     0 NOTYPE  LOCAL  DEFAULT  ABS BAR_1
     6: 00000000     0 NOTYPE  LOCAL  DEFAULT  ABS VALUE_0
     7: 00000001     0 NOTYPE  LOCAL  DEFAULT  ABS VALUE_1
     8: 00000002     0 NOTYPE  LOCAL  DEFAULT  ABS VALUE_2
     9: 00000001     0 NOTYPE  LOCAL  DEFAULT  ABS VALUE_2a
    10: 00000002     0 NOTYPE  LOCAL  DEFAULT  ABS VALUE_3
    11: 00000000     0 SECTION LOCAL  DEFAULT    4 .ARM.attributes
```