### PR TITLE
Improved support for the CLion IDE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,11 @@ SHELL := bash -o pipefail
 ASFLAGS := -mcpu=arm7tdmi --defsym MODERN=$(MODERN)
 
 INCLUDE_DIRS := include
-INCLUDE_CPP_ARGS := $(INCLUDE_DIRS:%=-iquote %)
+ifdef CLION_IDE
+  INCLUDE_CPP_ARGS := $(INCLUDE_DIRS:%=-iquote%)
+else
+  INCLUDE_CPP_ARGS := $(INCLUDE_DIRS:%=-iquote %)
+endif
 INCLUDE_SCANINC_ARGS := $(INCLUDE_DIRS:%=-I %)
 
 O_LEVEL ?= 2

--- a/include/global.h
+++ b/include/global.h
@@ -24,7 +24,7 @@
 #define NAKED __attribute__((naked))
 
 /// IDE support
-#if defined(__APPLE__) || defined(__CYGWIN__) || defined(__INTELLISENSE__)
+#if defined(__APPLE__) || defined(__CYGWIN__) || defined(__INTELLISENSE__) || defined(__CLION_IDE__)
 // We define these when using certain IDEs to fool preproc
 #define _(x)        {x}
 #define __(x)       {x}


### PR DESCRIPTION
## Description

When loading the project in the JetBrains CLion, the IDE would not properly resolve includes from the `include/` directory.

That's because apparently, CLion does not understand the `-iquote include` flag when parsing the `Makefile`, but it _does_ unterstand `-iquoteinclude` without the space.

I realise that that's probably more of an issue with CLion itself as the syntax with space seems to be valid. But for better or worse, at least this fixed my immediate issue of not being able to properly use the project in CLion.

Because I'm not entirely sure if that syntax will work with other tools as well, I've put it in a clunky `ifdef` block inside the `Makefile`.

I have also added CLion's compiler flag to the dummy defines in `include/global.h`.

**Before**
![image](https://github.com/user-attachments/assets/e3958e6d-d3a9-4480-aa1a-c0698b4d158f)

**After**
![image](https://github.com/user-attachments/assets/7c57316b-cf47-4b58-965c-815949886b0d)


## **Discord contact info**

untitled_tino
