### PR TITLE
BUGFIX: Have fallback if level is 1

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2911,7 +2911,13 @@ u8 GetLevelFromMonExp(struct Pokemon *mon)
     while (level <= MAX_LEVEL && gExperienceTables[gSpeciesInfo[species].growthRate][level] <= exp)
         level++;
 
+    // In the event gExperience level is changed and level is 1, to prevent level from being 0.
+    // Does not happen in vanilla.
+#ifdef BUGFIX
+    return level <= 1 ? 1 : level - 1;
+#else
     return level - 1;
+#endif
 }
 
 u8 GetLevelFromBoxMonExp(struct BoxPokemon *boxMon)

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2914,7 +2914,7 @@ u8 GetLevelFromMonExp(struct Pokemon *mon)
     // In the event gExperience level is changed and level is 1, to prevent level from being 0.
     // Does not happen in vanilla.
 #ifdef BUGFIX
-    return level <= 1 ? 1 : level - 1;
+    return level > 1 ? level - 1 : 1;
 #else
     return level - 1;
 #endif

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2911,7 +2911,7 @@ u8 GetLevelFromMonExp(struct Pokemon *mon)
     while (level <= MAX_LEVEL && gExperienceTables[gSpeciesInfo[species].growthRate][level] <= exp)
         level++;
 
-    // In the event gExperience level is changed and level is 1, to prevent level from being 0.
+    // In the event gExperienceTables is changed and level is 1, to prevent level from being 0.
     // Does not happen in vanilla.
 #ifdef BUGFIX
     return level > 1 ? level - 1 : 1;
@@ -2929,7 +2929,13 @@ u8 GetLevelFromBoxMonExp(struct BoxPokemon *boxMon)
     while (level <= MAX_LEVEL && gExperienceTables[gSpeciesInfo[species].growthRate][level] <= exp)
         level++;
 
+    // In the event gExperienceTables is changed and level is 1, to prevent level from being 0.
+    // Does not happen in vanilla.
+#ifdef BUGFIX
+    return level > 1 ? level - 1 : 1;
+#else
     return level - 1;
+#endif
 }
 
 u16 GiveMoveToMon(struct Pokemon *mon, u16 move)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This does not happen in vanilla, but in the event level is 1, prevent GetLevelFromMonExp from returning 0.