### PR TITLE
AddSpriteToOamBuffer: TRUE/FALSE

### DIFF
--- a/src/sprite.c
+++ b/src/sprite.c
@@ -1662,13 +1662,13 @@ void SetSubspriteTables(struct Sprite *sprite, const struct SubspriteTable *subs
 bool8 AddSpriteToOamBuffer(struct Sprite *sprite, u8 *oamIndex)
 {
     if (*oamIndex >= gOamLimit)
-        return 1;
+        return TRUE;
 
     if (!sprite->subspriteTables || sprite->subspriteMode == SUBSPRITES_OFF)
     {
         gMain.oamBuffer[*oamIndex] = sprite->oam;
         (*oamIndex)++;
-        return 0;
+        return FALSE;
     }
     else
     {
@@ -1682,7 +1682,7 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
     struct OamData *oam;
 
     if (*oamIndex >= gOamLimit)
-        return 1;
+        return TRUE;
 
     subspriteTable = &sprite->subspriteTables[sprite->subspriteTableNum];
     oam = &sprite->oam;
@@ -1691,7 +1691,7 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
     {
         *destOam = *oam;
         (*oamIndex)++;
-        return 0;
+        return FALSE;
     }
     else
     {
@@ -1716,7 +1716,7 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
             u16 y;
 
             if (*oamIndex >= gOamLimit)
-                return 1;
+                return TRUE;
 
             x = subspriteTable->subsprites[i].x;
             y = subspriteTable->subsprites[i].y;
@@ -1751,5 +1751,5 @@ bool8 AddSubspritesToOamBuffer(struct Sprite *sprite, struct OamData *destOam, u
         }
     }
 
-    return 0;
+    return FALSE;
 }


### PR DESCRIPTION
Use `TRUE` and `FALSE` instead of `1` and `0` in functions returning `bool8`.

Aside: I think it would be helpful to separate `bool*` into two types: `bool*` with values `FALSE` and `TRUE`, and `error*` with values `SUCCESS` and `ERROR`. I find it really counterintuitive to read/write functions that return `FALSE` for success.