### PR TITLE
extern void * const gNullScriptPtr;

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -29,7 +29,7 @@ static bool8 sLockFieldControls;
 
 extern ScrCmdFunc gScriptCmdTable[];
 extern ScrCmdFunc gScriptCmdTableEnd[];
-extern void *gNullScriptPtr;
+extern void * const gNullScriptPtr;
 
 void InitScriptContext(struct ScriptContext *ctx, void *cmdTable, void *cmdTableEnd)
 {


### PR DESCRIPTION
For consistency with `src/scrcmd.c` `void * const gNullScriptPtr = NULL;`