### PR TITLE
Add smol artifacts and tools to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 *.8bpp
 *.gbapal
 *.lz
+*.smol
+*.fastSmol
+*.smolTM
 *.rl
 *.latfont
 *.hwjpnfont
@@ -20,6 +23,8 @@
 sound/**/*.bin
 sound/songs/midi/*.s
 tools/agbcc
+tools/compresSmol/compresSmol
+tools/compresSmol/compresSmolTilemap
 *.map
 *.bat
 *.dump

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,7 @@
 sound/**/*.bin
 sound/songs/midi/*.s
 tools/agbcc
-tools/compresSmol/compresSmol
-tools/compresSmol/compresSmolTilemap
+tools/compresSmol/
 *.map
 *.bat
 *.dump


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Since Porymap officially supports the Smol compressor, figured it should include them in the gitignore to make switching branches less annoying.

## **Discord contact info**
AsparagusEduardo