### PR TITLE
Fixed switchout bug in multibattle where order of mons gets messed up

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7210,18 +7210,18 @@ static void Cmd_forcerandomswitch(void)
             {
                 firstMonId = PARTY_SIZE / 2;
                 #ifdef BUGFIX
-                    lastMonId = PARTY_SIZE - 1;
+                lastMonId = PARTY_SIZE; - 1
                 #else
-                    lastMonId = PARTY_SIZE;
+                lastMonId = PARTY_SIZE;
                 #endif
             }
             else
             {
                 firstMonId = 0;
                 #ifdef BUGFIX
-                    lastMonId = PARTY_SIZE / 2 - 1;
+                lastMonId = PARTY_SIZE / 2 - 1;
                 #else
-                    lastMonId = PARTY_SIZE;
+                lastMonId = PARTY_SIZE / 2;
                 #endif
             }
             monsCount = PARTY_SIZE / 2;
@@ -7236,18 +7236,18 @@ static void Cmd_forcerandomswitch(void)
             {
                 firstMonId = PARTY_SIZE / 2;
                 #ifdef BUGFIX
-                    lastMonId = PARTY_SIZE - 1;
+                lastMonId = PARTY_SIZE -  1;
                 #else
-                    lastMonId = PARTY_SIZE;
+                lastMonId = PARTY_SIZE;
                 #endif
             }
             else
             {
                 firstMonId = 0;
                 #ifdef BUGFIX
-                    lastMonId = PARTY_SIZE / 2 - 1;
+                lastMonId = PARTY_SIZE / 2 - 1;
                 #else
-                    lastMonId = PARTY_SIZE;
+                lastMonId = PARTY_SIZE / 2;
                 #endif
             }
             monsCount = PARTY_SIZE / 2;
@@ -7261,9 +7261,9 @@ static void Cmd_forcerandomswitch(void)
             {
                 firstMonId = 0;
                 #ifdef BUGFIX
-                    lastMonId = PARTY_SIZE - 1;
+                lastMonId = PARTY_SIZE - 1;
                 #else
-                    lastMonId = PARTY_SIZE;
+                lastMonId = PARTY_SIZE;
                 #endif
                 monsCount = PARTY_SIZE;
                 minNeeded = 2; // since there are two opponents, it has to be a double battle
@@ -7274,18 +7274,18 @@ static void Cmd_forcerandomswitch(void)
                 {
                     firstMonId = PARTY_SIZE / 2;
                     #ifdef BUGFIX
-                        lastMonId = PARTY_SIZE - 1;
+                    lastMonId = PARTY_SIZE - 1;
                     #else
-                        lastMonId = PARTY_SIZE;
+                    lastMonId = PARTY_SIZE;
                     #endif
                 }
                 else
                 {
                     firstMonId = 0;
                     #ifdef BUGFIX
-                        lastMonId = PARTY_SIZE / 2 - 1;
+                    lastMonId = PARTY_SIZE / 2 - 1;
                     #else
-                        lastMonId = PARTY_SIZE / 2;
+                    lastMonId = PARTY_SIZE / 2;
                     #endif
                 }
                 monsCount = PARTY_SIZE / 2;
@@ -7298,10 +7298,10 @@ static void Cmd_forcerandomswitch(void)
         {
             firstMonId = 0;
             #ifdef BUGFIX
-                lastMonId = PARTY_SIZE - 1;
+            lastMonId = PARTY_SIZE - 1;
             #else
-                lastMonId = PARTY_SIZE;
-            #endif           
+            lastMonId = PARTY_SIZE;
+            #endif
             monsCount = PARTY_SIZE;
             minNeeded = 2;
             battler2PartyId = gBattlerPartyIndexes[gBattlerTarget];
@@ -7311,10 +7311,10 @@ static void Cmd_forcerandomswitch(void)
         {
             firstMonId = 0;
             #ifdef BUGFIX
-                lastMonId = PARTY_SIZE - 1;
+            lastMonId = PARTY_SIZE - 1;
             #else
-                lastMonId = PARTY_SIZE;
-            #endif 
+            lastMonId = PARTY_SIZE;
+            #endif
             monsCount = PARTY_SIZE;
             minNeeded = 1;
             battler2PartyId = gBattlerPartyIndexes[gBattlerTarget]; // there is only one Pokémon out in single battles
@@ -7337,6 +7337,7 @@ static void Cmd_forcerandomswitch(void)
         }
         else
         {
+            #ifdef BUGFIX
             if (TryDoForceSwitchOut())
             {
                 do
@@ -7350,9 +7351,7 @@ static void Cmd_forcerandomswitch(void)
                 } while (GetMonData(&party[i], MON_DATA_SPECIES) == SPECIES_NONE
                        || GetMonData(&party[i], MON_DATA_IS_EGG) == TRUE
                        || GetMonData(&party[i], MON_DATA_HP) == 0); //should be one while loop, but that doesn't match.
-            
-        #ifdef BUGFIX
-                *(gBattleStruct->monToSwitchIntoId + gBattlerTarget) = i;
+            *(gBattleStruct->monToSwitchIntoId + gBattlerTarget) = i;
 
                 if (!IsMultiBattle())
                     SwitchPartyOrder(gBattlerTarget);
@@ -7369,25 +7368,39 @@ static void Cmd_forcerandomswitch(void)
                 if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER)
                     SwitchPartyOrderInGameMulti(gBattlerTarget, i);
             }
-        #else   
+            #else
+            if (TryDoForceSwitchOut())
+            {
+                do
+                {
+                    do
+                    {
+                        i = Random() % monsCount;
+                        i += firstMonId;
+                    }
+                    while (i == battler2PartyId || i == battler1PartyId);
+                } while (GetMonData(&party[i], MON_DATA_SPECIES) == SPECIES_NONE
+                       || GetMonData(&party[i], MON_DATA_IS_EGG) == TRUE
+                       || GetMonData(&party[i], MON_DATA_HP) == 0); //should be one while loop, but that doesn't match.
+            }
+            *(gBattleStruct->monToSwitchIntoId + gBattlerTarget) = i;
+
+            if (!IsMultiBattle())
+                SwitchPartyOrder(gBattlerTarget);
+
+            if ((gBattleTypeFlags & BATTLE_TYPE_LINK && gBattleTypeFlags & BATTLE_TYPE_BATTLE_TOWER)
+                || (gBattleTypeFlags & BATTLE_TYPE_LINK && gBattleTypeFlags & BATTLE_TYPE_MULTI)
+                || (gBattleTypeFlags & BATTLE_TYPE_RECORDED_LINK && gBattleTypeFlags & BATTLE_TYPE_BATTLE_TOWER)
+                || (gBattleTypeFlags & BATTLE_TYPE_RECORDED_LINK && gBattleTypeFlags & BATTLE_TYPE_MULTI))
+            {
+                SwitchPartyOrderLinkMulti(gBattlerTarget, i, 0);
+                SwitchPartyOrderLinkMulti(BATTLE_PARTNER(gBattlerTarget), i, 1);
+            }
+
+            if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER)
+                SwitchPartyOrderInGameMulti(gBattlerTarget, i);
+            #endif
         }
-        *(gBattleStruct->monToSwitchIntoId + gBattlerTarget) = i;
-
-        if (!IsMultiBattle())
-            SwitchPartyOrder(gBattlerTarget);
-
-        if ((gBattleTypeFlags & BATTLE_TYPE_LINK && gBattleTypeFlags & BATTLE_TYPE_BATTLE_TOWER)
-            || (gBattleTypeFlags & BATTLE_TYPE_LINK && gBattleTypeFlags & BATTLE_TYPE_MULTI)
-            || (gBattleTypeFlags & BATTLE_TYPE_RECORDED_LINK && gBattleTypeFlags & BATTLE_TYPE_BATTLE_TOWER)
-            || (gBattleTypeFlags & BATTLE_TYPE_RECORDED_LINK && gBattleTypeFlags & BATTLE_TYPE_MULTI))
-        {
-            SwitchPartyOrderLinkMulti(gBattlerTarget, i, 0);
-            SwitchPartyOrderLinkMulti(BATTLE_PARTNER(gBattlerTarget), i, 1);
-        }
-
-        if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER)
-            SwitchPartyOrderInGameMulti(gBattlerTarget, i);
-        #endif
     }
     else
     {

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7189,7 +7189,7 @@ static void Cmd_forcerandomswitch(void)
     s32 battler2PartyId = 0;
 
     s32 firstMonId;
-    s32 lastMonId = 0; // + 1
+    s32 lastMonId = 0;
     s32 monsCount;
     struct Pokemon *party = NULL;
     s32 validMons = 0;
@@ -7209,12 +7209,12 @@ static void Cmd_forcerandomswitch(void)
             if ((gBattlerTarget & BIT_FLANK) != B_FLANK_LEFT)
             {
                 firstMonId = PARTY_SIZE / 2;
-                lastMonId = PARTY_SIZE;
+                lastMonId = PARTY_SIZE - 1;
             }
             else
             {
                 firstMonId = 0;
-                lastMonId = PARTY_SIZE / 2;
+                lastMonId = PARTY_SIZE / 2 - 1;
             }
             monsCount = PARTY_SIZE / 2;
             minNeeded = 1;
@@ -7227,12 +7227,12 @@ static void Cmd_forcerandomswitch(void)
             if (GetLinkTrainerFlankId(GetBattlerMultiplayerId(gBattlerTarget)) == B_FLANK_RIGHT)
             {
                 firstMonId = PARTY_SIZE / 2;
-                lastMonId = PARTY_SIZE;
+                lastMonId = PARTY_SIZE - 1;
             }
             else
             {
                 firstMonId = 0;
-                lastMonId = PARTY_SIZE / 2;
+                lastMonId = PARTY_SIZE / 2 - 1;
             }
             monsCount = PARTY_SIZE / 2;
             minNeeded = 1;
@@ -7244,7 +7244,7 @@ static void Cmd_forcerandomswitch(void)
             if (GetBattlerSide(gBattlerTarget) == B_SIDE_PLAYER)
             {
                 firstMonId = 0;
-                lastMonId = PARTY_SIZE;
+                lastMonId = PARTY_SIZE - 1;
                 monsCount = PARTY_SIZE;
                 minNeeded = 2; // since there are two opponents, it has to be a double battle
             }
@@ -7253,12 +7253,12 @@ static void Cmd_forcerandomswitch(void)
                 if ((gBattlerTarget & BIT_FLANK) != B_FLANK_LEFT)
                 {
                     firstMonId = PARTY_SIZE / 2;
-                    lastMonId = PARTY_SIZE;
+                    lastMonId = PARTY_SIZE - 1;
                 }
                 else
                 {
                     firstMonId = 0;
-                    lastMonId = PARTY_SIZE / 2;
+                    lastMonId = PARTY_SIZE / 2 - 1;
                 }
                 monsCount = PARTY_SIZE / 2;
                 minNeeded = 1;
@@ -7269,7 +7269,7 @@ static void Cmd_forcerandomswitch(void)
         else if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
         {
             firstMonId = 0;
-            lastMonId = PARTY_SIZE;
+            lastMonId = PARTY_SIZE - 1;
             monsCount = PARTY_SIZE;
             minNeeded = 2;
             battler2PartyId = gBattlerPartyIndexes[gBattlerTarget];
@@ -7278,7 +7278,7 @@ static void Cmd_forcerandomswitch(void)
         else
         {
             firstMonId = 0;
-            lastMonId = PARTY_SIZE;
+            lastMonId = PARTY_SIZE - 1;
             monsCount = PARTY_SIZE;
             minNeeded = 1;
             battler2PartyId = gBattlerPartyIndexes[gBattlerTarget]; // there is only one Pokémon out in single battles
@@ -7314,23 +7314,24 @@ static void Cmd_forcerandomswitch(void)
                 } while (GetMonData(&party[i], MON_DATA_SPECIES) == SPECIES_NONE
                        || GetMonData(&party[i], MON_DATA_IS_EGG) == TRUE
                        || GetMonData(&party[i], MON_DATA_HP) == 0); //should be one while loop, but that doesn't match.
+            
+                *(gBattleStruct->monToSwitchIntoId + gBattlerTarget) = i;
+
+                if (!IsMultiBattle())
+                    SwitchPartyOrder(gBattlerTarget);
+
+                if ((gBattleTypeFlags & BATTLE_TYPE_LINK && gBattleTypeFlags & BATTLE_TYPE_BATTLE_TOWER)
+                    || (gBattleTypeFlags & BATTLE_TYPE_LINK && gBattleTypeFlags & BATTLE_TYPE_MULTI)
+                    || (gBattleTypeFlags & BATTLE_TYPE_RECORDED_LINK && gBattleTypeFlags & BATTLE_TYPE_BATTLE_TOWER)
+                    || (gBattleTypeFlags & BATTLE_TYPE_RECORDED_LINK && gBattleTypeFlags & BATTLE_TYPE_MULTI))
+                {
+                    SwitchPartyOrderLinkMulti(gBattlerTarget, i, 0);
+                    SwitchPartyOrderLinkMulti(BATTLE_PARTNER(gBattlerTarget), i, 1);
+                }
+
+                if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER)
+                    SwitchPartyOrderInGameMulti(gBattlerTarget, i);
             }
-            *(gBattleStruct->monToSwitchIntoId + gBattlerTarget) = i;
-
-            if (!IsMultiBattle())
-                SwitchPartyOrder(gBattlerTarget);
-
-            if ((gBattleTypeFlags & BATTLE_TYPE_LINK && gBattleTypeFlags & BATTLE_TYPE_BATTLE_TOWER)
-                || (gBattleTypeFlags & BATTLE_TYPE_LINK && gBattleTypeFlags & BATTLE_TYPE_MULTI)
-                || (gBattleTypeFlags & BATTLE_TYPE_RECORDED_LINK && gBattleTypeFlags & BATTLE_TYPE_BATTLE_TOWER)
-                || (gBattleTypeFlags & BATTLE_TYPE_RECORDED_LINK && gBattleTypeFlags & BATTLE_TYPE_MULTI))
-            {
-                SwitchPartyOrderLinkMulti(gBattlerTarget, i, 0);
-                SwitchPartyOrderLinkMulti(BATTLE_PARTNER(gBattlerTarget), i, 1);
-            }
-
-            if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER)
-                SwitchPartyOrderInGameMulti(gBattlerTarget, i);
         }
     }
     else

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7189,7 +7189,7 @@ static void Cmd_forcerandomswitch(void)
     s32 battler2PartyId = 0;
 
     s32 firstMonId;
-    s32 lastMonId = 0; // + 1
+    s32 lastMonId = 0;
     s32 monsCount;
     struct Pokemon *party = NULL;
     s32 validMons = 0;

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7210,7 +7210,7 @@ static void Cmd_forcerandomswitch(void)
             {
                 firstMonId = PARTY_SIZE / 2;
                 #ifdef BUGFIX
-                lastMonId = PARTY_SIZE; - 1
+                lastMonId = PARTY_SIZE - 1;
                 #else
                 lastMonId = PARTY_SIZE;
                 #endif
@@ -7236,7 +7236,7 @@ static void Cmd_forcerandomswitch(void)
             {
                 firstMonId = PARTY_SIZE / 2;
                 #ifdef BUGFIX
-                lastMonId = PARTY_SIZE -  1;
+                lastMonId = PARTY_SIZE - 1;
                 #else
                 lastMonId = PARTY_SIZE;
                 #endif
@@ -7351,7 +7351,7 @@ static void Cmd_forcerandomswitch(void)
                 } while (GetMonData(&party[i], MON_DATA_SPECIES) == SPECIES_NONE
                        || GetMonData(&party[i], MON_DATA_IS_EGG) == TRUE
                        || GetMonData(&party[i], MON_DATA_HP) == 0); //should be one while loop, but that doesn't match.
-            *(gBattleStruct->monToSwitchIntoId + gBattlerTarget) = i;
+                *(gBattleStruct->monToSwitchIntoId + gBattlerTarget) = i;
 
                 if (!IsMultiBattle())
                     SwitchPartyOrder(gBattlerTarget);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7351,7 +7351,7 @@ static void Cmd_forcerandomswitch(void)
                 } while (GetMonData(&party[i], MON_DATA_SPECIES) == SPECIES_NONE
                        || GetMonData(&party[i], MON_DATA_IS_EGG) == TRUE
                        || GetMonData(&party[i], MON_DATA_HP) == 0); //should be one while loop, but that doesn't match.
-                gBattleStruct->monToSwitchIntoId[gBattlerTarget]  = i;
+                *(gBattleStruct->monToSwitchIntoId + gBattlerTarget) = i;
 
                 if (!IsMultiBattle())
                     SwitchPartyOrder(gBattlerTarget);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7351,7 +7351,7 @@ static void Cmd_forcerandomswitch(void)
                 } while (GetMonData(&party[i], MON_DATA_SPECIES) == SPECIES_NONE
                        || GetMonData(&party[i], MON_DATA_IS_EGG) == TRUE
                        || GetMonData(&party[i], MON_DATA_HP) == 0); //should be one while loop, but that doesn't match.
-                *(gBattleStruct->monToSwitchIntoId + gBattlerTarget) = i;
+                gBattleStruct->monToSwitchIntoId[gBattlerTarget]  = i;
 
                 if (!IsMultiBattle())
                     SwitchPartyOrder(gBattlerTarget);

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -7189,7 +7189,7 @@ static void Cmd_forcerandomswitch(void)
     s32 battler2PartyId = 0;
 
     s32 firstMonId;
-    s32 lastMonId = 0;
+    s32 lastMonId = 0; // + 1
     s32 monsCount;
     struct Pokemon *party = NULL;
     s32 validMons = 0;
@@ -7209,12 +7209,20 @@ static void Cmd_forcerandomswitch(void)
             if ((gBattlerTarget & BIT_FLANK) != B_FLANK_LEFT)
             {
                 firstMonId = PARTY_SIZE / 2;
-                lastMonId = PARTY_SIZE - 1;
+                #ifdef BUGFIX
+                    lastMonId = PARTY_SIZE - 1;
+                #else
+                    lastMonId = PARTY_SIZE;
+                #endif
             }
             else
             {
                 firstMonId = 0;
-                lastMonId = PARTY_SIZE / 2 - 1;
+                #ifdef BUGFIX
+                    lastMonId = PARTY_SIZE / 2 - 1;
+                #else
+                    lastMonId = PARTY_SIZE;
+                #endif
             }
             monsCount = PARTY_SIZE / 2;
             minNeeded = 1;
@@ -7227,12 +7235,20 @@ static void Cmd_forcerandomswitch(void)
             if (GetLinkTrainerFlankId(GetBattlerMultiplayerId(gBattlerTarget)) == B_FLANK_RIGHT)
             {
                 firstMonId = PARTY_SIZE / 2;
-                lastMonId = PARTY_SIZE - 1;
+                #ifdef BUGFIX
+                    lastMonId = PARTY_SIZE - 1;
+                #else
+                    lastMonId = PARTY_SIZE;
+                #endif
             }
             else
             {
                 firstMonId = 0;
-                lastMonId = PARTY_SIZE / 2 - 1;
+                #ifdef BUGFIX
+                    lastMonId = PARTY_SIZE / 2 - 1;
+                #else
+                    lastMonId = PARTY_SIZE;
+                #endif
             }
             monsCount = PARTY_SIZE / 2;
             minNeeded = 1;
@@ -7244,7 +7260,11 @@ static void Cmd_forcerandomswitch(void)
             if (GetBattlerSide(gBattlerTarget) == B_SIDE_PLAYER)
             {
                 firstMonId = 0;
-                lastMonId = PARTY_SIZE - 1;
+                #ifdef BUGFIX
+                    lastMonId = PARTY_SIZE - 1;
+                #else
+                    lastMonId = PARTY_SIZE;
+                #endif
                 monsCount = PARTY_SIZE;
                 minNeeded = 2; // since there are two opponents, it has to be a double battle
             }
@@ -7253,12 +7273,20 @@ static void Cmd_forcerandomswitch(void)
                 if ((gBattlerTarget & BIT_FLANK) != B_FLANK_LEFT)
                 {
                     firstMonId = PARTY_SIZE / 2;
-                    lastMonId = PARTY_SIZE - 1;
+                    #ifdef BUGFIX
+                        lastMonId = PARTY_SIZE - 1;
+                    #else
+                        lastMonId = PARTY_SIZE;
+                    #endif
                 }
                 else
                 {
                     firstMonId = 0;
-                    lastMonId = PARTY_SIZE / 2 - 1;
+                    #ifdef BUGFIX
+                        lastMonId = PARTY_SIZE / 2 - 1;
+                    #else
+                        lastMonId = PARTY_SIZE / 2;
+                    #endif
                 }
                 monsCount = PARTY_SIZE / 2;
                 minNeeded = 1;
@@ -7269,7 +7297,11 @@ static void Cmd_forcerandomswitch(void)
         else if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
         {
             firstMonId = 0;
-            lastMonId = PARTY_SIZE - 1;
+            #ifdef BUGFIX
+                lastMonId = PARTY_SIZE - 1;
+            #else
+                lastMonId = PARTY_SIZE;
+            #endif           
             monsCount = PARTY_SIZE;
             minNeeded = 2;
             battler2PartyId = gBattlerPartyIndexes[gBattlerTarget];
@@ -7278,7 +7310,11 @@ static void Cmd_forcerandomswitch(void)
         else
         {
             firstMonId = 0;
-            lastMonId = PARTY_SIZE - 1;
+            #ifdef BUGFIX
+                lastMonId = PARTY_SIZE - 1;
+            #else
+                lastMonId = PARTY_SIZE;
+            #endif 
             monsCount = PARTY_SIZE;
             minNeeded = 1;
             battler2PartyId = gBattlerPartyIndexes[gBattlerTarget]; // there is only one Pokémon out in single battles
@@ -7315,6 +7351,7 @@ static void Cmd_forcerandomswitch(void)
                        || GetMonData(&party[i], MON_DATA_IS_EGG) == TRUE
                        || GetMonData(&party[i], MON_DATA_HP) == 0); //should be one while loop, but that doesn't match.
             
+        #ifdef BUGFIX
                 *(gBattleStruct->monToSwitchIntoId + gBattlerTarget) = i;
 
                 if (!IsMultiBattle())
@@ -7332,7 +7369,25 @@ static void Cmd_forcerandomswitch(void)
                 if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER)
                     SwitchPartyOrderInGameMulti(gBattlerTarget, i);
             }
+        #else   
         }
+        *(gBattleStruct->monToSwitchIntoId + gBattlerTarget) = i;
+
+        if (!IsMultiBattle())
+            SwitchPartyOrder(gBattlerTarget);
+
+        if ((gBattleTypeFlags & BATTLE_TYPE_LINK && gBattleTypeFlags & BATTLE_TYPE_BATTLE_TOWER)
+            || (gBattleTypeFlags & BATTLE_TYPE_LINK && gBattleTypeFlags & BATTLE_TYPE_MULTI)
+            || (gBattleTypeFlags & BATTLE_TYPE_RECORDED_LINK && gBattleTypeFlags & BATTLE_TYPE_BATTLE_TOWER)
+            || (gBattleTypeFlags & BATTLE_TYPE_RECORDED_LINK && gBattleTypeFlags & BATTLE_TYPE_MULTI))
+        {
+            SwitchPartyOrderLinkMulti(gBattlerTarget, i, 0);
+            SwitchPartyOrderLinkMulti(BATTLE_PARTNER(gBattlerTarget), i, 1);
+        }
+
+        if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER)
+            SwitchPartyOrderInGameMulti(gBattlerTarget, i);
+        #endif
     }
     else
     {

--- a/src/battle_util2.c
+++ b/src/battle_util2.c
@@ -109,12 +109,12 @@ void SwitchPartyOrderInGameMulti(u8 battlerId, u8 arg1)
     {
         s32 i;
         for (i = 0; i < (int)ARRAY_COUNT(gBattlePartyCurrentOrder); i++)
-            gBattlePartyCurrentOrder[i] = *(0 * 3 + i + (u8 *)(gBattleStruct->battlerPartyOrders));
+            gBattlePartyCurrentOrder[i] = *(i + (u8 *)(gBattleStruct->battlerPartyOrders));
 
         SwitchPartyMonSlots(GetPartyIdFromBattlePartyId(gBattlerPartyIndexes[battlerId]), GetPartyIdFromBattlePartyId(arg1));
 
         for (i = 0; i < (int)ARRAY_COUNT(gBattlePartyCurrentOrder); i++)
-            *(0 * 3 + i + (u8 *)(gBattleStruct->battlerPartyOrders)) = gBattlePartyCurrentOrder[i];
+            *(i + (u8 *)(gBattleStruct->battlerPartyOrders)) = gBattlePartyCurrentOrder[i];
     }
 }
 

--- a/src/battle_util2.c
+++ b/src/battle_util2.c
@@ -109,12 +109,12 @@ void SwitchPartyOrderInGameMulti(u8 battlerId, u8 arg1)
     {
         s32 i;
         for (i = 0; i < (int)ARRAY_COUNT(gBattlePartyCurrentOrder); i++)
-            gBattlePartyCurrentOrder[i] = *(i + (u8 *)(gBattleStruct->battlerPartyOrders));
+            gBattlePartyCurrentOrder[i] = *(0 * 3 + i + (u8 *)(gBattleStruct->battlerPartyOrders));
 
         SwitchPartyMonSlots(GetPartyIdFromBattlePartyId(gBattlerPartyIndexes[battlerId]), GetPartyIdFromBattlePartyId(arg1));
 
         for (i = 0; i < (int)ARRAY_COUNT(gBattlePartyCurrentOrder); i++)
-            *(i + (u8 *)(gBattleStruct->battlerPartyOrders)) = gBattlePartyCurrentOrder[i];
+            *(0 * 3 + i + (u8 *)(gBattleStruct->battlerPartyOrders)) = gBattlePartyCurrentOrder[i];
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed switchout bug that messed the order of pokemon in the summary screen after the opponent uses switchout moves (whirlwind, roar, etc...).

PROBLEM:
![Screenshot_12](https://github.com/user-attachments/assets/dae18a32-5c26-49c3-aaeb-64b339f13db2)



PROBLEM: If the opponent uses forced switchout moves in a multi battle, the player side party might get the order messed up where the mons appear in the wrong slots of the party screen.
This causes a hardlock when all mons on the player side are knocked out and the player can't select their mon that's on the partner side of the party screen.

FIX: Entered the switchout effects inside the if (TryDoForceSwitchOut()) statement, also adjusted firstmonId and lastmonId to stay between the boundaries of each player (0-2 PLAYER, 3-5 STEVEN)

## Description
<!--- Describe your changes in detail -->
#2093 Fixes

## **Discord contact info**
<!--- Formatted as username (e.g. pikalaxalt) or username#numbers (e.g. PikalaxALT#5823) -->
Shachar700
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
