### PR TITLE
Extern gSprites and gOamMatrices with known array size

### DIFF
--- a/include/sprite.h
+++ b/include/sprite.h
@@ -1,6 +1,7 @@
 #ifndef GUARD_SPRITE_H
 #define GUARD_SPRITE_H
 
+#define OAM_MATRIX_COUNT 32
 #define MAX_SPRITES 64
 #define SPRITE_NONE 0xFF
 #define TAG_NONE 0xFFFF
@@ -254,12 +255,12 @@ extern const union AffineAnimCmd *const gDummySpriteAffineAnimTable[];
 extern const struct SpriteTemplate gDummySpriteTemplate;
 
 extern u8 gReservedSpritePaletteCount;
-extern struct Sprite gSprites[];
+extern struct Sprite gSprites[MAX_SPRITES + 1];
 extern u8 gOamLimit;
 extern u16 gReservedSpriteTileCount;
 extern s16 gSpriteCoordOffsetX;
 extern s16 gSpriteCoordOffsetY;
-extern struct OamMatrix gOamMatrices[];
+extern struct OamMatrix gOamMatrices[OAM_MATRIX_COUNT];
 extern bool8 gAffineAnimsDisabled;
 
 void ResetSpriteData(void);

--- a/src/sprite.c
+++ b/src/sprite.c
@@ -5,8 +5,6 @@
 
 #define MAX_SPRITE_COPY_REQUESTS 64
 
-#define OAM_MATRIX_COUNT 32
-
 #define sAnchorX data[6]
 #define sAnchorY data[7]
 


### PR DESCRIPTION
This will be useful when working with modern, as it'll be able to (sometimes) detect if there was an attempted write past the array bounds.
For example, it should catch sth like `gSprites[0xFF].field = 0`;