### PR TITLE
Bugfix: ensure move is correctly read

### DIFF
--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -1803,7 +1803,13 @@ static void Cmd_if_cant_faint(void)
 static void Cmd_if_has_move(void)
 {
     s32 i;
+
+#ifdef BUGFIX
+    const u16 move = T1_READ_16(gAIScriptPtr + 2);
+    const u16 *movePtr = &move;    
+#else
     const u16 *movePtr = (u16 *)(gAIScriptPtr + 2);
+#endif
 
     switch (gAIScriptPtr[1])
     {
@@ -1855,7 +1861,13 @@ static void Cmd_if_has_move(void)
 static void Cmd_if_doesnt_have_move(void)
 {
     s32 i;
+
+#ifdef BUGFIX
+    const u16 move = T1_READ_16(gAIScriptPtr + 2);
+    const u16 *movePtr = &move;    
+#else
     const u16 *movePtr = (u16 *)(gAIScriptPtr + 2);
+#endif
 
     switch(gAIScriptPtr[1])
     {


### PR DESCRIPTION
This bugfix makes use of `T1_READ_16` to ensure the value passed to the function via `gAIScriptPtr` is correctly read in the cases where the pointer is not aligned correctly to two bytes.

This issue, & proposed bugfix were discussed on the discord [here](https://discord.com/channels/442462691542695948/442465020291317760/1508437266282844271).