### PR TITLE
refactor(field_camera): improve field_camera documentation

### DIFF
--- a/include/gba/defines.h
+++ b/include/gba/defines.h
@@ -81,6 +81,9 @@
 #define TILE_SIZE_4BPP TILE_SIZE(4) // 32
 #define TILE_SIZE_8BPP TILE_SIZE(8) // 64
 
+#define SCREEN_WIDTH 32
+#define SCREEN_HEIGHT 32
+
 #define TILE_OFFSET_4BPP(n) ((n) * TILE_SIZE_4BPP)
 #define TILE_OFFSET_8BPP(n) ((n) * TILE_SIZE_8BPP)
 

--- a/src/field_camera.c
+++ b/src/field_camera.c
@@ -23,8 +23,8 @@ struct FieldCameraOffset
     bool8 copyBGToVRAM;
 };
 
-static void RedrawMapSliceNorth(struct FieldCameraOffset *, const struct MapLayout *);
 static void RedrawMapSliceSouth(struct FieldCameraOffset *, const struct MapLayout *);
+static void RedrawMapSliceNorth(struct FieldCameraOffset *, const struct MapLayout *);
 static void RedrawMapSliceWest(struct FieldCameraOffset *, const struct MapLayout *);
 static void RedrawMapSliceEast(struct FieldCameraOffset *, const struct MapLayout *);
 static s32 MapPosToBgTilemapOffset(struct FieldCameraOffset *, s32, s32);
@@ -129,13 +129,13 @@ static void RedrawMapSlicesForCameraUpdate(struct FieldCameraOffset *cameraOffse
     if (deltaX < 0)
         RedrawMapSliceWest(cameraOffset, mapLayout);
     if (deltaY > 0)
-        RedrawMapSliceNorth(cameraOffset, mapLayout);
-    if (deltaY < 0)
         RedrawMapSliceSouth(cameraOffset, mapLayout);
+    if (deltaY < 0)
+        RedrawMapSliceNorth(cameraOffset, mapLayout);
     cameraOffset->copyBGToVRAM = TRUE;
 }
 
-static void RedrawMapSliceNorth(struct FieldCameraOffset *cameraOffset, const struct MapLayout *mapLayout)
+static void RedrawMapSliceSouth(struct FieldCameraOffset *cameraOffset, const struct MapLayout *mapLayout)
 {
     u8 i;
     u32 rowOffset;
@@ -155,7 +155,7 @@ static void RedrawMapSliceNorth(struct FieldCameraOffset *cameraOffset, const st
     }
 }
 
-static void RedrawMapSliceSouth(struct FieldCameraOffset *cameraOffset, const struct MapLayout *mapLayout)
+static void RedrawMapSliceNorth(struct FieldCameraOffset *cameraOffset, const struct MapLayout *mapLayout)
 {
     u8 i;
     u32 rowOffset = cameraOffset->yTileOffset * SCREEN_WIDTH;

--- a/src/field_camera.c
+++ b/src/field_camera.c
@@ -25,8 +25,8 @@ struct FieldCameraOffset
 
 static void RedrawMapSliceNorth(struct FieldCameraOffset *, const struct MapLayout *);
 static void RedrawMapSliceSouth(struct FieldCameraOffset *, const struct MapLayout *);
-static void RedrawMapSliceEast(struct FieldCameraOffset *, const struct MapLayout *);
 static void RedrawMapSliceWest(struct FieldCameraOffset *, const struct MapLayout *);
+static void RedrawMapSliceEast(struct FieldCameraOffset *, const struct MapLayout *);
 static s32 MapPosToBgTilemapOffset(struct FieldCameraOffset *, s32, s32);
 static void DrawWholeMapViewInternal(int, int, const struct MapLayout *);
 static void DrawMetatileAt(const struct MapLayout *, u16, int, int);
@@ -73,16 +73,16 @@ void ResetFieldCamera(void)
 
 void FieldUpdateBgTilemapScroll(void)
 {
-    u32 r4, r5;
-    r5 = sFieldCameraOffset.xPixelOffset + sHorizontalCameraPan;
-    r4 = sVerticalCameraPan + sFieldCameraOffset.yPixelOffset + 8;
+    u32 vOffset, hOffset;
+    hOffset = sFieldCameraOffset.xPixelOffset + sHorizontalCameraPan;
+    vOffset = sVerticalCameraPan + sFieldCameraOffset.yPixelOffset + 8;
 
-    SetGpuReg(REG_OFFSET_BG1HOFS, r5);
-    SetGpuReg(REG_OFFSET_BG1VOFS, r4);
-    SetGpuReg(REG_OFFSET_BG2HOFS, r5);
-    SetGpuReg(REG_OFFSET_BG2VOFS, r4);
-    SetGpuReg(REG_OFFSET_BG3HOFS, r5);
-    SetGpuReg(REG_OFFSET_BG3VOFS, r4);
+    SetGpuReg(REG_OFFSET_BG1HOFS, hOffset);
+    SetGpuReg(REG_OFFSET_BG1VOFS, vOffset);
+    SetGpuReg(REG_OFFSET_BG2HOFS, hOffset);
+    SetGpuReg(REG_OFFSET_BG2VOFS, vOffset);
+    SetGpuReg(REG_OFFSET_BG3HOFS, hOffset);
+    SetGpuReg(REG_OFFSET_BG3VOFS, vOffset);
 }
 
 void GetCameraOffsetWithPan(s16 *x, s16 *y)
@@ -99,38 +99,38 @@ void DrawWholeMapView(void)
 
 static void DrawWholeMapViewInternal(int x, int y, const struct MapLayout *mapLayout)
 {
-    u8 i;
-    u8 j;
-    u32 r6;
-    u8 temp;
+    u8 i,j;
+    u8 row;
+    u32 rowOffset;
 
-    for (i = 0; i < 32; i += 2)
+    for (i = 0; i < SCREEN_HEIGHT; i += 2)
     {
-        temp = sFieldCameraOffset.yTileOffset + i;
-        if (temp >= 32)
-            temp -= 32;
-        r6 = temp * 32;
-        for (j = 0; j < 32; j += 2)
+        row = sFieldCameraOffset.yTileOffset + i;
+        if (row >= SCREEN_HEIGHT)
+            row -= SCREEN_HEIGHT;
+        rowOffset = row * SCREEN_WIDTH;
+
+        for (j = 0; j < SCREEN_WIDTH; j += 2)
         {
-            temp = sFieldCameraOffset.xTileOffset + j;
-            if (temp >= 32)
-                temp -= 32;
-            DrawMetatileAt(mapLayout, r6 + temp, x + j / 2, y + i / 2);
+            u8 col = sFieldCameraOffset.xTileOffset + j;
+            if (col >= 32)
+                col -= 32;
+            DrawMetatileAt(mapLayout, rowOffset + col, x + j / 2, y + i / 2);
         }
     }
 }
 
-static void RedrawMapSlicesForCameraUpdate(struct FieldCameraOffset *cameraOffset, int x, int y)
+static void RedrawMapSlicesForCameraUpdate(struct FieldCameraOffset *cameraOffset, int deltaX, int deltaY)
 {
     const struct MapLayout *mapLayout = gMapHeader.mapLayout;
 
-    if (x > 0)
-        RedrawMapSliceWest(cameraOffset, mapLayout);
-    if (x < 0)
+    if (deltaX > 0)
         RedrawMapSliceEast(cameraOffset, mapLayout);
-    if (y > 0)
+    if (deltaX < 0)
+        RedrawMapSliceWest(cameraOffset, mapLayout);
+    if (deltaY > 0)
         RedrawMapSliceNorth(cameraOffset, mapLayout);
-    if (y < 0)
+    if (deltaY < 0)
         RedrawMapSliceSouth(cameraOffset, mapLayout);
     cameraOffset->copyBGToVRAM = TRUE;
 }
@@ -138,66 +138,67 @@ static void RedrawMapSlicesForCameraUpdate(struct FieldCameraOffset *cameraOffse
 static void RedrawMapSliceNorth(struct FieldCameraOffset *cameraOffset, const struct MapLayout *mapLayout)
 {
     u8 i;
-    u8 temp;
-    u32 r7;
+    u32 rowOffset;
 
-    temp = cameraOffset->yTileOffset + 28;
-    if (temp >= 32)
-        temp -= 32;
-    r7 = temp * 32;
-    for (i = 0; i < 32; i += 2)
+    u8 row = cameraOffset->yTileOffset + MAP_OFFSET * 4;
+    if (row >= SCREEN_HEIGHT)
+        row -= SCREEN_HEIGHT;
+
+    rowOffset = row * SCREEN_WIDTH;
+
+    for (i = 0; i < SCREEN_WIDTH; i += 2)
     {
-        temp = cameraOffset->xTileOffset + i;
-        if (temp >= 32)
-            temp -= 32;
-        DrawMetatileAt(mapLayout, r7 + temp, gSaveBlock1Ptr->pos.x + i / 2, gSaveBlock1Ptr->pos.y + 14);
+        u8 col = cameraOffset->xTileOffset + i;
+        if (col >= SCREEN_WIDTH)
+            col -= SCREEN_WIDTH;
+        DrawMetatileAt(mapLayout, rowOffset + col, gSaveBlock1Ptr->pos.x + i / 2, gSaveBlock1Ptr->pos.y + 2 * MAP_OFFSET);
     }
 }
 
 static void RedrawMapSliceSouth(struct FieldCameraOffset *cameraOffset, const struct MapLayout *mapLayout)
 {
     u8 i;
-    u8 temp;
-    u32 r7 = cameraOffset->yTileOffset * 32;
+    u32 rowOffset = cameraOffset->yTileOffset * SCREEN_WIDTH;
 
-    for (i = 0; i < 32; i += 2)
+    for (i = 0; i < SCREEN_WIDTH; i += 2)
     {
-        temp = cameraOffset->xTileOffset + i;
-        if (temp >= 32)
-            temp -= 32;
-        DrawMetatileAt(mapLayout, r7 + temp, gSaveBlock1Ptr->pos.x + i / 2, gSaveBlock1Ptr->pos.y);
-    }
-}
-
-static void RedrawMapSliceEast(struct FieldCameraOffset *cameraOffset, const struct MapLayout *mapLayout)
-{
-    u8 i;
-    u8 temp;
-    u32 r6 = cameraOffset->xTileOffset;
-
-    for (i = 0; i < 32; i += 2)
-    {
-        temp = cameraOffset->yTileOffset + i;
-        if (temp >= 32)
-            temp -= 32;
-        DrawMetatileAt(mapLayout, temp * 32 + r6, gSaveBlock1Ptr->pos.x, gSaveBlock1Ptr->pos.y + i / 2);
+        u8 col = cameraOffset->xTileOffset + i;
+        if (col >= SCREEN_WIDTH)
+            col -= SCREEN_WIDTH;
+        DrawMetatileAt(mapLayout, rowOffset + col, gSaveBlock1Ptr->pos.x + i / 2, gSaveBlock1Ptr->pos.y);
     }
 }
 
 static void RedrawMapSliceWest(struct FieldCameraOffset *cameraOffset, const struct MapLayout *mapLayout)
 {
     u8 i;
-    u8 temp;
-    u8 r5 = cameraOffset->xTileOffset + 28;
+    u32 col = cameraOffset->xTileOffset;
 
-    if (r5 >= 32)
-        r5 -= 32;
-    for (i = 0; i < 32; i += 2)
+    for (i = 0; i < SCREEN_HEIGHT; i += 2)
     {
-        temp = cameraOffset->yTileOffset + i;
-        if (temp >= 32)
-            temp -= 32;
-        DrawMetatileAt(mapLayout, temp * 32 + r5, gSaveBlock1Ptr->pos.x + 14, gSaveBlock1Ptr->pos.y + i / 2);
+        u8 row = cameraOffset->yTileOffset + i;
+        if (row >= SCREEN_HEIGHT)
+            row -= SCREEN_HEIGHT;
+
+        DrawMetatileAt(mapLayout, row * SCREEN_WIDTH + col, gSaveBlock1Ptr->pos.x, gSaveBlock1Ptr->pos.y + i / 2);
+    }
+}
+
+static void RedrawMapSliceEast(struct FieldCameraOffset *cameraOffset, const struct MapLayout *mapLayout)
+{
+    u8 i;
+    u8 col = cameraOffset->xTileOffset + MAP_OFFSET * 4;
+
+    if (col >= SCREEN_WIDTH)
+        col -= SCREEN_WIDTH;
+
+    for (i = 0; i < SCREEN_HEIGHT; i += 2)
+    {
+        u8 row = cameraOffset->yTileOffset + i;
+        if (row >= SCREEN_HEIGHT)
+            row -= SCREEN_HEIGHT;
+
+        DrawMetatileAt(mapLayout, row * SCREEN_WIDTH + col, gSaveBlock1Ptr->pos.x + 2 * MAP_OFFSET, gSaveBlock1Ptr->pos.y + i / 2);
     }
 }
 
@@ -250,58 +251,58 @@ static void DrawMetatile(s32 metatileLayerType, const u16 *tiles, u16 offset)
         // Draw metatile's bottom layer to the bottom background layer.
         gOverworldTilemapBuffer_Bg3[offset] = tiles[0];
         gOverworldTilemapBuffer_Bg3[offset + 1] = tiles[1];
-        gOverworldTilemapBuffer_Bg3[offset + 0x20] = tiles[2];
-        gOverworldTilemapBuffer_Bg3[offset + 0x21] = tiles[3];
+        gOverworldTilemapBuffer_Bg3[offset + SCREEN_WIDTH] = tiles[2];
+        gOverworldTilemapBuffer_Bg3[offset + SCREEN_WIDTH + 1] = tiles[3];
 
         // Draw transparent tiles to the middle background layer.
         gOverworldTilemapBuffer_Bg2[offset] = 0;
         gOverworldTilemapBuffer_Bg2[offset + 1] = 0;
-        gOverworldTilemapBuffer_Bg2[offset + 0x20] = 0;
-        gOverworldTilemapBuffer_Bg2[offset + 0x21] = 0;
+        gOverworldTilemapBuffer_Bg2[offset + SCREEN_WIDTH] = 0;
+        gOverworldTilemapBuffer_Bg2[offset + SCREEN_WIDTH + 1] = 0;
 
         // Draw metatile's top layer to the top background layer.
         gOverworldTilemapBuffer_Bg1[offset] = tiles[4];
         gOverworldTilemapBuffer_Bg1[offset + 1] = tiles[5];
-        gOverworldTilemapBuffer_Bg1[offset + 0x20] = tiles[6];
-        gOverworldTilemapBuffer_Bg1[offset + 0x21] = tiles[7];
+        gOverworldTilemapBuffer_Bg1[offset + SCREEN_WIDTH] = tiles[6];
+        gOverworldTilemapBuffer_Bg1[offset + SCREEN_WIDTH + 1] = tiles[7];
         break;
     case METATILE_LAYER_TYPE_COVERED:
         // Draw metatile's bottom layer to the bottom background layer.
         gOverworldTilemapBuffer_Bg3[offset] = tiles[0];
         gOverworldTilemapBuffer_Bg3[offset + 1] = tiles[1];
-        gOverworldTilemapBuffer_Bg3[offset + 0x20] = tiles[2];
-        gOverworldTilemapBuffer_Bg3[offset + 0x21] = tiles[3];
+        gOverworldTilemapBuffer_Bg3[offset + SCREEN_WIDTH] = tiles[2];
+        gOverworldTilemapBuffer_Bg3[offset + SCREEN_WIDTH + 1] = tiles[3];
 
         // Draw metatile's top layer to the middle background layer.
         gOverworldTilemapBuffer_Bg2[offset] = tiles[4];
         gOverworldTilemapBuffer_Bg2[offset + 1] = tiles[5];
-        gOverworldTilemapBuffer_Bg2[offset + 0x20] = tiles[6];
-        gOverworldTilemapBuffer_Bg2[offset + 0x21] = tiles[7];
+        gOverworldTilemapBuffer_Bg2[offset + SCREEN_WIDTH] = tiles[6];
+        gOverworldTilemapBuffer_Bg2[offset + SCREEN_WIDTH + 1] = tiles[7];
 
         // Draw transparent tiles to the top background layer.
         gOverworldTilemapBuffer_Bg1[offset] = 0;
         gOverworldTilemapBuffer_Bg1[offset + 1] = 0;
-        gOverworldTilemapBuffer_Bg1[offset + 0x20] = 0;
-        gOverworldTilemapBuffer_Bg1[offset + 0x21] = 0;
+        gOverworldTilemapBuffer_Bg1[offset + SCREEN_WIDTH] = 0;
+        gOverworldTilemapBuffer_Bg1[offset + SCREEN_WIDTH + 1] = 0;
         break;
     case METATILE_LAYER_TYPE_NORMAL:
         // Draw garbage to the bottom background layer.
         gOverworldTilemapBuffer_Bg3[offset] = 0x3014;
         gOverworldTilemapBuffer_Bg3[offset + 1] = 0x3014;
-        gOverworldTilemapBuffer_Bg3[offset + 0x20] = 0x3014;
-        gOverworldTilemapBuffer_Bg3[offset + 0x21] = 0x3014;
+        gOverworldTilemapBuffer_Bg3[offset + SCREEN_WIDTH] = 0x3014;
+        gOverworldTilemapBuffer_Bg3[offset + SCREEN_WIDTH + 1] = 0x3014;
 
         // Draw metatile's bottom layer to the middle background layer.
         gOverworldTilemapBuffer_Bg2[offset] = tiles[0];
         gOverworldTilemapBuffer_Bg2[offset + 1] = tiles[1];
-        gOverworldTilemapBuffer_Bg2[offset + 0x20] = tiles[2];
-        gOverworldTilemapBuffer_Bg2[offset + 0x21] = tiles[3];
+        gOverworldTilemapBuffer_Bg2[offset + SCREEN_WIDTH] = tiles[2];
+        gOverworldTilemapBuffer_Bg2[offset + SCREEN_WIDTH + 1] = tiles[3];
 
         // Draw metatile's top layer to the top background layer, which covers object event sprites.
         gOverworldTilemapBuffer_Bg1[offset] = tiles[4];
         gOverworldTilemapBuffer_Bg1[offset + 1] = tiles[5];
-        gOverworldTilemapBuffer_Bg1[offset + 0x20] = tiles[6];
-        gOverworldTilemapBuffer_Bg1[offset + 0x21] = tiles[7];
+        gOverworldTilemapBuffer_Bg1[offset + SCREEN_WIDTH] = tiles[6];
+        gOverworldTilemapBuffer_Bg1[offset + SCREEN_WIDTH + 1] = tiles[7];
         break;
     }
     ScheduleBgCopyTilemapToVram(1);
@@ -359,15 +360,16 @@ u32 InitCameraUpdateCallback(u8 trackedSpriteId)
 
 void CameraUpdate(void)
 {
-    int deltaX;
-    int deltaY;
-    int curMovementOffsetY;
-    int curMovementOffsetX;
-    int movementSpeedX;
-    int movementSpeedY;
+    s32 deltaX;
+    s32 deltaY;
+    s32 curMovementOffsetY;
+    s32 curMovementOffsetX;
+    s32 movementSpeedX;
+    s32 movementSpeedY;
 
     if (gFieldCamera.callback != NULL)
         gFieldCamera.callback(&gFieldCamera);
+
     movementSpeedX = gFieldCamera.movementSpeedX;
     movementSpeedY = gFieldCamera.movementSpeedY;
     deltaX = 0;
@@ -375,35 +377,17 @@ void CameraUpdate(void)
     curMovementOffsetX = gFieldCamera.x;
     curMovementOffsetY = gFieldCamera.y;
 
-
     if (curMovementOffsetX == 0 && movementSpeedX != 0)
-    {
-        if (movementSpeedX > 0)
-            deltaX = 1;
-        else
-            deltaX = -1;
-    }
+        deltaX = movementSpeedX > 0 ? 1 : -1;
+
     if (curMovementOffsetY == 0 && movementSpeedY != 0)
-    {
-        if (movementSpeedY > 0)
-            deltaY = 1;
-        else
-            deltaY = -1;
-    }
+        deltaY = movementSpeedY > 0 ? 1 : -1;
+
     if (curMovementOffsetX != 0 && curMovementOffsetX == -movementSpeedX)
-    {
-        if (movementSpeedX > 0)
-            deltaX = 1;
-        else
-            deltaX = -1;
-    }
+        deltaX = movementSpeedX > 0 ? 1 : -1;
+
     if (curMovementOffsetY != 0 && curMovementOffsetY == -movementSpeedY)
-    {
-        if (movementSpeedY > 0)
-            deltaX = 1;
-        else
-            deltaX = -1;
-    }
+        deltaX = movementSpeedY > 0 ? 1 : -1;
 
     gFieldCamera.x += movementSpeedX;
     gFieldCamera.x %= 16;
@@ -464,7 +448,7 @@ void UpdateCameraPanning(void)
 
 static void CameraPanningCB_PanAhead(void)
 {
-    u8 var;
+    u8 dir;
 
     if (gUnusedBikeCameraAheadPanback == FALSE)
     {
@@ -484,13 +468,13 @@ static void CameraPanningCB_PanAhead(void)
             sBikeCameraPanFlag = FALSE;
         }
 
-        var = GetPlayerMovementDirection();
-        if (var == 2)
+        dir = GetPlayerMovementDirection();
+        if (dir == 2)
         {
             if (sVerticalCameraPan > -8)
                 sVerticalCameraPan -= 2;
         }
-        else if (var == 1)
+        else if (dir == 1)
         {
             if (sVerticalCameraPan < 72)
                 sVerticalCameraPan += 2;


### PR DESCRIPTION
This PR tries to improve the documentation in `field_camera.c`.

## Description

Several function had local variables named after registers and some other 
variables with names like `temp`.

This PR replaces those with proper names. New block-scoped local variables are 
introduced in a few places because they still preserve matching.
These were potentially fakematches.

The PR also added defines for `SCREEN_WIDTH` and `SCREEN_HEIGHT` to replace the
hardcoded 32 in several places.

Notably, the function `RedrawMapSliceWest` and `RedrawMapSliceEast` seem to
have their names flipped. I've swapped the names to match what they're
actually doing.

i.e., `RedrawMapSliceWest` was drawing the east slice and vice-versa.

Additionally, A couple if-else blocks have been replaced with ternaries.
I'm not entirely sure if this counts as an improvement though.

This is my first meaningful PR to this repo so apologies if something's amiss.

## **Discord contact info**

@miriamlefae 