### PR TITLE
Mention the width of RAM variables in constants/battle.h

### DIFF
--- a/include/constants/battle.h
+++ b/include/constants/battle.h
@@ -109,8 +109,8 @@ enum BattlerId
 #define B_OUTCOME_MON_TELEPORTED       10
 #define B_OUTCOME_LINK_BATTLE_RAN      (1 << 7) // 128
 
-// Non-volatile status conditions
-// These persist remain outside of battle and after switching out
+// Non-volatile status conditions select from gBattleMons[n].status1, which is a u32.
+// These persist outside of battle and after switching out.
 #define STATUS1_NONE             0
 #define STATUS1_SLEEP            (1 << 0 | 1 << 1 | 1 << 2) // First 3 bits (Number of turns to sleep)
 #define STATUS1_SLEEP_TURN(num)  ((num) << 0) // Just for readability (or if rearranging statuses)
@@ -124,8 +124,8 @@ enum BattlerId
 #define STATUS1_PSN_ANY          (STATUS1_POISON | STATUS1_TOXIC_POISON)
 #define STATUS1_ANY              (STATUS1_SLEEP | STATUS1_POISON | STATUS1_BURN | STATUS1_FREEZE | STATUS1_PARALYSIS | STATUS1_TOXIC_POISON)
 
-// Volatile status ailments
-// These are removed after exiting the battle or switching out
+// Volatile status conditions select from gBattleMons[n].status2, which is a u32.
+// They are removed after exiting the battle or switching out.
 #define STATUS2_CONFUSION             (1 << 0 | 1 << 1 | 1 << 2)
 #define STATUS2_CONFUSION_TURN(num)   ((num) << 0)
 #define STATUS2_FLINCHED              (1 << 3)
@@ -154,7 +154,7 @@ enum BattlerId
 #define STATUS2_DEFENSE_CURL          (1 << 30)
 #define STATUS2_TORMENT               (1 << 31)
 
-// Seems like per-battler statuses. Not quite sure how to categorize these
+// These select from gStatuses3[n], which is a u32.
 #define STATUS3_LEECHSEED_BATTLER       (1 << 0 | 1 << 1) // The battler to receive HP from Leech Seed
 #define STATUS3_LEECHSEED               (1 << 2)
 #define STATUS3_ALWAYS_HITS             (1 << 3 | 1 << 4)
@@ -205,7 +205,8 @@ enum BattlerId
 #define HITMARKER_FAINTED(battler)      (gBitTable[battler] << 28)
 #define HITMARKER_FAINTED2(battler)     ((1 << 28) << battler)
 
-// Per-side statuses that affect an entire party
+// Per-side statuses that affect an entire party.
+// These select from gSideStatuses[n], which is a u16.
 #define SIDE_STATUS_REFLECT          (1 << 0)
 #define SIDE_STATUS_LIGHTSCREEN      (1 << 1)
 #define SIDE_STATUS_X4               (1 << 2)
@@ -226,7 +227,8 @@ enum BattlerId
 #define MOVE_RESULT_FOE_HUNG_ON        (1 << 7)
 #define MOVE_RESULT_NO_EFFECT          (MOVE_RESULT_MISSED | MOVE_RESULT_DOESNT_AFFECT_FOE | MOVE_RESULT_FAILED)
 
-// Battle Weather flags
+// Battle weather flags.
+// These select from gBattleWeather, which is a u16.
 #define B_WEATHER_RAIN_TEMPORARY      (1 << 0)
 #define B_WEATHER_RAIN_DOWNPOUR       (1 << 1)  // unused
 #define B_WEATHER_RAIN_PERMANENT      (1 << 2)


### PR DESCRIPTION
Something I've found myself needing to know when fiddling with status conditions and weather is how many additional bits I have available to me. Having it mentioned explicitly in the header itself would be convenient to save chasing through a layer of indirection to find out.

## **Discord contact info**
`.ketsuban`