### PR TITLE
Fix Repeat Ball Particle Animation Sprite Count

### DIFF
--- a/src/battle_anim_throw.c
+++ b/src/battle_anim_throw.c
@@ -1864,7 +1864,7 @@ static void RepeatBallOpenParticleAnimation(u8 taskId)
     priority = gTasks[taskId].data[3];
     subpriority = gTasks[taskId].data[4];
 
-    for (i = 0; i < POKEBALL_COUNT; i++)
+    for (i = 0; i < 12; i++)
     {
         spriteId = CreateSprite(&sBallParticleSpriteTemplates[ballId], x, y, subpriority);
         if (spriteId != MAX_SPRITES)


### PR DESCRIPTION
The repeat ball  is currently looping up to POKEBALL_COUNT for its ball particle animation in `RepeatBallOpenParticleAnimation`, but when new poke balls are added (e.g. expansion) this creates an unnecessary number of sprites. The extreme case of this is that the party status summary runs out of sprites to generate during in-battle switching, but otherwise it is relatively harmless