### PR TITLE
Apply fixes to preproc for Windows compatibility

### DIFF
--- a/tools/preproc/asm_file.cpp
+++ b/tools/preproc/asm_file.cpp
@@ -679,7 +679,7 @@ void AsmFile::RaiseWarning(const char* format, ...)
 int AsmFile::SkipWhitespaceAndEol()
 {
     int newlines = 0;
-    while (m_buffer[m_pos] == '\t' || m_buffer[m_pos] == ' ' || m_buffer[m_pos] == '\n')
+    while (m_buffer[m_pos] == '\t' || m_buffer[m_pos] == ' ' || m_buffer[m_pos] == '\r' || m_buffer[m_pos] == '\n')
     {
         if (m_buffer[m_pos] == '\n')
             newlines++;
@@ -702,14 +702,14 @@ int AsmFile::FindLastLineNumber(std::string& filename)
 
     if (pos < 0)
         RaiseError("line indicator for header file not found before `enum`");
-    
+
     pos++;
     while (m_buffer[pos] == ' ' || m_buffer[pos] == '\t')
         pos++;
 
     if (!IsAsciiDigit(m_buffer[pos]))
         RaiseError("malformatted line indicator found before `enum`, expected line number");
-    
+
     unsigned n = 0;
     int digit = 0;
     while ((digit = ConvertDigit(m_buffer[pos++], 10)) != -1)
@@ -744,7 +744,7 @@ int AsmFile::FindLastLineNumber(std::string& filename)
 
         filename += c;
     }
-    
+
     return n + linebreaks - 1;
 }
 

--- a/tools/preproc/preproc.cpp
+++ b/tools/preproc/preproc.cpp
@@ -26,6 +26,11 @@
 #include "c_file.h"
 #include "charmap.h"
 
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#endif
+
 static void UsageAndExit(const char *program);
 
 Charmap* g_charmap;
@@ -178,6 +183,11 @@ int main(int argc, char **argv)
     charmap = argv[optind + 1];
 
     g_charmap = new Charmap(charmap);
+
+#ifdef _WIN32
+	// On Windows, piping from stdout can break newlines. Treat stdout as binary stream to avoid this.
+	_setmode(_fileno(stdout), _O_BINARY);
+#endif
 
     const char* extension = GetFileExtension(source);
 


### PR DESCRIPTION
## Description
tools/preproc/asm_file.cpp was not correctly skipping Windows CRLF newlines in AsmFile::SkipWhitespaceAndEol. This could cause preproc to incorrectly claim some enums were empty while they were not.

Added binary mode for stdout in Windows, as otherwise output files would have double newlines, making later steps report error/warning linenums incorrectly.

## **Discord contact info**
anarqts
