### PR TITLE
feat: add Docker build environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+Dockerfile
+docker-compose.yml
+build/**

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,30 @@
+# Docker
+
+Build pokeemerald without installing the toolchain on your host machine.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) with Compose v2
+
+## Usage
+
+```bash
+# Build the ROM
+make docker-build
+
+# Open a shell inside the container
+make docker-shell
+
+# Clean build artifacts
+make docker-clean
+```
+
+The output ROM is written to `pokeemerald_modern.gba` in the project root.
+
+## How it works
+
+The container is an Ubuntu 24.04 image with the ARM cross-compilation toolchain (`gcc-arm-none-eabi`, `binutils-arm-none-eabi`) and build dependencies pre-installed. Your project directory is volume-mounted into the container at `/workspace`, so source edits on the host are immediately reflected.
+
+The build uses `MODERN=1`, which compiles with the system `arm-none-eabi-gcc` rather than the legacy `agbcc` compiler. A persistent Docker volume caches `ccache` data across builds to speed up recompilation.
+
+On first run, Docker will build the image - subsequent runs reuse the cached image.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/usr/lib/ccache:${PATH}"
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    binutils-arm-none-eabi \
+    gcc-arm-none-eabi \
+    git \
+    make \
+    python3 \
+    ccache \
+    libpng-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV CCACHE_DIR=/ccache
+
+WORKDIR /workspace
+
+CMD ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -389,3 +389,15 @@ $(ROM): $(ELF)
 # Symbol file (`make syms`)
 $(SYM): $(ELF)
 	$(OBJDUMP) -t $< | sort -u | grep -E "^0[2389]" | $(PERL) -p -e 's/^(\w{8}) (\w).{6} \S+\t(\w{8}) (\S+)$$/\1 \2 \3 \4/g' > $@
+
+# Docker
+.PHONY: docker-build docker-shell docker-clean
+
+docker-build:
+	HOST_UID=$$(id -u) HOST_GID=$$(id -g) docker compose run --rm pokeemerald
+
+docker-shell:
+	HOST_UID=$$(id -u) HOST_GID=$$(id -g) docker compose run --rm pokeemerald bash
+
+docker-clean:
+	HOST_UID=$$(id -u) HOST_GID=$$(id -g) docker compose run --rm pokeemerald make clean

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  pokeemerald:
+    build: .
+    working_dir: /workspace
+    environment:
+      CCACHE_DIR: /ccache
+    volumes:
+      - ./:/workspace
+      - pokeemerald_ccache:/ccache
+    command: bash -lc "make clean-tools && make MODERN=1 -j$$(nproc)"
+
+volumes:
+  pokeemerald_ccache:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Main goal: Remove as many toolchain requirements for build/compilation.

Adds a docker env to reduce host machine toolchain requirements. The built rom outputs to the host machine (not persisted in the container).

Tested locally, and currently making mods with it. Roms are building and running as expected.

This does not remove the requirement for tools such as porymap, etc..

## **Discord contact info**
<!--- Formatted as username (e.g. pikalaxalt) or username#numbers (e.g. PikalaxALT#5823) -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->
gregthegreek