### PR TITLE
remove undef TASK_NONE from list_menu

### DIFF
--- a/src/list_menu.c
+++ b/src/list_menu.c
@@ -678,8 +678,6 @@ static void ListMenuDrawCursor(struct ListMenu *list)
     }
 }
 
-#undef TASK_NONE
-
 static u8 ListMenuAddCursorObject(struct ListMenu *list, u32 cursorObjId)
 {
     struct CursorStruct cursor;


### PR DESCRIPTION
TASK_NONE is defined in `include/task.h` and there's no reason to undef it. I assume it's a leftover from when it wasn't defined there.