### PR TITLE
Fix -WSign warning in battle_transition

### DIFF
--- a/src/battle_transition.c
+++ b/src/battle_transition.c
@@ -268,7 +268,7 @@ static void InitTransitionData(void);
 static void FadeScreenBlack(void);
 static void CreateIntroTask(s16, s16, s16, s16, s16);
 static void SetCircularMask(u16 *, s16, s16, s16);
-static void SetSinWave(s16 *, s16, s16, s16, s16, s16);
+static void SetSinWave(u16 *, s16, s16, s16, s16, s16);
 static void GetBg0TilemapDst(u16 **);
 static void InitBlackWipe(s16 *, s16, s16, s16, s16, s16, s16);
 static bool8 UpdateBlackWipe(s16 *, bool8, bool8);
@@ -4084,7 +4084,7 @@ static void FadeScreenBlack(void)
     BlendPalettes(PALETTES_ALL, 16, RGB_BLACK);
 }
 
-static void SetSinWave(s16 *array, s16 sinAdd, s16 index, s16 indexIncrementer, s16 amplitude, s16 arrSize)
+static void SetSinWave(u16 *array, s16 sinAdd, s16 index, s16 indexIncrementer, s16 amplitude, s16 arrSize)
 {
     u8 i;
     for (i = 0; arrSize > 0; arrSize--, i++, index += indexIncrementer)


### PR DESCRIPTION
src/battle_transition.c:1199:16: warning: passing 'u16[960]' (aka 'unsigned short[960]') to parameter of type 's16 *' (aka 'short *') converts between pointers to integer types with different sign [-Wpointer-sign]
 1199 |     SetSinWave(gScanlineEffectRegBuffers[1], sTransitionData->cameraX, 0, 2, 0, 160);