### PR TITLE
Fix preproc not correctly reading skipped lines symbols inside enum

### DIFF
--- a/tools/preproc/asm_file.h
+++ b/tools/preproc/asm_file.h
@@ -73,6 +73,7 @@ private:
     void VerifyStringLength(int length);
     int SkipWhitespaceAndEol();
     int FindLastLineNumber(std::string& filename);
+    int ParseLineSkipInEnum(void);
     std::string ReadIdentifier();
     long ReadInteger(std::string filename, long line);
 };


### PR DESCRIPTION
When you have a lot of newlines in an enum like this:
```
enum Test_preproc {
  Test_Preproc_A,
  Test_Preproc_B,








  Test_Preproc_C,
  
};
```
the compiler will convert it into something like this
```
enum Test_preproc {
  Test_Preproc_A,
  Test_Preproc_B,
# 13 "include/constants/coins.h"
  Test_Preproc_C,
};
```
and preproc wasn't coded to handle this kind of comment inside an enum, this PR fixes that

## **Discord contact info**
Jamie (foster_harmony)
