### PR TITLE
Relax MAPSEC region map data requirements

### DIFF
--- a/src/data/region_map/region_map_sections.json.txt
+++ b/src/data/region_map/region_map_sections.json.txt
@@ -19,9 +19,23 @@ static const u8 sMapName_{{ cleanString(map_section.name) }}_Clone[] = _("{{ map
 
 const struct RegionMapLocation gRegionMapEntries[] = {
 ## for map_section in map_sections
-{% if existsIn(map_section, "x") and existsIn(map_section, "y") and existsIn(map_section, "width") and existsIn(map_section, "height") and existsIn(map_section, "name") %}
-    [{{ map_section.id }}] = { {{ map_section.x }}, {{ map_section.y }}, {{ map_section.width }}, {{ map_section.height }}, sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %} },
+    [{{ map_section.id }}] = {
+{% if existsIn(map_section, "x") %}
+        .x = {{ map_section.x }},
 {% endif %}
+{% if existsIn(map_section, "y") %}
+        .y = {{ map_section.y }},
+{% endif %}
+{% if existsIn(map_section, "width") %}
+        .width = {{ map_section.width }},
+{% endif %}
+{% if existsIn(map_section, "height") %}
+        .height = {{ map_section.height }},
+{% endif %}
+{% if existsIn(map_section, "name") %}
+        .name = sMapName_{{ cleanString(map_section.name) }}{% if existsIn(map_section, "name_clone") %}_Clone{% endif %},
+{% endif %}
+    },
 ## endfor
 };
 


### PR DESCRIPTION
Relaxes the requirements to output data for `gRegionMapEntries`. Currently it will only output data if all fields are present, and now it will output data for whichever fields are present. This should make problems less likely if e.g. someone has a `MAPSEC` that has name data but no positional data.

Also uses designators for the output, so that the data is still correct if the struct members are reordered.