### PR TITLE
Make GetMonData and GetBoxMonData ABI-safe

### DIFF
--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -441,12 +441,29 @@ void SetMultiuseSpriteTemplateToTrainerFront(u16 trainerPicId, u8 battlerPositio
  * either Get(Box)MonData2 or Get(Box)MonData3 based on the number of
  * arguments. The two functions are aliases of each other, but they
  * differ for matching purposes in the caller's codegen. */
-#define GetMonData(...) CAT(GetMonData, NARG_8(__VA_ARGS__))(__VA_ARGS__)
-#define GetBoxMonData(...) CAT(GetBoxMonData, NARG_8(__VA_ARGS__))(__VA_ARGS__)
-u32 GetMonData3(struct Pokemon *mon, s32 field, u8 *data);
+#ifndef UBFIX
+#define DISPATCH_MATCH(FUNC, ...) CAT(FUNC, NARG_8(__VA_ARGS__))(__VA_ARGS__)
+
+#define GetMonData(...)    DISPATCH_MATCH(GetMonData, __VA_ARGS__)
+#define GetBoxMonData(...) DISPATCH_MATCH(GetBoxMonData, __VA_ARGS__)
+
+// agbcc still needs to know about the 2-argument aliases
 u32 GetMonData2(struct Pokemon *mon, s32 field);
-u32 GetBoxMonData3(struct BoxPokemon *boxMon, s32 field, u8 *data);
 u32 GetBoxMonData2(struct BoxPokemon *boxMon, s32 field);
+#else
+#define GetMonData_(mon, field, data, ...) (GetMonData)(mon, field, data)
+#define GetMonData(...) GetMonData_(__VA_ARGS__, NULL, NULL)
+
+#define GetBoxMonData_(boxMon, field, data, ...) (GetBoxMonData)(boxMon, field, data)
+#define GetBoxMonData(...) GetBoxMonData_(__VA_ARGS__, NULL, NULL)
+
+// Intercept calls
+#define GetMonData2(mon, field)          (GetMonData)(mon, field, NULL)
+#define GetBoxMonData2(boxMon, field)    (GetBoxMonData)(boxMon, field, NULL)
+#endif
+
+u32 GetMonData(struct Pokemon *mon, s32 field, u8 *data);
+u32 GetBoxMonData(struct BoxPokemon *boxMon, s32 field, u8 *data);
 
 void SetMonData(struct Pokemon *mon, s32 field, const void *dataArg);
 void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg);

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3639,7 +3639,7 @@ static union PokemonSubstruct *GetSubstruct(struct BoxPokemon *boxMon, u32 perso
  * safety we have a GetMonData macro (in include/pokemon.h) which
  * dispatches to either GetMonData2 or GetMonData3 based on the number
  * of arguments. */
-u32 GetMonData3(struct Pokemon *mon, s32 field, u8 *data)
+u32 GetMonData(struct Pokemon *mon, s32 field, u8 *data)
 {
     u32 ret;
 
@@ -3707,13 +3707,15 @@ u32 GetMonData3(struct Pokemon *mon, s32 field, u8 *data)
     return ret;
 }
 
+#ifndef UBFIX
 u32 GetMonData2(struct Pokemon *mon, s32 field) __attribute__((alias("GetMonData3")));
+#endif
 
 /* GameFreak called GetBoxMonData with either 2 or 3 arguments, for type
  * safety we have a GetBoxMonData macro (in include/pokemon.h) which
  * dispatches to either GetBoxMonData2 or GetBoxMonData3 based on the
  * number of arguments. */
-u32 GetBoxMonData3(struct BoxPokemon *boxMon, s32 field, u8 *data)
+u32 GetBoxMonData(struct BoxPokemon *boxMon, s32 field, u8 *data)
 {
     s32 i;
     u32 retVal = 0;
@@ -4069,7 +4071,9 @@ u32 GetBoxMonData3(struct BoxPokemon *boxMon, s32 field, u8 *data)
     return retVal;
 }
 
+#ifndef UBFIX
 u32 GetBoxMonData2(struct BoxPokemon *boxMon, s32 field) __attribute__((alias("GetBoxMonData3")));
+#endif
 
 #define SET8(lhs) (lhs) = *data
 #define SET16(lhs) (lhs) = data[0] + (data[1] << 8)


### PR DESCRIPTION
Clang and LLVM hate this, so instead I am doing the manual work of using macros to do the equivalent of a default parameter in C++ to avoid work downstream.
