### PR TITLE
Fix collision comparison in PlayerNotOnBikeMoving

### DIFF
--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -620,9 +620,27 @@ static void PlayerNotOnBikeMoving(u8 direction, u16 heldKeys)
         }
         else
         {
-            u8 adjustedCollision = collision - COLLISION_STOP_SURFING;
-            if (adjustedCollision > 3)
+            // Player collided with something. Certain collisions have special handling that precludes the normal collision effect.
+            // COLLISION_STOP_SURFING and COLLISION_PUSHED_BOULDER's effects are started by CheckForObjectEventCollision.
+            // COLLISION_LEDGE_JUMP's effect is handled further up in this function, so it will never reach this point.
+            // COLLISION_ROTATING_GATE is unusual however, this was probably included by mistake. When the player walks into a
+            // rotating gate that cannot rotate there is no additional handling, it's just a regular collision. Its exclusion here
+            // means that the player avatar won't update if they encounter this kind of collision. This has two noticeable effects:
+            // - Colliding with it head-on stops the player dead, rather than playing the walking animation and playing a bump sound effect
+            // - Colliding with it by changing direction won't turn the player avatar, their walking animation will just speed up.
+#ifdef BUGFIX
+            if (collision != COLLISION_STOP_SURFING
+             && collision != COLLISION_LEDGE_JUMP
+             && collision != COLLISION_PUSHED_BOULDER)
+#else
+            if (collision != COLLISION_STOP_SURFING
+             && collision != COLLISION_LEDGE_JUMP
+             && collision != COLLISION_PUSHED_BOULDER
+             && collision != COLLISION_ROTATING_GATE)
+#endif
+            {
                 PlayerNotOnBikeCollide(direction);
+            }
             return;
         }
     }


### PR DESCRIPTION
The condition was optimized to a single comparison, which made it hard to read. While making it more readable I noticed that it was treating `COLLISION_ROTATING_GATE` specially despite it not having any special behavior. The result is that walking into a rotating gate that can't rotate won't update the player avatar correctly. This looks especially weird if you try to collide with a rotating gate by changing direction.

Before bug fix (walking head-on, and then trying to turn into it):
![collision-bad](https://github.com/user-attachments/assets/cd152e30-c5bc-4424-8f1c-c617f8bb4bf2)

After bug fix (same inputs as above)
![collision-good](https://github.com/user-attachments/assets/6dfa7c01-5e1b-48cc-8998-52e1f3ce581c)
