### PR TITLE
Change rangeX and rangeY to u8 in ObjectEvent struct

### DIFF
--- a/include/global.fieldmap.h
+++ b/include/global.fieldmap.h
@@ -229,8 +229,8 @@ struct ObjectEvent
              u16 movementDirection:4;
              struct __attribute__((packed))
              {
-                u16 rangeX:4;
-                u16 rangeY:4;
+                u8 rangeX:4;
+                u8 rangeY:4;
              } range;
     /*0x1A*/ u8 fieldEffectSpriteId;
     /*0x1B*/ u8 warpArrowSpriteId;


### PR DESCRIPTION
## Description
This seems to be the more correct type than u16 as the data only needs 8 bits. On agbcc this makes no difference but when compiling the same code in x86 using gcc it causes this struct to be a different size which breaks save file compatibility, changing the type to u8 makes the struct correct size. I have not tested this on ARM gcc modern myself but according to pull request #2118 changing the type u8 should give the correct struct size too.

## **Discord contact info** 
nt_x86