### PR TITLE
Added enum for IsMonDisobedient

### DIFF
--- a/include/battle_util.h
+++ b/include/battle_util.h
@@ -47,6 +47,10 @@
 #define WEATHER_HAS_EFFECT ((!ABILITY_ON_FIELD(ABILITY_CLOUD_NINE) && !ABILITY_ON_FIELD(ABILITY_AIR_LOCK)))
 #define WEATHER_HAS_EFFECT2 ((!ABILITY_ON_FIELD2(ABILITY_CLOUD_NINE) && !ABILITY_ON_FIELD2(ABILITY_AIR_LOCK)))
 
+#define DISOBEDIENCE_OBEDIENT 0
+#define DISOBEDIENCE_IGNORED  1 // command is ignored
+#define DISOBEDIENCE_OTHER    2 // random move or self-hit
+
 void HandleAction_UseMove(void);
 void HandleAction_Switch(void);
 void HandleAction_UseItem(void);

--- a/include/constants/battle.h
+++ b/include/constants/battle.h
@@ -199,7 +199,7 @@ enum BattlerId
 #define HITMARKER_PLAYER_FAINTED        (1 << 22)
 #define HITMARKER_ALLOW_NO_PP           (1 << 23)
 #define HITMARKER_GRUDGE                (1 << 24)
-#define HITMARKER_OBEYS                 (1 << 25)
+#define HITMARKER_OBEYS                 (1 << 25) // Set after obedience check has been performed
 #define HITMARKER_NEVER_SET             (1 << 26) // Cleared as part of a large group. Never set or checked
 #define HITMARKER_CHARGING              (1 << 27)
 #define HITMARKER_FAINTED(battler)      (gBitTable[battler] << 28)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -946,12 +946,12 @@ static void Cmd_attackcanceler(void)
         i = IsMonDisobedient(); // why use the 'i' variable...?
         switch (i)
         {
-        case 0:
+        case DISOBEDIENCE_OBEDIENT:
             break;
-        case 2:
+        case DISOBEDIENCE_OTHER:
             gHitMarker |= HITMARKER_OBEYS;
             return;
-        default:
+        default: // DISOBEDIENCE_IGNORED
             gMoveResultFlags |= MOVE_RESULT_MISSED;
             return;
         }

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -3927,22 +3927,22 @@ u8 IsMonDisobedient(void)
     u8 obedienceLevel = 0;
 
     if (gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_RECORDED_LINK))
-        return 0;
+        return DISOBEDIENCE_OBEDIENT;
     if (GetBattlerSide(gBattlerAttacker) == B_SIDE_OPPONENT)
-        return 0;
+        return DISOBEDIENCE_OBEDIENT;
 
     if (IsBattlerModernFatefulEncounter(gBattlerAttacker)) // only false if illegal Mew or Deoxys
     {
         if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER && GetBattlerPosition(gBattlerAttacker) == 2)
-            return 0;
+            return DISOBEDIENCE_OBEDIENT;
         if (gBattleTypeFlags & BATTLE_TYPE_FRONTIER)
-            return 0;
+            return DISOBEDIENCE_OBEDIENT;
         if (gBattleTypeFlags & BATTLE_TYPE_RECORDED)
-            return 0;
+            return DISOBEDIENCE_OBEDIENT;
         if (!IsOtherTrainer(gBattleMons[gBattlerAttacker].otId, gBattleMons[gBattlerAttacker].otName))
-            return 0;
+            return DISOBEDIENCE_OBEDIENT;
         if (FlagGet(FLAG_BADGE08_GET))
-            return 0;
+            return DISOBEDIENCE_OBEDIENT;
 
         obedienceLevel = 10;
 
@@ -3955,11 +3955,11 @@ u8 IsMonDisobedient(void)
     }
 
     if (gBattleMons[gBattlerAttacker].level <= obedienceLevel)
-        return 0;
+        return DISOBEDIENCE_OBEDIENT;
     rnd = (Random() & 255);
     calc = (gBattleMons[gBattlerAttacker].level + obedienceLevel) * rnd >> 8;
     if (calc < obedienceLevel)
-        return 0;
+        return DISOBEDIENCE_OBEDIENT;
 
     // is not obedient
     if (gCurrentMove == MOVE_RAGE)
@@ -3967,7 +3967,7 @@ u8 IsMonDisobedient(void)
     if (gBattleMons[gBattlerAttacker].status1 & STATUS1_SLEEP && (gCurrentMove == MOVE_SNORE || gCurrentMove == MOVE_SLEEP_TALK))
     {
         gBattlescriptCurrInstr = BattleScript_IgnoresWhileAsleep;
-        return 1;
+        return DISOBEDIENCE_IGNORED;
     }
 
     rnd = (Random() & 255);
@@ -3981,7 +3981,7 @@ u8 IsMonDisobedient(void)
             // B_MSG_LOAFING, B_MSG_WONT_OBEY, B_MSG_TURNED_AWAY, or B_MSG_PRETEND_NOT_NOTICE
             gBattleCommunication[MULTISTRING_CHOOSER] = MOD(Random(), NUM_LOAF_STRINGS);
             gBattlescriptCurrInstr = BattleScript_MoveUsedLoafingAround;
-            return 1;
+            return DISOBEDIENCE_IGNORED;
         }
         else // use a random move
         {
@@ -3994,7 +3994,7 @@ u8 IsMonDisobedient(void)
             gBattlescriptCurrInstr = BattleScript_IgnoresAndUsesRandomMove;
             gBattlerTarget = GetMoveTarget(gCalledMove, NO_TARGET_OVERRIDE);
             gHitMarker |= HITMARKER_DISOBEDIENT_MOVE;
-            return 2;
+            return DISOBEDIENCE_OTHER;
         }
     }
     else
@@ -4014,7 +4014,7 @@ u8 IsMonDisobedient(void)
             if (i == gBattlersCount)
             {
                 gBattlescriptCurrInstr = BattleScript_IgnoresAndFallsAsleep;
-                return 1;
+                return DISOBEDIENCE_IGNORED;
             }
         }
         calc -= obedienceLevel;
@@ -4024,7 +4024,7 @@ u8 IsMonDisobedient(void)
             gBattlerTarget = gBattlerAttacker;
             gBattlescriptCurrInstr = BattleScript_IgnoresAndHitsItself;
             gHitMarker |= HITMARKER_UNABLE_TO_USE_MOVE;
-            return 2;
+            return DISOBEDIENCE_OTHER;
         }
         else
         {
@@ -4032,7 +4032,7 @@ u8 IsMonDisobedient(void)
             // B_MSG_LOAFING, B_MSG_WONT_OBEY, B_MSG_TURNED_AWAY, or B_MSG_PRETEND_NOT_NOTICE
             gBattleCommunication[MULTISTRING_CHOOSER] = MOD(Random(), NUM_LOAF_STRINGS);
             gBattlescriptCurrInstr = BattleScript_MoveUsedLoafingAround;
-            return 1;
+            return DISOBEDIENCE_IGNORED;
         }
     }
 }


### PR DESCRIPTION
Adds enum to replace magic numbers returned by `IsMonDisobedient`

## Description

`IsMonDisobedient` returns magic numbers (0 to 2) and this PR adds an enum:

```c
#define DISOBEDIENCE_OBEDIENT 0
#define DISOBEDIENCE_IGNORED  1 // command is ignored
#define DISOBEDIENCE_OTHER    2 // random move or self-hit
```

I also noticed that `HITMARKER_OBEYS` does not necessarily mean that the Pokemon actually obeyed the command, so I'd like to rename that, but didn't have a good idea and just left a comment. It seems the flag is always set, unless the Pokemon chose to use a different move (incl. hitting itself with pseudo-POUND).

## **Discord contact info**

Mitsunee