### PR TITLE
extern gAncientPowerRockSpriteTemplate fix

### DIFF
--- a/src/intro.c
+++ b/src/intro.c
@@ -110,7 +110,7 @@ static void MainCB2_EndIntro(void);
 
 extern const struct CompressedSpriteSheet gBattleAnimPicTable[];
 extern const struct CompressedSpritePalette gBattleAnimPaletteTable[];
-extern const struct SpriteTemplate gAncientPowerRockSpriteTemplate[];
+extern const struct SpriteTemplate gAncientPowerRockSpriteTemplate;
 
 enum {
     COPYRIGHT_INITIALIZE,
@@ -1993,7 +1993,7 @@ static void CreateGroudonRockSprites(u8 taskId)
 
     for (i = 0; i < (int)ARRAY_COUNT(sGroudonRockData); i++)
     {
-        spriteId = CreateSprite(gAncientPowerRockSpriteTemplate, sGroudonRockData[i][0], DISPLAY_HEIGHT, i);
+        spriteId = CreateSprite(&gAncientPowerRockSpriteTemplate, sGroudonRockData[i][0], DISPLAY_HEIGHT, i);
         gSprites[spriteId].callback = SpriteCB_GroudonRocks;
         gSprites[spriteId].oam.priority = 0;
         gSprites[spriteId].sRockId = i;


### PR DESCRIPTION
Since it's `const struct SpriteTemplate gAncientPowerRockSpriteTemplate =` in `battle_anim_rock.c` and not an array