### PR TITLE
STATIC_ASSERT for sizeof(struct ListMenu)

### DIFF
--- a/src/list_menu.c
+++ b/src/list_menu.c
@@ -13,6 +13,10 @@
 #include "sound.h"
 #include "constants/songs.h"
 
+// GF cast Task data to ListMenu in many places, which effectively puts
+// an upper bound on sizeof(struct ListMenu).
+STATIC_ASSERT(sizeof(struct ListMenu) <= sizeof(((struct Task *)NULL)->data), ListMenuTooLargeForTaskData);
+
 // Cursors after this point are created using a sprite with their own task.
 // This allows them to have idle animations. Cursors prior to this are simply printed text.
 #define CURSOR_OBJECT_START CURSOR_RED_OUTLINE


### PR DESCRIPTION
Task data is cast to `struct ListMenu` all over `src/list_menu.c` which means that if `sizeof(struct ListMenu)` grows the code will stomp over other data (probably in `gTasks`, but if you're unlucky whatever follows it).