### PR TITLE
Bugfix for cable car hikerGraphicsIds array

### DIFF
--- a/src/cable_car.c
+++ b/src/cable_car.c
@@ -881,7 +881,7 @@ static void CreateCableCarSprites(void)
     if ((rval % 64) == 0)
     {
         // BUGFIX: The - 1 in the below ARRAY_COUNT means the Zigzagoon is never used
-#ifdef #BUGFIX
+#ifdef BUGFIX
         spriteId = CreateObjectGraphicsSprite(hikerGraphicsIds[rval % ARRAY_COUNT(hikerGraphicsIds)], hikerCallbacks[GOING_DOWN], hikerCoords[GOING_DOWN][0], hikerCoords[GOING_DOWN][1], 106);
 #else
         spriteId = CreateObjectGraphicsSprite(hikerGraphicsIds[rval % (ARRAY_COUNT(hikerGraphicsIds) - 1)], hikerCallbacks[GOING_DOWN], hikerCoords[GOING_DOWN][0], hikerCoords[GOING_DOWN][1], 106);

--- a/src/cable_car.c
+++ b/src/cable_car.c
@@ -880,8 +880,12 @@ static void CreateCableCarSprites(void)
     // 1/64 chance for an NPC to appear hiking on the ground below the Cable Car
     if ((rval % 64) == 0)
     {
-        // Unclear if this was intentional, but the - 1 in the below ARRAY_COUNT means the Zigzagoon is never used
+        // BUGFIX: The - 1 in the below ARRAY_COUNT means the Zigzagoon is never used
+#ifdef #BUGFIX
+        spriteId = CreateObjectGraphicsSprite(hikerGraphicsIds[rval % ARRAY_COUNT(hikerGraphicsIds)], hikerCallbacks[GOING_DOWN], hikerCoords[GOING_DOWN][0], hikerCoords[GOING_DOWN][1], 106);
+#else
         spriteId = CreateObjectGraphicsSprite(hikerGraphicsIds[rval % (ARRAY_COUNT(hikerGraphicsIds) - 1)], hikerCallbacks[GOING_DOWN], hikerCoords[GOING_DOWN][0], hikerCoords[GOING_DOWN][1], 106);
+#endif
         if (spriteId != MAX_SPRITES)
         {
             gSprites[spriteId].oam.priority = 2;


### PR DESCRIPTION
## Description
During the Cable Car transition cutscene, there's a 1/64 chance for an NPC sprite to appear walking below. The available NPCs include the Hiker, Camper, Picnicker, and Zigzagoon. However, due to the use of `ARRAY_COUNT(hikerGraphicsIds) - 1`, it is impossible for Zigzagoon to appear during the cable car cutscene.

It seems this is an oversight by Game Freak, as there is no clear rationale for including Zigzagoon in the array of NPCs if the intent was for it not to appear during this cutscene.

**Proposed solution:** remove the `- 1` from the array count.

## **Discord contact info**
Scyrous
