### PR TITLE
Fix sScrollableMultichoice_ListMenuItem allocation size magic number

### DIFF
--- a/src/field_specials.c
+++ b/src/field_specials.c
@@ -2555,7 +2555,7 @@ static void Task_ShowScrollableMultichoice(u8 taskId)
     sScrollableMultichoice_ItemSpriteId = MAX_SPRITES;
     FillFrontierExchangeCornerWindowAndItemIcon(task->tScrollMultiId, 0);
     ShowBattleFrontierTutorWindow(task->tScrollMultiId, 0);
-    sScrollableMultichoice_ListMenuItem = AllocZeroed(task->tNumItems * 8);
+    sScrollableMultichoice_ListMenuItem = AllocZeroed(task->tNumItems * sizeof(struct ListMenuItem));
     sFrontierExchangeCorner_NeverRead = 0;
     InitScrollableMultichoice();
 


### PR DESCRIPTION
## Description
The code originally used a magic number instead of sizeof, this causes issues if the size of ListMenuItem struct is made to be bigger like when compiling the game in 64 bit which increases the pointer size in the struct

## **Discord contact info**
nt_x86