### PR TITLE
Extract GiveGiftRibbonToParty from file about size records

### DIFF
--- a/include/give_gift_ribbon_to_party.h
+++ b/include/give_gift_ribbon_to_party.h
@@ -1,0 +1,6 @@
+#ifndef GUARD_GIVE_GIFT_RIBBON_TO_PARTY_H
+#define GUARD_GIVE_GIFT_RIBBON_TO_PARTY_H
+
+void GiveGiftRibbonToParty(u8 index, u8 ribbonId);
+
+#endif // GUARD_GIVE_GIFT_RIBBON_TO_PARTY_H

--- a/include/pokemon_size_record.h
+++ b/include/pokemon_size_record.h
@@ -9,6 +9,4 @@ void InitLotadSizeRecord(void);
 void GetLotadSizeRecordInfo(void);
 void CompareLotadSize(void);
 
-void GiveGiftRibbonToParty(u8 index, u8 ribbonId);
-
 #endif // GUARD_POKEMON_SIZE_RECORD_H

--- a/ld_script.ld
+++ b/ld_script.ld
@@ -180,6 +180,7 @@ SECTIONS {
         src/script_pokemon_util.o(.text);
         src/field_poison.o(.text);
         src/pokemon_size_record.o(.text);
+        src/give_gift_ribbon_to_party.o(.text);
         src/fldeff_misc.o(.text);
         src/field_special_scene.o(.text);
         src/rotating_gate.o(.text);
@@ -557,6 +558,7 @@ SECTIONS {
         src/contest_util.o(.rodata);
         src/script_pokemon_util.o(.rodata);
         src/pokemon_size_record.o(.rodata)
+        src/give_gift_ribbon_to_party.o(.rodata);
         src/fldeff_misc.o(.rodata);
         src/field_special_scene.o(.rodata);
         src/rotating_gate.o(.rodata);

--- a/src/give_gift_ribbon_to_party.c
+++ b/src/give_gift_ribbon_to_party.c
@@ -1,0 +1,38 @@
+#include "global.h"
+#include "event_data.h"
+#include "give_gift_ribbon_to_party.h"
+#include "pokemon.h"
+
+// - 4 for unused gift ribbon bits in MON_DATA_UNUSED_RIBBONS
+static const u8 sGiftRibbonsMonDataIds[GIFT_RIBBONS_COUNT - 4] =
+{
+    MON_DATA_MARINE_RIBBON, MON_DATA_LAND_RIBBON, MON_DATA_SKY_RIBBON,
+    MON_DATA_COUNTRY_RIBBON, MON_DATA_NATIONAL_RIBBON, MON_DATA_EARTH_RIBBON,
+    MON_DATA_WORLD_RIBBON
+};
+
+void GiveGiftRibbonToParty(u8 index, u8 ribbonId)
+{
+    s32 i;
+    bool32 gotRibbon = FALSE;
+    u8 data = 1;
+    u8 array[ARRAY_COUNT(sGiftRibbonsMonDataIds)];
+    memcpy(array, sGiftRibbonsMonDataIds, sizeof(sGiftRibbonsMonDataIds));
+
+    if (index < GIFT_RIBBONS_COUNT && ribbonId <= MAX_GIFT_RIBBON)
+    {
+        gSaveBlock1Ptr->giftRibbons[index] = ribbonId;
+        for (i = 0; i < PARTY_SIZE; i++)
+        {
+            struct Pokemon *mon = &gPlayerParty[i];
+
+            if (GetMonData(mon, MON_DATA_SPECIES) != 0 && GetMonData(mon, MON_DATA_SANITY_IS_EGG) == 0)
+            {
+                SetMonData(mon, array[index], &data);
+                gotRibbon = TRUE;
+            }
+        }
+        if (gotRibbon)
+            FlagSet(FLAG_SYS_RIBBON_GET);
+    }
+}

--- a/src/mystery_event_script.c
+++ b/src/mystery_event_script.c
@@ -7,7 +7,7 @@
 #include "mystery_event_script.h"
 #include "pokedex.h"
 #include "pokemon.h"
-#include "pokemon_size_record.h"
+#include "give_gift_ribbon_to_party.h"
 #include "script.h"
 #include "strings.h"
 #include "string_util.h"

--- a/src/pokemon_size_record.c
+++ b/src/pokemon_size_record.c
@@ -36,14 +36,6 @@ static const struct UnknownStruct sBigMonSizeTable[] =
     { 1700,   1,   -26 },
 };
 
-// - 4 for unused gift ribbon bits in MON_DATA_UNUSED_RIBBONS
-static const u8 sGiftRibbonsMonDataIds[GIFT_RIBBONS_COUNT - 4] =
-{
-    MON_DATA_MARINE_RIBBON, MON_DATA_LAND_RIBBON, MON_DATA_SKY_RIBBON,
-    MON_DATA_COUNTRY_RIBBON, MON_DATA_NATIONAL_RIBBON, MON_DATA_EARTH_RIBBON,
-    MON_DATA_WORLD_RIBBON
-};
-
 extern const u8 gText_DecimalPoint[];
 extern const u8 gText_Marco[];
 
@@ -191,30 +183,4 @@ void CompareLotadSize(void)
     u16 *sizeRecord = GetVarPointer(VAR_LOTAD_SIZE_RECORD);
 
     gSpecialVar_Result = CompareMonSize(SPECIES_LOTAD, sizeRecord);
-}
-
-void GiveGiftRibbonToParty(u8 index, u8 ribbonId)
-{
-    s32 i;
-    bool32 gotRibbon = FALSE;
-    u8 data = 1;
-    u8 array[ARRAY_COUNT(sGiftRibbonsMonDataIds)];
-    memcpy(array, sGiftRibbonsMonDataIds, sizeof(sGiftRibbonsMonDataIds));
-
-    if (index < GIFT_RIBBONS_COUNT && ribbonId <= MAX_GIFT_RIBBON)
-    {
-        gSaveBlock1Ptr->giftRibbons[index] = ribbonId;
-        for (i = 0; i < PARTY_SIZE; i++)
-        {
-            struct Pokemon *mon = &gPlayerParty[i];
-
-            if (GetMonData(mon, MON_DATA_SPECIES) != 0 && GetMonData(mon, MON_DATA_SANITY_IS_EGG) == 0)
-            {
-                SetMonData(mon, array[index], &data);
-                gotRibbon = TRUE;
-            }
-        }
-        if (gotRibbon)
-            FlagSet(FLAG_SYS_RIBBON_GET);
-    }
 }


### PR DESCRIPTION
## Description
`GiveGiftRibbonToParty` was in `pokemon_size_record.c`, a which is other than `GiveGiftRibbonToParty` a very cohesive file about the Lotad and Seedot size records. Since `GiveGiftRibbonToParty` and related data was at the end of the compilation unit, it is possible to split out this method cleanly into a separate file, resulting in two files that are more cohesive than the original file.

## **Discord contact info**
yoshord
