### PR TITLE
Add fix for possible crash when decompressing trainer back pics

### DIFF
--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -710,9 +710,17 @@ void DecompressTrainerFrontPic(u16 frontPicId, u8 battlerId)
 void DecompressTrainerBackPic(u16 backPicId, u8 battlerId)
 {
     u8 position = GetBattlerPosition(battlerId);
+#ifdef BUGFIX
+    CpuCopy32(gTrainerBackPicTable[backPicId].data, gMonSpritesGfxPtr->sprites.ptr[position], gTrainerBackPicTable[backPicId].size);
+#else
+    // Trainer back pics aren't compressed!
+    // Attempting to decompress the uncompressed data can softlock or crash the game.
+    // This is ok in vanilla by chance, because the pixels in the trainer back sprites that correspond
+    // to the compressed data's header are all 0, so the decompression does nothing.
     DecompressPicFromTable_2(&gTrainerBackPicTable[backPicId],
                              gMonSpritesGfxPtr->sprites.ptr[position],
                              SPECIES_NONE);
+#endif
     LoadCompressedPalette(gTrainerBackPicPaletteTable[backPicId].data,
                           OBJ_PLTT_ID(battlerId), PLTT_SIZE_4BPP);
 }

--- a/src/trainer_pokemon_sprites.c
+++ b/src/trainer_pokemon_sprites.c
@@ -57,10 +57,11 @@ bool16 ResetAllPicSprites(void)
     return FALSE;
 }
 
-static bool16 DecompressPic(u16 species, u32 personality, bool8 isFrontPic, u8 *dest, bool8 isTrainer, bool8 ignoreDeoxys)
+static bool16 DecompressPic(u16 picId, u32 personality, bool8 isFrontPic, u8 *dest, bool8 isTrainer, bool8 ignoreDeoxys)
 {
     if (!isTrainer)
     {
+        u16 species = picId;
         if (isFrontPic)
         {
             if (!ignoreDeoxys)
@@ -78,10 +79,23 @@ static bool16 DecompressPic(u16 species, u32 personality, bool8 isFrontPic, u8 *
     }
     else
     {
+        u16 trainerPicId = picId;
         if (isFrontPic)
-            DecompressPicFromTable(&gTrainerFrontPicTable[species], dest, species);
+        {
+            DecompressPicFromTable(&gTrainerFrontPicTable[trainerPicId], dest, trainerPicId);
+        }
         else
-            DecompressPicFromTable(&gTrainerBackPicTable[species], dest, species);
+        {
+#ifdef BUGFIX
+            CpuCopy32(gTrainerBackPicTable[trainerPicId].data, dest, gTrainerBackPicTable[trainerPicId].size);
+#else
+            // Trainer back pics aren't compressed!
+            // Attempting to decompress the uncompressed data can softlock or crash the game.
+            // This is ok in vanilla by chance, because the pixels in the trainer back sprites that correspond
+            // to the compressed data's header are all 0, so the decompression does nothing.
+            DecompressPicFromTable(&gTrainerBackPicTable[trainerPicId], dest, trainerPicId);
+#endif
+        }
     }
     return FALSE;
 }


### PR DESCRIPTION
Adding a `BUGFIX` for an issue found by @hedara90 while working on their decompressor. It's perhaps a slightly fragile fix (it's now assuming data that should be compressed isn't) but the problem there should be much more obvious than the current issue.

(incidentally, renamed the confusing variable calling trainer front/back pic IDs `species`)