### PR TITLE
Ensure sMonMarkings_Gfx alingment

### DIFF
--- a/src/mon_markings.c
+++ b/src/mon_markings.c
@@ -23,7 +23,7 @@ static void SpriteCB_Cursor(struct Sprite *);
 static struct Sprite *CreateMarkingComboSprite(u16, u16, const u16 *, u16);
 
 static const u16 sMonMarkings_Pal[] = INCBIN_U16("graphics/interface/mon_markings.gbapal");
-static const u8 sMonMarkings_Gfx[] = INCBIN_U8("graphics/interface/mon_markings.4bpp");
+static const ALIGNED(4) u8 sMonMarkings_Gfx[] = INCBIN_U8("graphics/interface/mon_markings.4bpp"); // Alignment needed for dma copy
 
 static const struct OamData sOamData_MenuWindow =
 {


### PR DESCRIPTION
Another case of what if `-Os` accidentally unaligns stuff which needs to be aligned.
![pokeemerald_01](https://github.com/user-attachments/assets/51274473-b9c1-43a2-b13d-ff9cde72ebed)
