### PR TITLE
switched from head -c 12 to dd bs=1 count=12, to support OpenBSD.

### DIFF
--- a/graphics_file_rules.mk
+++ b/graphics_file_rules.mk
@@ -428,7 +428,7 @@ $(RAYQUAZAGFXDIR)/scene_3/rayquaza.4bpp: %.4bpp: %.png
 
 $(RAYQUAZAGFXDIR)/scene_3/rayquaza_tail_fix.4bpp: $(RAYQUAZAGFXDIR)/scene_3/rayquaza_tail.4bpp
 	cp $< $@
-	head -c 12 /dev/zero >> $@
+	dd if=/dev/zero bs=1 count=12 >> $@
 
 $(RAYQUAZAGFXDIR)/scene_4/streaks.4bpp: %.4bpp: %.png
 	$(GFX) $< $@ -num_tiles 19 -Wnum_tiles


### PR DESCRIPTION
OpenBSD's head don't support -c parameter, so dd can be used.

## Description
head -c 12 /dev/zero >> $@ 
is the same as:
dd if=/dev/zero bs=1 count=12 >> $@

but it will support OpenBSD.

## **Discord contact info**

FOSS-Unixlover
