### PR TITLE
Warn on suspicious setvar usages

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -145,7 +145,10 @@
 	.endm
 
 	@ Changes the value of destination to value.
-	.macro setvar destination:req, value:req
+	.macro setvar destination:req, value:req, warn=TRUE
+	.if \warn && ((\value >= VARS_START && \value <= VARS_END) || (\value >= SPECIAL_VARS_START && \value <= SPECIAL_VARS_END))
+	.warning "setvar with a value that might be a VAR_ constant; did you mean copyvar instead?"
+	.endif
 	.byte SCR_OP_SETVAR
 	.2byte \destination
 	.2byte \value


### PR DESCRIPTION
I think people very often write `setvar VAR_FOO, VAR_BAR` when they mean `copyvar VAR_FOO, VAR_BAR`. This PR adds a warning for usages of `setvar` with values that are in the var ranges (it can't be an error because maybe somebody really does want `0x4000` in their var).

Example:
```diff
+++ b/data/maps/LittlerootTown/scripts.inc
 LittlerootTown_EventScript_SetRivalLeftForRoute103::
+       setvar VAR_0x8004, VAR_RESULT
        setflag FLAG_RIVAL_LEFT_FOR_ROUTE103
```
Output:
```
data/maps/LittlerootTown/scripts.inc: Assembler messages:
data/maps/LittlerootTown/scripts.inc:150: Warning: setvar with a value that might be a VAR_ constant; did you mean copyvar instead?
data/maps/LittlerootTown/scripts.inc:65:  Info: macro invoked from here
```
Happy to accept proposed changes to the wording.

Also, should `copyvar` have the opposite check? i.e. that the value _is_ in the ranges that make sense for a var. I don't think I see people make the opposite mistake, but it might still be useful?

Admittedly there's `setorcopyvar` which people could use to avoid this issue... But I don't think I ever see people using that!