### PR TITLE
✨Mark bugs that involve genuine undefined behavior as UBFix

### DIFF
--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -1804,7 +1804,7 @@ static void Cmd_if_has_move(void)
 {
     s32 i;
 
-#ifdef BUGFIX
+#ifdef UBFIX
     const u16 move = T1_READ_16(gAIScriptPtr + 2);
     const u16 *movePtr = &move;    
 #else
@@ -1862,7 +1862,7 @@ static void Cmd_if_doesnt_have_move(void)
 {
     s32 i;
 
-#ifdef BUGFIX
+#ifdef UBFIX
     const u16 move = T1_READ_16(gAIScriptPtr + 2);
     const u16 *movePtr = &move;    
 #else

--- a/src/battle_factory.c
+++ b/src/battle_factory.c
@@ -744,7 +744,7 @@ u8 GetFactoryMonFixedIV(u8 challengeNum, bool8 isLastBattle)
 // The Factory has an out-of-bounds access when generating the rental draft for round 9 (challengeNum==8),
 // or the "elevated" rentals from round 8 (challengeNum+1==8)
 // This happens to land on a number higher than 31, which is interpreted as "random IVs"
-#ifdef BUGFIX
+#ifdef UBFIX
     if (challengeNum >= ARRAY_COUNT(sFixedIVTable))
 #else
     if (challengeNum > ARRAY_COUNT(sFixedIVTable))

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -710,7 +710,7 @@ void DecompressTrainerFrontPic(u16 frontPicId, u8 battler)
 void DecompressTrainerBackPic(u16 backPicId, u8 battler)
 {
     u8 position = GetBattlerPosition(battler);
-#ifdef BUGFIX
+#ifdef UBFIX
     CpuCopy32(gTrainerBackPicTable[backPicId].data, gMonSpritesGfxPtr->sprites.ptr[position], gTrainerBackPicTable[backPicId].size);
 #else
     // Trainer back pics aren't compressed!

--- a/src/battle_tower.c
+++ b/src/battle_tower.c
@@ -2770,7 +2770,7 @@ static void AwardBattleTowerRibbons(void)
 {
     s32 i;
     u32 partyIndex;
-#ifdef BUGFIX
+#ifdef UBFIX
     struct RibbonCounter ribbons[MAX_FRONTIER_PARTY_SIZE];
 #else
     struct RibbonCounter ribbons[3]; // BUG: 4 Pokémon can receive ribbons in a double battle mode.

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2016,7 +2016,7 @@ static void LoadObjectEventPalette(u16 paletteTag)
     u16 i = FindObjectEventPaletteIndexByTag(paletteTag);
 
 // FindObjectEventPaletteIndexByTag returns 0xFF on failure, not OBJ_EVENT_PAL_TAG_NONE.
-#ifdef BUGFIX
+#ifdef UBFIX
     if (i != 0xFF)
 #else
     if (i != OBJ_EVENT_PAL_TAG_NONE)

--- a/src/pokedex_area_screen.c
+++ b/src/pokedex_area_screen.c
@@ -391,7 +391,7 @@ static bool8 MapHasSpecies(const struct WildPokemonHeader *info, u16 species)
         return TRUE;
 // When searching the fishing encounters, this incorrectly uses the size of the land encounters.
 // As a result it's reading out of bounds of the fishing encounters tables.
-#ifdef BUGFIX
+#ifdef UBFIX
     if (MonListHasSpecies(info->fishingMonsInfo, species, NUM_FISHING_MONS_ENCOUNTER_SLOTS))
 #else
     if (MonListHasSpecies(info->fishingMonsInfo, species, NUM_LAND_MONS_ENCOUNTER_SLOTS))

--- a/src/pokemon_animation.c
+++ b/src/pokemon_animation.c
@@ -902,11 +902,11 @@ u8 GetSpeciesBackAnimSet(u16 species)
 // as 0xFFFFXXXX instead of the desired 0x02YYXXXX.
 // By dumb luck, this is not an issue in vanilla. However,
 // changing the link order revealed this bug.
-#if MODERN || defined(BUGFIX)
+#ifdef UBFIX
 #define ANIM_SPRITE(taskId)   ((struct Sprite *)((gTasks[taskId].tPtrHi << 16) | ((u16)gTasks[taskId].tPtrLo)))
 #else
 #define ANIM_SPRITE(taskId)   ((struct Sprite *)((gTasks[taskId].tPtrHi << 16) | (gTasks[taskId].tPtrLo)))
-#endif //MODERN || BUGFIX
+#endif
 
 static void Task_HandleMonAnimation(u8 taskId)
 {

--- a/src/pokenav_ribbons_summary.c
+++ b/src/pokenav_ribbons_summary.c
@@ -542,7 +542,7 @@ void FreeRibbonsSummaryScreen2(void)
     RemoveWindow(menu->ribbonCountWindowId);
     RemoveWindow(menu->nameWindowId);
     RemoveWindow(menu->listIdxWindowId);
-#ifndef BUGFIX
+#ifndef UBFIX
     RemoveWindow(menu->unusedWindowId); // Removing window, but window id is never set
 #endif
     DestroyRibbonsMonFrontPic(menu);

--- a/src/script_pokemon_util.c
+++ b/src/script_pokemon_util.c
@@ -151,7 +151,7 @@ void CreateScriptedWildMon(u16 species, u8 level, u16 item)
 void ScriptSetMonMoveSlot(u8 monIndex, u16 move, u8 slot)
 {
 // Allows monIndex to go out of bounds of gPlayerParty. Doesn't occur in vanilla
-#ifdef BUGFIX
+#ifdef UBFIX
     if (monIndex >= PARTY_SIZE)
 #else
     if (monIndex > PARTY_SIZE)

--- a/src/trainer_pokemon_sprites.c
+++ b/src/trainer_pokemon_sprites.c
@@ -86,7 +86,7 @@ static bool16 DecompressPic(u16 picId, u32 personality, bool8 isFrontPic, u8 *de
         }
         else
         {
-#ifdef BUGFIX
+#ifdef UBFIX
             CpuCopy32(gTrainerBackPicTable[trainerPicId].data, dest, gTrainerBackPicTable[trainerPicId].size);
 #else
             // Trainer back pics aren't compressed!


### PR DESCRIPTION
The objEvent->localId != OBJ_EVENT_ID_CAMERA counts because this results in a null dereference, which is fine for vanilla I guess, but still wrong.