### PR TITLE
PSG data should be aligned

### DIFF
--- a/sound/programmable_wave_data.inc
+++ b/sound/programmable_wave_data.inc
@@ -1,78 +1,103 @@
+    .align 2
 ProgrammableWaveData_1::
 	.incbin "sound/programmable_wave_samples/01.pcm"
 
+    .align 2
 ProgrammableWaveData_2::
 	.incbin "sound/programmable_wave_samples/02.pcm"
 
+    .align 2
 ProgrammableWaveData_3::
 	.incbin "sound/programmable_wave_samples/03.pcm"
 
+    .align 2
 ProgrammableWaveData_4::
 	.incbin "sound/programmable_wave_samples/04.pcm"
 
+    .align 2
 ProgrammableWaveData_5::
 	.incbin "sound/programmable_wave_samples/05.pcm"
 
+    .align 2
 ProgrammableWaveData_6::
 	.incbin "sound/programmable_wave_samples/06.pcm"
 
+    .align 2
 ProgrammableWaveData_7::
 	.incbin "sound/programmable_wave_samples/07.pcm"
 
+    .align 2
 ProgrammableWaveData_8::
 	.incbin "sound/programmable_wave_samples/08.pcm"
 
+    .align 2
 ProgrammableWaveData_9::
 	.incbin "sound/programmable_wave_samples/09.pcm"
 
+    .align 2
 ProgrammableWaveData_10::
 	.incbin "sound/programmable_wave_samples/10.pcm"
 
+    .align 2
 ProgrammableWaveData_11::
 	.incbin "sound/programmable_wave_samples/11.pcm"
 
+    .align 2
 ProgrammableWaveData_12::
 	.incbin "sound/programmable_wave_samples/12.pcm"
 
+    .align 2
 ProgrammableWaveData_13::
 	.incbin "sound/programmable_wave_samples/13.pcm"
 
+    .align 2
 ProgrammableWaveData_14::
 	.incbin "sound/programmable_wave_samples/14.pcm"
 
+    .align 2
 ProgrammableWaveData_15::
 	.incbin "sound/programmable_wave_samples/15.pcm"
 
+    .align 2
 ProgrammableWaveData_16::
 	.incbin "sound/programmable_wave_samples/16.pcm"
 
 @ Unused
+    .align 2
 ProgrammableWaveData_17::
 	.incbin "sound/programmable_wave_samples/17.pcm"
 
 @ Unused
+    .align 2
 ProgrammableWaveData_18::
 	.incbin "sound/programmable_wave_samples/18.pcm"
 
 @ Unused
+    .align 2
 ProgrammableWaveData_19::
 	.incbin "sound/programmable_wave_samples/19.pcm"
 
 @ Unused
+    .align 2
 ProgrammableWaveData_20::
 	.incbin "sound/programmable_wave_samples/20.pcm"
 
+    .align 2
 ProgrammableWaveData_21::
 	.incbin "sound/programmable_wave_samples/21.pcm"
 
+    .align 2
 ProgrammableWaveData_22::
 	.incbin "sound/programmable_wave_samples/22.pcm"
 
+    .align 2
 ProgrammableWaveData_23::
 	.incbin "sound/programmable_wave_samples/23.pcm"
 
+    .align 2
 ProgrammableWaveData_24::
 	.incbin "sound/programmable_wave_samples/24.pcm"
 
+    .align 2
 ProgrammableWaveData_25::
 	.incbin "sound/programmable_wave_samples/25.pcm"


### PR DESCRIPTION
PSG wave data should be aligned

## Description
Sometimes when adding custom voicegroups, the PSG data is not read correctly, resulting it doesn't sound correctly in-game.

## **Discord contact info**
AichiyaSanae#8333
