### PR TITLE
Renamed a berry tag variable

### DIFF
--- a/include/graphics.h
+++ b/include/graphics.h
@@ -3307,7 +3307,7 @@ extern const u16 gPokedexSearchMenu_Pal[];
 extern const u32 gBerryCheck_Gfx[];
 extern const u32 gBerryCheck_Pal[];
 extern const u32 gBerryTag_Gfx[];
-extern const u32 gBerryTag_Pal[];
+extern const u32 gBerryTag_Tilemap[];
 
 // rayquaza scene gfx
 extern const u32 gRaySceneDuoFight_Groudon_Gfx[];

--- a/src/berry_tag_screen.c
+++ b/src/berry_tag_screen.c
@@ -331,7 +331,7 @@ static bool8 LoadBerryTagGfx(void)
         }
         break;
     case 2:
-        LZDecompressWram(gBerryTag_Pal, sBerryTag->tilemapBuffers[2]);
+        LZDecompressWram(gBerryTag_Tilemap, sBerryTag->tilemapBuffers[2]);
         sBerryTag->gfxState++;
         break;
     case 3:

--- a/src/data/graphics/berries.h
+++ b/src/data/graphics/berries.h
@@ -2,7 +2,7 @@ const u32 gBerryCheck_Gfx[] = INCBIN_U32("graphics/bag/check_berry.4bpp.lz");
 const u32 gBerryCheck_Pal[] = INCBIN_U32("graphics/bag/check_berry.gbapal.lz");
 
 const u32 gBerryTag_Gfx[] = INCBIN_U32("graphics/bag/berry_tag.bin.lz");
-const u32 gBerryTag_Pal[] = INCBIN_U32("graphics/bag/berry_tag_title.bin.lz");
+const u32 gBerryTag_Tilemap[] = INCBIN_U32("graphics/bag/berry_tag_title.bin.lz");
 
 const u32 gBerryCheckCircle_Gfx[] = INCBIN_U32("graphics/bag/check_berry_circle.4bpp.lz");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
From what I could see, `gBerryTag_Pal` behaves more like a tilemap than a palette, so it was renamed to match.

## **Discord contact info**
<!--- Formatted as username (e.g. pikalaxalt) or username#numbers (e.g. PikalaxALT#5823) -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
hedara