### PR TITLE
Fix potential stack memory leak in gbagfx due to out of bounds read

### DIFF
--- a/tools/gbagfx/main.c
+++ b/tools/gbagfx/main.c
@@ -333,7 +333,8 @@ void HandleJascToGbaPaletteCommand(char *inputPath, char *outputPath, int argc, 
 
             if (numColors < 1)
                 FATAL_ERROR("Number of colors must be positive.\n");
-            if (numColors > 256)
+            
+            if (numColors > 255)
                 FATAL_ERROR("Number of colors must be less than 256.\n");
         }
         else

--- a/tools/gbagfx/main.c
+++ b/tools/gbagfx/main.c
@@ -333,6 +333,8 @@ void HandleJascToGbaPaletteCommand(char *inputPath, char *outputPath, int argc, 
 
             if (numColors < 1)
                 FATAL_ERROR("Number of colors must be positive.\n");
+            if (numColors > 256)
+                FATAL_ERROR("Number of colors must be less than 256.\n");
         }
         else
         {


### PR DESCRIPTION
`gbagfx` parses the `-num_colors` cli argument and accepts values greater than the maximum amount of colors stored in a `struct Palette` (256) leading to an out of bounds read if high values are passed to gbagfx.

## Description
Example behavior:

```
$ tools/gbagfx/gbagfx graphics/pokemon/abra/normal.pal normal.gbapal -num_colors 100000
fish: Job 1, 'tools/gbagfx/gbagfx graphics/po…' terminated by signal SIGSEGV (Address boundary error)
```

Fix:

```
$ tools/gbagfx/gbagfx graphics/pokemon/abra/normal.pal normal.gbapal -num_colors 100000
Number of colors must be less than 256.
```

## **Discord contact info**
karathan
