### PR TITLE
Fixed potential unaligned issue in PC screen

### DIFF
--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -432,7 +432,7 @@ struct PokemonStorageSystemData
     u16 scrollUnused5; // Never read
     u16 scrollUnused6; // Never read
     u8 filler1[22];
-    u8 boxTitleTiles[1024];
+    u8 ALIGNED(2) boxTitleTiles[1024];
     u8 boxTitleCycleId;
     u8 wallpaperLoadState; // Written to, but never read.
     u8 wallpaperLoadBoxId;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`boxTitleTiles` most be `u16` aligned for the box title to display correctly.
Example of unalignment created by resizing `filler1[23]`.
![20250114_09h45m05s_grim](https://github.com/user-attachments/assets/07b1b65c-32a4-4712-8cd8-def169537625)
And with `ALIGN(2)`
![20250114_09h47m31s_grim](https://github.com/user-attachments/assets/a3746a3d-d071-49c0-97ed-d09fb61c963d)

`make compare` returns `OK` after the change.

## **Discord contact info**
<!--- Formatted as username (e.g. pikalaxalt) or username#numbers (e.g. PikalaxALT#5823) -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
hedara