### PR TITLE
Remove unnecessary looping for rule generation and unroll macros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,69 +297,52 @@ endif
 # As a side effect, they're evaluated immediately instead of when the rule is invoked.
 # It doesn't look like $(shell) can be deferred so there might not be a better way (Icedude_907: there is soon).
 
-# For C dependencies.
-# Args: $1 = Output file without extension (build/assets/src/data), $2 = Input file (src/data.c)
-define C_DEP
-$(call C_DEP_IMPL,$1,$2,$1)
-endef
-# Internal implementation details.
-# $1: Output file without extension, $2 input file, $3 temp path (if keeping)
-define C_DEP_IMPL
-$1.o: $2
+$(C_BUILDDIR)/%.o: $(C_SUBDIR)/%.c
 ifneq ($(KEEP_TEMPS),1)
-	@echo "$$(CC1) <flags> -o $$@ $$<"
-	@$$(CPP) $$(CPPFLAGS) $$< | $$(PREPROC) -i $$< charmap.txt | $$(CC1) $$(CFLAGS) -o - - | cat - <(echo -e ".text\n\t.align\t2, 0") | $$(AS) $$(ASFLAGS) -o $$@ -
+	@echo "$(CC1) <flags> -o $@ $<"
+	@$(CPP) $(CPPFLAGS) $< | $(PREPROC) -i $< charmap.txt | $(CC1) $(CFLAGS) -o - - | cat - <(echo -e ".text\n\t.align\t2, 0") | $(AS) $(ASFLAGS) -o $@ -
 else
-	@$$(CPP) $$(CPPFLAGS) $$< -o $3.i
-	@$$(PREPROC) $3.i charmap.txt | $$(CC1) $$(CFLAGS) -o $3.s
-	@echo -e ".text\n\t.align\t2, 0\n" >> $3.s
-	$$(AS) $$(ASFLAGS) -o $$@ $3.s
+	@$(CPP) $(CPPFLAGS) $< -o $*.i
+	@$(PREPROC) $*.i charmap.txt | $(CC1) $(CFLAGS) -o $*.s
+	@echo -e ".text\n\t.align\t2, 0\n" >> $*.s
+	$(AS) $(ASFLAGS) -o $@ $*.s
 endif
+
+$(C_BUILDDIR)/%.d: $(C_SUBDIR)/%.c
+	$(SCANINC) -M $@ $(INCLUDE_SCANINC_ARGS) -I tools/agbcc/include $<
+
 ifneq ($(NODEP),1)
-$1.d: $2
-	$(SCANINC) -M $1.d $(INCLUDE_SCANINC_ARGS) -I tools/agbcc/include $2
--include $1.d
-endif
-endef
-
-# Create generic rules if no dependency scanning, else create the real rules
-ifeq ($(NODEP),1)
-$(eval $(call C_DEP,$(C_BUILDDIR)/%,$(C_SUBDIR)/%.c))
-else
-$(foreach src,$(C_SRCS),$(eval $(call C_DEP,$(OBJ_DIR)/$(basename $(src)),$(src))))
+-include $(addprefix $(OBJ_DIR)/,$(C_SRCS:.c=.d))
 endif
 
-# Similar methodology for Assembly files
-# $1: Output path without extension, $2: Input file (`*.s`)
-define ASM_DEP
-$1.o: $2
-	$$(AS) $$(ASFLAGS) -o $$@ $$<
-$(call ASM_SCANINC,$1,$2)
-endef
-# As above but first doing a preprocessor pass
-define ASM_DEP_PREPROC
-$1.o: $2
-	$$(PREPROC) $$< charmap.txt | $$(CPP) $(INCLUDE_SCANINC_ARGS) - | $$(PREPROC) -ie $$< charmap.txt | $$(AS) $$(ASFLAGS) -o $$@
-$(call ASM_SCANINC,$1,$2)
-endef
+$(ASM_BUILDDIR)/%.o: $(ASM_SUBDIR)/%.s
+	$(AS) $(ASFLAGS) -o $@ $<
 
-define ASM_SCANINC
+$(ASM_BUILDDIR)/%.d: $(ASM_SUBDIR)/%.s
+	$(SCANINC) -M $@ $(INCLUDE_SCANINC_ARGS) -I "" $<
+
 ifneq ($(NODEP),1)
-$1.d: $2
-	$(SCANINC) -M $1.d $(INCLUDE_SCANINC_ARGS) -I "" $2
--include $1.d
+-include $(addprefix $(OBJ_DIR)/,$(ASM_SRCS:.s=.d))
 endif
-endef
 
-# Dummy rules or real rules
-ifeq ($(NODEP),1)
-$(eval $(call ASM_DEP,$(ASM_BUILDDIR)/%,$(ASM_SUBDIR)/%.s))
-$(eval $(call ASM_DEP_PREPROC,$(C_BUILDDIR)/%,$(C_SUBDIR)/%.s))
-$(eval $(call ASM_DEP_PREPROC,$(DATA_ASM_BUILDDIR)/%,$(DATA_ASM_SUBDIR)/%.s))
-else
-$(foreach src, $(ASM_SRCS), $(eval $(call ASM_DEP,$(src:%.s=$(OBJ_DIR)/%),$(src))))
-$(foreach src, $(C_ASM_SRCS), $(eval $(call ASM_DEP_PREPROC,$(src:%.s=$(OBJ_DIR)/%),$(src))))
-$(foreach src, $(REGULAR_DATA_ASM_SRCS), $(eval $(call ASM_DEP_PREPROC,$(src:%.s=$(OBJ_DIR)/%),$(src))))
+$(C_BUILDDIR)/%.o: $(C_SUBDIR)/%.s
+	$(PREPROC) $< charmap.txt | $(CPP) $(INCLUDE_SCANINC_ARGS) - | $(PREPROC) -ie $< charmap.txt | $(AS) $(ASFLAGS) -o $@
+
+$(C_BUILDDIR)/%.d: $(C_SUBDIR)/%.s
+	$(SCANINC) -M $@ $(INCLUDE_SCANINC_ARGS) -I "" $<
+
+ifneq ($(NODEP),1)
+-include $(addprefix $(OBJ_DIR)/,$(C_ASM_SRCS:.s=.d))
+endif
+
+$(DATA_ASM_BUILDDIR)/%.o: $(DATA_ASM_SUBDIR)/%.s
+	$(PREPROC) $< charmap.txt | $(CPP) $(INCLUDE_SCANINC_ARGS) - | $(PREPROC) -ie $< charmap.txt | $(AS) $(ASFLAGS) -o $@
+
+$(DATA_ASM_BUILDDIR)/%.d: $(DATA_ASM_SUBDIR)/%.s
+	$(SCANINC) -M $@ $(INCLUDE_SCANINC_ARGS) -I "" $<
+
+ifneq ($(NODEP),1)
+-include $(addprefix $(OBJ_DIR)/,$(REGULAR_DATA_ASM_SRCS:.s=.d))
 endif
 
 $(OBJ_DIR)/sym_bss.ld: sym_bss.txt


### PR DESCRIPTION
Due to the addition of proper dependency scanning and .d files, the big
amount of confusing and hard-to-read macros that were used before,
aren't necessary anymore. NODEP is kept, and has the same behavior.
