### PR TITLE
ub fix for OOB access with gActiveBattler

### DIFF
--- a/src/battle_controllers.c
+++ b/src/battle_controllers.c
@@ -57,6 +57,11 @@ void SetUpBattleVarsAndBirchZigzagoon(void)
     gBattleControllerExecFlags = 0;
     ClearBattleAnimationVars();
     ClearBattleMonForms();
+// UB: at the start of a battle CheckMoveLimitations is called with gActiveBattler 
+// from the previous battle, which can lead to multiple arrays being accessed out of bounds
+#ifdef UBFIX
+    gActiveBattler = 0;
+#endif
     BattleAI_HandleItemUseBeforeAISetup(0xF);
 
     if (gBattleTypeFlags & BATTLE_TYPE_FIRST_BATTLE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The first call of `CheckMoveLimitations` each battle (except for the first one each load) is done with `gBattlersCount` from the previous battle, which is either 2 or 4 and in most cases OOB.
Since the first call after loading the game is always done with 0, setting `gActiveBattler = 0` is presumably safe.
![oob](https://github.com/user-attachments/assets/29130c76-9cc5-4eb2-b650-d684a53aca84)


## **Discord contact info**
.cawt
