### PR TITLE
Rename mass outbreak show  to distinguish from savefile outbreakDaysLeft

### DIFF
--- a/include/global.tv.h
+++ b/include/global.tv.h
@@ -486,7 +486,7 @@ typedef union // size = 0x24
         /*0x13*/ u8 probability;
         /*0x14*/ u8 level;
         /*0x15*/ u8 unused5;
-        /*0x16*/ u16 daysLeft;
+        /*0x16*/ u16 daysBeforeOutbreak;
         /*0x18*/ u8 language;
         /*0x19*/ //u8 padding;
     } massOutbreak;

--- a/src/tv.c
+++ b/src/tv.c
@@ -137,7 +137,7 @@ static void TryPutPokemonTodayFailedOnTheAir(void);
 static void TryStartRandomMassOutbreak(void);
 static void TryPutRandomPokeNewsOnAir(void);
 static void SortPurchasesByQuantity(void);
-static void UpdateMassOutbreakTimeLeft(u16);
+static void UpdateTimeBeforeMassOutbreak(u16);
 static void TryEndMassOutbreak(u16);
 static void UpdatePokeNewsCountdown(u16);
 static void ResolveWorldOfMastersShow(u16);

--- a/src/tv.c
+++ b/src/tv.c
@@ -797,7 +797,7 @@ u8 GetRandomActiveShowIdx(void)
         else
         {
             show = &gSaveBlock1Ptr->tvShows[j];
-            if (show->massOutbreak.daysLeft == 0 && show->massOutbreak.active == TRUE)
+            if (show->massOutbreak.daysBeforeOutbreak == 0 && show->massOutbreak.active == TRUE)
                 return j;
         }
 
@@ -1679,7 +1679,7 @@ static void TryStartRandomMassOutbreak(void)
                 show->massOutbreak.unused4 = 0;
                 show->massOutbreak.probability = 50;
                 show->massOutbreak.unused5 = 0;
-                show->massOutbreak.daysLeft = 1;
+                show->massOutbreak.daysBeforeOutbreak = 1;
                 StorePlayerIdInNormalShow(show);
                 show->massOutbreak.language = gGameLanguage;
             }
@@ -1706,14 +1706,14 @@ void EndMassOutbreak(void)
 
 void UpdateTVShowsPerDay(u16 days)
 {
-    UpdateMassOutbreakTimeLeft(days);
+    UpdateTimeBeforeMassOutbreak(days);
     TryEndMassOutbreak(days);
     UpdatePokeNewsCountdown(days);
     ResolveWorldOfMastersShow(days);
     ResolveNumberOneShow(days);
 }
 
-static void UpdateMassOutbreakTimeLeft(u16 days)
+static void UpdateTimeBeforeMassOutbreak(u16 days)
 {
     u8 i;
     TVShow *show;
@@ -1725,10 +1725,10 @@ static void UpdateMassOutbreakTimeLeft(u16 days)
             if (gSaveBlock1Ptr->tvShows[i].massOutbreak.kind == TVSHOW_MASS_OUTBREAK && gSaveBlock1Ptr->tvShows[i].massOutbreak.active == TRUE)
             {
                 show = &gSaveBlock1Ptr->tvShows[i];
-                if (show->massOutbreak.daysLeft < days)
-                    show->massOutbreak.daysLeft = 0;
+                if (show->massOutbreak.daysBeforeOutbreak < days)
+                    show->massOutbreak.daysBeforeOutbreak = 0;
                 else
-                    show->massOutbreak.daysLeft -= days;
+                    show->massOutbreak.daysBeforeOutbreak -= days;
 
                 break;
             }
@@ -3619,7 +3619,7 @@ static bool8 TryMixOutbreakTVShow(TVShow *dest, TVShow *src, u8 idx)
     src->common.srcTrainerIdHi = linkTrainerId >> 8;
     *dest = *src;
     dest->common.active = TRUE;
-    dest->massOutbreak.daysLeft = 1;
+    dest->massOutbreak.daysBeforeOutbreak = 1;
     return TRUE;
 }
 


### PR DESCRIPTION
Once you get an outbreak from random chance or mix, you need to wait one day before having a chance for the tv show to appear and start the mass outbreak. (you need to roll this show if you have other shows active and if you already have an active outbreak, you will need for it to end first)

The massOutbreak has its own day timer and so after 2 days, the mass outbreak will end. 
I was working with outbreak and was getting confused by the values having the same name (number of days before the outbreaks vs number of days the outbreak lasts) so I renamed the tv show one



## **Discord contact info**
Jamie
