### PR TITLE
[preproc] support C23 enum underlying type syntax

### DIFF
--- a/tools/preproc/asm_file.cpp
+++ b/tools/preproc/asm_file.cpp
@@ -524,6 +524,17 @@ bool AsmFile::ParseEnum()
     long enumCounter = 0;
     long symbolCount = 0;
 
+    if (m_buffer[m_pos] == ':') // : <type>
+    {
+        m_pos++;
+        std::string underlyingType;
+        do {
+            currentHeaderLine += SkipWhitespaceAndEol();
+            underlyingType = ReadIdentifier();
+        } while (!underlyingType.empty());
+        currentHeaderLine += SkipWhitespaceAndEol();
+    }
+
     if (m_buffer[m_pos] != '{') // assume assembly macro, otherwise assume enum and report errors accordingly
     {
         m_pos = fallbackPosition - 4;


### PR DESCRIPTION
Introduces support for the C23 underlying type `enum` syntax. We wouldn't be able to use that syntax with `agbcc`, but it's potentially helpful for projects which exclusively use `make modern` (e.g. Expansion from v1.10 onward).

The `do`-`while` loop is to support things like `enum : unsigned char { ... };`, albeit I don't expect we'll see anything like that in practice.