### PR TITLE
Fixed init call when using AGBPrint as log handler

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -125,7 +125,7 @@ void AgbMain()
 #if (LOG_HANDLER == LOG_HANDLER_MGBA_PRINT)
     (void) MgbaOpen();
 #elif (LOG_HANDLER == LOG_HANDLER_AGB_PRINT)
-    AGBPrintfInit();
+    AGBPrintInit();
 #endif
 #endif
     for (;;)


### PR DESCRIPTION
Renamed AGBPrintfInit should be AGBPrintInit

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If using the AGBPrint log handler, the AGBPrintfInit call would be made but that doesn't exist. I just replaced AGBPrintfInit with AGBPrintInit.
## **Discord contact info**
<!--- Formatted as username (e.g. pikalaxalt) or username#numbers (e.g. PikalaxALT#5823) -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
pokemonmasteraaron