### PR TITLE
Implicit waitstate for special/specialvars

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1,6 +1,11 @@
 	.set ALLOCATE_SCRIPT_CMD_TABLE, 0
 	.include "data/script_cmd_table.inc"
 
+	.set ALLOCATE_SPECIAL_TABLE, 0
+	.include "data/specials.inc"
+
+	.set _last_implicit_waitstate, -1
+
 	@ Does nothing.
 	.macro nop
 	.byte SCR_OP_NOP
@@ -272,6 +277,9 @@
 	.macro special function:req
 	.byte SCR_OP_SPECIAL
 	.2byte SPECIAL_\function
+	.if SPECIAL_WAITSTATE_\function
+	waitstate implicit=1
+	.endif
 	.endm
 
 	@ Calls a function listed in the table in data/specials.inc.
@@ -280,12 +288,25 @@
 	.byte SCR_OP_SPECIALVAR
 	.2byte \output
 	.2byte SPECIAL_\function
+	.if SPECIAL_WAITSTATE_\function
+	waitstate implicit=1
+	.endif
 	.endm
 
 	@ Blocks script execution until a command or C code manually unblocks it. Generally used with specific
 	@ commands and specials. Calling ScriptContext_Enable for instance will allow execution to continue.
-	.macro waitstate
+	@
+	@ implicit is set when a waitstate is generated as part of another command (e.g. special)
+	@ if an implicit waitstate is immediately followed by another waitstate, a warning is raised
+	.macro waitstate, implicit=0
+	.if _last_implicit_waitstate == .
+	.warning "explicit waitstate follows implicit waitstate, ignoring"
+	.else
 	.byte SCR_OP_WAITSTATE
+	.endif
+	.if \implicit
+	.set _last_implicit_waitstate, .
+	.endif
 	.endm
 
 	@ Blocks script execution for frames. (Pokemon Emerald runs at just shy of 60 frames per second.)

--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -87,6 +87,8 @@ gSpecialVars::
 	.4byte gSpecialVar_Unused_0x8014
 	.4byte gTrainerBattleOpponent_A
 
+	.purgem def_special
+	.set ALLOCATE_SPECIAL_TABLE, 1
 	.include "data/specials.inc"
 
 gStdScripts::
@@ -729,7 +731,6 @@ EventScript_RegionMap::
 	msgbox Common_Text_LookCloserAtMap, MSGBOX_DEFAULT
 	fadescreen FADE_TO_BLACK
 	special FieldShowRegionMap
-	waitstate
 	releaseall
 	end
 
@@ -812,7 +813,6 @@ Common_EventScript_FerryDepartIsland::
 Common_EventScript_NameReceivedPartyMon::
 	fadescreen FADE_TO_BLACK
 	special ChangePokemonNickname
-	waitstate
 	return
 
 Common_EventScript_PlayerHandedOverTheItem::

--- a/data/maps/AncientTomb/scripts.inc
+++ b/data/maps/AncientTomb/scripts.inc
@@ -64,7 +64,6 @@ AncientTomb_EventScript_Registeel::
 	setwildbattle SPECIES_REGISTEEL, 40
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special StartRegiBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	specialvar VAR_RESULT, GetBattleOutcome
 	goto_if_eq VAR_RESULT, B_OUTCOME_WON, AncientTomb_EventScript_DefeatedRegisteel

--- a/data/maps/BattleFrontier_BattleArenaBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleArenaBattleRoom/scripts.inc
@@ -367,7 +367,6 @@ BattleFrontier_BattleArenaBattleRoom_EventScript_DoArenaBattle::
 	setvar VAR_0x8004, SPECIAL_BATTLE_ARENA
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	frontier_restorehelditems
 	special HealPlayerParty
 	frontier_resetsketch

--- a/data/maps/BattleFrontier_BattleArenaLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattleArenaLobby/scripts.inc
@@ -135,7 +135,6 @@ BattleFrontier_BattleArenaLobby_EventScript_TryEnterChallenge::
 	copyvar VAR_0x8004, VAR_RESULT
 	setvar VAR_0x8005, FRONTIER_PARTY_SIZE
 	special ChoosePartyForBattleFrontier
-	waitstate
 	goto_if_eq VAR_RESULT, 0, BattleFrontier_BattleArenaLobby_EventScript_LoadPartyAndCancelChallenge
 	msgbox BattleFrontier_BattleArenaLobby_Text_OkayToSave, MSGBOX_YESNO
 	switch VAR_RESULT

--- a/data/maps/BattleFrontier_BattleDomeBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleDomeBattleRoom/scripts.inc
@@ -448,7 +448,6 @@ BattleFrontier_BattleDomeBattleRoom_EventScript_DoDomeBattle::
 	setvar VAR_0x8005, 0
 	setvar VAR_TEMP_9, 1
 	special DoSpecialTrainerBattle
-	waitstate
 	setvar VAR_TEMP_9, 0
 	dome_restorehelditems
 	special HealPlayerParty

--- a/data/maps/BattleFrontier_BattleDomeLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattleDomeLobby/scripts.inc
@@ -161,7 +161,6 @@ BattleFrontier_BattleDomeLobby_EventScript_TryEnterChallenge::
 	copyvar VAR_0x8004, VAR_RESULT
 	setvar VAR_0x8005, FRONTIER_PARTY_SIZE
 	special ChoosePartyForBattleFrontier
-	waitstate
 	goto_if_eq VAR_RESULT, 0, BattleFrontier_BattleDomeLobby_EventScript_LoadPartyCancelChallenge
 	msgbox BattleFrontier_BattleDomeLobby_Text_OkayToSaveBeforeChallenge, MSGBOX_YESNO
 	switch VAR_RESULT

--- a/data/maps/BattleFrontier_BattleDomePreBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleDomePreBattleRoom/scripts.inc
@@ -140,7 +140,6 @@ BattleFrontier_BattleDomePreBattleRoom_EventScript_ContinueChallenge::
 	copyvar VAR_0x8004, VAR_RESULT
 	setvar VAR_0x8005, DOME_BATTLE_PARTY_SIZE  @ 2 of the 3 party mons are selected for battle
 	special ChoosePartyForBattleFrontier
-	waitstate
 	frontier_resetsketch
 	goto_if_eq VAR_RESULT, 0, BattleFrontier_BattleDomePreBattleRoom_EventScript_AskReadyForNextRound
 	dome_set DOME_DATA_SELECTED_MONS

--- a/data/maps/BattleFrontier_BattleFactoryBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleFactoryBattleRoom/scripts.inc
@@ -83,7 +83,6 @@ BattleFrontier_BattleFactoryBattleRoom_EventScript_BattleOpponent::
 	setvar VAR_0x8004, SPECIAL_BATTLE_FACTORY
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	switch VAR_RESULT
 	case 1, BattleFrontier_BattleFactoryBattleRoom_EventScript_DefeatedOpponent
 BattleFrontier_BattleFactoryBattleRoom_EventScript_WarpToLobbyLost::
@@ -174,7 +173,6 @@ BattleFrontier_BattleFactoryBattleRoom_EventScript_DoNolandBattle::
 	setvar VAR_0x8004, SPECIAL_BATTLE_FACTORY
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	return
 
 BattleFrontier_BattleFactoryBattleRoom_EventScript_DefeatedNoland::

--- a/data/maps/BattleFrontier_BattlePalaceBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePalaceBattleRoom/scripts.inc
@@ -277,7 +277,6 @@ BattleFrontier_BattlePalaceBattleRoom_EventScript_DoPalaceBattle::
 	setvar VAR_0x8004, SPECIAL_BATTLE_PALACE
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	frontier_restorehelditems
 	special HealPlayerParty
 	frontier_resetsketch

--- a/data/maps/BattleFrontier_BattlePalaceLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePalaceLobby/scripts.inc
@@ -152,7 +152,6 @@ BattleFrontier_BattlePalaceLobby_EventScript_TryEnterChallenge::
 	copyvar VAR_0x8004, VAR_RESULT
 	setvar VAR_0x8005, FRONTIER_PARTY_SIZE
 	special ChoosePartyForBattleFrontier
-	waitstate
 	goto_if_eq VAR_RESULT, 0, BattleFrontier_BattlePalaceLobby_EventScript_LoadPartyAndCancelChallenge
 	msgbox BattleFrontier_BattlePalaceLobby_Text_MustSaveBeforeChallenge2, MSGBOX_YESNO
 	switch VAR_RESULT

--- a/data/maps/BattleFrontier_BattlePikeLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeLobby/scripts.inc
@@ -121,7 +121,6 @@ BattleFrontier_BattlePikeLobby_EventScript_TryEnterChallenge::
 	copyvar VAR_0x8004, VAR_RESULT
 	setvar VAR_0x8005, FRONTIER_PARTY_SIZE
 	special ChoosePartyForBattleFrontier
-	waitstate
 	goto_if_eq VAR_RESULT, 0, BattleFrontier_BattlePikeLobby_EventScript_LoadPartyAndCancelChallenge
 	msgbox BattleFrontier_BattlePikeLobby_Text_SaveBeforeChallenge, MSGBOX_YESNO
 	switch VAR_RESULT
@@ -261,7 +260,6 @@ BattleFrontier_BattlePikeLobby_EventScript_ExitRules::
 BattleFrontier_BattlePike_EventScript_CloseCurtain::
 	playse SE_PIKE_CURTAIN_CLOSE
 	special CloseBattlePikeCurtain
-	waitstate
 	waitse
 	return
 

--- a/data/maps/BattleFrontier_BattlePikeRoomNormal/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePikeRoomNormal/scripts.inc
@@ -34,7 +34,6 @@ BattleFrontier_BattlePikeRoomNormal_EventScript_EnterSingleBattleRoom::
 	setvar VAR_0x8004, SPECIAL_BATTLE_PIKE_SINGLE
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	switch VAR_RESULT
 	case 1, BattleFrontier_BattlePikeRoomNormal_EventScript_WonSingleBattle
 BattleFrontier_BattlePikeRoomNormal_EventScript_WarpToLobbyLost::
@@ -64,7 +63,6 @@ BattleFrontier_BattlePikeRoomNormal_EventScript_EnterHardBattleRoom::
 	setvar VAR_0x8004, SPECIAL_BATTLE_PIKE_SINGLE
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	switch VAR_RESULT
 	case 1, BattleFrontier_BattlePikeRoomNormal_EventScript_WonHardBattle
 	goto BattleFrontier_BattlePikeRoomNormal_EventScript_WarpToLobbyLost
@@ -255,7 +253,6 @@ BattleFrontier_BattlePikeRoomNormal_EventScript_EnterDoubleBattleRoom::
 	setvar VAR_0x8004, SPECIAL_BATTLE_PIKE_DOUBLE
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	switch VAR_RESULT
 	case 1, BattleFrontier_BattlePikeRoomNormal_EventScript_WonDoubleBattle
 	goto BattleFrontier_BattlePikeRoomNormal_EventScript_WarpToLobbyLost
@@ -383,7 +380,6 @@ BattleFrontier_BattlePikeRoomNormal_EventScript_DoPikeQueenBattle::
 	setvar VAR_0x8004, SPECIAL_BATTLE_PIKE_SINGLE
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	return
 
 BattleFrontier_BattlePikeRoomNormal_Movement_ApproachPlayer:

--- a/data/maps/BattleFrontier_BattlePyramidLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePyramidLobby/scripts.inc
@@ -133,7 +133,6 @@ BattleFrontier_BattlePyramidLobby_EventScript_TryEnterChallenge::
 	copyvar VAR_0x8004, VAR_RESULT
 	setvar VAR_0x8005, FRONTIER_PARTY_SIZE
 	special ChoosePartyForBattleFrontier
-	waitstate
 	goto_if_eq VAR_RESULT, 0, BattleFrontier_BattlePyramidLobby_EventScript_LoadPartyAndCancelChallenge
 	msgbox BattleFrontier_BattlePyramidLobby_Text_OkayToSaveBeforeChallenge, MSGBOX_YESNO
 	switch VAR_RESULT
@@ -444,7 +443,6 @@ BattleFrontier_BattlePyramidLobby_EventScript_PickItemsToKeep::
 
 BattleFrontier_BattlePyramidLobby_EventScript_PickItemsFromBag::
 	special ChooseItemsToTossFromPyramidBag
-	waitstate
 	message BattleFrontier_BattlePyramidLobby_Text_PickItemsToKeep
 	waitmessage
 	goto BattleFrontier_BattlePyramidLobby_EventScript_PickItemsToKeep
@@ -452,7 +450,6 @@ BattleFrontier_BattlePyramidLobby_EventScript_PickItemsFromBag::
 
 BattleFrontier_BattlePyramidLobby_EventScript_PickItemsFromParty::
 	special BattlePyramidChooseMonHeldItems
-	waitstate
 	message BattleFrontier_BattlePyramidLobby_Text_PickItemsToKeep
 	waitmessage
 	goto BattleFrontier_BattlePyramidLobby_EventScript_PickItemsToKeep

--- a/data/maps/BattleFrontier_BattlePyramidTop/scripts.inc
+++ b/data/maps/BattleFrontier_BattlePyramidTop/scripts.inc
@@ -183,7 +183,6 @@ BattleFrontier_BattlePyramidTop_EventScript_DoBrandonBattle::
 	setvar VAR_0x8004, SPECIAL_BATTLE_PYRAMID
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	return
 
 BattleFrontier_BattlePyramidTop_Movement_AttendantMoveAside:

--- a/data/maps/BattleFrontier_BattleTowerBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerBattleRoom/scripts.inc
@@ -299,7 +299,6 @@ BattleFrontier_BattleTowerBattleRoom_EventScript_DoTowerBattle::
 	setvar VAR_0x8004, SPECIAL_BATTLE_TOWER
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	copyvar VAR_0x8004, VAR_FRONTIER_BATTLE_MODE
 	goto_if_eq VAR_0x8004, FRONTIER_MODE_LINK_MULTIS, BattleFrontier_BattleTowerBattleRoom_EventScript_EndTowerBattle
 	frontier_restorehelditems

--- a/data/maps/BattleFrontier_BattleTowerElevator/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerElevator/scripts.inc
@@ -15,7 +15,6 @@ BattleFrontier_BattleTowerElevator_EventScript_EnterElevator::
 	special BufferBattleTowerElevatorFloors
 	waitse
 	special MoveElevator
-	waitstate
 	delay 48
 	applymovement LOCALID_TOWER_ELEVATOR_ATTENDANT, BattleFrontier_BattleTowerElevator_Movement_AttendantExit
 	applymovement LOCALID_PLAYER, BattleFrontier_BattleTowerElevator_Movement_PlayerExit

--- a/data/maps/BattleFrontier_BattleTowerLobby/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerLobby/scripts.inc
@@ -197,7 +197,6 @@ BattleFrontier_BattleTowerLobby_EventScript_TryEnterSinglesChallenge::
 	copyvar VAR_0x8004, VAR_RESULT
 	setvar VAR_0x8005, FRONTIER_PARTY_SIZE
 	special ChoosePartyForBattleFrontier
-	waitstate
 	goto_if_eq VAR_RESULT, 0, BattleFrontier_BattleTowerLobby_EventScript_LoadPartyCancelChallenge
 	msgbox BattleFrontier_BattleTowerLobby_Text_OkayToSaveBeforeEntering, MSGBOX_YESNO
 	switch VAR_RESULT
@@ -260,7 +259,6 @@ BattleFrontier_BattleTowerLobby_EventScript_TryEnterDoublesChallenge::
 	copyvar VAR_0x8004, VAR_RESULT
 	setvar VAR_0x8005, FRONTIER_DOUBLES_PARTY_SIZE
 	special ChoosePartyForBattleFrontier
-	waitstate
 	goto_if_eq VAR_RESULT, 0, BattleFrontier_BattleTowerLobby_EventScript_LoadPartyCancelChallenge
 	msgbox BattleFrontier_BattleTowerLobby_Text_OkayToSaveBeforeEntering, MSGBOX_YESNO
 	switch VAR_RESULT
@@ -324,7 +322,6 @@ BattleFrontier_BattleTowerLobby_EventScript_TryEnterMultisChallenge::
 	copyvar VAR_0x8004, VAR_RESULT
 	setvar VAR_0x8005, FRONTIER_MULTI_PARTY_SIZE
 	special ChoosePartyForBattleFrontier
-	waitstate
 	goto_if_eq VAR_RESULT, 0, BattleFrontier_BattleTowerLobby_EventScript_LoadPartyCancelChallenge
 	msgbox BattleFrontier_BattleTowerLobby_Text_OkayToSaveBeforeEntering, MSGBOX_YESNO
 	switch VAR_RESULT
@@ -387,7 +384,6 @@ BattleFrontier_BattleTowerLobby_EventScript_TryEnterLinkMultisChallenge::
 	copyvar VAR_0x8004, VAR_RESULT
 	setvar VAR_0x8005, FRONTIER_MULTI_PARTY_SIZE
 	special ChoosePartyForBattleFrontier
-	waitstate
 	goto_if_eq VAR_RESULT, 0, BattleFrontier_BattleTowerLobby_EventScript_LoadPartyCancelChallenge
 	msgbox BattleFrontier_BattleTowerLobby_Text_OkayToSaveBeforeEntering, MSGBOX_YESNO
 	switch VAR_RESULT
@@ -754,7 +750,6 @@ BattleFrontier_BattleTowerLobby_EventScript_TryCableLink::
 	waitmessage
 	setvar VAR_0x8005, 0
 	special TryBattleLinkup
-	waitstate
 	goto_if_eq VAR_RESULT, LINKUP_SUCCESS, BattleFrontier_BattleTowerLobby_EventScript_CableLinkSuccessful
 	goto_if_eq VAR_RESULT, LINKUP_SOMEONE_NOT_READY, CableClub_EventScript_AbortLinkSomeoneNotReady
 	goto_if_eq VAR_RESULT, LINKUP_DIFF_SELECTIONS, BattleFrontier_BattleTowerLobby_EventScript_AbortLinkDifferentSelections
@@ -812,7 +807,6 @@ BattleFrontier_BattleTowerLobby_EventScript_CableLinkSuccessful::
 	waitmessage
 	tower_save CHALLENGE_STATUS_SAVING
 	special SaveForBattleTowerLink
-	waitstate
 	playse SE_SAVE
 	waitse
 	special TrySetBattleTowerLinkType
@@ -865,7 +859,6 @@ BattleFrontier_BattleTowerLobby_EventScript_WirelessLinkSuccessful::
 	waitmessage
 	tower_save CHALLENGE_STATUS_SAVING
 	special SaveForBattleTowerLink
-	waitstate
 	playse SE_SAVE
 	waitse
 	goto BattleFrontier_BattleTowerLobby_EventScript_EnterElevator

--- a/data/maps/BattleFrontier_BattleTowerMultiBattleRoom/scripts.inc
+++ b/data/maps/BattleFrontier_BattleTowerMultiBattleRoom/scripts.inc
@@ -331,7 +331,6 @@ BattleFrontier_BattleTowerMultiBattleRoom_EventScript_ContinueChallengeLink::
 	message gText_LinkStandby3
 	waitmessage
 	special LinkRetireStatusWithBattleTowerPartner
-	waitstate
 	goto_if_ne VAR_RESULT, BATTLE_TOWER_LINKSTAT_CONTINUE, BattleFrontier_BattleTowerMultiBattleRoom_EventScript_WarpToLobbyLost
 	goto BattleFrontier_BattleTowerMultiBattleRoom_EventScript_LinkDelayForMsg
 	end
@@ -362,7 +361,6 @@ BattleFrontier_BattleTowerMultiBattleRoom_EventScript_RetireChallengeLink::
 	message gText_LinkStandby3
 	waitmessage
 	special LinkRetireStatusWithBattleTowerPartner
-	waitstate
 	goto BattleFrontier_BattleTowerMultiBattleRoom_EventScript_WarpToLobbyLost
 	end
 

--- a/data/maps/BattleFrontier_ExchangeServiceCorner/scripts.inc
+++ b/data/maps/BattleFrontier_ExchangeServiceCorner/scripts.inc
@@ -78,7 +78,6 @@ BattleFrontier_ExchangeServiceCorner_EventScript_ChooseDecor1::
 	setvar VAR_0x8004, SCROLL_MULTI_BF_EXCHANGE_CORNER_DECOR_VENDOR_1
 	special ShowFrontierExchangeCornerItemIconWindow
 	special ShowScrollableMultichoice
-	waitstate
 	special CloseFrontierExchangeCornerItemIconWindow
 	switch VAR_RESULT
 	case 0, BattleFrontier_ExchangeServiceCorner_EventScript_KissPoster
@@ -187,7 +186,6 @@ BattleFrontier_ExchangeServiceCorner_EventScript_ChooseDecor2::
 	setvar VAR_0x8004, SCROLL_MULTI_BF_EXCHANGE_CORNER_DECOR_VENDOR_2
 	special ShowFrontierExchangeCornerItemIconWindow
 	special ShowScrollableMultichoice
-	waitstate
 	special CloseFrontierExchangeCornerItemIconWindow
 	switch VAR_RESULT
 	case 0, BattleFrontier_ExchangeServiceCorner_EventScript_LaprasDoll
@@ -251,7 +249,6 @@ BattleFrontier_ExchangeServiceCorner_EventScript_ChooseVitamin::
 	setvar VAR_0x8004, SCROLL_MULTI_BF_EXCHANGE_CORNER_VITAMIN_VENDOR
 	special ShowFrontierExchangeCornerItemIconWindow
 	special ShowScrollableMultichoice
-	waitstate
 	special CloseFrontierExchangeCornerItemIconWindow
 	switch VAR_RESULT
 	case 0, BattleFrontier_ExchangeServiceCorner_EventScript_Protein
@@ -324,7 +321,6 @@ BattleFrontier_ExchangeServiceCorner_EventScript_ChooseHoldItem::
 	setvar VAR_0x8004, SCROLL_MULTI_BF_EXCHANGE_CORNER_HOLD_ITEM_VENDOR
 	special ShowFrontierExchangeCornerItemIconWindow
 	special ShowScrollableMultichoice
-	waitstate
 	special CloseFrontierExchangeCornerItemIconWindow
 	switch VAR_RESULT
 	case 0, BattleFrontier_ExchangeServiceCorner_EventScript_Leftovers

--- a/data/maps/BattleFrontier_Lounge1/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge1/scripts.inc
@@ -13,7 +13,6 @@ BattleFrontier_Lounge1_EventScript_Breeder::
 
 BattleFrontier_Lounge1_EventScript_ChooseMonToShowBreeder::
 	special ChoosePartyMon
-	waitstate
 	goto_if_ne VAR_0x8004, PARTY_NOTHING_CHOSEN, BattleFrontier_Lounge1_EventScript_ShowMonToBreeder
 	goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, BattleFrontier_Lounge1_EventScript_CancelMonSelect
 	end

--- a/data/maps/BattleFrontier_Lounge5/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge5/scripts.inc
@@ -7,7 +7,6 @@ BattleFrontier_Lounge5_EventScript_NatureGirl::
 	msgbox BattleFrontier_Lounge5_Text_NatureGirlGreeting, MSGBOX_YESNO
 	goto_if_eq VAR_RESULT, NO, BattleFrontier_Lounge5_EventScript_NatureGirlNoneShown
 	special ChoosePartyMon
-	waitstate
 	lock
 	faceplayer
 	goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, BattleFrontier_Lounge5_EventScript_NatureGirlNoneShown

--- a/data/maps/BattleFrontier_Lounge6/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge6/scripts.inc
@@ -12,7 +12,6 @@ BattleFrontier_Lounge6_EventScript_Trader::
 	msgbox BattleFrontier_Lounge6_Text_WouldYouLikeToTrade, MSGBOX_YESNO
 	goto_if_eq VAR_RESULT, NO, BattleFrontier_Lounge6_EventScript_DeclineTrade
 	special ChoosePartyMon
-	waitstate
 	copyvar VAR_0x800A, VAR_0x8004
 	goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, BattleFrontier_Lounge6_EventScript_DeclineTrade
 	copyvar VAR_0x8005, VAR_0x800A
@@ -23,7 +22,6 @@ BattleFrontier_Lounge6_EventScript_Trader::
 	copyvar VAR_0x8005, VAR_0x800A
 	special CreateInGameTradePokemon
 	special DoInGameTradeScene
-	waitstate
 	msgbox BattleFrontier_Lounge6_Text_PromiseIllBeGoodToIt, MSGBOX_DEFAULT
 	setflag FLAG_BATTLE_FRONTIER_TRADE_DONE
 	release

--- a/data/maps/BattleFrontier_Lounge7/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge7/scripts.inc
@@ -24,7 +24,6 @@ BattleFrontier_Lounge7_EventScript_ChooseLeftTutorMove::
 	setvar VAR_0x8004, SCROLL_MULTI_BF_MOVE_TUTOR_1
 	setvar VAR_0x8006, 0
 	special ShowScrollableMultichoice
-	waitstate
 	copyvar VAR_TEMP_FRONTIER_TUTOR_SELECTION, VAR_RESULT
 	switch VAR_RESULT
 	case 0, BattleFrontier_Lounge7_EventScript_Softboiled
@@ -48,7 +47,6 @@ BattleFrontier_Lounge7_EventScript_ChooseNewLeftTutorMove::
 	setvar VAR_0x8004, SCROLL_MULTI_BF_MOVE_TUTOR_1
 	setvar VAR_0x8006, 1
 	special ShowScrollableMultichoice
-	waitstate
 	copyvar VAR_TEMP_FRONTIER_TUTOR_SELECTION, VAR_RESULT
 	switch VAR_RESULT
 	case 0, BattleFrontier_Lounge7_EventScript_Softboiled
@@ -138,7 +136,6 @@ BattleFrontier_Lounge7_EventScript_ChooseRightTutorMove::
 	setvar VAR_0x8004, SCROLL_MULTI_BF_MOVE_TUTOR_2
 	setvar VAR_0x8006, 0
 	special ShowScrollableMultichoice
-	waitstate
 	copyvar VAR_TEMP_FRONTIER_TUTOR_SELECTION, VAR_RESULT
 	switch VAR_RESULT
 	case 0, BattleFrontier_Lounge7_EventScript_DefenseCurl
@@ -162,7 +159,6 @@ BattleFrontier_Lounge7_EventScript_ChooseNewRightTutorMove::
 	setvar VAR_0x8004, SCROLL_MULTI_BF_MOVE_TUTOR_2
 	setvar VAR_0x8006, 1
 	special ShowScrollableMultichoice
-	waitstate
 	copyvar VAR_TEMP_FRONTIER_TUTOR_SELECTION, VAR_RESULT
 	switch VAR_RESULT
 	case 0, BattleFrontier_Lounge7_EventScript_DefenseCurl
@@ -266,7 +262,6 @@ BattleFrontier_Lounge7_EventScript_TeachTutorMove::
 	special CloseBattlePointsWindow
 	special CloseBattleFrontierTutorWindow
 	special ChooseMonForMoveTutor
-	waitstate
 	goto_if_eq VAR_RESULT, FALSE, BattleFrontier_Lounge7_EventScript_CancelChooseMon
 	msgbox BattleFrontier_Lounge7_Text_IllTakeBattlePoints, MSGBOX_DEFAULT
 	copyvar VAR_0x8004, VAR_0x8008

--- a/data/maps/BattleFrontier_OutsideEast/scripts.inc
+++ b/data/maps/BattleFrontier_OutsideEast/scripts.inc
@@ -115,7 +115,6 @@ BattleFrontier_OutsideEast_EventScript_WaterSudowoodo::
 	lock
 	faceplayer
 	special DoWateringBerryTreeAnim
-	waitstate
 	waitse
 	playse SE_SUDOWOODO_SHAKE
 	applymovement LOCALID_FRONTIER_SUDOWOODO, BattleFrontier_OutsideEast_Movement_SudowoodoShake

--- a/data/maps/BattleFrontier_ReceptionGate/scripts.inc
+++ b/data/maps/BattleFrontier_ReceptionGate/scripts.inc
@@ -139,7 +139,6 @@ BattleFrontier_ReceptionGate_EventScript_ChooseFacilityToLearnAbout::
 	waitmessage
 	setvar VAR_0x8004, SCROLL_MULTI_BF_RECEPTIONIST
 	special ShowScrollableMultichoice
-	waitstate
 	switch VAR_RESULT
 	case 0, BattleFrontier_ReceptionGate_EventScript_BattleTower
 	case 1, BattleFrontier_ReceptionGate_EventScript_BattleDome

--- a/data/maps/BirthIsland_Exterior/scripts.inc
+++ b/data/maps/BirthIsland_Exterior/scripts.inc
@@ -42,7 +42,6 @@ BirthIsland_Exterior_EventScript_Triangle::
 	lock
 	faceplayer
 	special DoDeoxysRockInteraction
-	waitstate
 	switch VAR_RESULT
 	case DEOXYS_ROCK_FAILED,     BirthIsland_Exterior_EventScript_Failed
 	case DEOXYS_ROCK_PROGRESSED, BirthIsland_Exterior_EventScript_Progressed
@@ -84,7 +83,6 @@ BirthIsland_Exterior_EventScript_Deoxys::
 	seteventmon SPECIES_DEOXYS, 30
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	specialvar VAR_RESULT, GetBattleOutcome
 	goto_if_eq VAR_RESULT, B_OUTCOME_WON, BirthIsland_Exterior_EventScript_DefeatedDeoxys

--- a/data/maps/DesertRuins/scripts.inc
+++ b/data/maps/DesertRuins/scripts.inc
@@ -64,7 +64,6 @@ DesertRuins_EventScript_Regirock::
 	setwildbattle SPECIES_REGIROCK, 40
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special StartRegiBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	specialvar VAR_RESULT, GetBattleOutcome
 	goto_if_eq VAR_RESULT, B_OUTCOME_WON, DesertRuins_EventScript_DefeatedRegirock

--- a/data/maps/EverGrandeCity_HallOfFame/scripts.inc
+++ b/data/maps/EverGrandeCity_HallOfFame/scripts.inc
@@ -52,7 +52,6 @@ EverGrandeCity_HallOfFame_EventScript_GameClearMale::
 	setrespawn HEAL_LOCATION_LITTLEROOT_TOWN_BRENDANS_HOUSE_2F
 	fadescreenspeed FADE_TO_BLACK, 24
 	special GameClear
-	waitstate
 	releaseall
 	end
 
@@ -60,7 +59,6 @@ EverGrandeCity_HallOfFame_EventScript_GameClearFemale::
 	setrespawn HEAL_LOCATION_LITTLEROOT_TOWN_MAYS_HOUSE_2F
 	fadescreenspeed FADE_TO_BLACK, 24
 	special GameClear
-	waitstate
 	releaseall
 	end
 

--- a/data/maps/FallarborTown_BattleTentLobby/scripts.inc
+++ b/data/maps/FallarborTown_BattleTentLobby/scripts.inc
@@ -129,7 +129,6 @@ FallarborTown_BattleTentLobby_EventScript_TryEnterChallenge::
 	setvar VAR_0x8004, 2
 	setvar VAR_0x8005, FRONTIER_PARTY_SIZE
 	special ChoosePartyForBattleFrontier
-	waitstate
 	goto_if_eq VAR_RESULT, 0, FallarborTown_BattleTentLobby_EventScript_LoadPartyCancelChallenge
 	msgbox FallarborTown_BattleTentLobby_Text_SaveBeforeChallenge, MSGBOX_YESNO
 	switch VAR_RESULT

--- a/data/maps/FallarborTown_MoveRelearnersHouse/scripts.inc
+++ b/data/maps/FallarborTown_MoveRelearnersHouse/scripts.inc
@@ -23,7 +23,6 @@ FallarborTown_MoveRelearnersHouse_EventScript_AskTeachMove::
 FallarborTown_MoveRelearnersHouse_EventScript_ChooseMon::
 	msgbox FallarborTown_MoveRelearnersHouse_Text_TutorWhichMon, MSGBOX_DEFAULT
 	special ChooseMonForMoveRelearner
-	waitstate
 	goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, FallarborTown_MoveRelearnersHouse_EventScript_ComeBackWithHeartScale
 	special IsSelectedMonEgg
 	goto_if_eq VAR_RESULT, TRUE, FallarborTown_MoveRelearnersHouse_EventScript_CantTeachEgg
@@ -34,7 +33,6 @@ FallarborTown_MoveRelearnersHouse_EventScript_ChooseMon::
 FallarborTown_MoveRelearnersHouse_EventScript_ChooseMove::
 	msgbox FallarborTown_MoveRelearnersHouse_Text_TeachWhichMove, MSGBOX_DEFAULT
 	special TeachMoveRelearnerMove
-	waitstate
 	goto_if_eq VAR_0x8004, 0, FallarborTown_MoveRelearnersHouse_EventScript_ChooseMon
 	msgbox FallarborTown_MoveRelearnersHouse_Text_HandedOverHeartScale, MSGBOX_DEFAULT
 	removeitem ITEM_HEART_SCALE

--- a/data/maps/FarawayIsland_Interior/scripts.inc
+++ b/data/maps/FarawayIsland_Interior/scripts.inc
@@ -130,7 +130,6 @@ FarawayIsland_Interior_EventScript_Mew::
 	seteventmon SPECIES_MEW, 30
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	specialvar VAR_RESULT, GetBattleOutcome
 	goto_if_eq VAR_RESULT, B_OUTCOME_WON, FarawayIsland_Interior_EventScript_MewDefeated

--- a/data/maps/FortreeCity_House1/scripts.inc
+++ b/data/maps/FortreeCity_House1/scripts.inc
@@ -12,7 +12,6 @@ FortreeCity_House1_EventScript_Trader::
 	msgbox FortreeCity_House1_Text_YouWillTradeWontYou, MSGBOX_YESNO
 	goto_if_eq VAR_RESULT, NO, FortreeCity_House1_EventScript_DeclineTrade
 	special ChoosePartyMon
-	waitstate
 	copyvar VAR_0x800A, VAR_0x8004
 	goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, FortreeCity_House1_EventScript_DeclineTrade
 	copyvar VAR_0x8005, VAR_0x800A
@@ -23,7 +22,6 @@ FortreeCity_House1_EventScript_Trader::
 	copyvar VAR_0x8005, VAR_0x800A
 	special CreateInGameTradePokemon
 	special DoInGameTradeScene
-	waitstate
 	bufferspeciesname STR_VAR_1, VAR_0x8009
 	msgbox FortreeCity_House1_Text_MonYouTakeCare, MSGBOX_DEFAULT
 	setflag FLAG_FORTREE_NPC_TRADE_COMPLETED

--- a/data/maps/IslandCave/scripts.inc
+++ b/data/maps/IslandCave/scripts.inc
@@ -97,7 +97,6 @@ IslandCave_EventScript_Regice::
 	setwildbattle SPECIES_REGICE, 40
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special StartRegiBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	specialvar VAR_RESULT, GetBattleOutcome
 	goto_if_eq VAR_RESULT, B_OUTCOME_WON, IslandCave_EventScript_DefeatedRegice

--- a/data/maps/LilycoveCity_ContestLobby/scripts.inc
+++ b/data/maps/LilycoveCity_ContestLobby/scripts.inc
@@ -370,31 +370,26 @@ LilycoveCity_ContestLobby_EventScript_WarpToContestHall::
 LilycoveCity_ContestLobby_EventScript_WarpToCoolContestHall::
 	setwarp MAP_CONTEST_HALL_COOL, 7, 5
 	special DoContestHallWarp
-	waitstate
 	return
 
 LilycoveCity_ContestLobby_EventScript_WarpToBeautyContestHall::
 	setwarp MAP_CONTEST_HALL_BEAUTY, 7, 5
 	special DoContestHallWarp
-	waitstate
 	return
 
 LilycoveCity_ContestLobby_EventScript_WarpToCuteContestHall::
 	setwarp MAP_CONTEST_HALL_CUTE, 7, 5
 	special DoContestHallWarp
-	waitstate
 	return
 
 LilycoveCity_ContestLobby_EventScript_WarpToSmartContestHall::
 	setwarp MAP_CONTEST_HALL_SMART, 7, 5
 	special DoContestHallWarp
-	waitstate
 	return
 
 LilycoveCity_ContestLobby_EventScript_WarpToToughContestHall::
 	setwarp MAP_CONTEST_HALL_TOUGH, 7, 5
 	special DoContestHallWarp
-	waitstate
 	return
 
 LilycoveCity_ContestLobby_EventScript_LeadToContestHall::
@@ -758,12 +753,10 @@ LilycoveCity_ContestLobby_EventScript_TrySetUpLinkContest::
 
 LilycoveCity_ContestLobby_EventScript_TryLinkEMode::
 	special TryContestEModeLinkup
-	waitstate
 	return
 
 LilycoveCity_ContestLobby_EventScript_TryLinkGMode::
 	special TryContestGModeLinkup
-	waitstate
 	return
 
 LilycoveCity_ContestLobby_EventScript_CancelLinkDifferentContest::
@@ -871,12 +864,10 @@ LilycoveCity_ContestLobby_EventScript_TryJoinGroup::
 
 LilycoveCity_ContestLobby_EventScript_TryBecomeLinkLeader::
 	special TryBecomeLinkLeader
-	waitstate
 	return
 
 LilycoveCity_ContestLobby_EventScript_TryJoinLinkGroup::
 	special TryJoinLinkGroup
-	waitstate
 	return
 
 LilycoveCity_ContestLobby_EventScript_LinkLeaderDecided::

--- a/data/maps/LilycoveCity_CoveLilyMotel_2F/scripts.inc
+++ b/data/maps/LilycoveCity_CoveLilyMotel_2F/scripts.inc
@@ -27,7 +27,6 @@ LilycoveCity_CoveLilyMotel_2F_EventScript_ShowDiploma::
 	waitmessage
 	call Common_EventScript_PlayGymBadgeFanfare
 	special Special_ShowDiploma
-	waitstate
 	release
 	end
 

--- a/data/maps/LilycoveCity_DepartmentStoreElevator/scripts.inc
+++ b/data/maps/LilycoveCity_DepartmentStoreElevator/scripts.inc
@@ -114,7 +114,6 @@ LilycoveCity_DepartmentStoreElevator_EventScript_MoveElevator::
 	waitmovement 0
 	waitse
 	special MoveElevator
-	waitstate
 	setflag FLAG_TEMP_2
 	return
 

--- a/data/maps/LilycoveCity_Harbor/scripts.inc
+++ b/data/maps/LilycoveCity_Harbor/scripts.inc
@@ -37,7 +37,6 @@ LilycoveCity_Harbor_EventScript_NoFirstTimeEventTickets::
 LilycoveCity_Harbor_EventScript_FerryRegularLocationSelect::
 	setvar VAR_0x8004, 0
 	special ScriptMenu_CreateLilycoveSSTidalMultichoice
-	waitstate
 	special GetLilycoveSSTidalSelection
 	switch VAR_RESULT
 	case 0, LilycoveCity_Harbor_EventScript_GoToSlateport
@@ -285,7 +284,6 @@ LilycoveCity_Harbor_EventScript_MultipleEventTicketsFirstTime::
 	waitmessage
 	setvar VAR_0x8004, 1
 	special ScriptMenu_CreateLilycoveSSTidalMultichoice
-	waitstate
 	special GetLilycoveSSTidalSelection
 	switch VAR_RESULT
 	case 2, LilycoveCity_Harbor_EventScript_GoToSouthernIslandFirstTime

--- a/data/maps/LilycoveCity_MoveDeletersHouse/scripts.inc
+++ b/data/maps/LilycoveCity_MoveDeletersHouse/scripts.inc
@@ -15,7 +15,6 @@ LilycoveCity_MoveDeletersHouse_EventScript_MoveDeleter::
 LilycoveCity_MoveDeletersHouse_EventScript_ChooseMonAndMoveToForget::
 	msgbox LilycoveCity_MoveDeletersHouse_Text_WhichMonShouldForget, MSGBOX_DEFAULT
 	special ChoosePartyMon
-	waitstate
 	goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, LilycoveCity_MoveDeletersHouse_EventScript_ComeAgain
 	special IsSelectedMonEgg
 	goto_if_eq VAR_RESULT, TRUE, LilycoveCity_MoveDeletersHouse_EventScript_EggCantForgetMoves

--- a/data/maps/LilycoveCity_PokemonTrainerFanClub/scripts.inc
+++ b/data/maps/LilycoveCity_PokemonTrainerFanClub/scripts.inc
@@ -511,7 +511,6 @@ LilycoveCity_PokemonTrainerFanClub_EventScript_RateTrainer::
 	waitmessage
 	setvar VAR_0x8004, SCROLL_MULTI_POKEMON_FAN_CLUB_RATER
 	special ShowScrollableMultichoice
-	waitstate
 	setvar VAR_0x8004, FANCLUB_MEMBER1
 	switch VAR_RESULT
 	case 11, LilycoveCity_PokemonTrainerFanClub_EventScript_CancelRateTrainer

--- a/data/maps/LittlerootTown_BrendansHouse_2F/scripts.inc
+++ b/data/maps/LittlerootTown_BrendansHouse_2F/scripts.inc
@@ -246,7 +246,6 @@ LittlerootTown_BrendansHouse_2F_EventScript_CheckPlayersPC::
 	playse SE_PC_ON
 	msgbox gText_PlayerHouseBootPC, MSGBOX_DEFAULT
 	special BedroomPC
-	waitstate
 	releaseall
 	end
 

--- a/data/maps/LittlerootTown_MaysHouse_2F/scripts.inc
+++ b/data/maps/LittlerootTown_MaysHouse_2F/scripts.inc
@@ -297,7 +297,6 @@ LittlerootTown_MaysHouse_2F_EventScript_CheckPlayersPC::
 	playse SE_PC_ON
 	msgbox gText_PlayerHouseBootPC, MSGBOX_DEFAULT
 	special BedroomPC
-	waitstate
 	releaseall
 	end
 

--- a/data/maps/MagmaHideout_4F/scripts.inc
+++ b/data/maps/MagmaHideout_4F/scripts.inc
@@ -25,7 +25,6 @@ MagmaHideout_4F_EventScript_Maxie::
 	applymovement LOCALID_MAGMA_HIDEOUT_4F_GROUDON, MagmaHideout_4F_Movement_GroudonApproach
 	waitmovement 0
 	special FadeOutOrbEffect
-	waitstate
 	setvar VAR_0x8004, 1  @ vertical pan
 	setvar VAR_0x8005, 1  @ horizontal pan
 	setvar VAR_0x8006, 8  @ num shakes

--- a/data/maps/MarineCave_End/scripts.inc
+++ b/data/maps/MarineCave_End/scripts.inc
@@ -36,7 +36,6 @@ MarineCave_End_EventScript_Kyogre::
 	setwildbattle SPECIES_KYOGRE, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	setvar VAR_TEMP_1, 0
 	specialvar VAR_RESULT, GetBattleOutcome

--- a/data/maps/MirageTower_4F/scripts.inc
+++ b/data/maps/MirageTower_4F/scripts.inc
@@ -49,7 +49,6 @@ MirageTower_4F_EventScript_CollapseMirageTower::
 	special ShakeCamera
 	waitstate
 	special DoMirageTowerCeilingCrumble
-	waitstate
 	setvar VAR_MIRAGE_TOWER_STATE, 1
 	clearflag FLAG_LANDMARK_MIRAGE_TOWER
 	warp MAP_ROUTE111, 19, 59

--- a/data/maps/MossdeepCity_SpaceCenter_2F/scripts.inc
+++ b/data/maps/MossdeepCity_SpaceCenter_2F/scripts.inc
@@ -240,7 +240,6 @@ MossdeepCity_SpaceCenter_2F_EventScript_ChoosePartyForMultiBattle::
 	special SavePlayerParty
 	fadescreen FADE_TO_BLACK
 	special ChooseHalfPartyForBattle
-	waitstate
 	goto_if_ne VAR_RESULT, 0, MossdeepCity_SpaceCenter_2F_EventScript_DoStevenMultiBattle
 	special LoadPlayerParty
 	goto MossdeepCity_SpaceCenter_2F_EventScript_ReadyForBattlePrompt
@@ -251,14 +250,12 @@ MossdeepCity_SpaceCenter_2F_EventScript_DoStevenMultiBattle::
 	setvar VAR_0x8004, SPECIAL_BATTLE_STEVEN
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	frontier_saveparty
 	special LoadPlayerParty
 	switch VAR_RESULT
 	case 1, MossdeepCity_SpaceCenter_2F_EventScript_DefeatedMaxieTabitha
 	fadescreen FADE_TO_BLACK
 	special SetCB2WhiteOut
-	waitstate
 
 MossdeepCity_SpaceCenter_2F_EventScript_DefeatedMaxieTabitha::
 	msgbox MossdeepCity_SpaceCenter_2F_Text_MaxieWeFailedIsAquaAlsoMisguided, MSGBOX_DEFAULT

--- a/data/maps/MtChimney_CableCarStation/scripts.inc
+++ b/data/maps/MtChimney_CableCarStation/scripts.inc
@@ -46,7 +46,6 @@ MtChimney_CableCarStation_EventScript_RideCableCar::
 	incrementgamestat GAME_STAT_RODE_CABLE_CAR
 	special CableCarWarp
 	special CableCar
-	waitstate
 	release
 	end
 

--- a/data/maps/NavelRock_Bottom/scripts.inc
+++ b/data/maps/NavelRock_Bottom/scripts.inc
@@ -54,7 +54,6 @@ NavelRock_Bottom_EventScript_Lugia::
 	seteventmon SPECIES_LUGIA, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	specialvar VAR_RESULT, GetBattleOutcome
 	goto_if_eq VAR_RESULT, B_OUTCOME_WON, NavelRock_Bottom_EventScript_DefeatedLugia

--- a/data/maps/NavelRock_Top/scripts.inc
+++ b/data/maps/NavelRock_Top/scripts.inc
@@ -58,7 +58,6 @@ NavelRock_Top_EventScript_HoOh::
 	seteventmon SPECIES_HO_OH, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	setvar VAR_LAST_TALKED, LOCALID_NAVEL_ROCK_HO_OH
 	specialvar VAR_RESULT, GetBattleOutcome

--- a/data/maps/PacifidlogTown_House3/scripts.inc
+++ b/data/maps/PacifidlogTown_House3/scripts.inc
@@ -12,7 +12,6 @@ PacifidlogTown_House3_EventScript_Trader::
 	msgbox PacifidlogTown_House3_Text_WillingToTradeIt, MSGBOX_YESNO
 	goto_if_eq VAR_RESULT, NO, PacifidlogTown_House3_EventScript_DeclineTrade
 	special ChoosePartyMon
-	waitstate
 	copyvar VAR_0x800A, VAR_0x8004
 	goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, PacifidlogTown_House3_EventScript_DeclineTrade
 	copyvar VAR_0x8005, VAR_0x800A
@@ -23,7 +22,6 @@ PacifidlogTown_House3_EventScript_Trader::
 	copyvar VAR_0x8005, VAR_0x800A
 	special CreateInGameTradePokemon
 	special DoInGameTradeScene
-	waitstate
 	bufferspeciesname STR_VAR_1, VAR_0x8009
 	msgbox PacifidlogTown_House3_Text_ItsSubtlyDifferentThankYou, MSGBOX_DEFAULT
 	setflag FLAG_PACIFIDLOG_NPC_TRADE_COMPLETED

--- a/data/maps/PetalburgCity/scripts.inc
+++ b/data/maps/PetalburgCity/scripts.inc
@@ -38,7 +38,6 @@ PetalburgCity_EventScript_WallyTutorial::
 	waitmovement 0
 	msgbox Route102_Text_WatchMeCatchPokemon, MSGBOX_DEFAULT
 	special StartWallyTutorialBattle
-	waitstate
 	msgbox Route102_Text_WallyIDidIt, MSGBOX_DEFAULT
 	applymovement LOCALID_PETALBURG_WALLY, Common_Movement_WalkInPlaceFasterLeft, MAP_PETALBURG_CITY
 	waitmovement LOCALID_PETALBURG_WALLY, MAP_PETALBURG_CITY

--- a/data/maps/PetalburgCity_Gym/scripts.inc
+++ b/data/maps/PetalburgCity_Gym/scripts.inc
@@ -1095,7 +1095,6 @@ PetalburgCity_Gym_EventScript_SetOHKORoomDoorMetatiles::
 
 PetalburgCity_Gym_EventScript_SlideOpenRoomDoors::
 	special PetalburgGymSlideOpenRoomDoors
-	waitstate
 	return
 
 PetalburgCity_Gym_EventScript_UnlockRoomDoors::

--- a/data/maps/Route101/scripts.inc
+++ b/data/maps/Route101/scripts.inc
@@ -226,7 +226,6 @@ Route101_EventScript_BirchsBag::
 	applymovement LOCALID_PLAYER, Common_Movement_WalkInPlaceFasterLeft
 	waitmovement 0
 	special ChooseStarter
-	waitstate
 	applymovement LOCALID_ROUTE101_BIRCH, Route101_Movement_BirchApproachPlayer
 	waitmovement 0
 	msgbox Route101_Text_YouSavedMe, MSGBOX_DEFAULT

--- a/data/maps/Route111/scripts.inc
+++ b/data/maps/Route111/scripts.inc
@@ -107,21 +107,17 @@ Route111_OnFrame:
 Route111_EventScript_MirageTowerDisappear::
 	lockall
 	special StartMirageTowerShake
-	waitstate
 	delay 24
 	playse SE_FALL
 	addobject LOCALID_ROUTE111_PLAYER_FALLING
 	special StartPlayerDescendMirageTower
-	waitstate
 	showobjectat LOCALID_PLAYER, MAP_LITTLEROOT_TOWN
 	removeobject LOCALID_ROUTE111_PLAYER_FALLING
 	delay 16
 	turnobject LOCALID_PLAYER, DIR_NORTH
 	delay 16
 	special StartMirageTowerDisintegration
-	waitstate
 	special StartMirageTowerFossilFallAndSink
-	waitstate
 	setvar VAR_MIRAGE_TOWER_STATE, 2
 	clearflag FLAG_HIDE_DESERT_UNDERPASS_FOSSIL
 	goto_if_set FLAG_CHOSE_CLAW_FOSSIL, Route111_EventScript_RootFossilDisappeared

--- a/data/maps/Route112_CableCarStation/scripts.inc
+++ b/data/maps/Route112_CableCarStation/scripts.inc
@@ -47,7 +47,6 @@ Route112_CableCarStation_EventScript_RideCableCar::
 	incrementgamestat GAME_STAT_RODE_CABLE_CAR
 	special CableCarWarp
 	special CableCar
-	waitstate
 	release
 	end
 

--- a/data/maps/Route113_GlassWorkshop/scripts.inc
+++ b/data/maps/Route113_GlassWorkshop/scripts.inc
@@ -57,7 +57,6 @@ Route113_GlassWorkshop_EventScript_ChooseGlassItem::
 	setvar VAR_0x8009, 0
 	setvar VAR_0x8004, SCROLL_MULTI_GLASS_WORKSHOP_VENDOR
 	special ShowScrollableMultichoice
-	waitstate
 	switch VAR_RESULT
 	case 0, Route113_GlassWorkshop_EventScript_BlueFlute
 	case 1, Route113_GlassWorkshop_EventScript_YellowFlute

--- a/data/maps/RustboroCity/scripts.inc
+++ b/data/maps/RustboroCity/scripts.inc
@@ -76,7 +76,6 @@ RustboroCity_EventScript_PleaseSelectPokenav::
 RustboroCity_EventScript_MatchCallTutorial::
 	setflag FLAG_ADDED_MATCH_CALL_TO_POKENAV
 	special ScriptMenu_CreateStartMenuForPokenavTutorial
-	waitstate
 	switch VAR_RESULT
 	case 0, RustboroCity_EventScript_PleaseSelectPokenav
 	case 1, RustboroCity_EventScript_PleaseSelectPokenav
@@ -87,7 +86,6 @@ RustboroCity_EventScript_MatchCallTutorial::
 	case 7, RustboroCity_EventScript_PleaseSelectPokenav
 	case MULTI_B_PRESSED, RustboroCity_EventScript_PleaseSelectPokenav
 	special OpenPokenavForTutorial
-	waitstate
 	delay 20
 	msgbox RustboroCity_Text_IdBetterGetBackToWork, MSGBOX_DEFAULT
 	closemessage

--- a/data/maps/RustboroCity_Flat1_2F/scripts.inc
+++ b/data/maps/RustboroCity_Flat1_2F/scripts.inc
@@ -10,7 +10,6 @@ RustboroCity_Flat1_2F_EventScript_WaldasDad::
 
 RustboroCity_Flat1_2F_EventScript_GivePhrase::
 	special DoWaldaNamingScreen
-	waitstate
 	goto_if_eq VAR_0x8004, 1, RustboroCity_Flat1_2F_EventScript_CancelGivePhrase
 	goto_if_eq VAR_0x8004, 2, RustboroCity_Flat1_2F_EventScript_CancelGiveFirstPhrase
 	specialvar VAR_RESULT, TryGetWallpaperWithWaldaPhrase

--- a/data/maps/RustboroCity_House1/scripts.inc
+++ b/data/maps/RustboroCity_House1/scripts.inc
@@ -12,7 +12,6 @@ RustboroCity_House1_EventScript_Trader::
 	msgbox RustboroCity_House1_Text_IllTradeIfYouWant, MSGBOX_YESNO
 	goto_if_eq VAR_RESULT, NO, RustboroCity_House1_EventScript_DeclineTrade
 	special ChoosePartyMon
-	waitstate
 	copyvar VAR_0x800A, VAR_0x8004
 	goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, RustboroCity_House1_EventScript_DeclineTrade
 	copyvar VAR_0x8005, VAR_0x800A
@@ -23,7 +22,6 @@ RustboroCity_House1_EventScript_Trader::
 	copyvar VAR_0x8005, VAR_0x800A
 	special CreateInGameTradePokemon
 	special DoInGameTradeScene
-	waitstate
 	msgbox RustboroCity_House1_Text_PleaseBeGoodToMyPokemon, MSGBOX_DEFAULT
 	setflag FLAG_RUSTBORO_NPC_TRADE_COMPLETED
 	release

--- a/data/maps/SSTidalCorridor/scripts.inc
+++ b/data/maps/SSTidalCorridor/scripts.inc
@@ -150,7 +150,6 @@ SSTidalCorridor_EventScript_Porthole::
 
 SSTidalCorridor_EventScript_LookThroughPorthole::
 	special LookThroughPorthole
-	waitstate
 	end
 
 SSTidalCorridor_EventScript_Sailor::

--- a/data/maps/SeafloorCavern_Room9/scripts.inc
+++ b/data/maps/SeafloorCavern_Room9/scripts.inc
@@ -31,10 +31,8 @@ SeafloorCavern_Room9_EventScript_ArchieAwakenKyogre::
 	setweather WEATHER_NONE
 	doweather
 	special Script_FadeOutMapMusic
-	waitstate
 	msgbox SeafloorCavern_Room9_Text_RedOrbShinesByItself, MSGBOX_DEFAULT
 	special WaitWeather
-	waitstate
 	setvar VAR_RESULT, 1
 	playse SE_M_DETECT
 	dofieldeffectsparkle 16, 42, 0
@@ -55,7 +53,6 @@ SeafloorCavern_Room9_EventScript_ArchieAwakenKyogre::
 	applymovement LOCALID_SEAFLOOR_CAVERN_KYOGRE, SeafloorCavern_Room9_Movement_KyogreApproach
 	waitmovement 0
 	special FadeOutOrbEffect
-	waitstate
 	setvar VAR_0x8004, 1  @ vertical pan
 	setvar VAR_0x8005, 1  @ horizontal pan
 	setvar VAR_0x8006, 8  @ num shakes

--- a/data/maps/SealedChamber_InnerRoom/scripts.inc
+++ b/data/maps/SealedChamber_InnerRoom/scripts.inc
@@ -10,18 +10,14 @@ SealedChamber_InnerRoom_EventScript_BrailleBackWall::
 	fadeoutbgm 0
 	playse SE_TRUCK_MOVE
 	special DoSealedChamberShakingEffect_Long
-	waitstate
 	delay 40
 	special DoSealedChamberShakingEffect_Short
-	waitstate
 	playse SE_DOOR
 	delay 40
 	special DoSealedChamberShakingEffect_Short
-	waitstate
 	playse SE_DOOR
 	delay 40
 	special DoSealedChamberShakingEffect_Short
-	waitstate
 	playse SE_DOOR
 	delay 40
 	msgbox gText_DoorOpenedFarAway, MSGBOX_DEFAULT

--- a/data/maps/SkyPillar_Outside/scripts.inc
+++ b/data/maps/SkyPillar_Outside/scripts.inc
@@ -73,7 +73,6 @@ SkyPillar_Outside_EventScript_WallaceScene::
 	setweather WEATHER_ABNORMAL
 	doweather
 	special WaitWeather
-	waitstate
 	delay 30
 	msgbox SkyPillar_Outside_Text_GotToGoBackForSootopolis, MSGBOX_DEFAULT
 	closemessage

--- a/data/maps/SkyPillar_Top/scripts.inc
+++ b/data/maps/SkyPillar_Top/scripts.inc
@@ -49,7 +49,6 @@ SkyPillar_Top_EventScript_Rayquaza::
 	setwildbattle SPECIES_RAYQUAZA, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	specialvar VAR_RESULT, GetBattleOutcome
 	goto_if_eq VAR_RESULT, B_OUTCOME_WON, SkyPillar_Top_EventScript_DefeatedRayquaza

--- a/data/maps/SlateportCity/scripts.inc
+++ b/data/maps/SlateportCity/scripts.inc
@@ -733,7 +733,6 @@ SlateportCity_EventScript_ChooseBerryPowderItem::
 	waitmessage
 	setvar VAR_0x8004, SCROLL_MULTI_BERRY_POWDER_VENDOR
 	special ShowScrollableMultichoice
-	waitstate
 	switch VAR_RESULT
 	case 0, SlateportCity_EventScript_EnergyPowder
 	case 1, SlateportCity_EventScript_EnergyRoot
@@ -915,7 +914,6 @@ SlateportCity_Movement_ScottExitAfterBattleTent:
 SlateportCity_EventScript_BerryCrushRankingsSign::
 	lockall
 	special ShowBerryCrushRankings
-	waitstate
 	releaseall
 	end
 

--- a/data/maps/SlateportCity_BattleTentBattleRoom/scripts.inc
+++ b/data/maps/SlateportCity_BattleTentBattleRoom/scripts.inc
@@ -59,7 +59,6 @@ SlateportCity_BattleTentBattleRoom_EventScript_EnterRoom::
 	setvar VAR_0x8004, SPECIAL_BATTLE_FACTORY
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	switch VAR_RESULT
 	case 1, SlateportCity_BattleTentBattleRoom_EventScript_DefeatedOpponent
 SlateportCity_BattleTent_EventScript_WarpToLobbyLost::

--- a/data/maps/SlateportCity_NameRatersHouse/scripts.inc
+++ b/data/maps/SlateportCity_NameRatersHouse/scripts.inc
@@ -12,7 +12,6 @@ SlateportCity_NameRatersHouse_EventScript_NameRater::
 SlateportCity_NameRatersHouse_EventScript_ChooseMonToRate::
 	msgbox SlateportCity_NameRatersHouse_Text_CritiqueWhichMonNickname, MSGBOX_DEFAULT
 	special ChoosePartyMon
-	waitstate
 	goto_if_ne VAR_0x8004, PARTY_NOTHING_CHOSEN, SlateportCity_NameRatersHouse_EventScript_RateMonNickname
 	goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, SlateportCity_NameRatersHouse_EventScript_DeclineNameRate
 	end

--- a/data/maps/SootopolisCity/scripts.inc
+++ b/data/maps/SootopolisCity/scripts.inc
@@ -188,7 +188,6 @@ SootopolisCity_EventScript_LegendariesSceneFromPokeCenter::
 	doweather
 	setvar VAR_0x8004, FALSE @ Just do Groudon/Kyogre fight scene
 	special Script_DoRayquazaScene
-	waitstate
 	applymovement LOCALID_SOOTOPOLIS_KYOGRE, Common_Movement_WalkInPlaceFasterLeft
 	applymovement LOCALID_SOOTOPOLIS_GROUDON, Common_Movement_WalkInPlaceFasterRight
 	waitmovement 0
@@ -288,7 +287,6 @@ SootopolisCity_EventScript_LegendariesSceneFromDive::
 	doweather
 	setvar VAR_0x8004, FALSE @ Just do Groudon/Kyogre fight scene
 	special Script_DoRayquazaScene
-	waitstate
 	applymovement LOCALID_SOOTOPOLIS_KYOGRE, Common_Movement_WalkInPlaceFasterLeft
 	applymovement LOCALID_SOOTOPOLIS_GROUDON, Common_Movement_WalkInPlaceFasterRight
 	waitmovement 0
@@ -479,7 +477,6 @@ SootopolisCity_EventScript_RayquazaSceneFromPokeCenter::
 	addobject LOCALID_SOOTOPOLIS_RAYQUAZA
 	setvar VAR_0x8004, TRUE
 	special Script_DoRayquazaScene
-	waitstate
 	playse SE_THUNDER
 	special SpawnCameraObject
 	applymovement LOCALID_CAMERA, SootopolisCity_Movement_PanUp
@@ -507,7 +504,6 @@ SootopolisCity_EventScript_RayquazaSceneFromPokeCenter::
 	waitmovement 0
 	removeobject LOCALID_SOOTOPOLIS_RAYQUAZA
 	special WaitWeather
-	waitstate
 	clearflag FLAG_SYS_WEATHER_CTRL
 	setvar VAR_SKY_PILLAR_STATE, 3
 	clearflag FLAG_LEGENDARIES_IN_SOOTOPOLIS
@@ -532,7 +528,6 @@ SootopolisCity_EventScript_RayquazaSceneFromDive::
 	addobject LOCALID_SOOTOPOLIS_RAYQUAZA
 	setvar VAR_0x8004, TRUE
 	special Script_DoRayquazaScene
-	waitstate
 	special SpawnCameraObject
 	applymovement LOCALID_CAMERA, SootopolisCity_Movement_PanUp
 	applymovement LOCALID_PLAYER, SootopolisCity_Movement_PlayerApproachLegendaries
@@ -560,7 +555,6 @@ SootopolisCity_EventScript_RayquazaSceneFromDive::
 	waitmovement 0
 	removeobject LOCALID_SOOTOPOLIS_RAYQUAZA
 	special WaitWeather
-	waitstate
 	clearflag FLAG_SYS_WEATHER_CTRL
 	setvar VAR_SKY_PILLAR_STATE, 2
 	clearflag FLAG_LEGENDARIES_IN_SOOTOPOLIS

--- a/data/maps/SootopolisCity_LotadAndSeedotHouse/scripts.inc
+++ b/data/maps/SootopolisCity_LotadAndSeedotHouse/scripts.inc
@@ -7,7 +7,6 @@ SootopolisCity_LotadAndSeedotHouse_EventScript_SeedotBrother::
 	faceplayer
 	msgbox SootopolisCity_LotadAndSeedotHouse_Text_PleaseShowMeBigSeedot, MSGBOX_DEFAULT
 	special ChoosePartyMon
-	waitstate
 	copyvar VAR_RESULT, VAR_0x8004
 	goto_if_eq VAR_RESULT, PARTY_NOTHING_CHOSEN, SootopolisCity_LotadAndSeedotHouse_EventScript_CancelShowSeedot
 	special CompareSeedotSize
@@ -51,7 +50,6 @@ SootopolisCity_LotadAndSeedotHouse_EventScript_LotadBrother::
 	faceplayer
 	msgbox SootopolisCity_LotadAndSeedotHouse_Text_PleaseShowMeBigLotad, MSGBOX_DEFAULT
 	special ChoosePartyMon
-	waitstate
 	copyvar VAR_RESULT, VAR_0x8004
 	goto_if_eq VAR_RESULT, PARTY_NOTHING_CHOSEN, SootopolisCity_LotadAndSeedotHouse_EventScript_CancelShowLotad
 	special CompareLotadSize

--- a/data/maps/SootopolisCity_MysteryEventsHouse_1F/scripts.inc
+++ b/data/maps/SootopolisCity_MysteryEventsHouse_1F/scripts.inc
@@ -114,7 +114,6 @@ SootopolisCity_MysteryEventsHouse_1F_EventScript_ChooseParty::
 	msgbox SootopolisCity_MysteryEventsHouse_1F_Text_KeepItTo3On3, MSGBOX_DEFAULT
 	fadescreen FADE_TO_BLACK
 	special ChooseHalfPartyForBattle
-	waitstate
 	return
 
 SootopolisCity_MysteryEventsHouse_1F_EventScript_EnterBasementNorth::

--- a/data/maps/SootopolisCity_MysteryEventsHouse_B1F/scripts.inc
+++ b/data/maps/SootopolisCity_MysteryEventsHouse_B1F/scripts.inc
@@ -21,7 +21,6 @@ SootopolisCity_MysteryEventsHouse_B1F_EventScript_BattleVisitingTrainer::
 	setvar VAR_0x8004, SPECIAL_BATTLE_EREADER
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	call_if_eq VAR_RESULT, B_OUTCOME_DREW, SootopolisCity_MysteryEventsHouse_B1F_EventScript_BattleTie
 	call_if_eq VAR_RESULT, B_OUTCOME_WON, SootopolisCity_MysteryEventsHouse_B1F_EventScript_BattleWon
 	call_if_eq VAR_RESULT, B_OUTCOME_LOST, SootopolisCity_MysteryEventsHouse_B1F_EventScript_BattleLost

--- a/data/maps/SouthernIsland_Interior/scripts.inc
+++ b/data/maps/SouthernIsland_Interior/scripts.inc
@@ -76,7 +76,6 @@ SouthernIsland_Interior_EventScript_Lati::
 	call_if_ne VAR_ROAMER_POKEMON, 0, SouthernIsland_Interior_EventScript_SetLatiasBattleVars
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLatiBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	specialvar VAR_RESULT, GetBattleOutcome
 	goto_if_eq VAR_RESULT, B_OUTCOME_WON, SouthernIsland_Interior_EventScript_LatiDefeated

--- a/data/maps/TerraCave_End/scripts.inc
+++ b/data/maps/TerraCave_End/scripts.inc
@@ -36,7 +36,6 @@ TerraCave_End_EventScript_Groudon::
 	setwildbattle SPECIES_GROUDON, 70
 	setflag FLAG_SYS_CTRL_OBJ_DELETE
 	special BattleSetup_StartLegendaryBattle
-	waitstate
 	clearflag FLAG_SYS_CTRL_OBJ_DELETE
 	setvar VAR_TEMP_1, 0
 	specialvar VAR_RESULT, GetBattleOutcome

--- a/data/maps/TrainerHill_Elevator/scripts.inc
+++ b/data/maps/TrainerHill_Elevator/scripts.inc
@@ -52,7 +52,6 @@ TrainerHill_Elevator_EventScript_CloseFloorSelect::
 TrainerHill_Elevator_EventScript_MoveElevator::
 	waitse
 	special MoveElevator
-	waitstate
 	return
 
 TrainerHill_Elevator_Movement_PlayerMoveToCenterOfElevator:

--- a/data/maps/TrainerHill_Entrance/scripts.inc
+++ b/data/maps/TrainerHill_Entrance/scripts.inc
@@ -214,7 +214,6 @@ TrainerHill_Entrance_EventScript_Records::
 	lockall
 	fadescreen FADE_TO_BLACK
 	special ShowTrainerHillRecords
-	waitstate
 	releaseall
 	end
 

--- a/data/maps/VerdanturfTown_BattleTentLobby/scripts.inc
+++ b/data/maps/VerdanturfTown_BattleTentLobby/scripts.inc
@@ -130,7 +130,6 @@ VerdanturfTown_BattleTentLobby_EventScript_TryEnterChallenge::
 	setvar VAR_0x8004, 1
 	setvar VAR_0x8005, FRONTIER_PARTY_SIZE
 	special ChoosePartyForBattleFrontier
-	waitstate
 	goto_if_eq VAR_RESULT, 0, VerdanturfTown_BattleTentLobby_EventScript_LoadPartyCancelChallenge
 	msgbox VerdanturfTown_BattleTentLobby_Text_SaveBeforeChallenge, MSGBOX_YESNO
 	switch VAR_RESULT
@@ -279,7 +278,6 @@ VerdanturfTown_BattleTentLobby_EventScript_ReadRulesBoard::
 	waitmessage
 	setvar VAR_0x8004, SCROLL_MULTI_BATTLE_TENT_RULES
 	special ShowScrollableMultichoice
-	waitstate
 	switch VAR_RESULT
 	case 0, VerdanturfTown_BattleTentLobby_EventScript_RulesLevel
 	case 1, VerdanturfTown_BattleTentLobby_EventScript_RulesBasics

--- a/data/scripts/berry_blender.inc
+++ b/data/scripts/berry_blender.inc
@@ -300,7 +300,6 @@ BerryBlender_EventScript_DoBerryBlending:
 	copyvar VAR_0x8004, NUM_OPPONENTS
 	fadescreen FADE_TO_BLACK
 	special DoBerryBlending
-	waitstate
 	releaseall
 	end
 
@@ -565,7 +564,6 @@ BerryBlender_EventScript_TryDoLinkBlender:
 	message BerryBlender_Text_SearchingForFriends
 	waitmessage
 	special TryBerryBlenderLinkup
-	waitstate
 	goto_if_eq VAR_RESULT, LINKUP_SUCCESS, BerryBlender_EventScript_SpawnLinkPartners
 	goto_if_eq VAR_RESULT, LINKUP_SOMEONE_NOT_READY, BerryBlender_EventScript_CloseLinkNotReady
 	goto_if_eq VAR_RESULT, LINKUP_DIFF_SELECTIONS, BerryBlender_EventScript_CloseLinkDifferentSelections
@@ -596,7 +594,6 @@ BerryBlender_EventScript_DoLinkBerryBlending:
 	removeobject 238
 	removeobject 237
 	special DoBerryBlending
-	waitstate
 	releaseall
 	end
 
@@ -689,12 +686,10 @@ BerryBlender_EventScript_TryJoinGroup:
 
 BerryBlender_EventScript_TryBecomeLinkLeader:
 	special TryBecomeLinkLeader
-	waitstate
 	return
 
 BerryBlender_EventScript_TryJoinLinkGroup:
 	special TryJoinLinkGroup
-	waitstate
 	return
 
 BerryBlender_EventScript_LinkLeaderDecided:

--- a/data/scripts/berry_tree.inc
+++ b/data/scripts/berry_tree.inc
@@ -39,7 +39,6 @@ BerryTree_EventScript_ChooseBerryToPlant::
 	fadescreen FADE_TO_BLACK
 	closemessage
 	special Bag_ChooseBerry
-	waitstate
 	goto_if_eq VAR_ITEM_ID, 0, BerryTree_EventScript_CancelPlanting
 	removeitem VAR_ITEM_ID
 	call BerryTree_EventScript_PlantBerry
@@ -165,7 +164,6 @@ BerryTree_EventScript_WaterBerry::
 	waitmessage
 	special ObjectEventInteractionWaterBerryTree
 	special DoWateringBerryTreeAnim
-	waitstate
 	message BerryTree_Text_PlantIsDelighted
 	waitmessage
 	waitbuttonpress

--- a/data/scripts/cable_club.inc
+++ b/data/scripts/cable_club.inc
@@ -327,7 +327,6 @@ CableClub_EventScript_TryEnterColosseum::
 	message gText_PleaseWaitForLink
 	waitmessage
 	special TryBattleLinkup
-	waitstate
 	goto_if_eq VAR_RESULT, LINKUP_SUCCESS, CableClub_EventScript_EnterColosseum
 	goto_if_eq VAR_RESULT, LINKUP_SOMEONE_NOT_READY, CableClub_EventScript_AbortLinkSomeoneNotReady
 	goto_if_eq VAR_RESULT, LINKUP_DIFF_SELECTIONS, CableClub_EventScript_AbortLinkDifferentSelections
@@ -364,7 +363,6 @@ CableClub_EventScript_EnterColosseum::
 	special SetCableClubWarp
 	warp MAP_BATTLE_COLOSSEUM_2P, 6, 8
 	special DoCableClubWarp
-	waitstate
 	end
 
 @ Unused
@@ -377,7 +375,6 @@ CableClub_EventScript_WarpTo4PColosseum::
 	special SetCableClubWarp
 	warp MAP_BATTLE_COLOSSEUM_4P, 5, 8
 	special DoCableClubWarp
-	waitstate
 	end
 
 CableClub_EventScript_AbortLinkIncorrectNumberOfBattlers::
@@ -421,7 +418,6 @@ CableClub_EventScript_TradeCenter::
 	message gText_PleaseWaitForLink
 	waitmessage
 	special TryTradeLinkup
-	waitstate
 	goto_if_eq VAR_RESULT, LINKUP_SUCCESS, CableClub_EventScript_EnterTradeCenter
 	goto_if_eq VAR_RESULT, LINKUP_SOMEONE_NOT_READY, CableClub_EventScript_AbortLinkSomeoneNotReady
 	goto_if_eq VAR_RESULT, LINKUP_DIFF_SELECTIONS, CableClub_EventScript_AbortLinkDifferentSelections
@@ -457,7 +453,6 @@ CableClub_EventScript_EnterTradeCenter::
 	special SetCableClubWarp
 	setwarp MAP_TRADE_CENTER, 5, 8
 	special DoCableClubWarp
-	waitstate
 	end
 
 CableClub_EventScript_CheckPartyTradeRequirements::
@@ -485,9 +480,7 @@ CableClub_EventScript_RecordCorner::
 	message gText_PleaseWaitForLink
 	waitmessage
 	special TryRecordMixLinkup
-	waitstate
 	special ValidateMixingGameLanguage
-	waitstate
 	goto_if_eq VAR_RESULT, LINKUP_FOREIGN_GAME, CableClub_EventScript_AbortLinkForeignGame
 	goto_if_eq VAR_RESULT, LINKUP_SUCCESS, CableClub_EventScript_EnterRecordCorner
 	goto_if_eq VAR_RESULT, LINKUP_SOMEONE_NOT_READY, CableClub_EventScript_AbortLinkSomeoneNotReady
@@ -522,7 +515,6 @@ CableClub_EventScript_EnterRecordCorner::
 	special SetCableClubWarp
 	setwarp MAP_RECORD_CORNER, 8, 9
 	special DoCableClubWarp
-	waitstate
 	end
 
 CableClub_EventScript_AbortLinkPlayerNotReady::
@@ -571,7 +563,6 @@ MossdeepCity_GameCorner_1F_EventScript_AbortMinigame::
 CableClub_EventScript_CableClubWarp::
 	special SetCableClubWarp
 	special DoCableClubWarp
-	waitstate
 	end
 
 CableClub_EventScript_AbortLinkIncorrectNumberOfParticipants::
@@ -665,53 +656,43 @@ EventScript_CableBoxResults::
 EventScript_BattleColosseum_2P_PlayerSpot0::
 	setvar VAR_0x8005, 0
 	special ColosseumPlayerSpotTriggered
-	waitstate
 	end
 
 EventScript_BattleColosseum_2P_PlayerSpot1::
 	setvar VAR_0x8005, 1
 	special ColosseumPlayerSpotTriggered
-	waitstate
 	end
 
 EventScript_BattleColosseum_4P_PlayerSpot0::
 	fadescreen FADE_TO_BLACK
 	special ChooseHalfPartyForBattle
-	waitstate
 	goto_if_eq VAR_RESULT, 0, EventScript_BattleColosseum_4P_CancelSpotTrigger
 	setvar VAR_0x8005, 0
 	special ColosseumPlayerSpotTriggered
-	waitstate
 	end
 
 EventScript_BattleColosseum_4P_PlayerSpot1::
 	fadescreen FADE_TO_BLACK
 	special ChooseHalfPartyForBattle
-	waitstate
 	goto_if_eq VAR_RESULT, 0, EventScript_BattleColosseum_4P_CancelSpotTrigger
 	setvar VAR_0x8005, 1
 	special ColosseumPlayerSpotTriggered
-	waitstate
 	end
 
 EventScript_BattleColosseum_4P_PlayerSpot2::
 	fadescreen FADE_TO_BLACK
 	special ChooseHalfPartyForBattle
-	waitstate
 	goto_if_eq VAR_RESULT, 0, EventScript_BattleColosseum_4P_CancelSpotTrigger
 	setvar VAR_0x8005, 2
 	special ColosseumPlayerSpotTriggered
-	waitstate
 	end
 
 EventScript_BattleColosseum_4P_PlayerSpot3::
 	fadescreen FADE_TO_BLACK
 	special ChooseHalfPartyForBattle
-	waitstate
 	goto_if_eq VAR_RESULT, 0, EventScript_BattleColosseum_4P_CancelSpotTrigger
 	setvar VAR_0x8005, 3
 	special ColosseumPlayerSpotTriggered
-	waitstate
 	end
 
 EventScript_BattleColosseum_4P_CancelSpotTrigger::
@@ -720,54 +701,46 @@ EventScript_BattleColosseum_4P_CancelSpotTrigger::
 EventScript_TradeCenter_Chair0::
 	setvar VAR_0x8005, 0
 	special PlayerEnteredTradeSeat
-	waitstate
 	end
 
 EventScript_TradeCenter_Chair1::
 	setvar VAR_0x8005, 1
 	special PlayerEnteredTradeSeat
-	waitstate
 	end
 
 /* Never used */
 EventScript_TradeCenter_Chair2::
 	setvar VAR_0x8005, 2
 	special PlayerEnteredTradeSeat
-	waitstate
 	end
 
 /* Never used */
 EventScript_TradeCenter_Chair3::
 	setvar VAR_0x8005, 3
 	special PlayerEnteredTradeSeat
-	waitstate
 	end
 
 EventScript_RecordCenter_Spot0::
 	setvar VAR_0x8005, 0
 	special RecordMixingPlayerSpotTriggered
-	waitstate
 	goto_if_ne VAR_TEMP_RECORD_MIX_GIFT_ITEM, ITEM_NONE, RecordCorner_EventScript_ReceivedGiftItem
 	end
 
 EventScript_RecordCenter_Spot1::
 	setvar VAR_0x8005, 1
 	special RecordMixingPlayerSpotTriggered
-	waitstate
 	goto_if_ne VAR_TEMP_RECORD_MIX_GIFT_ITEM, ITEM_NONE, RecordCorner_EventScript_ReceivedGiftItem
 	end
 
 EventScript_RecordCenter_Spot2::
 	setvar VAR_0x8005, 2
 	special RecordMixingPlayerSpotTriggered
-	waitstate
 	goto_if_ne VAR_TEMP_RECORD_MIX_GIFT_ITEM, ITEM_NONE, RecordCorner_EventScript_ReceivedGiftItem
 	end
 
 EventScript_RecordCenter_Spot3::
 	setvar VAR_0x8005, 3
 	special RecordMixingPlayerSpotTriggered
-	waitstate
 	goto_if_ne VAR_TEMP_RECORD_MIX_GIFT_ITEM, ITEM_NONE, RecordCorner_EventScript_ReceivedGiftItem
 	end
 
@@ -783,14 +756,12 @@ CableClub_EventScript_ReadTrainerCard::
 	msgbox CableClub_Text_GotToLookAtTrainerCard, MSGBOX_DEFAULT
 	fadescreen FADE_TO_BLACK
 	special Script_ShowLinkTrainerCard
-	waitstate
 	end
 
 CableClub_EventScript_ReadTrainerCardColored::
 	msgbox CableClub_Text_GotToLookAtColoredTrainerCard, MSGBOX_DEFAULT
 	fadescreen FADE_TO_BLACK
 	special Script_ShowLinkTrainerCard
-	waitstate
 	end
 
 CableClub_EventScript_TooBusyToNotice::
@@ -847,7 +818,6 @@ EventScript_TerminateLink::
 EventScript_DoLinkRoomExit::
 	special CleanupLinkRoomState
 	special ReturnFromLinkRoom
-	waitstate
 	end
 
 CableClub_EventScript_UnionRoomAttendant::
@@ -1175,12 +1145,10 @@ CableClub_EventScript_TryJoinGroupXPlayers::
 
 CableClub_EventScript_TryBecomeLinkLeader::
 	special TryBecomeLinkLeader
-	waitstate
 	return
 
 CableClub_EventScript_TryJoinLinkGroup::
 	special TryJoinLinkGroup
-	waitstate
 	return
 
 CableClub_EventScript_EnterWirelessLinkRoom::
@@ -1216,7 +1184,6 @@ EventScript_WirelessBoxResults::
 	goto_if_eq VAR_RESULT, FALSE, CableClub_EventScript_AdapterNotConnected
 	fadescreen FADE_TO_BLACK
 	special ShowWirelessCommunicationScreen
-	waitstate
 	msgbox CableClub_Text_ParticipantsStepUpToCounter, MSGBOX_DEFAULT
 	releaseall
 	end
@@ -1314,7 +1281,6 @@ MossdeepCity_GameCorner_1F_EventScript_PlayPokemonJump::
 	fadescreen FADE_TO_BLACK
 	setvar VAR_0x8005, 0
 	special ChooseMonForWirelessMinigame
-	waitstate
 	goto_if_ge VAR_0x8004, PARTY_SIZE, MossdeepCity_GameCorner_1F_EventScript_AbortMinigame
 	call Common_EventScript_SaveGame
 	goto_if_eq VAR_RESULT, 0, MossdeepCity_GameCorner_1F_EventScript_AbortMinigame
@@ -1330,7 +1296,6 @@ MossdeepCity_GameCorner_1F_EventScript_PlayDodrioBerryPicking::
 	fadescreen FADE_TO_BLACK
 	setvar VAR_0x8005, 1
 	special ChooseMonForWirelessMinigame
-	waitstate
 	goto_if_ge VAR_0x8004, PARTY_SIZE, MossdeepCity_GameCorner_1F_EventScript_AbortMinigame
 	call Common_EventScript_SaveGame
 	goto_if_eq VAR_RESULT, 0, MossdeepCity_GameCorner_1F_EventScript_AbortMinigame
@@ -1410,13 +1375,11 @@ MossdeepCity_GameCorner_1F_EventScript_ExplainDodrioBerryPickingRequirements::
 MossdeepCity_GameCorner_1F_EventScript_PokemonJumpRecords::
 	lockall
 	special ShowPokemonJumpRecords
-	waitstate
 	releaseall
 	end
 
 MossdeepCity_GameCorner_1F_EventScript_DodrioBerryPickingRecords::
 	lockall
 	special ShowDodrioBerryPickingRecords
-	waitstate
 	releaseall
 	end

--- a/data/scripts/cave_hole.inc
+++ b/data/scripts/cave_hole.inc
@@ -25,7 +25,6 @@ EventScript_FallDownHoleMtPyre::
 	playse SE_FALL
 	delay 60
 	special DoFallWarp
-	waitstate
 	end
 
 Movement_SetInvisible:

--- a/data/scripts/contest_hall.inc
+++ b/data/scripts/contest_hall.inc
@@ -312,7 +312,6 @@ ContestHall_EventScript_TryWaitForLink::
 
 ContestHall_EventScript_WaitForLink::
 	special LinkContestWaitForConnection
-	waitstate
 	return
 
 ContestHall_EventScript_ContestantWalkToCenter::

--- a/data/scripts/day_care.inc
+++ b/data/scripts/day_care.inc
@@ -91,7 +91,6 @@ Route117_PokemonDayCare_EventScript_GiveMonToRaise::
 	msgbox Route117_PokemonDayCare_Text_WhichMonShouldWeRaise, MSGBOX_DEFAULT
 	fadescreen FADE_TO_BLACK
 	special ChooseSendDaycareMon
-	waitstate
 	goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, Route117_PokemonDayCare_EventScript_ComeAgain
 	specialvar VAR_RESULT, CountPartyAliveNonEggMons_IgnoreVar0x8004Slot
 	goto_if_eq VAR_RESULT, 0, Route117_PokemonDayCare_EventScript_OnlyOneAliveMon
@@ -165,7 +164,6 @@ Route117_PokemonDayCare_EventScript_TryRetrieveMon::
 	setvar VAR_0x8004, 0
 	goto_if_eq VAR_RESULT, DAYCARE_ONE_MON, Route117_PokemonDayCare_EventScript_CostPrompt
 	special ShowDaycareLevelMenu
-	waitstate
 	copyvar VAR_0x8004, VAR_RESULT
 	goto_if_eq VAR_RESULT, DAYCARE_EXITED_LEVEL_MENU, Route117_PokemonDayCare_EventScript_ComeAgain
 	goto Route117_PokemonDayCare_EventScript_CostPrompt
@@ -253,7 +251,6 @@ Route117_PokemonDayCare_EventScript_TwoMonsInDaycare::
 @ Unused
 Route117_PokemonDayCare_EventScript_UnusedRetrieveMon::
 	special ShowDaycareLevelMenu
-	waitstate
 	goto_if_eq VAR_RESULT, 2, Route117_PokemonDayCare_EventScript_ComeAgain
 	copyvar VAR_0x8004, VAR_RESULT
 	specialvar VAR_RESULT, TakePokemonFromDaycare
@@ -266,7 +263,6 @@ EventScript_EggHatch::
 	lockall
 	msgbox Text_EggHatchHuh, MSGBOX_DEFAULT
 	special EggHatch
-	waitstate
 	releaseall
 	end
 

--- a/data/scripts/field_poison.inc
+++ b/data/scripts/field_poison.inc
@@ -1,7 +1,6 @@
 EventScript_FieldPoison::
 	lockall
 	special TryFieldPoisonWhiteOut
-	waitstate
 	goto_if_eq VAR_RESULT, FLDPSN_WHITEOUT, EventScript_FieldWhiteOut
 	goto_if_eq VAR_RESULT, FLDPSN_FRONTIER_WHITEOUT, EventScript_FrontierFieldWhiteOut
 	releaseall
@@ -12,11 +11,9 @@ EventScript_FieldWhiteOut::
 	waitmessage
 	waitbuttonpress
 	special Script_FadeOutMapMusic
-	waitstate
 	fadescreen FADE_TO_BLACK
 	call_if_set FLAG_WHITEOUT_TO_LAVARIDGE, EventScript_SetRespawnLavaridgePkmnCenter
 	special SetCB2WhiteOut
-	waitstate
 	end
 
 EventScript_SetRespawnLavaridgePkmnCenter::
@@ -35,8 +32,6 @@ EventScript_FrontierFieldWhiteOut::
 	trainerhill_inchallenge
 	goto_if_eq VAR_RESULT, TRUE, TrainerHill_1F_EventScript_Lost
 	special Script_FadeOutMapMusic
-	waitstate
 	fadescreen FADE_TO_BLACK
 	special SetCB2WhiteOut
-	waitstate
 	end

--- a/data/scripts/lilycove_lady.inc
+++ b/data/scripts/lilycove_lady.inc
@@ -67,7 +67,6 @@ LilycoveCity_PokemonCenter_1F_EventScript_ChooseFavorItem::
 	fadescreen FADE_TO_BLACK
 	setvar VAR_RESULT, 0
 	special Script_FavorLadyOpenBagMenu
-	waitstate
 	goto_if_eq VAR_RESULT, 0, LilycoveCity_PokemonCenter_1F_EventScript_AskQuitChooseFavorItem
 	goto_if_eq VAR_RESULT, 1, LilycoveCity_PokemonCenter_1F_EventScript_GiveFavorItem
 	end
@@ -189,13 +188,11 @@ LilycoveCity_PokemonCenter_1F_EventScript_CheckQuizTakingState::
 
 LilycoveCity_PokemonCenter_1F_EventScript_ShowQuestion::
 	special QuizLadyShowQuizQuestion
-	waitstate
 	goto LilycoveCity_PokemonCenter_1F_EventScript_CheckQuizTakingState
 	end
 
 LilycoveCity_PokemonCenter_1F_EventScript_GetAnswer::
 	special QuizLadyGetPlayerAnswer
-	waitstate
 	goto LilycoveCity_PokemonCenter_1F_EventScript_CheckQuizTakingState
 	end
 
@@ -287,7 +284,6 @@ LilycoveCity_PokemonCenter_1F_EventScript_PickPrize::
 	fadescreen FADE_TO_BLACK
 	setvar VAR_RESULT, 0
 	special Script_QuizLadyOpenBagMenu
-	waitstate
 	goto_if_eq VAR_RESULT, 0, LilycoveCity_PokemonCenter_1F_EventScript_AskQuitChoosingPrize
 	goto_if_eq VAR_RESULT, 1, LilycoveCity_PokemonCenter_1F_EventScript_WriteQuiz
 	end
@@ -306,7 +302,6 @@ LilycoveCity_PokemonCenter_1F_EventScript_WriteQuiz::
 LilycoveCity_PokemonCenter_1F_EventScript_WriteQuizQuestion::
 	fadescreen FADE_TO_BLACK
 	special QuizLadySetCustomQuestion
-	waitstate
 	goto_if_eq VAR_RESULT, 0, LilycoveCity_PokemonCenter_1F_EventScript_AskQuitWritingQuizQuestion
 	goto LilycoveCity_PokemonCenter_1F_EventScript_FinishMakingQuiz
 	end
@@ -364,7 +359,6 @@ LilycoveCity_PokemonCenter_1F_EventScript_DeclineGivePokeblock::
 LilycoveCity_PokemonCenter_1F_EventScript_ChoosePokeblock::
 	fadescreen FADE_TO_BLACK
 	special OpenPokeblockCaseForContestLady
-	waitstate
 	goto_if_eq VAR_RESULT, 0xFFFF, LilycoveCity_PokemonCenter_1F_EventScript_AskQuitGivingPokeblock
 	goto_if_ne VAR_RESULT, 0xFFFF, LilycoveCity_PokemonCenter_1F_EventScript_GivePokeblock
 	end

--- a/data/scripts/mauville_man.inc
+++ b/data/scripts/mauville_man.inc
@@ -169,7 +169,6 @@ MauvilleCity_PokemonCenter_1F_EventScript_AlreadyTraded::
 
 MauvilleCity_PokemonCenter_1F_EventScript_PickDecorToReceive::
 	special TraderMenuGetDecoration
-	waitstate
 	goto_if_eq VAR_0x8004, 0, MauvilleCity_PokemonCenter_1F_EventScript_CancelPickDecor
 	goto_if_eq VAR_0x8004, 0xFFFF, MauvilleCity_PokemonCenter_1F_EventScript_InvalidDecor
 	msgbox MauvilleCity_PokemonCenter_1F_Text_OnceBelongedToPlayerDoYouWantIt, MSGBOX_YESNO
@@ -204,7 +203,6 @@ MauvilleCity_PokemonCenter_1F_EventScript_DontHaveAnyDecor::
 MauvilleCity_PokemonCenter_1F_EventScript_PickDecorToGive::
 	msgbox MauvilleCity_PokemonCenter_1F_Text_PickTheDecorToTrade, MSGBOX_DEFAULT
 	special TraderShowDecorationMenu
-	waitstate
 	goto_if_eq VAR_0x8006, 0, MauvilleCity_PokemonCenter_1F_EventScript_CancelGiveDecor
 	goto_if_eq VAR_0x8006, 0xFFFF, MauvilleCity_PokemonCenter_1F_EventScript_DecorInUse
 	special IsDecorationCategoryFull
@@ -803,7 +801,6 @@ MauvilleCity_PokemonCenter_1F_EventScript_Storyteller::
 	message MauvilleCity_PokemonCenter_1F_Text_WhichTaleToTell
 	waitmessage
 	special StorytellerStoryListMenu
-	waitstate
 	goto_if_eq VAR_RESULT, 0, MauvilleCity_PokemonCenter_1F_EventScript_CancelStorySelection
 	setvar VAR_0x8008, 1
 	special Script_StorytellerDisplayStory

--- a/data/scripts/move_tutors.inc
+++ b/data/scripts/move_tutors.inc
@@ -260,7 +260,6 @@ MoveTutor_EventScript_ExplosionTaught::
 
 MoveTutor_EventScript_OpenPartyMenu::
 	special ChooseMonForMoveTutor
-	waitstate
 	lock
 	faceplayer
 	return

--- a/data/scripts/pc.inc
+++ b/data/scripts/pc.inc
@@ -11,7 +11,6 @@ EventScript_PCMainMenu::
 	message gText_WhichPCShouldBeAccessed
 	waitmessage
 	special ScriptMenu_CreatePCMultichoice
-	waitstate
 	goto EventScript_AccessPC
 	end
 
@@ -28,7 +27,6 @@ EventScript_AccessPlayersPC::
 	playse SE_PC_LOGIN
 	msgbox gText_AccessedPlayersPC, MSGBOX_DEFAULT
 	special PlayerPC
-	waitstate
 	goto EventScript_PCMainMenu
 	end
 
@@ -38,7 +36,6 @@ EventScript_AccessPokemonStorage::
 	call_if_set FLAG_SYS_PC_LANETTE, EventScript_AccessLanettesPC
 	msgbox gText_StorageSystemOpened, MSGBOX_DEFAULT
 	special ShowPokemonStorageSystemPC
-	waitstate
 	goto EventScript_PCMainMenu
 	end
 
@@ -61,6 +58,5 @@ EventScript_AccessHallOfFame::
 	goto_if_unset FLAG_SYS_GAME_CLEAR, EventScript_TurnOffPC
 	playse SE_PC_LOGIN
 	special AccessHallOfFamePC
-	waitstate
 	goto EventScript_AccessPC
 	end

--- a/data/scripts/pc_transfer.inc
+++ b/data/scripts/pc_transfer.inc
@@ -8,7 +8,6 @@ Common_EventScript_GetGiftMonPartySlot::
 Common_EventScript_NameReceivedBoxMon::
 	fadescreen FADE_TO_BLACK
 	special ChangeBoxPokemonNickname
-	waitstate
 	lock
 	faceplayer
 	return

--- a/data/scripts/players_house.inc
+++ b/data/scripts/players_house.inc
@@ -99,14 +99,12 @@ PlayersHouse_2F_EventScript_CheckWallClock::
 	incrementgamestat GAME_STAT_CHECKED_CLOCK
 	fadescreen FADE_TO_BLACK
 	special Special_ViewWallClock
-	waitstate
 	releaseall
 	end
 
 PlayersHouse_2F_EventScript_SetWallClock::
 	fadescreen FADE_TO_BLACK
 	special StartWallClock
-	waitstate
 	return
 
 PlayersHouse_2F_Movement_MomEntersMale:

--- a/data/scripts/record_mix.inc
+++ b/data/scripts/record_mix.inc
@@ -9,7 +9,6 @@ EventScript_MixRecordsPrompt::
 
 EventScript_MixRecords::
 	special RecordMixingPlayerSpotTriggered
-	waitstate
 	lock
 	faceplayer
 EventScript_EndMixRecords::

--- a/data/scripts/roulette.inc
+++ b/data/scripts/roulette.inc
@@ -20,7 +20,6 @@ Roulette_EventScript_Table2::
 
 Roulette_EventScript_Play::
 	special PlayRoulette
-	waitstate
 	end
 
 Roulette_Text_PlayMinimumWagerIsX::

--- a/data/scripts/safari_zone.inc
+++ b/data/scripts/safari_zone.inc
@@ -51,7 +51,6 @@ EventScript_PokeBlockFeeder::
 SafariZone_EventScript_ChoosePokeblock::
 	fadescreen FADE_TO_BLACK
 	special OpenPokeblockCaseOnFeeder
-	waitstate
 	goto_if_ne VAR_RESULT, 0xFFFF, SafariZone_EventScript_PokeblockPlaced
 #ifdef BUGFIX
 	releaseall  @ Only gets called from EventScript_PokeBlockFeeder which uses lockall.

--- a/data/scripts/secret_base.inc
+++ b/data/scripts/secret_base.inc
@@ -158,7 +158,6 @@ SecretBase_EventScript_SetAsBase::
 	closemessage
 	setflag FLAG_RECEIVED_SECRET_POWER
 	special EnterNewlyCreatedSecretBase
-	waitstate
 	end
 
 SecretBase_Movement_EnterBase:
@@ -641,7 +640,6 @@ SecretBase_EventScript_BattleTrainer::
 	setvar VAR_0x8004, SPECIAL_BATTLE_SECRET_BASE
 	setvar VAR_0x8005, 0
 	special DoSpecialTrainerBattle
-	waitstate
 	call_if_eq VAR_RESULT, B_OUTCOME_DREW, SecretBase_EventScript_DrewSecretBaseBattle
 	call_if_eq VAR_RESULT, B_OUTCOME_WON, SecretBase_EventScript_WonSecretBaseBattle
 	call_if_eq VAR_RESULT, B_OUTCOME_LOST, SecretBase_EventScript_LostSecretBaseBattle

--- a/data/scripts/std_msgbox.inc
+++ b/data/scripts/std_msgbox.inc
@@ -45,5 +45,4 @@ EventScript_UnusedReturn:
 
 Common_EventScript_SaveGame::
 	special SaveGame
-	waitstate
 	return

--- a/data/scripts/trainer_battle.inc
+++ b/data/scripts/trainer_battle.inc
@@ -4,7 +4,6 @@ EventScript_StartTrainerApproach::
 EventScript_TrainerApproach::
 	special PlayTrainerEncounterMusic
 	special DoTrainerApproach
-	waitstate
 	goto EventScript_ShowTrainerIntroMsg
 
 EventScript_TryDoNormalTrainerBattle::
@@ -60,7 +59,6 @@ EventScript_TryDoRematchBattle::
 	waitmessage
 	waitbuttonpress
 	special BattleSetup_StartRematchBattle
-	waitstate
 	releaseall
 	end
 
@@ -78,7 +76,6 @@ EventScript_TryDoDoubleRematchBattle::
 	waitmessage
 	waitbuttonpress
 	special BattleSetup_StartRematchBattle
-	waitstate
 	releaseall
 	end
 

--- a/data/specials.inc
+++ b/data/specials.inc
@@ -1,17 +1,22 @@
-.macro def_special ptr
-.global SPECIAL_\ptr
-.set SPECIAL_\ptr, __special__
-.set __special__, __special__ + 1
+	.macro def_special ptr:req, waitstate=0
+	.if ALLOCATE_SPECIAL_TABLE
+	.global SPECIAL_\ptr
+	.set SPECIAL_\ptr, __special__
 	.4byte \ptr
+	.endif
+	.set SPECIAL_WAITSTATE_\ptr, \waitstate
+	.set __special__, __special__ + 1
 	.endm
 
 .set __special__, 0
+.if ALLOCATE_SPECIAL_TABLE
 		.align 2
 gSpecials::
+.endif
 	def_special HealPlayerParty
 	def_special SetCableClubWarp
-	def_special DoCableClubWarp
-	def_special ReturnFromLinkRoom
+	def_special DoCableClubWarp, waitstate=1
+	def_special ReturnFromLinkRoom, waitstate=1
 	def_special CleanupLinkRoomState
 	def_special ExitLinkRoom
 	def_special SetPlayerSecretBase
@@ -32,30 +37,30 @@ gSpecials::
 	def_special GetSecretBaseTypeInFrontOfPlayer
 	def_special SetSecretBaseOwnerGfxId
 	def_special PutAwayDecorationIteration
-	def_special EnterNewlyCreatedSecretBase
+	def_special EnterNewlyCreatedSecretBase, waitstate=1
 	def_special SetBattledOwnerFromResult
 	def_special DoSecretBasePCTurnOffEffect
-	def_special RecordMixingPlayerSpotTriggered
-	def_special TryBattleLinkup
-	def_special TryTradeLinkup
-	def_special TryRecordMixLinkup
-	def_special ValidateMixingGameLanguage
+	def_special RecordMixingPlayerSpotTriggered, waitstate=1
+	def_special TryBattleLinkup, waitstate=1
+	def_special TryTradeLinkup, waitstate=1
+	def_special TryRecordMixLinkup, waitstate=1
+	def_special ValidateMixingGameLanguage, waitstate=1
 	def_special CloseLink
-	def_special ColosseumPlayerSpotTriggered
-	def_special PlayerEnteredTradeSeat
+	def_special ColosseumPlayerSpotTriggered, waitstate=1
+	def_special PlayerEnteredTradeSeat, waitstate=1
 	def_special Script_StartWiredTrade
 	def_special CableClubSaveGame
-	def_special TryBerryBlenderLinkup
+	def_special TryBerryBlenderLinkup, waitstate=1
 	def_special GetLinkPartnerNames
 	def_special SpawnLinkPartnerObjectEvent
 	def_special SavePlayerParty
 	def_special LoadPlayerParty
-	def_special ChooseHalfPartyForBattle
-	def_special Script_ShowLinkTrainerCard
+	def_special ChooseHalfPartyForBattle, waitstate=1
+	def_special Script_ShowLinkTrainerCard, waitstate=1
 	def_special ObjectEventInteractionGetBerryTreeData
 	def_special ObjectEventInteractionGetBerryName
 	def_special ObjectEventInteractionGetBerryCountString
-	def_special Bag_ChooseBerry
+	def_special Bag_ChooseBerry, waitstate=1
 	def_special ObjectEventInteractionPlantBerryTree
 	def_special ObjectEventInteractionPickBerryTree
 	def_special ObjectEventInteractionRemoveBerryTree
@@ -66,12 +71,12 @@ gSpecials::
 	def_special ShowTrainerIntroSpeech
 	def_special ShowTrainerCantBattleSpeech
 	def_special GetTrainerFlag
-	def_special DoTrainerApproach
+	def_special DoTrainerApproach, waitstate=1
 	def_special PlayTrainerEncounterMusic
 	def_special ShouldTryRematchBattle
 	def_special IsTrainerReadyForRematch
-	def_special BattleSetup_StartRematchBattle
-	def_special ShowPokemonStorageSystemPC
+	def_special BattleSetup_StartRematchBattle, waitstate=1
+	def_special ShowPokemonStorageSystemPC, waitstate=1
 	def_special HasEnoughMonsForDoubleBattle
 	def_special TurnOffTVScreen
 	def_special DoTVShow
@@ -103,9 +108,9 @@ gSpecials::
 	def_special GiveMonContestRibbon
 	def_special IsContestDebugActive
 	def_special GiveMonArtistRibbon
-	def_special TryContestGModeLinkup
-	def_special SaveGame
-	def_special DoWateringBerryTreeAnim
+	def_special TryContestGModeLinkup, waitstate=1
+	def_special SaveGame, waitstate=1
+	def_special DoWateringBerryTreeAnim, waitstate=1
 	def_special ShowEasyChatScreen
 	def_special ShowEasyChatProfile
 	def_special Script_GetCurrentMauvilleMan
@@ -120,15 +125,15 @@ gSpecials::
 	def_special GiddyShouldTellAnotherTale
 	def_special StorytellerGetFreeStorySlot
 	def_special Script_StorytellerDisplayStory
-	def_special StorytellerStoryListMenu
+	def_special StorytellerStoryListMenu, waitstate=1
 	def_special StorytellerUpdateStat
 	def_special Script_StorytellerInitializeRandomStat
 	def_special HasStorytellerAlreadyRecorded
-	def_special TraderMenuGetDecoration
+	def_special TraderMenuGetDecoration, waitstate=1
 	def_special GetTraderTradedFlag
 	def_special DoesPlayerHaveNoDecorations
 	def_special IsDecorationCategoryFull
-	def_special TraderShowDecorationMenu
+	def_special TraderShowDecorationMenu, waitstate=1
 	def_special TraderDoDecorationTrade
 	def_special GetSeedotSizeRecordInfo
 	def_special CompareSeedotSize
@@ -156,24 +161,24 @@ gSpecials::
 	def_special DrawWholeMapView
 	def_special StorePlayerCoordsInVars
 	def_special MauvilleGymDeactivatePuzzle
-	def_special PetalburgGymSlideOpenRoomDoors
+	def_special PetalburgGymSlideOpenRoomDoors, waitstate=1
 	def_special PetalburgGymUnlockRoomDoors
 	def_special GetPlayerTrainerIdOnesDigit
 	def_special GetPlayerBigGuyGirlString
 	def_special GetRivalSonDaughterString
 	def_special SetHiddenItemFlag
 	def_special CableCarWarp
-	def_special CableCar
+	def_special CableCar, waitstate=1
 	def_special Overworld_PlaySpecialMapMusic
-	def_special StartWallClock
-	def_special Special_ViewWallClock
-	def_special ChooseStarter
-	def_special StartWallyTutorialBattle
-	def_special ChangePokemonNickname
-	def_special ChoosePartyMon
+	def_special StartWallClock, waitstate=1
+	def_special Special_ViewWallClock, waitstate=1
+	def_special ChooseStarter, waitstate=1
+	def_special StartWallyTutorialBattle, waitstate=1
+	def_special ChangePokemonNickname, waitstate=1
+	def_special ChoosePartyMon, waitstate=1
 	def_special GetFirstFreePokeblockSlot
-	def_special DoBerryBlending
-	def_special PlayRoulette
+	def_special DoBerryBlending, waitstate=1
+	def_special PlayRoulette, waitstate=1
 	def_special IsFanClubMemberFanOfPlayer
 	def_special GetNumFansOfPlayerInTrainerFanClub
 	def_special BufferFanClubTrainerName
@@ -199,19 +204,19 @@ gSpecials::
 	def_special SetDaycareCompatibilityString
 	def_special GetSelectedMonNicknameAndSpecies
 	def_special StoreSelectedPokemonInDaycare
-	def_special ChooseSendDaycareMon
-	def_special ShowDaycareLevelMenu
+	def_special ChooseSendDaycareMon, waitstate=1
+	def_special ShowDaycareLevelMenu, waitstate=1
 	def_special GetNumLevelsGainedFromDaycare
 	def_special GetDaycareCost
 	def_special TakePokemonFromDaycare
 	def_special ScriptHatchMon
-	def_special EggHatch
+	def_special EggHatch, waitstate=1
 	def_special CheckDaycareMonReceivedMail
 	def_special ShowLinkBattleRecords
 	def_special IsEnoughForCostInVar0x8005
 	def_special SubtractMoneyFromVar0x8005
-	def_special TryFieldPoisonWhiteOut
-	def_special SetCB2WhiteOut
+	def_special TryFieldPoisonWhiteOut, waitstate=1
+	def_special SetCB2WhiteOut, waitstate=1
 	def_special RotatingGate_InitPuzzle
 	def_special RotatingGate_InitPuzzleAndGraphics
 	def_special SetSSTidalFlag
@@ -219,7 +224,7 @@ gSpecials::
 	def_special EnterSafariMode
 	def_special ExitSafariMode
 	def_special GetPokeblockFeederInFront
-	def_special OpenPokeblockCaseOnFeeder
+	def_special OpenPokeblockCaseOnFeeder, waitstate=1
 	def_special IsMirageIslandPresent
 	def_special UpdateShoalTideFlag
 	def_special InitBirchState
@@ -230,12 +235,12 @@ gSpecials::
 	def_special SetDeptStoreFloor
 	def_special DoLotteryCornerComputerEffect
 	def_special EndLotteryCornerComputerEffect
-	def_special ChooseMonForMoveRelearner
+	def_special ChooseMonForMoveRelearner, waitstate=1
 	def_special MoveDeleterChooseMoveToForget
 	def_special MoveDeleterForgetMove
 	def_special BufferMoveDeleterNicknameAndMove
 	def_special GetNumMovesSelectedMonHas
-	def_special TeachMoveRelearnerMove
+	def_special TeachMoveRelearnerMove, waitstate=1
 	def_special GetRecordedCyclingRoadResults
 	def_special Special_BeginCyclingRoadChallenge
 	def_special GetPlayerAvatarBike
@@ -247,7 +252,7 @@ gSpecials::
 	def_special CallBattleDomeFunction
 	def_special CallBattlePalaceFunction
 	def_special CopyEReaderTrainerGreeting
-	def_special DoSpecialTrainerBattle
+	def_special DoSpecialTrainerBattle, waitstate=1
 	def_special CallBattleArenaFunction
 	def_special CallBattleFactoryFunction
 	def_special CallBattlePikeFunction
@@ -256,16 +261,16 @@ gSpecials::
 	def_special CallVerdanturfTentFunction
 	def_special CallFallarborTentFunction
 	def_special CallSlateportTentFunction
-	def_special ChoosePartyForBattleFrontier
+	def_special ChoosePartyForBattleFrontier, waitstate=1
 	def_special ValidateEReaderTrainer
 	def_special GetBattleTowerSinglesStreak
 	def_special ReducePlayerPartyToSelectedMons
-	def_special BedroomPC
-	def_special PlayerPC
-	def_special FieldShowRegionMap
+	def_special BedroomPC, waitstate=1
+	def_special PlayerPC, waitstate=1
+	def_special FieldShowRegionMap, waitstate=1
 	def_special GetInGameTradeSpeciesInfo
 	def_special CreateInGameTradePokemon
-	def_special DoInGameTradeScene
+	def_special DoInGameTradeScene, waitstate=1
 	def_special GetTradeSpecies
 	def_special GetWeekCount
 	def_special RetrieveLotteryNumber
@@ -273,18 +278,18 @@ gSpecials::
 	def_special ShowBerryBlenderRecordWindow
 	def_special ResetTrickHouseNuggetFlag
 	def_special SetTrickHouseNuggetFlag
-	def_special ScriptMenu_CreatePCMultichoice
-	def_special AccessHallOfFamePC
-	def_special Special_ShowDiploma
+	def_special ScriptMenu_CreatePCMultichoice, waitstate=1
+	def_special AccessHallOfFamePC, waitstate=1
+	def_special Special_ShowDiploma, waitstate=1
 	def_special CheckLeadMonCool
 	def_special CheckLeadMonBeauty
 	def_special CheckLeadMonCute
 	def_special CheckLeadMonSmart
 	def_special CheckLeadMonTough
-	def_special LookThroughPorthole
+	def_special LookThroughPorthole, waitstate=1
 	def_special DoSoftReset
-	def_special GameClear
-	def_special MoveElevator
+	def_special GameClear, waitstate=1
+	def_special MoveElevator, waitstate=1
 	def_special ShowGlassWorkshopMenu
 	def_special SpawnCameraObject
 	def_special RemoveCameraObject
@@ -293,8 +298,8 @@ gSpecials::
 	def_special CheckRelicanthWailord
 	def_special ShouldDoBrailleRegirockEffectOld
 	def_special DoOrbEffect
-	def_special FadeOutOrbEffect
-	def_special WaitWeather
+	def_special FadeOutOrbEffect, waitstate=1
+	def_special WaitWeather, waitstate=1
 	def_special BufferEReaderTrainerName
 	def_special GetSlotMachineId
 	def_special GetPlayerFacingDirection
@@ -310,30 +315,30 @@ gSpecials::
 	def_special InitRoamer
 	def_special TryUpdateRusturfTunnelState
 	def_special IsGrassTypeInParty
-	def_special DoContestHallWarp
+	def_special DoContestHallWarp, waitstate=1
 	def_special LoadWallyZigzagoon
 	def_special IsStarterInParty
 	def_special CopyCurSecretBaseOwnerName_StrVar1
 	def_special ScriptCheckFreePokemonStorageSpace
-	def_special DoSealedChamberShakingEffect_Long
+	def_special DoSealedChamberShakingEffect_Long, waitstate=1
 	def_special ShowDeptStoreElevatorFloorSelect
 	def_special InteractWithShieldOrTVDecoration
 	def_special IsPokerusInParty
 	def_special SetSootopolisGymCrackedIceMetatiles
 	def_special ShakeCamera
 	def_special StartGroudonKyogreBattle
-	def_special BattleSetup_StartLegendaryBattle
-	def_special StartRegiBattle
+	def_special BattleSetup_StartLegendaryBattle, waitstate=1
+	def_special StartRegiBattle, waitstate=1
 	def_special SetTrainerFacingDirection
-	def_special DoSealedChamberShakingEffect_Short
+	def_special DoSealedChamberShakingEffect_Short, waitstate=1
 	def_special FoundBlackGlasses
 	def_special StartDroughtWeatherBlend
 	def_special DoDiveWarp
-	def_special DoFallWarp
+	def_special DoFallWarp, waitstate=1
 	def_special ShowContestEntryMonPic
 	def_special HideContestEntryMonPic
 	def_special SetEReaderTrainerGfxId
-	def_special BattleSetup_StartLatiBattle
+	def_special BattleSetup_StartLatiBattle, waitstate=1
 	def_special SetRoute119Weather
 	def_special SetRoute123Weather
 	def_special GetContestMultiplayerId
@@ -342,7 +347,7 @@ gSpecials::
 	def_special TryInitBattleTowerAwardManObjectEvent
 	def_special MoveOutOfSecretBaseFromOutside
 	def_special LoadPlayerBag
-	def_special Script_FadeOutMapMusic
+	def_special Script_FadeOutMapMusic, waitstate=1
 	def_special SetPacifidlogTMReceivedDay
 	def_special GetDaysUntilPacifidlogTMAvailable
 	def_special HasAllHoennMons
@@ -380,7 +385,7 @@ gSpecials::
 	def_special BufferFavorLadyItemName
 	def_special BufferFavorLadyPlayerName
 	def_special DidFavorLadyLikeItem
-	def_special Script_FavorLadyOpenBagMenu
+	def_special Script_FavorLadyOpenBagMenu, waitstate=1
 	def_special Script_DoesFavorLadyLikeItem
 	def_special IsFavorLadyThresholdMet
 	def_special FavorLadyGetPrize
@@ -388,17 +393,17 @@ gSpecials::
 	def_special GetQuizLadyState
 	def_special GetQuizAuthor
 	def_special IsQuizLadyWaitingForChallenger
-	def_special QuizLadyShowQuizQuestion
-	def_special QuizLadyGetPlayerAnswer
+	def_special QuizLadyShowQuizQuestion, waitstate=1
+	def_special QuizLadyGetPlayerAnswer, waitstate=1
 	def_special IsQuizAnswerCorrect
 	def_special BufferQuizPrizeItem
 	def_special SetQuizLadyState_Complete
 	def_special BufferQuizAuthorNameAndCheckIfLady
 	def_special SetQuizLadyState_GivePrize
 	def_special ClearQuizLadyPlayerAnswer
-	def_special Script_QuizLadyOpenBagMenu
+	def_special Script_QuizLadyOpenBagMenu, waitstate=1
 	def_special ClearQuizLadyQuestionAndAnswer
-	def_special QuizLadySetCustomQuestion
+	def_special QuizLadySetCustomQuestion, waitstate=1
 	def_special QuizLadyTakePrizeForCustomQuiz
 	def_special GetMysteryGiftCardStat
 	def_special QuizLadyRecordCustomQuizData
@@ -409,41 +414,41 @@ gSpecials::
 	def_special ShouldContestLadyShowGoOnAir
 	def_special HasPlayerGivenContestLadyPokeblock
 	def_special Script_BufferContestLadyCategoryAndMonName
-	def_special OpenPokeblockCaseForContestLady
+	def_special OpenPokeblockCaseForContestLady, waitstate=1
 	def_special SetContestLadyGivenPokeblock
 	def_special GetContestLadyMonSpecies
 	def_special GetContestLadyCategory
 	def_special PutLilycoveContestLadyShowOnTheAir
-	def_special CloseBattlePikeCurtain
+	def_special CloseBattlePikeCurtain, waitstate=1
 	def_special CallApprenticeFunction
 	def_special ShouldTryGetTrainerScript
 	def_special ShowMapNamePopup
 	def_special ShowMapNamePopup
-	def_special DoMirageTowerCeilingCrumble
+	def_special DoMirageTowerCeilingCrumble, waitstate=1
 	def_special SetMirageTowerVisibility
-	def_special StartPlayerDescendMirageTower
+	def_special StartPlayerDescendMirageTower, waitstate=1
 	def_special BufferTMHMMoveName
 	def_special IsWirelessAdapterConnected
-	def_special TryBecomeLinkLeader
-	def_special TryJoinLinkGroup
+	def_special TryBecomeLinkLeader, waitstate=1
+	def_special TryJoinLinkGroup, waitstate=1
 	def_special RunUnionRoom
-	def_special ShowWirelessCommunicationScreen
+	def_special ShowWirelessCommunicationScreen, waitstate=1
 	def_special InitUnionRoom
 	def_special BufferUnionRoomPlayerName
 	def_special WonderNews_GetRewardInfo
-	def_special ChooseMonForWirelessMinigame
+	def_special ChooseMonForWirelessMinigame, waitstate=1
 	def_special Script_ResetUnionRoomTrade
 	def_special IsBadEggInParty
 	def_special ValidateSavedWonderCard
 	def_special HasAtLeastOneBerry
 	def_special IsPokemonJumpSpeciesInParty
-	def_special ShowPokemonJumpRecords
+	def_special ShowPokemonJumpRecords, waitstate=1
 	def_special IsDodrioInParty
-	def_special ShowDodrioBerryPickingRecords
+	def_special ShowDodrioBerryPickingRecords, waitstate=1
 	def_special OffsetCameraForBattle
 	def_special GetDeptStoreDefaultFloorChoice
 	def_special BufferVarsForIVRater
-	def_special LinkContestWaitForConnection
+	def_special LinkContestWaitForConnection, waitstate=1
 	def_special GetWirelessCommType
 	def_special LinkContestTryShowWirelessIndicator
 	def_special LinkContestTryHideWirelessIndicator
@@ -453,14 +458,14 @@ gSpecials::
 	def_special ShowFrontierManiacMessage
 	def_special IsContestWithRSPlayer
 	def_special ClearLinkContestFlags
-	def_special TryContestEModeLinkup
-	def_special ShowScrollableMultichoice
+	def_special TryContestEModeLinkup, waitstate=1
+	def_special ShowScrollableMultichoice, waitstate=1
 	def_special ScrollableMultichoice_TryReturnToList
 	def_special BufferBattleTowerElevatorFloors
 	def_special TryStoreHeldItemsInPyramidBag
-	def_special ChooseItemsToTossFromPyramidBag
+	def_special ChooseItemsToTossFromPyramidBag, waitstate=1
 	def_special DoBattlePyramidMonsHaveHeldItem
-	def_special BattlePyramidChooseMonHeldItems
+	def_special BattlePyramidChooseMonHeldItems, waitstate=1
 	def_special SetBattleTowerLinkPlayerGfx
 	def_special ShowNatureGirlMessage
 	def_special ShowBattlePointsWindow
@@ -478,23 +483,23 @@ gSpecials::
 	def_special PrintPlayerBerryPowderAmount
 	def_special ShowFrontierGamblerLookingMessage
 	def_special ShowFrontierGamblerGoMessage
-	def_special Script_DoRayquazaScene
-	def_special OpenPokenavForTutorial
-	def_special ScriptMenu_CreateStartMenuForPokenavTutorial
+	def_special Script_DoRayquazaScene, waitstate=1
+	def_special OpenPokenavForTutorial, waitstate=1
+	def_special ScriptMenu_CreateStartMenuForPokenavTutorial, waitstate=1
 	def_special CountPlayerTrainerStars
 	def_special BufferBattleFrontierTutorMoveName
 	def_special CloseBattleFrontierTutorWindow
 	def_special ScrollableMultichoice_RedrawPersistentMenu
-	def_special ChooseMonForMoveTutor
+	def_special ChooseMonForMoveTutor, waitstate=1
 	def_special GetBattleFrontierTutorMoveIndex
 	def_special ScrollableMultichoice_ClosePersistentMenu
-	def_special DoDeoxysRockInteraction
+	def_special DoDeoxysRockInteraction, waitstate=1
 	def_special SetDeoxysRockPalette
 	def_special CreateEnemyEventMon
-	def_special StartMirageTowerDisintegration
-	def_special StartMirageTowerShake
-	def_special StartMirageTowerFossilFallAndSink
-	def_special ChangeBoxPokemonNickname
+	def_special StartMirageTowerDisintegration, waitstate=1
+	def_special StartMirageTowerShake, waitstate=1
+	def_special StartMirageTowerFossilFallAndSink, waitstate=1
+	def_special ChangeBoxPokemonNickname, waitstate=1
 	def_special GetPCBoxToSendMon
 	def_special ShouldShowBoxWasFullMessage
 	def_special SetMatchCallRegisteredFlag
@@ -502,31 +507,31 @@ gSpecials::
 	def_special CreateAbnormalWeatherEvent
 	def_special GetAbnormalWeatherMapNameAndType
 	def_special GetMartEmployeeObjectEventId
-	def_special SaveForBattleTowerLink
+	def_special SaveForBattleTowerLink, waitstate=1
 	def_special Unused_SetWeatherSunny
 	def_special SetUnlockedPokedexFlags
 	def_special IsTrainerRegistered
 	def_special ShouldDoBrailleRegicePuzzle
 	def_special EnableNationalPokedex
-	def_special ScriptMenu_CreateLilycoveSSTidalMultichoice
+	def_special ScriptMenu_CreateLilycoveSSTidalMultichoice, waitstate=1
 	def_special GetLilycoveSSTidalSelection
 	def_special TurnOnTVScreen
 	def_special SetMewAboveGrass
 	def_special ShouldDistributeEonTicket
-	def_special LinkRetireStatusWithBattleTowerPartner
+	def_special LinkRetireStatusWithBattleTowerPartner, waitstate=1
 	def_special BattleTowerReconnectLink
 	def_special CallTrainerHillFunction
-	def_special Script_DoRayquazaScene @ Listed twice
+	def_special Script_DoRayquazaScene, waitstate=1 @ Listed twice
 	def_special LoopWingFlapSE
 	def_special DestroyMewEmergingGrassSprite
-	def_special ShowBerryCrushRankings
+	def_special ShowBerryCrushRankings, waitstate=1
 	def_special TryBufferWaldaPhrase
-	def_special DoWaldaNamingScreen
+	def_special DoWaldaNamingScreen, waitstate=1
 	def_special TryGetWallpaperWithWaldaPhrase
 	def_special PlayerNotAtTrainerHillEntrance
 	def_special GetBattlePyramidHint
 	def_special LoadLinkContestPlayerPalettes
-	def_special ShowTrainerHillRecords
+	def_special ShowTrainerHillRecords, waitstate=1
 	def_special PlayerFaceTrainerAfterBattle
 	def_special ResetHealLocationFromDewford
 	def_special IsLastMonThatKnowsSurf


### PR DESCRIPTION
`special` and `specialvar`s that are always followed by a `waitstate` now implicitly generate that `waitstate` when called. This should make it easier to use those specials for newcomers who have not internalized "a UI special needs a `waitstate` after it to stop the script progressing to a disastrous result".

If an implicit `waitstate` is immediately followed by an explicit `waitstate` the second one is ignored and a warning is reported, thus making the change harmless for downstream projects (if a little noisy). If there are other instructions between the implicit and explicit `waitstate`s then both are generated, which would manifest as a softlock; I think writing code like that is unidiomatic, so hopefully this will not affect (m)any downstream projects.

The candidate `special`s were mostly identified with the following: `git grep -B1 waitstate data | grep -v '^-' | sed 'N;s/\n/ /;p' | grep -o 'special [a-zA-Z0-9_]*' | sort -u`.

Notable `special`s that are not always followed by `waitstate` are `EnterSecretBase`, `RunUnionRoom`, and `ShakeCamera`. Of these, `ShakeCamera` is particularly disappointing because 22/24 of the uses are immediately followed by `waitstate`. In the future we could consider extending `special` to support this use-case.

Discussed in the [pret](https://discord.com/channels/442462691542695948/442465020291317760/1435764841594880202) and [rh-hideout](https://discord.com/channels/419213663107416084/1077168246555430962/1435760564130418830) Discord servers.