### PR TITLE
Fix typo: | should be || in Task_TryFieldPoisonWhiteOut

### DIFF
--- a/src/field_poison.c
+++ b/src/field_poison.c
@@ -89,7 +89,11 @@ static void Task_TryFieldPoisonWhiteOut(u8 taskId)
         if (AllMonsFainted())
         {
             // Battle facilities have their own white out script to handle the challenge loss
+#ifdef BUGFIX
+            if (InBattlePyramid() || InBattlePike() || InTrainerHillChallenge())
+#else
             if (InBattlePyramid() | InBattlePike() || InTrainerHillChallenge())
+#endif
                 gSpecialVar_Result = FLDPSN_FRONTIER_WHITEOUT;
             else
                 gSpecialVar_Result = FLDPSN_WHITEOUT;


### PR DESCRIPTION
Yes, this is honestly overkill, as it doesn't actually fix any behavioral bugs, but I was suggested to do this. This was a typo made in the source that Game Freak made, and the compiler warns against this. I opened a PR in pokeemerald expansion and was suggested to open one here.

<!--- Provide a general summary of your changes in the Title above -->

## **Discord contact info**
<!--- Formatted as username (e.g. pikalaxalt) or username#numbers (e.g. PikalaxALT#5823) -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
RoseSilicon