### PR TITLE
no longer pad PNG palette

### DIFF
--- a/tools/gbagfx/gfx.c
+++ b/tools/gbagfx/gfx.c
@@ -557,12 +557,6 @@ void ReadGbaPalette(char *path, struct Palette *palette)
 		palette->colors[i].green = UPCONVERT_BIT_DEPTH(GET_GBA_PAL_GREEN(paletteEntry));
 		palette->colors[i].blue = UPCONVERT_BIT_DEPTH(GET_GBA_PAL_BLUE(paletteEntry));
 	}
-	// png can only accept 16 or 256 colors, so fill the remainder with black
-	if (palette->numColors > 16)
-    {
-	    memset(&palette->colors[palette->numColors], 0, (256 - palette->numColors) * sizeof(struct Color));
-	    palette->numColors = 256;
-    }
 
 	free(data);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removes gbagfx code that pads the PNG palette to 256 colors.
## Description
<!--- Describe your changes in detail -->
When converting GBA graphics to PNG, if the gbapal file provided has less than 256 colors (and more than 16), it is padded with zeros, because gbagfx assumes that the PNG format can only accept 16 or 256 colors when a palette is used (as seen by the removed comment). It might be worth checking if any PNGs in the repo have more colors than needed in their palette, and regenerating them if so.