### PR TITLE
Fixes for C23 Support

### DIFF
--- a/include/gba/m4a_internal.h
+++ b/include/gba/m4a_internal.h
@@ -170,7 +170,11 @@ struct SoundChannel
 
 struct MusicPlayerInfo;
 
+#if !MODERN
 typedef void (*MPlayFunc)();
+#else
+typedef void (*MPlayFunc)(...);
+#endif
 typedef void (*PlyNoteFunc)(u32, struct MusicPlayerInfo *, struct MusicPlayerTrack *);
 typedef void (*CgbSoundFunc)(void);
 typedef void (*CgbOscOffFunc)(u8);

--- a/include/global.h
+++ b/include/global.h
@@ -23,6 +23,10 @@
 #define asm_unified(x) asm(".syntax unified\n" x "\n.syntax divided")
 #define NAKED __attribute__((naked))
 
+#if MODERN
+#define asm __asm__
+#endif
+
 /// IDE support
 #if defined(__APPLE__) || defined(__CYGWIN__) || defined(__INTELLISENSE__)
 // We define these when using certain IDEs to fool preproc

--- a/include/librfu.h
+++ b/include/librfu.h
@@ -316,7 +316,11 @@ struct STWIStatus
     u8 recoveryCount;
     u8 unk_16;
     u8 unk_17;
+#if !MODERN
     void (*callbackM)();
+#else
+    void (*callbackM)(...);
+#endif
     void (*callbackS)(u16);
     void (*callbackID)(void);
     union RfuPacket *txPacket;

--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -38,14 +38,13 @@ EWRAM_DATA struct ObjectEvent gObjectEvents[OBJECT_EVENTS_COUNT] = {};
 EWRAM_DATA struct PlayerAvatar gPlayerAvatar = {};
 
 // static declarations
-
-static u8 ObjectEventCB2_NoMovement2();
+static u8 ObjectEventCB2_NoMovement2(void);
 static bool8 TryInterruptObjectEventSpecialAnim(struct ObjectEvent *, u8);
 static void npc_clear_strange_bits(struct ObjectEvent *);
 static void MovePlayerAvatarUsingKeypadInput(u8, u16, u16);
-static void PlayerAllowForcedMovementIfMovingSameDirection();
-static bool8 TryDoMetatileBehaviorForcedMovement();
-static u8 GetForcedMovementByMetatileBehavior();
+static void PlayerAllowForcedMovementIfMovingSameDirection(void);
+static bool8 TryDoMetatileBehaviorForcedMovement(void);
+static u8 GetForcedMovementByMetatileBehavior(void);
 
 static bool8 ForcedMovement_None(void);
 static bool8 ForcedMovement_Slip(void);
@@ -318,7 +317,7 @@ static bool8 (*const sPlayerAvatarSecretBaseMatSpin[])(struct Task *, struct Obj
 
 void MovementType_Player(struct Sprite *sprite)
 {
-    UpdateObjectEventCurrentMovement(&gObjectEvents[sprite->data[0]], sprite, ObjectEventCB2_NoMovement2);
+    UpdateObjectEventCurrentMovement(&gObjectEvents[sprite->data[0]], sprite, (bool8 (*)(struct ObjectEvent *, struct Sprite *))ObjectEventCB2_NoMovement2);
 }
 
 static u8 ObjectEventCB2_NoMovement2(void)

--- a/src/librfu_intr.c
+++ b/src/librfu_intr.c
@@ -7,7 +7,11 @@ static u16 handshake_wait(u16 slot);
 static void STWI_set_timer_in_RAM(u8 count);
 static void STWI_stop_timer_in_RAM(void);
 static void STWI_init_slave(void);
+#if !MODERN
 static void Callback_Dummy_M(int reqCommandId, int error, void (*callbackM)());
+#else
+static void Callback_Dummy_M(int reqCommandId, int error, void (*callbackM)(...));
+#endif
 static void Callback_Dummy_S(u16 reqCommandId, void (*callbackS)(u16));
 static void Callback_Dummy_ID(void (*callbackId)(void));
 
@@ -135,7 +139,11 @@ static void sio32intr_clock_master(void)
         }
         gSTWIStatus->sending = 0;
         if (gSTWIStatus->callbackM != NULL)
+#if !MODERN
             Callback_Dummy_M(gSTWIStatus->reqActiveCommand, gSTWIStatus->error, gSTWIStatus->callbackM);
+#else
+            Callback_Dummy_M(gSTWIStatus->reqActiveCommand, gSTWIStatus->error, (void (*)(...))gSTWIStatus->callbackM);
+#endif
     }
     else
     {
@@ -388,7 +396,11 @@ static void STWI_init_slave(void)
 }
 
 NAKED
+#if !MODERN
 static void Callback_Dummy_M(int reqCommandId, int error, void (*callbackM)())
+#else
+static void Callback_Dummy_M(int reqCommandId, int error, void (*callbackM)(...))
+#endif
 {
     asm("bx r2");
 }

--- a/src/m4a.c
+++ b/src/m4a.c
@@ -1,4 +1,3 @@
-#include <string.h>
 #include "global.h"
 #include "gba/m4a_internal.h"
 

--- a/src/m4a.c
+++ b/src/m4a.c
@@ -5,6 +5,10 @@ extern const u8 gCgb3Vol[];
 
 #define BSS_CODE __attribute__((section(".bss.code")))
 
+#if MODERN
+#define asm __asm__
+#endif
+
 BSS_CODE ALIGNED(4) char SoundMainRAM_Buffer[0x800] = {0};
 
 COMMON_DATA struct SoundInfo gSoundInfo = {0};
@@ -283,6 +287,7 @@ void MPlayExtender(struct CgbChannel *cgbChans)
 
     soundInfo->ident++;
 
+#if !MODERN
     gMPlayJumpTable[8] = ply_memacc;
     gMPlayJumpTable[17] = ply_lfos;
     gMPlayJumpTable[19] = ply_mod;
@@ -292,6 +297,17 @@ void MPlayExtender(struct CgbChannel *cgbChans)
     gMPlayJumpTable[31] = TrackStop;
     gMPlayJumpTable[32] = FadeOutBody;
     gMPlayJumpTable[33] = TrkVolPitSet;
+#else
+    gMPlayJumpTable[8] = (void (*)(...))ply_memacc;
+    gMPlayJumpTable[17] = (void (*)(...))ply_lfos;
+    gMPlayJumpTable[19] = (void (*)(...))ply_mod;
+    gMPlayJumpTable[28] = (void (*)(...))ply_xcmd;
+    gMPlayJumpTable[29] = (void (*)(...))ply_endtie;
+    gMPlayJumpTable[30] = (void (*)(...))SampleFreqSet;
+    gMPlayJumpTable[31] = (void (*)(...))TrackStop;
+    gMPlayJumpTable[32] = (void (*)(...))FadeOutBody;
+    gMPlayJumpTable[33] = (void (*)(...))TrkVolPitSet;
+#endif
 
     soundInfo->cgbChans = cgbChans;
     soundInfo->CgbSound = CgbSound;
@@ -320,13 +336,21 @@ void MusicPlayerJumpTableCopy(void)
 
 void ClearChain(void *x)
 {
+#if !MODERN
     void (*func)(void *) = *(&gMPlayJumpTable[34]);
+#else
+    void (*func)(...) = *(&gMPlayJumpTable[34]);
+#endif
     func(x);
 }
 
 void Clear64byte(void *x)
 {
+#if !MODERN
     void (*func)(void *) = *(&gMPlayJumpTable[35]);
+#else
+    void (*func)(...) = *(&gMPlayJumpTable[35]);
+#endif
     func(x);
 }
 

--- a/src/m4a.c
+++ b/src/m4a.c
@@ -1,13 +1,10 @@
 #include <string.h>
+#include "global.h"
 #include "gba/m4a_internal.h"
 
 extern const u8 gCgb3Vol[];
 
 #define BSS_CODE __attribute__((section(".bss.code")))
-
-#if MODERN
-#define asm __asm__
-#endif
 
 BSS_CODE ALIGNED(4) char SoundMainRAM_Buffer[0x800] = {0};
 

--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -237,7 +237,7 @@ static void SpriteCB_MovePlayerDownWhileShrinking(struct Sprite *);
 static void Task_NewGameBirchSpeech_WaitForPlayerShrink(u8);
 static void Task_NewGameBirchSpeech_FadePlayerToWhite(u8);
 static void Task_NewGameBirchSpeech_Cleanup(u8);
-static void SpriteCB_Null();
+static void SpriteCB_Null(struct Sprite *);
 static void Task_NewGameBirchSpeech_ReturnFromNamingScreenShowTextbox(u8);
 static void MainMenu_FormatSavegamePlayer(void);
 static void MainMenu_FormatSavegamePokedex(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
C23 introduces a few changes to the standard that break with our current code. The main change is that `()` now behaves like `(void)`, and the old behavior is replaced by `(...)`. This has been changed where necessary; some functions that previously had no arguments were also given void arguments or proper argument lists if they still matched.

Additionally, casts were added where necessary to silence warnings.

## **Discord contact info**
kurausukun
