### PR TITLE
Align gMPlayTrack_BGM

### DIFF
--- a/sound/music_player_table.inc
+++ b/sound/music_player_table.inc
@@ -5,6 +5,7 @@
 	.equiv NUM_TRACKS_SE3, 1
 
     .bss
+    .align 2
 
 gMPlayTrack_BGM::
     .space TRACK_SIZE * NUM_TRACKS_BGM


### PR DESCRIPTION
Found when built with `-flto`. The address wasn't aligned, and the game just hanged when trying to play sound.