### PR TITLE
Remove PokenavListSub

### DIFF
--- a/include/pokenav.h
+++ b/include/pokenav.h
@@ -324,7 +324,7 @@ void SetPokenavVBlankCallback(void);
 void SetVBlankCallback_(IntrCallback callback);
 
 // pokenav_list.c
-bool32 CreatePokenavList(const struct BgTemplate *bgTemplate, struct PokenavListTemplate *listTemplate, s32 tileOffset);
+bool32 CreatePokenavList(const struct BgTemplate *bgTemplate, struct PokenavListTemplate *listTemplate, u32 tileOffset);
 bool32 IsCreatePokenavListTaskActive(void);
 void DestroyPokenavList(void);
 u32 PokenavList_GetSelectedIndex(void);

--- a/src/pokenav_list.c
+++ b/src/pokenav_list.c
@@ -211,31 +211,31 @@ static bool32 IsPrintListItemsTaskActive(void)
 static u32 LoopedTask_PrintListItems(s32 state)
 {
     u32 row;
-    struct PokenavList *listSub = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
+    struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
 
     switch (state)
     {
     case 0:
-        row = (listSub->listWindow.unkA + listSub->listWindow.numPrinted + listSub->printStart) & 0xF;
-        listSub->bufferItemFunc(listSub->listPtr, listSub->itemTextBuffer);
-        if (listSub->iconDrawFunc != NULL)
-            listSub->iconDrawFunc(listSub->listWindow.windowId, listSub->printIndex, row);
+        row = (list->listWindow.unkA + list->listWindow.numPrinted + list->printStart) & 0xF;
+        list->bufferItemFunc(list->listPtr, list->itemTextBuffer);
+        if (list->iconDrawFunc != NULL)
+            list->iconDrawFunc(list->listWindow.windowId, list->printIndex, row);
 
-        AddTextPrinterParameterized(listSub->listWindow.windowId, listSub->listWindow.fontId, listSub->itemTextBuffer, 8, (row << 4) + 1, TEXT_SKIP_DRAW, NULL);
-        if (++listSub->listWindow.numPrinted >= listSub->listWindow.numToPrint)
+        AddTextPrinterParameterized(list->listWindow.windowId, list->listWindow.fontId, list->itemTextBuffer, 8, (row << 4) + 1, TEXT_SKIP_DRAW, NULL);
+        if (++list->listWindow.numPrinted >= list->listWindow.numToPrint)
         {
             // Finished printing items. If icons were being drawn, draw the
             // window tilemap and graphics. Otherwise just do the graphics
-            if (listSub->iconDrawFunc != NULL)
-                CopyWindowToVram(listSub->listWindow.windowId, COPYWIN_FULL);
+            if (list->iconDrawFunc != NULL)
+                CopyWindowToVram(list->listWindow.windowId, COPYWIN_FULL);
             else
-                CopyWindowToVram(listSub->listWindow.windowId, COPYWIN_GFX);
+                CopyWindowToVram(list->listWindow.windowId, COPYWIN_GFX);
             return LT_INC_AND_PAUSE;
         }
         else
         {
-            listSub->listPtr += listSub->itemSize;
-            listSub->printIndex++;
+            list->listPtr += list->itemSize;
+            list->printIndex++;
             return LT_CONTINUE;
         }
     case 1:

--- a/src/pokenav_list.c
+++ b/src/pokenav_list.c
@@ -11,7 +11,8 @@
 #define GFXTAG_ARROW 10
 #define PALTAG_ARROW 20
 
-struct PokenavListMenuWindow {
+struct PokenavListMenuWindow
+{
     u8 bg;
     u8 fillValue;
     u8 x;
@@ -25,7 +26,8 @@ struct PokenavListMenuWindow {
     u16 numToPrint;
 };
 
-struct PokenavListWindowState {
+struct PokenavListWindowState
+{
     // The index of the element at the top of the window.
     u16 windowTopIndex;
     u16 listLength;

--- a/src/pokenav_list.c
+++ b/src/pokenav_list.c
@@ -37,7 +37,7 @@ struct PokenavListWindowState {
     void *listPtr;
 };
 
-struct PokenavListSub
+struct PokenavList
 {
     struct PokenavListMenuWindow listWindow;
     u32 printStart;
@@ -55,36 +55,31 @@ struct PokenavListSub
     struct Sprite *upArrow;
     struct Sprite *downArrow;
     u8 itemTextBuffer[64];
-};
-
-struct PokenavList
-{
-    struct PokenavListSub sub;
     u8 tilemapBuffer[BG_SCREEN_SIZE];
     struct PokenavListWindowState windowState;
     s32 eraseIndex;
-    u32 loopedTaskId;
+    u32 loopedTaskId2;
 };
 
 static void InitPokenavListBg(struct PokenavList *);
-static bool32 CopyPokenavListMenuTemplate(struct PokenavListSub *, const struct BgTemplate *, struct PokenavListTemplate *, s32);
-static void InitPokenavListWindowState(struct PokenavListWindowState *, struct PokenavListTemplate *);
+static bool32 CopyPokenavListMenuTemplate(struct PokenavList *, const struct BgTemplate *, const struct PokenavListTemplate *, u32);
+static void InitPokenavListWindowState(struct PokenavListWindowState *, const struct PokenavListTemplate *);
 static void SpriteCB_UpArrow(struct Sprite *);
 static void SpriteCB_DownArrow(struct Sprite *);
 static void SpriteCB_RightArrow(struct Sprite *);
-static void ToggleListArrows(struct PokenavListSub *, bool32);
-static void DestroyListArrows(struct PokenavListSub *);
-static void CreateListArrowSprites(struct PokenavListWindowState *, struct PokenavListSub *);
+static void ToggleListArrows(struct PokenavList *, bool32);
+static void DestroyListArrows(struct PokenavList *);
+static void CreateListArrowSprites(const struct PokenavListWindowState *, struct PokenavList *);
 static void LoadListArrowGfx(void);
-static void PrintMatchCallFlavorText(struct PokenavListWindowState *, struct PokenavListSub *, u32);
-static void PrintMatchCallFieldNames(struct PokenavListSub *, u32);
-static void PrintMatchCallListTrainerName(struct PokenavListWindowState *, struct PokenavListSub *);
-static void PrintCheckPageTrainerName(struct PokenavListWindowState *, struct PokenavListSub *);
+static void PrintMatchCallFlavorText(struct PokenavListWindowState *, struct PokenavList *, u32);
+static void PrintMatchCallFieldNames(struct PokenavList *, u32);
+static void PrintMatchCallListTrainerName(struct PokenavListWindowState *, struct PokenavList *);
+static void PrintCheckPageTrainerName(struct PokenavListWindowState *, struct PokenavList *);
 static void EraseListEntry(struct PokenavListMenuWindow *, s32, s32);
-static void CreateMoveListWindowTask(s32, struct PokenavListSub *);
-static void PrintListItems(void *, u32, u32, u32, u32, struct PokenavListSub *);
-static void InitListItems(struct PokenavListWindowState *, struct PokenavListSub *);
-static void InitPokenavListWindow(struct PokenavListMenuWindow *);
+static void CreateMoveListWindowTask(s32, struct PokenavList *);
+static void PrintListItems(void *, u32, u32, u32, u32, struct PokenavList *);
+static void InitListItems(const struct PokenavListWindowState *, struct PokenavList *);
+static void InitPokenavListWindow(const struct PokenavListMenuWindow *);
 static u32 LoopedTask_CreatePokenavList(s32);
 static bool32 IsPrintListItemsTaskActive(void);
 static u32 LoopedTask_PrintListItems(s32);
@@ -98,14 +93,14 @@ static const u32 sListArrow_Gfx[] = INCGFX_U32("graphics/pokenav/list_arrows.png
 
 static EWRAM_DATA u32 sMoveWindowDownIndex = 0; // Read, but pointlessly
 
-bool32 CreatePokenavList(const struct BgTemplate *bgTemplate, struct PokenavListTemplate *listTemplate, s32 tileOffset)
+bool32 CreatePokenavList(const struct BgTemplate *bgTemplate, struct PokenavListTemplate *listTemplate, u32 tileOffset)
 {
     struct PokenavList *list = AllocSubstruct(POKENAV_SUBSTRUCT_LIST, sizeof(struct PokenavList));
     if (list == NULL)
         return FALSE;
 
     InitPokenavListWindowState(&list->windowState, listTemplate);
-    if (!CopyPokenavListMenuTemplate(&list->sub, bgTemplate, listTemplate, tileOffset))
+    if (!CopyPokenavListMenuTemplate(list, bgTemplate, listTemplate, tileOffset))
         return FALSE;
 
     CreateLoopedTask(LoopedTask_CreatePokenavList, 6);
@@ -120,8 +115,8 @@ bool32 IsCreatePokenavListTaskActive(void)
 void DestroyPokenavList(void)
 {
     struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
-    DestroyListArrows(&list->sub);
-    RemoveWindow(list->sub.listWindow.windowId);
+    DestroyListArrows(list);
+    RemoveWindow(list->listWindow.windowId);
     FreePokenavSubstruct(POKENAV_SUBSTRUCT_LIST);
 }
 
@@ -140,10 +135,10 @@ static u32 LoopedTask_CreatePokenavList(s32 state)
         InitPokenavListBg(list);
         return LT_INC_AND_PAUSE;
     case 1:
-        InitPokenavListWindow(&list->sub.listWindow);
+        InitPokenavListWindow(&list->listWindow);
         return LT_INC_AND_PAUSE;
     case 2:
-        InitListItems(&list->windowState, &list->sub);
+        InitListItems(&list->windowState, list);
         return LT_INC_AND_PAUSE;
     case 3:
         if (IsPrintListItemsTaskActive())
@@ -156,7 +151,7 @@ static u32 LoopedTask_CreatePokenavList(s32 state)
             return LT_INC_AND_CONTINUE;
         }
     case 4:
-        CreateListArrowSprites(&list->windowState, &list->sub);
+        CreateListArrowSprites(&list->windowState, list);
         return LT_FINISH;
     default:
         return LT_FINISH;
@@ -165,34 +160,34 @@ static u32 LoopedTask_CreatePokenavList(s32 state)
 
 static void InitPokenavListBg(struct PokenavList *list)
 {
-    u16 tileNum = (list->sub.listWindow.fillValue << 12) | list->sub.listWindow.tileOffset;
-    BgDmaFill(list->sub.listWindow.bg, PIXEL_FILL(1), list->sub.listWindow.tileOffset, 1);
-    BgDmaFill(list->sub.listWindow.bg, PIXEL_FILL(4), list->sub.listWindow.tileOffset + 1, 1);
-    SetBgTilemapBuffer(list->sub.listWindow.bg, list->tilemapBuffer);
-    FillBgTilemapBufferRect_Palette0(list->sub.listWindow.bg, tileNum, 0, 0, 32, 32);
-    ChangeBgY(list->sub.listWindow.bg, 0, BG_COORD_SET);
-    ChangeBgX(list->sub.listWindow.bg, 0, BG_COORD_SET);
-    ChangeBgY(list->sub.listWindow.bg, list->sub.listWindow.y << 11, BG_COORD_SUB);
-    CopyBgTilemapBufferToVram(list->sub.listWindow.bg);
+    u16 tileNum = (list->listWindow.fillValue << 12) | list->listWindow.tileOffset;
+    BgDmaFill(list->listWindow.bg, PIXEL_FILL(1), list->listWindow.tileOffset, 1);
+    BgDmaFill(list->listWindow.bg, PIXEL_FILL(4), list->listWindow.tileOffset + 1, 1);
+    SetBgTilemapBuffer(list->listWindow.bg, list->tilemapBuffer);
+    FillBgTilemapBufferRect_Palette0(list->listWindow.bg, tileNum, 0, 0, 32, 32);
+    ChangeBgY(list->listWindow.bg, 0, BG_COORD_SET);
+    ChangeBgX(list->listWindow.bg, 0, BG_COORD_SET);
+    ChangeBgY(list->listWindow.bg, list->listWindow.y << 11, BG_COORD_SUB);
+    CopyBgTilemapBufferToVram(list->listWindow.bg);
 }
 
-static void InitPokenavListWindow(struct PokenavListMenuWindow *listWindow)
+static void InitPokenavListWindow(const struct PokenavListMenuWindow *listWindow)
 {
     FillWindowPixelBuffer(listWindow->windowId, PIXEL_FILL(1));
     PutWindowTilemap(listWindow->windowId);
     CopyWindowToVram(listWindow->windowId, COPYWIN_MAP);
 }
 
-static void InitListItems(struct PokenavListWindowState *windowState, struct PokenavListSub *subPtr)
+static void InitListItems(const struct PokenavListWindowState *windowState, struct PokenavList *list)
 {
     s32 numToPrint = windowState->listLength - windowState->windowTopIndex;
     if (numToPrint > windowState->entriesOnscreen)
         numToPrint = windowState->entriesOnscreen;
 
-    PrintListItems(windowState->listPtr, windowState->windowTopIndex, numToPrint, windowState->listItemSize, 0, subPtr);
+    PrintListItems(windowState->listPtr, windowState->windowTopIndex, numToPrint, windowState->listItemSize, 0, list);
 }
 
-static void PrintListItems(void *listPtr, u32 topIndex, u32 numItems, u32 itemSize, u32 printStart, struct PokenavListSub *list)
+static void PrintListItems(void *listPtr, u32 topIndex, u32 numItems, u32 itemSize, u32 printStart, struct PokenavList *list)
 {
     if (numItems == 0)
         return;
@@ -214,7 +209,7 @@ static bool32 IsPrintListItemsTaskActive(void)
 static u32 LoopedTask_PrintListItems(s32 state)
 {
     u32 row;
-    struct PokenavListSub *listSub = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
+    struct PokenavList *listSub = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
 
     switch (state)
     {
@@ -274,7 +269,7 @@ static void MoveListWindow(s32 delta, bool32 printItems)
         if (windowState->windowTopIndex + delta < 0)
             delta = -1 * windowState->windowTopIndex;
         if (printItems)
-            PrintListItems(windowState->listPtr, windowState->windowTopIndex + delta, delta * -1, windowState->listItemSize, delta, &list->sub);
+            PrintListItems(windowState->listPtr, windowState->windowTopIndex + delta, delta * -1, windowState->listItemSize, delta, list);
     }
     else if (printItems)
     {
@@ -282,14 +277,14 @@ static void MoveListWindow(s32 delta, bool32 printItems)
         if (index + delta >= windowState->listLength)
             delta = windowState->listLength - index;
 
-        PrintListItems(windowState->listPtr, index, delta, windowState->listItemSize, windowState->entriesOnscreen, &list->sub);
+        PrintListItems(windowState->listPtr, index, delta, windowState->listItemSize, windowState->entriesOnscreen, list);
     }
 
-    CreateMoveListWindowTask(delta, &list->sub);
+    CreateMoveListWindowTask(delta, list);
     windowState->windowTopIndex += delta;
 }
 
-static void CreateMoveListWindowTask(s32 delta, struct PokenavListSub *list)
+static void CreateMoveListWindowTask(s32 delta, struct PokenavList *list)
 {
     list->startBgY = GetBgY(list->listWindow.bg);
     list->endBgY = list->startBgY + (delta << 12);
@@ -306,7 +301,6 @@ static u32 LoopedTask_MoveListWindow(s32 state)
     s32 oldY, newY;
     bool32 finished;
     struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
-    struct PokenavListSub *subPtr = &list->sub;
 
     switch (state)
     {
@@ -316,23 +310,23 @@ static u32 LoopedTask_MoveListWindow(s32 state)
         return LT_PAUSE;
     case 1:
         finished = FALSE;
-        oldY = GetBgY(subPtr->listWindow.bg);
-        newY = ChangeBgY(subPtr->listWindow.bg, 0x1000, subPtr->bgMoveType);
-        if (subPtr->bgMoveType == BG_COORD_SUB)
+        oldY = GetBgY(list->listWindow.bg);
+        newY = ChangeBgY(list->listWindow.bg, 0x1000, list->bgMoveType);
+        if (list->bgMoveType == BG_COORD_SUB)
         {
-            if ((oldY > subPtr->endBgY || oldY <= subPtr->startBgY) && newY <= subPtr->endBgY)
+            if ((oldY > list->endBgY || oldY <= list->startBgY) && newY <= list->endBgY)
                 finished = TRUE;
         }
         else // BG_COORD_ADD
         {
-            if ((oldY < subPtr->endBgY || oldY >= subPtr->startBgY) && newY >= subPtr->endBgY)
+            if ((oldY < list->endBgY || oldY >= list->startBgY) && newY >= list->endBgY)
                 finished = TRUE;
         }
 
         if (finished)
         {
-            subPtr->listWindow.unkA = (subPtr->listWindow.unkA + subPtr->moveDelta) & 0xF;
-            ChangeBgY(subPtr->listWindow.bg, subPtr->endBgY, BG_COORD_SET);
+            list->listWindow.unkA = (list->listWindow.unkA + list->moveDelta) & 0xF;
+            ChangeBgY(list->listWindow.bg, list->endBgY, BG_COORD_SET);
             return LT_FINISH;
         }
         return LT_PAUSE;
@@ -343,7 +337,7 @@ static u32 LoopedTask_MoveListWindow(s32 state)
 bool32 PokenavList_IsMoveWindowTaskActive(void)
 {
     struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
-    return IsLoopedTaskActive(list->sub.loopedTaskId);
+    return IsLoopedTaskActive(list->loopedTaskId);
 }
 
 static struct PokenavListWindowState *GetPokenavListWindowState(void)
@@ -464,7 +458,7 @@ void PokenavList_EraseListForCheckPage(void)
 {
     struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
     list->eraseIndex = 0;
-    list->loopedTaskId = CreateLoopedTask(LoopedTask_EraseListForCheckPage, 6);
+    list->loopedTaskId2 = CreateLoopedTask(LoopedTask_EraseListForCheckPage, 6);
 }
 
 void PrintCheckPageInfo(s16 delta)
@@ -472,28 +466,28 @@ void PrintCheckPageInfo(s16 delta)
     struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
     list->windowState.windowTopIndex += delta;
     list->eraseIndex = 0;
-    list->loopedTaskId = CreateLoopedTask(LoopedTask_PrintCheckPageInfo, 6);
+    list->loopedTaskId2 = CreateLoopedTask(LoopedTask_PrintCheckPageInfo, 6);
 }
 
 void PokenavList_ReshowListFromCheckPage(void)
 {
     struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
     list->eraseIndex = 0;
-    list->loopedTaskId = CreateLoopedTask(LoopedTask_ReshowListFromCheckPage, 6);
+    list->loopedTaskId2 = CreateLoopedTask(LoopedTask_ReshowListFromCheckPage, 6);
 }
 
 bool32 PokenavList_IsTaskActive(void)
 {
     struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
-    return IsLoopedTaskActive(list->loopedTaskId);
+    return IsLoopedTaskActive(list->loopedTaskId2);
 }
 
 void PokenavList_DrawCurrentItemIcon(void)
 {
     struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
     struct PokenavListWindowState *windowState = &list->windowState;
-    list->sub.iconDrawFunc(list->sub.listWindow.windowId, windowState->windowTopIndex + windowState->selectedIndexOffset, (list->sub.listWindow.unkA + windowState->selectedIndexOffset) & 0xF);
-    CopyWindowToVram(list->sub.listWindow.windowId, COPYWIN_MAP);
+    list->iconDrawFunc(list->listWindow.windowId, windowState->windowTopIndex + windowState->selectedIndexOffset, (list->listWindow.unkA + windowState->selectedIndexOffset) & 0xF);
+    CopyWindowToVram(list->listWindow.windowId, COPYWIN_MAP);
 }
 
 static u32 LoopedTask_EraseListForCheckPage(s32 state)
@@ -503,11 +497,11 @@ static u32 LoopedTask_EraseListForCheckPage(s32 state)
     switch (state)
     {
     case 0:
-        ToggleListArrows(&list->sub, TRUE);
+        ToggleListArrows(list, TRUE);
         // fall-through
     case 1:
         if (list->eraseIndex != list->windowState.selectedIndexOffset)
-            EraseListEntry(&list->sub.listWindow, list->eraseIndex, 1);
+            EraseListEntry(&list->listWindow, list->eraseIndex, 1);
 
         list->eraseIndex++;
         return LT_INC_AND_PAUSE;
@@ -517,7 +511,7 @@ static u32 LoopedTask_EraseListForCheckPage(s32 state)
             if (list->eraseIndex != list->windowState.entriesOnscreen)
                 return LT_SET_STATE(1);
             if (list->windowState.selectedIndexOffset != 0)
-                EraseListEntry(&list->sub.listWindow, list->eraseIndex, list->windowState.selectedIndexOffset);
+                EraseListEntry(&list->listWindow, list->eraseIndex, list->windowState.selectedIndexOffset);
 
             return LT_INC_AND_PAUSE;
         }
@@ -552,28 +546,28 @@ static u32 LoopedTask_PrintCheckPageInfo(s32 state)
     switch (state)
     {
     case 0:
-        PrintCheckPageTrainerName(&list->windowState, &list->sub);
+        PrintCheckPageTrainerName(&list->windowState, list);
         break;
     case 1:
-        PrintMatchCallFieldNames(&list->sub, 0);
+        PrintMatchCallFieldNames(list, 0);
         break;
     case 2:
-        PrintMatchCallFlavorText(&list->windowState, &list->sub, CHECK_PAGE_STRATEGY);
+        PrintMatchCallFlavorText(&list->windowState, list, CHECK_PAGE_STRATEGY);
         break;
     case 3:
-        PrintMatchCallFieldNames(&list->sub, 1);
+        PrintMatchCallFieldNames(list, 1);
         break;
     case 4:
-        PrintMatchCallFlavorText(&list->windowState, &list->sub, CHECK_PAGE_POKEMON);
+        PrintMatchCallFlavorText(&list->windowState, list, CHECK_PAGE_POKEMON);
         break;
     case 5:
-        PrintMatchCallFieldNames(&list->sub, 2);
+        PrintMatchCallFieldNames(list, 2);
         break;
     case 6:
-        PrintMatchCallFlavorText(&list->windowState, &list->sub, CHECK_PAGE_INTRO_1);
+        PrintMatchCallFlavorText(&list->windowState, list, CHECK_PAGE_INTRO_1);
         break;
     case 7:
-        PrintMatchCallFlavorText(&list->windowState, &list->sub, CHECK_PAGE_INTRO_2);
+        PrintMatchCallFlavorText(&list->windowState, list, CHECK_PAGE_INTRO_2);
         break;
     default:
         return LT_FINISH;
@@ -583,9 +577,8 @@ static u32 LoopedTask_PrintCheckPageInfo(s32 state)
 
 static u32 LoopedTask_ReshowListFromCheckPage(s32 state)
 {
-    struct PokenavList *list;
+    struct PokenavList *list, *listAlias; // listAlias is needed for matching.
     struct PokenavListWindowState *windowState;
-    struct PokenavListSub *subPtr;
     s32 r5, *ptr;
 
     if (IsDma3ManagerBusyWithBgCopy())
@@ -593,20 +586,20 @@ static u32 LoopedTask_ReshowListFromCheckPage(s32 state)
 
     list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
     windowState = &list->windowState;
-    subPtr = &list->sub;
+    listAlias = list;
 
     switch (state)
     {
     case 0:
         // Rewrite the name of the trainer whose check page was just being viewed.
         // This is done to erase the red background it had.
-        PrintMatchCallListTrainerName(windowState, subPtr);
+        PrintMatchCallListTrainerName(windowState, listAlias);
         return LT_INC_AND_PAUSE;
     case 1:
         ptr = &list->eraseIndex;
         if (++(*ptr) < list->windowState.entriesOnscreen)
         {
-            EraseListEntry(&subPtr->listWindow, *ptr, 1);
+            EraseListEntry(&listAlias->listWindow, *ptr, 1);
             return LT_PAUSE;
         }
 
@@ -617,7 +610,7 @@ static u32 LoopedTask_ReshowListFromCheckPage(s32 state)
             {
                 s32 r4 = windowState->windowTopIndex;
                 r5 = -r4;
-                EraseListEntry(&subPtr->listWindow, r5, r4);
+                EraseListEntry(&listAlias->listWindow, r5, r4);
                 windowState->selectedIndexOffset = r4;
                 *ptr = r5;
                 return LT_INC_AND_PAUSE;
@@ -629,7 +622,7 @@ static u32 LoopedTask_ReshowListFromCheckPage(s32 state)
             {
                 s32 r4 = windowState->windowTopIndex + windowState->entriesOnscreen - windowState->listLength;
                 r5 = -r4;
-                EraseListEntry(&subPtr->listWindow, r5, r4);
+                EraseListEntry(&listAlias->listWindow, r5, r4);
                 windowState->selectedIndexOffset = r4;
                 *ptr = r5;
                 return LT_INC_AND_PAUSE;
@@ -647,7 +640,7 @@ static u32 LoopedTask_ReshowListFromCheckPage(s32 state)
         }
         return LT_PAUSE;
     case 4:
-        PrintListItems(windowState->listPtr, windowState->windowTopIndex + list->eraseIndex, 1, windowState->listItemSize, list->eraseIndex, &list->sub);
+        PrintListItems(windowState->listPtr, windowState->windowTopIndex + list->eraseIndex, 1, windowState->listItemSize, list->eraseIndex, list);
         return LT_INC_AND_PAUSE;
     case 5:
         if (IsPrintListItemsTaskActive())
@@ -656,7 +649,7 @@ static u32 LoopedTask_ReshowListFromCheckPage(s32 state)
             return LT_INC_AND_CONTINUE;
         return LT_SET_STATE(4);
     case 6:
-        ToggleListArrows(subPtr, FALSE);
+        ToggleListArrows(listAlias, FALSE);
         return LT_FINISH;
     }
 
@@ -707,7 +700,7 @@ static void SetListMarginTile(struct PokenavListMenuWindow *listWindow, bool32 d
 }
 
 // Print the trainer's name and title at the top of their check page
-static void PrintCheckPageTrainerName(struct PokenavListWindowState *state, struct PokenavListSub *list)
+static void PrintCheckPageTrainerName(struct PokenavListWindowState *state, struct PokenavList *list)
 {
     u8 colors[3] = {TEXT_COLOR_TRANSPARENT, TEXT_COLOR_DARK_GRAY, TEXT_COLOR_LIGHT_RED};
 
@@ -720,7 +713,7 @@ static void PrintCheckPageTrainerName(struct PokenavListWindowState *state, stru
 }
 
 // Print the trainer's name and title for the list (to replace the check page name and title, which has a red background)
-static void PrintMatchCallListTrainerName(struct PokenavListWindowState *state, struct PokenavListSub *list)
+static void PrintMatchCallListTrainerName(struct PokenavListWindowState *state, struct PokenavList *list)
 {
     list->bufferItemFunc(state->listPtr + state->listItemSize * state->windowTopIndex, list->itemTextBuffer);
     FillWindowPixelRect(list->listWindow.windowId, PIXEL_FILL(1), 0, list->listWindow.unkA * 16, list->listWindow.width * 8, 16);
@@ -729,7 +722,7 @@ static void PrintMatchCallListTrainerName(struct PokenavListWindowState *state, 
     CopyWindowToVram(list->listWindow.windowId, COPYWIN_FULL);
 }
 
-static void PrintMatchCallFieldNames(struct PokenavListSub *list, u32 fieldId)
+static void PrintMatchCallFieldNames(struct PokenavList *list, u32 fieldId)
 {
     const u8 *fieldNames[] = {
         gText_PokenavMatchCall_Strategy,
@@ -744,7 +737,7 @@ static void PrintMatchCallFieldNames(struct PokenavListSub *list, u32 fieldId)
     CopyWindowRectToVram(list->listWindow.windowId, COPYWIN_GFX, 0, top << 1, list->listWindow.width, 2);
 }
 
-static void PrintMatchCallFlavorText(struct PokenavListWindowState *windowState, struct PokenavListSub *list, u32 checkPageEntry)
+static void PrintMatchCallFlavorText(struct PokenavListWindowState *windowState, struct PokenavList *list, u32 checkPageEntry)
 {
     // lines 1, 3, and 5 are the field names printed by PrintMatchCallFieldNames
     static const u8 lineOffsets[CHECK_PAGE_ENTRY_COUNT] = {
@@ -844,7 +837,7 @@ static void LoadListArrowGfx(void)
     Pokenav_AllocAndLoadPalettes(sListArrowPalettes);
 }
 
-static void CreateListArrowSprites(struct PokenavListWindowState *windowState, struct PokenavListSub *list)
+static void CreateListArrowSprites(const struct PokenavListWindowState *windowState, struct PokenavList *list)
 {
     u32 spriteId;
     s16 x;
@@ -864,7 +857,7 @@ static void CreateListArrowSprites(struct PokenavListWindowState *windowState, s
     list->upArrow->callback = SpriteCB_UpArrow;
 }
 
-static void DestroyListArrows(struct PokenavListSub *list)
+static void DestroyListArrows(struct PokenavList *list)
 {
     DestroySprite(list->rightArrow);
     DestroySprite(list->upArrow);
@@ -873,7 +866,7 @@ static void DestroyListArrows(struct PokenavListSub *list)
     FreeSpritePaletteByTag(PALTAG_ARROW);
 }
 
-static void ToggleListArrows(struct PokenavListSub *list, bool32 invisible)
+static void ToggleListArrows(struct PokenavList *list, bool32 invisible)
 {
     if (invisible)
     {
@@ -941,15 +934,15 @@ static void SpriteCB_UpArrow(struct Sprite *sprite)
 void PokenavList_ToggleVerticalArrows(bool32 invisible)
 {
     struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
-    list->sub.upArrow->sInvisible = invisible;
-    list->sub.downArrow->sInvisible = invisible;
+    list->upArrow->sInvisible = invisible;
+    list->downArrow->sInvisible = invisible;
 }
 
 #undef sTimer
 #undef sOffset
 #undef sInvisible
 
-static void InitPokenavListWindowState(struct PokenavListWindowState *dst, struct PokenavListTemplate *template)
+static void InitPokenavListWindowState(struct PokenavListWindowState *dst, const struct PokenavListTemplate *template)
 {
     dst->listPtr = template->list;
     dst->windowTopIndex = template->startIndex;
@@ -977,7 +970,7 @@ static void InitPokenavListWindowState(struct PokenavListWindowState *dst, struc
     }
 }
 
-static bool32 CopyPokenavListMenuTemplate(struct PokenavListSub *dest, const struct BgTemplate *bgTemplate, struct PokenavListTemplate *template, s32 tileOffset)
+static bool32 CopyPokenavListMenuTemplate(struct PokenavList *dest, const struct BgTemplate *bgTemplate, const struct PokenavListTemplate *template, u32 tileOffset)
 {
     struct WindowTemplate window;
 

--- a/src/pokenav_list.c
+++ b/src/pokenav_list.c
@@ -579,7 +579,6 @@ static u32 LoopedTask_ReshowListFromCheckPage(s32 state)
 {
     struct PokenavList *list, *listAlias; // listAlias is needed for matching.
     struct PokenavListWindowState *windowState;
-    s32 r5, *ptr;
 
     if (IsDma3ManagerBusyWithBgCopy())
         return LT_PAUSE;
@@ -596,23 +595,22 @@ static u32 LoopedTask_ReshowListFromCheckPage(s32 state)
         PrintMatchCallListTrainerName(windowState, listAlias);
         return LT_INC_AND_PAUSE;
     case 1:
-        ptr = &list->eraseIndex;
-        if (++(*ptr) < list->windowState.entriesOnscreen)
+        if (++list->eraseIndex < list->windowState.entriesOnscreen)
         {
-            EraseListEntry(&listAlias->listWindow, *ptr, 1);
+            EraseListEntry(&listAlias->listWindow, list->eraseIndex, 1);
             return LT_PAUSE;
         }
 
-        *ptr = 0;
+        list->eraseIndex = 0;
+
         if (windowState->listLength <= windowState->entriesOnscreen)
         {
             if (windowState->windowTopIndex != 0)
             {
-                s32 r4 = windowState->windowTopIndex;
-                r5 = -r4;
-                EraseListEntry(&listAlias->listWindow, r5, r4);
-                windowState->selectedIndexOffset = r4;
-                *ptr = r5;
+                s32 entries = windowState->windowTopIndex;
+                EraseListEntry(&listAlias->listWindow, -entries, entries);
+                windowState->selectedIndexOffset = entries;
+                list->eraseIndex = -entries;
                 return LT_INC_AND_PAUSE;
             }
         }
@@ -620,11 +618,10 @@ static u32 LoopedTask_ReshowListFromCheckPage(s32 state)
         {
             if (windowState->windowTopIndex + windowState->entriesOnscreen > windowState->listLength)
             {
-                s32 r4 = windowState->windowTopIndex + windowState->entriesOnscreen - windowState->listLength;
-                r5 = -r4;
-                EraseListEntry(&listAlias->listWindow, r5, r4);
-                windowState->selectedIndexOffset = r4;
-                *ptr = r5;
+                s32 entries = windowState->windowTopIndex + windowState->entriesOnscreen - windowState->listLength;
+                EraseListEntry(&listAlias->listWindow, -entries, entries);
+                windowState->selectedIndexOffset = entries;
+                list->eraseIndex = -entries;
                 return LT_INC_AND_PAUSE;
             }
         }

--- a/src/pokenav_list.c
+++ b/src/pokenav_list.c
@@ -48,7 +48,7 @@ struct PokenavList
     void *listPtr;
     s32 startBgY;
     s32 endBgY;
-    u32 loopedTaskId;
+    u32 moveListWindowLoopedTaskId;
     s32 moveDelta;
     u32 bgMoveType;
     PokenavListBufferItemFunc bufferItemFunc;
@@ -60,7 +60,7 @@ struct PokenavList
     u8 tilemapBuffer[BG_SCREEN_SIZE];
     struct PokenavListWindowState windowState;
     s32 eraseIndex;
-    u32 loopedTaskId2;
+    u32 loopedTaskId;
 };
 
 static void InitPokenavListBg(struct PokenavList *);
@@ -295,7 +295,7 @@ static void CreateMoveListWindowTask(s32 delta, struct PokenavList *list)
     else
         list->bgMoveType = BG_COORD_SUB;
     list->moveDelta = delta;
-    list->loopedTaskId = CreateLoopedTask(LoopedTask_MoveListWindow, 6);
+    list->moveListWindowLoopedTaskId = CreateLoopedTask(LoopedTask_MoveListWindow, 6);
 }
 
 static u32 LoopedTask_MoveListWindow(s32 state)
@@ -339,7 +339,7 @@ static u32 LoopedTask_MoveListWindow(s32 state)
 bool32 PokenavList_IsMoveWindowTaskActive(void)
 {
     struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
-    return IsLoopedTaskActive(list->loopedTaskId);
+    return IsLoopedTaskActive(list->moveListWindowLoopedTaskId);
 }
 
 static struct PokenavListWindowState *GetPokenavListWindowState(void)
@@ -460,7 +460,7 @@ void PokenavList_EraseListForCheckPage(void)
 {
     struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
     list->eraseIndex = 0;
-    list->loopedTaskId2 = CreateLoopedTask(LoopedTask_EraseListForCheckPage, 6);
+    list->loopedTaskId = CreateLoopedTask(LoopedTask_EraseListForCheckPage, 6);
 }
 
 void PrintCheckPageInfo(s16 delta)
@@ -468,20 +468,20 @@ void PrintCheckPageInfo(s16 delta)
     struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
     list->windowState.windowTopIndex += delta;
     list->eraseIndex = 0;
-    list->loopedTaskId2 = CreateLoopedTask(LoopedTask_PrintCheckPageInfo, 6);
+    list->loopedTaskId = CreateLoopedTask(LoopedTask_PrintCheckPageInfo, 6);
 }
 
 void PokenavList_ReshowListFromCheckPage(void)
 {
     struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
     list->eraseIndex = 0;
-    list->loopedTaskId2 = CreateLoopedTask(LoopedTask_ReshowListFromCheckPage, 6);
+    list->loopedTaskId = CreateLoopedTask(LoopedTask_ReshowListFromCheckPage, 6);
 }
 
 bool32 PokenavList_IsTaskActive(void)
 {
     struct PokenavList *list = GetSubstructPtr(POKENAV_SUBSTRUCT_LIST);
-    return IsLoopedTaskActive(list->loopedTaskId2);
+    return IsLoopedTaskActive(list->loopedTaskId);
 }
 
 void PokenavList_DrawCurrentItemIcon(void)


### PR DESCRIPTION
Inspired-by and an-alternative-to #2307, `struct PokenavListSub` is removed rather than renamed.

This is probably a fakematch because `LoopedTask_ReshowListFromCheckPage` has something weird going on with `list` and `listAlias` pointing to the same object, but I think it makes the code clearer? Or at least, I couldn't work out what the pattern between a member going in `struct PokenavList` and `struct PokenavListSub` is supposed to be.

Additionally, fix some fakematches in `LoopedTask_ReshowListFromCheckPage`.