### PR TITLE
BUGFIX: Zigagoon can hold an oran berry even when zeroed out

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -6663,7 +6663,12 @@ static s32 GetWildMonTableIdInAlteringCave(u16 species)
 
 void SetWildMonHeldItem(void)
 {
+    // BUG: Zigzagoon can hold an oran berry because this function is called.
+    #if !BUGFIX
     if (!(gBattleTypeFlags & (BATTLE_TYPE_LEGENDARY | BATTLE_TYPE_TRAINER | BATTLE_TYPE_PYRAMID | BATTLE_TYPE_PIKE)))
+    #else
+    if (!(gBattleTypeFlags & (BATTLE_TYPE_LEGENDARY | BATTLE_TYPE_TRAINER | BATTLE_TYPE_PYRAMID | BATTLE_TYPE_PIKE | BATTLE_TYPE_FIRST_BATTLE)))
+    #endif
     {
         u16 rnd = Random() % 100;
         u16 species = GetMonData(&gEnemyParty[0], MON_DATA_SPECIES, 0);


### PR DESCRIPTION
ORAS does not have this. It seems to be unintentional. BATTLE_TYPE_FIRST_BATTLE was never set.