### PR TITLE
BUGFIX: Use the unique fully open Timer Ball sprite

### DIFF
--- a/src/pokeball.c
+++ b/src/pokeball.c
@@ -1319,6 +1319,10 @@ void LoadBallGfx(u8 ballId)
     switch (ballId)
     {
     case BALL_DIVE:
+// BUGFIX: The thrown Timer Ball has a unique fully open sprite that is never used, as it was never included in this case
+#ifdef BUGFIX
+    case BALL_TIMER:
+#endif
     case BALL_LUXURY:
     case BALL_PREMIER:
         break;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
From TCRF:
> When the player throws a Poké Ball, there are three frames used: one for the ball closed, partially open, and fully open. Each Ball has unique sprites for the first two, however the Dive Ball, Luxury Ball, Premier Ball, and Timer Ball are the only ones with unique sprites for the fully open frame, with the rest leaving that space blank. A generic fully open sprite is used and fills the empty space for the rest of the Poké Balls due to an oversight, which also overwrites the unique Timer Ball fully open sprite. This is because the function only checks for Poké Ball IDs 6, 10, and 11 corresponding to Dive, Luxury, and Premier, but not ID 9 for the Timer Ball.
<img width="240" height="160" alt="pokeemerald_modern-0" src="https://github.com/user-attachments/assets/5f294f23-0e3d-4595-a459-75fae828e40a" />

## **Discord contact info**
kittenchilly