### PR TITLE
Bugfix: mass outbreak encounters are not replaced by regular encounters if they are blocked by a repel

### DIFF
--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -612,7 +612,7 @@ bool8 StandardWildEncounter(u16 curMetatileBehavior, u16 prevMetatileBehavior)
             }
             else
             {
-                #if BUGFIX
+                #ifdef BUGFIX
                     // The bugfix prevents the game from trying to get a regular tall grass encounter on the same tile the repel blocked a mass outbreak encounter
                     if (DoMassOutbreakEncounterTest() == TRUE)
                     {

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -612,11 +612,22 @@ bool8 StandardWildEncounter(u16 curMetatileBehavior, u16 prevMetatileBehavior)
             }
             else
             {
+                #if BUGFIX
+                    // The bugfix prevents the game from trying to get a regular tall grass encounter on the same tile the repel blocked a mass outbreak encounter
+                    if (DoMassOutbreakEncounterTest() == TRUE)
+                    {
+                        if (!SetUpMassOutbreakEncounter(WILD_CHECK_REPEL | WILD_CHECK_KEEN_EYE))
+                            return FALSE;
+                        BattleSetup_StartWildBattle();
+                        return TRUE;
+                    }
+                #else
                 if (DoMassOutbreakEncounterTest() == TRUE && SetUpMassOutbreakEncounter(WILD_CHECK_REPEL | WILD_CHECK_KEEN_EYE) == TRUE)
                 {
                     BattleSetup_StartWildBattle();
                     return TRUE;
                 }
+                #endif
 
                 // try a regular wild land encounter
                 if (TryGenerateWildMon(gWildMonHeaders[headerId].landMonsInfo, WILD_AREA_LAND, WILD_CHECK_REPEL | WILD_CHECK_KEEN_EYE) == TRUE)


### PR DESCRIPTION
This is super niche and could arguably be considered a feature not a bug. When you step on a new tall grass tile and the game decides to give you a wild encounter, it will in this order:
- check if a roamer is active and roll for a chance to give you that roamer
- check if a mass outbreak is active and roll for a chance to give you that pokemon
- roll a wild pokemon from the local encounter table

If you have a repel active and a pokemon with higher level than the chosen encounter, the encounter is skipped and you won't get an encounter until you step on another tile and happen to roll an encounter with a level high enough to bypass your repel EXCEPT for mass outbreak encounters which are bugged (arguably) and will still roll the local encounter table if you blocked the encounter with a repel. 

So I added a preproc to fix that 

## **Discord contact info**
Jamie (foster_harmony)
