### PR TITLE
INCGFX performance - define individual Make variables instead of appending to list

### DIFF
--- a/tools/scaninc/scaninc.cpp
+++ b/tools/scaninc/scaninc.cpp
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include <algorithm>
 #include <cctype>
 #include <cstdio>
 #include <cstdlib>
@@ -225,19 +226,24 @@ int main(int argc, char **argv)
         // GNU make will issue a warning if there is more than one
         // recipe for a target. This would occur whenever a target is
         // 'INCGFX'ed multiple times, which is something that happens a
-        // few times in vanilla. As a workaround, we maintain a variable
-        // with all the 'INCGFX' targets and only emit the recipe if
-        // the target is not in that variable. This is safe, because
+        // few times in vanilla. As a workaround, we define a variable
+        // with the target's name sanitized and only emit the recipe if
+        // the target is not yet defined. This is safe, because
         // targets with the same name necessarily have the same recipe.
-        output
-            << "ifndef _INCGFX\n"
-            << "_INCGFX :=\n"
-            << "endif\n";
         for (auto gfx_rule : dependencies_gfx_rules)
         {
+            std::string gfx_var_name = gfx_rule.first;
+            gfx_var_name.erase(
+                std::remove_if(
+                    gfx_var_name.begin(), 
+                    gfx_var_name.end(), 
+                    [] (char c) { return c == '#' || c == ':' || c == '='; } // invalid chars in GNU Make variables
+                ), gfx_var_name.end()
+            );
+            
             output
-                << "ifeq (,$(findstring " << gfx_rule.first << ",$(_INCGFX)))\n"
-                << "_INCGFX += " << gfx_rule.first << "\n"
+                << "ifndef " << gfx_var_name << "\n"
+                << gfx_var_name << " := defined\n"
                 << gfx_rule.first << ": " << gfx_rule.second.first << "\n" << gfx_rule.second.second
                 << "endif\n";
         }


### PR DESCRIPTION
## Description
The changes to `scaninc` introduced in #2283 increased build times noticeably. On my machine, a `make` with zero changes went from ~0.9 seconds to ~3 seconds. The effect was much more pronounced on downstream forks with additional graphics like pokeemerald-expansion, where a zero-change build took my machine ~20 seconds to run.

The time to read all of the Make rules was increased significantly by incorporating the following pattern for each INCGFX rule:
```
ifeq (,$(findstring foo,$(_INCGFX)))
_INCGFX += foo
foo: bar
endif
```

Which was intended to suppress the warning Make creates when you have multiple recipes for a single target. My fix takes an alternative approach to accomplish that in a more performant way:

```
ifndef foo
foo := defined
foo: bar
endif
```

With my fix, a zero-change build is back down to ~0.9 seconds. Building pokeemerald-expansion with zero changes is down to ~1.75 seconds.

The only caveat I see here is that it introduces a potential for duplicate recipes to be created by having two files with the same exact path except for any special characters needed to sanitize the target as a Make variable. E.g. files named `pokeball.png` and `pokeball=.png` in the same directory would create an issue. Given that most people aren't putting `=`, `#`, or `:` in their file names, and that the issue only creates a Make warning, I'm not too concerned about it. 

## **Discord contact info**
raveposum
